### PR TITLE
Tweak jenkinsfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,3 +27,5 @@ npm-debug.log
 # we ignore priv/static. You may want to comment
 # this depending on your deployment strategy.
 /priv/static/
+
+Jenkinsfile

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,9 +23,7 @@ podTemplate(label: 'sanbase-builder', containers: [
             variable: 'aws_account_id'
           )
         ]) {
-          docker.build("sanbase-test:${env.BRANCH_NAME}", '-f Dockerfile-test .').inside("--link ${dbImage.id}:db") {
-            "sh mix test"
-          }
+          docker.build("sanbase-test:${env.BRANCH_NAME}", '-f Dockerfile-test .').run()
 
 //            if (env.BRANCH_NAME == "master") {
             docker.withRegistry("${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com", "ecr:eu-central-1:ecr-credentials") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ podTemplate(label: 'sanbase-builder', containers: [
   node('sanbase-builder') {
     stage('Run Tests') {
       container('docker') {
+        stage 'Checkout'
         checkout scm
 
         withCredentials([
@@ -14,30 +15,25 @@ podTemplate(label: 'sanbase-builder', containers: [
           string(
             credentialsId: 'aws_account_id',
             variable: 'aws_account_id'
-          ),
-          [
-            $class: 'UsernamePasswordMultiBinding',
-            credentialsId: 'DOCKER_HUB_CREDENTIALS',
-            usernameVariable: 'DOCKER_HUB_USERNAME',
-            passwordVariable: 'DOCKER_HUB_PASSWORD'
-          ]
+          )
         ]) {
-          sh "docker -H tcp://docker-host-docker-host:2375 build -t sanbase-test:${env.BRANCH_NAME} -f Dockerfile-test ."
+          docker.withServer('tcp://docker-host-docker-host:2375') {
+            stage 'Run tests'
+            docker.image("postgres:9.6-alpine").withRun { dbImage ->
+              docker.build("sanbase-test:${env.BRANCH_NAME}", '-f Dockerfile-test .').inside("--link ${dbImage.id}:db") {
+                "sh mix test"
+              }
+            }
 
-          sh "docker -H tcp://docker-host-docker-host:2375 run --rm --name postgres_${env.BRANCH_NAME} -d postgres:9.6-alpine"
-          try {
-            sh "docker -H tcp://docker-host-docker-host:2375 run --rm --link postgres_${env.BRANCH_NAME}:db --env DATABASE_URL=postgres://postgres:password@db:5432/postgres -t sanbase-test:${env.BRANCH_NAME}"
-          } finally {
-            sh "docker -H tcp://docker-host-docker-host:2375 kill postgres_${env.BRANCH_NAME}"
-          }
+#            if (env.BRANCH_NAME == "master") {
+              stage 'Push to registry'
+              docker.withRegistry("${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com", "ecr:eu-central-1:ecr-credentials") {
+                def image = docker.build("sanbase")
 
-          if (env.BRANCH_NAME == "master") {
-            sh "docker -H tcp://docker-host-docker-host:2375 build -t ${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com/sanbase:${env.BRANCH_NAME} -t ${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com/sanbase:${env.GIT_COMMIT} --build-arg SECRET_KEY_BASE=${env.SECRET_KEY_BASE} ."
-
-            sh "docker -H tcp://docker-host-docker-host:2375 login -u ${env.DOCKER_HUB_USERNAME} -p ${env.DOCKER_HUB_PASSWORD} https://${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com"
-
-            sh "docker -H tcp://docker-host-docker-host:2375 push ${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com/sanbase:${env.BRANCH_NAME}"
-            sh "docker -H tcp://docker-host-docker-host:2375 push ${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com/sanbase:${env.GIT_COMMIT}"
+                image.push(env.BRANCH_NAME)
+                image.push(env.GIT_COMMIT)
+              }
+#            }
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,16 +23,13 @@ podTemplate(label: 'sanbase-builder', containers: [
             variable: 'aws_account_id'
           )
         ]) {
+          docker.withRegistry("${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com", "ecr:eu-central-1:ecr-credentials") {
+            def image = docker.build("sanbase", '.')
+
+            image.push(env.BRANCH_NAME)
+            image.push(env.GIT_COMMIT)
+          }
           docker.build("sanbase-test:${env.BRANCH_NAME}", '-f Dockerfile-test .').run()
-
-//            if (env.BRANCH_NAME == "master") {
-            docker.withRegistry("${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com", "ecr:eu-central-1:ecr-credentials") {
-              def image = docker.build("sanbase")
-
-              image.push(env.BRANCH_NAME)
-              image.push(env.GIT_COMMIT)
-            }
-//            }
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,37 +1,42 @@
 podTemplate(label: 'sanbase-builder', containers: [
   containerTemplate(name: 'docker', image: 'docker', ttyEnabled: true, command: 'cat', envVars: [
     envVar(key: 'DOCKER_HOST', value: 'tcp://docker-host-docker-host:2375')
-  ]),
-  containerTemplate(
-    name: 'db',
-    image: 'postgres:9.6-alpine',
-    ttyEnabled: true,
-    ports: [portMapping(name: 'postgres', containerPort: 5432, hostPort: 5432)])
+  ])
 ]) {
   node('sanbase-builder') {
     stage('Run Tests') {
       container('docker') {
         checkout scm
 
-        withCredentials([
-          string(
-            credentialsId: 'SECRET_KEY_BASE',
-            variable: 'SECRET_KEY_BASE'
-          ),
-          string(
-            credentialsId: 'aws_account_id',
-            variable: 'aws_account_id'
-          )
-        ]) {
-          def awsRegistry = "${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com"
-          docker.withRegistry("https://${awsRegistry}", "ecr:eu-central-1:ecr-credentials") {
-            sh "docker build -t ${awsRegistry}/sanbase:${env.BRANCH_NAME} -t ${awsRegistry}/sanbase:${env.GIT_COMMIT} ."
-            sh "docker push ${awsRegistry}/sanbase:${env.BRANCH_NAME}"
-            sh "docker push ${awsRegistry}/sanbase:${env.GIT_COMMIT}"
-          }
+        sh "docker build -t sanbase-test:${env.BRANCH_NAME} -f Dockerfile-test ."
+        sh "docker run --rm --name postgres_${env.BRANCH_NAME} -d postgres:9.6-alpine"
+        try {
+          sh "docker run --rm --link postgres_${env.BRANCH_NAME}:db --env DATABASE_URL=postgres://postgres:password@db:5432/postgres -t sanbase-test:${env.BRANCH_NAME}"
+        } finally {
+          sh "docker kill postgres_${env.BRANCH_NAME}"
+        }
 
-          sh "docker build -t sanbase-test:${env.BRANCH_NAME} -f Dockerfile-test ."
-          sh "docker run --rm --env DATABASE_URL=postgres://postgres:password@db:5432/postgres -t sanbase-test:${env.BRANCH_NAME}"
+        if (env.BRANCH_NAME == "master") {
+          withCredentials([
+            string(
+              credentialsId: 'SECRET_KEY_BASE',
+              variable: 'SECRET_KEY_BASE'
+            ),
+            string(
+              credentialsId: 'aws_account_id',
+              variable: 'aws_account_id'
+            )
+          ]) {
+
+            def awsRegistry = "${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com"
+            def GIT_COMMIT = sh(script: "git rev-parse HEAD", returnStdout: true).trim()
+            docker.withRegistry("https://${awsRegistry}", "ecr:eu-central-1:ecr-credentials") {
+              sh "docker build -t ${awsRegistry}/sanbase:${env.BRANCH_NAME} -t ${awsRegistry}/sanbase:${GIT_COMMIT} --build-arg SECRET_KEY_BASE=${env.SECRET_KEY_BASE} ."
+              sh "docker push ${awsRegistry}/sanbase:${env.BRANCH_NAME}"
+              sh "docker push ${awsRegistry}/sanbase:${GIT_COMMIT}"
+            }
+
+          }
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ podTemplate(label: 'sanbase-builder', containers: [
             variable: 'aws_account_id'
           )
         ]) {
-          docker.withRegistry("${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com", "ecr:eu-central-1:ecr-credentials") {
+          docker.withRegistry("https://${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com", "ecr:eu-central-1:ecr-credentials") {
             def image = docker.build("sanbase", '.')
 
             image.push(env.BRANCH_NAME)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 podTemplate(label: 'sanbase-builder', containers: [
   containerTemplate(name: 'docker', image: 'docker', ttyEnabled: true, command: 'cat', envVars: [
-    envVar(key: 'DOCKER_HOST', 'value: tcp://docker-host-docker-host:2375')
+    envVar(key: 'DOCKER_HOST', value: 'tcp://docker-host-docker-host:2375')
   ])
 ]) {
   node('sanbase-builder') {


### PR DESCRIPTION
Improve the jenkisfile to issue new ECR credentials on each build. This is needed because ECR reads expire after 12 hours.