### PR TITLE
Adjust CMC scraping parameters

### DIFF
--- a/lib/sanbase/external_services/coinmarketcap/rate_limiter.ex
+++ b/lib/sanbase/external_services/coinmarketcap/rate_limiter.ex
@@ -5,15 +5,15 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.RateLimiter do
   require Logger
 
   # Allow max 10 requests per 60 seconds. Wait 4 seconds before
-  # executing each request. 
+  # executing each request.
   @scale 60_000
-  @limit 10
-  @time_between_requests 4000 #miliseconds
+  @limit 20
+  @time_between_requests 2000 #miliseconds
   @bucket "Coinmarketcap API Rate Limit"
-  
+
 
   @name {:global, :coinmarketcap_rate_limiter}
-  
+
   def start_link(_state) do
     Logger.info fn ->
       "Starting rate limiter #{@bucket}"
@@ -39,11 +39,11 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.RateLimiter do
     Process.sleep(wait_period)
     sleep_algorithm(Hammer.check_rate(@bucket, @scale, @limit))
   end
-    
+
 
   def handle_call(:wait, _from, _state) do
     result = sleep_algorithm(Hammer.check_rate(@bucket, @scale, @limit))
-    {:reply, result, nil} 
+    {:reply, result, nil}
   end
-  
+
 end

--- a/lib/sanbase/external_services/coinmarketcap/ticker_fetcher.ex
+++ b/lib/sanbase/external_services/coinmarketcap/ticker_fetcher.ex
@@ -12,7 +12,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcher do
   alias Sanbase.ExternalServices.Coinmarketcap.Ticker
 
   @default_update_interval 1000 * 60 * 5 # 5 minutes
-  @top_projects_to_follow 100
+  @top_projects_to_follow 25
 
   def start_link(_state) do
     GenServer.start_link(__MODULE__, :ok)


### PR DESCRIPTION
* By default follow the top 25 CMC projects. Top 100 is too much and
  will take a lot of time to keep the data up-to-date
* Increase the rate limit for CMC to 20 requests/min. Testing locally it
  seems that this is an acceptable limit and the script is not throttled

These changes should increase the speed at which we scrape the
historical prices and give us functional APIs faster.