### PR TITLE
Fix the ETH amounts on the cashflow page

### DIFF
--- a/app/components/projects-table/index.js
+++ b/app/components/projects-table/index.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 
+const wei_to_eth = 1000000000000000000.0;
+
 class ProjectsTable extends Component {
   constructor(props){
     super(props)
@@ -28,7 +30,7 @@ class ProjectsTable extends Component {
   }
 
   formatBalanceWallet(wallet, index){
-    const balance = wallet.balance !== null ? wallet.balance : 0;
+    const balance = wallet.balance !== null ? wallet.balance / wei_to_eth : 0;
 
     return (
       <div className="wallet" key={ index }>


### PR DESCRIPTION
The API returns the amounts in Wei and they need to be converted to ETH
before displayed.