### PR TITLE
Fix notification channel config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -66,6 +66,8 @@ config :ex_admin,
 
 config :xain, :after_callback, {Phoenix.HTML, :raw}
 
+config :tesla, adapter: :hackney
+
 config :sanbase, Sanbase.ExternalServices.Coinmarketcap,
   update_interval: 5 * 1000 * 60, # 5 minutes
   sync_enabled: true,

--- a/config/config.exs
+++ b/config/config.exs
@@ -82,8 +82,9 @@ config :sanbase, Sanbase.ExternalServices.Etherscan.Worker,
 config :sanbase, Sanbase.ExternalServices.Etherscan.Requests,
   apikey: {:system, "ETHERSCAN_APIKEY"}
 
-config :sanbase, SanBase.Notifications.CheckPrice,
-  webhook_url: {:system, "NOTIFICATIONS_WEBHOOK_URL"}
+config :sanbase, Sanbase.Notifications.CheckPrice,
+  webhook_url: {:system, "NOTIFICATIONS_WEBHOOK_URL"},
+  notification_channel: {:system, "NOTIFICATIONS_CHANNEL", "#signals-stage"}
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -65,7 +65,7 @@ config :ex_admin,
 config :sanbase, Sanbase.ExternalServices.Etherscan.RateLimiter,
   scale: 1000,
   limit: 5,
-  time_between_requests: 0
+  time_between_requests: 250
 
 if File.exists?("config/dev.secret.exs") do
   import_config "dev.secret.exs"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -71,7 +71,7 @@ config :sanbase, Sanbase.Repo,
 config :sanbase, Sanbase.ExternalServices.Etherscan.RateLimiter,
   scale: 1000,
   limit: 5,
-  time_between_requests: 0
+  time_between_requests: 250
 
 # Finally import the config/prod.secret.exs
 # which should be versioned separately.

--- a/lib/sanbase/external_services/etherscan/rate_limiter.ex
+++ b/lib/sanbase/external_services/etherscan/rate_limiter.ex
@@ -46,8 +46,8 @@ defmodule Sanbase.ExternalServices.Etherscan.RateLimiter do
   end
 
 
-  def sleep_algorithm({bucket,_,_,tbr}, {:allow, count}) do
-    Process.sleep(tbr)
+  def sleep_algorithm({bucket,_,_,time_between_requests}, {:allow, count}) do
+    Process.sleep(time_between_requests)
     {:ok, count}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,8 @@ defmodule Sanbase.Mixfile do
       {:mockery, "~> 2.0"},
       {:distillery, "~> 1.5", runtime: false},
       {:timex, "~> 3.0"},
-      {:timex_ecto, "~> 3.0"}
+      {:timex_ecto, "~> 3.0"},
+      {:hackney, "~> 1.10"}
     ]
   end
 


### PR DESCRIPTION
Put the notification channel in the config, as Mix.env is no available
in elixir releases

Replace the Tesla adapter with hackney, which resolves the incomplete
responses we are observing when making requests to etherscan.