### PR TITLE
Fix the project update logic to update only 2 fields

### DIFF
--- a/lib/sanbase/external_services/coinmarketcap/ticker_fetcher.ex
+++ b/lib/sanbase/external_services/coinmarketcap/ticker_fetcher.ex
@@ -75,7 +75,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcher do
   defp find_or_init_project(%Project{name: name} = project) do
     case Repo.get_by(Project, name: name) do
       nil -> Project.changeset(project)
-      existing_project -> Project.changeset(existing_project, Map.from_struct(project))
+      existing_project -> Project.changeset(existing_project, %{coinmarketcap_id: project.coinmarketcap_id, ticker: project.ticker})
     end
   end
 


### PR DESCRIPTION
There is a bug, which causes the script to delete some of the fields of
the projects. We should explicitly pass the data we want to update.