### PR TITLE
Make sure the write to InfluxDB succeeds

### DIFF
--- a/lib/mix/tasks/influx/setup.ex
+++ b/lib/mix/tasks/influx/setup.ex
@@ -5,11 +5,14 @@ defmodule Mix.Tasks.Influx.Setup do
 
   alias Sanbase.Prices.Store
 
-  def run(_args) do
+  def run(databases_to_create) do
     {:ok, _started} = Application.ensure_all_started(:sanbase)
 
-    Store.config[:database]
-    |> Instream.Admin.Database.create()
-    |> Store.execute()
+    databases_to_create
+    |> Enum.each(fn database ->
+      database
+      |> Instream.Admin.Database.create()
+      |> Store.execute()
+    end)
   end
 end

--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -18,7 +18,9 @@ defmodule Sanbase.Prices.Store do
     price_points
     |> Stream.map(&convert_to_price_series(&1, pair, tags))
     |> Stream.chunk_every(300) # About 1 day of 5 min resolution data
-    |> Enum.map(&Store.write(&1, database: @price_database))
+    |> Enum.map(fn points ->
+      :ok = Store.write(points, database: @price_database)
+    end)
   end
 
   def fetch_price_points(pair, from, to) do

--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,7 @@ defmodule Sanbase.Mixfile do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
-      "ecto.setup": ["ecto.create", "ecto.load", "run priv/repo/seeds.exs", "influx.setup"],
+      "ecto.setup": ["ecto.create", "ecto.load", "run priv/repo/seeds.exs", "influx.setup prices"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       "ecto.migrate": ["ecto.migrate", "ecto.dump"],
       "test": ["ecto.create --quiet", "ecto.load", "test"]    ]


### PR DESCRIPTION
Modified the `influx.setup` mix task to accept a list of databases to create.