### PR TITLE
Make the price alert logic execute parallel

### DIFF
--- a/lib/sanbase/notifications/check_prices/compute_movements.ex
+++ b/lib/sanbase/notifications/check_prices/compute_movements.ex
@@ -8,43 +8,35 @@ defmodule Sanbase.Notifications.CheckPrices.ComputeMovements do
 
   @notification_name "price_change"
 
-  def projects_to_monitor(cooldown_datetime) do
+  def recent_notification?(project, cooldown_datetime) do
     type_id = price_notification_type_id()
 
-    Project
-    |> where([p], not is_nil(p.ticker) and not is_nil(p.coinmarketcap_id))
-    |> Repo.all()
-    |> Enum.reject(&recent_notification?(&1, type_id, cooldown_datetime))
+    recent_notification?(project, type_id, cooldown_datetime)
   end
 
-  def compute_notifications(projects_with_prices, change_threshold_percent) do
+  def build_notification(project, prices, change_threshold_percent) do
     type_id = price_notification_type_id()
 
-    projects_with_prices
-    |> Enum.map(&price_difference/1)
-    |> Enum.filter(fn {_project, price_difference} ->
-      Kernel.abs(price_difference) >= change_threshold_percent
-    end)
-    |> Enum.map(&build_notification(&1, type_id))
+    diff = price_difference(prices)
+
+    if (Kernel.abs(diff) >= change_threshold_percent) do
+      {
+        %Notification{
+          project_id: project.id,
+          type_id: type_id
+        },
+        diff,
+        project
+      }
+    end
   end
 
-  defp price_difference({project, []}), do: {project, 0}
+  defp price_difference([]), do: 0
 
-  defp price_difference({project, prices}) do
+  defp price_difference(prices) do
     {[ts1, low_price | _], [ts2, high_price | _]} = Enum.min_max_by(prices, fn [_ts, price | _] -> price end)
 
-    {project, difference_sign(ts2, ts1) * (high_price - low_price) * 100 / low_price}
-  end
-
-  defp build_notification({%Project{id: id} = project, price_difference}, type_id) do
-    {
-      %Notification{
-        project_id: id,
-        type_id: type_id
-      },
-      price_difference,
-      project
-    }
+    difference_sign(ts2, ts1) * (high_price - low_price) * 100 / low_price
   end
 
   defp recent_notification?(%Project{id: id}, type_id, cooldown_datetime) do

--- a/test/sanbase/notifications/check_price_test.exs
+++ b/test/sanbase/notifications/check_price_test.exs
@@ -16,15 +16,11 @@ defmodule Sanbase.Notifications.CheckPricesTest do
     |> Store.execute()
   end
 
-  test "running the checks when there are no projects" do
-    assert CheckPrices.exec == []
-  end
-
   test "running the checks for a project without prices" do
     Store.drop_pair("SAN_USD")
-    Repo.insert!(%Project{name: "Santiment", ticker: "SAN", coinmarketcap_id: "santiment"})
+    project = Repo.insert!(%Project{name: "Santiment", ticker: "SAN", coinmarketcap_id: "santiment"})
 
-    assert CheckPrices.exec == []
+    assert CheckPrices.exec(project) == false
   end
 
   test "running the checks for a project with some prices" do
@@ -39,7 +35,7 @@ defmodule Sanbase.Notifications.CheckPricesTest do
 
     mock Tesla, [post: 3], %{status: 200}
 
-    [%Notification{project_id: project_id}] = CheckPrices.exec
+    %Notification{project_id: project_id} = CheckPrices.exec(project)
 
     assert project_id == project.id
     assert_called Tesla, post: 3

--- a/test/sanbase/notifications/check_prices/compute_movements_test.exs
+++ b/test/sanbase/notifications/check_prices/compute_movements_test.exs
@@ -6,7 +6,7 @@ defmodule Sanbase.Notifications.CheckPrices.ComputeMovementsTest do
   alias Sanbase.Model.Project
 
   test "computing the movements when there are no prices for the project" do
-    assert ComputeMovements.compute_notifications([{"Project", []}], 5) == []
+    assert ComputeMovements.build_notification("Project", [], 5) == nil
   end
 
   test "computing the notifications when there are no changes in the price" do
@@ -15,7 +15,7 @@ defmodule Sanbase.Notifications.CheckPrices.ComputeMovementsTest do
       [DateTime.from_unix!(1510928575), 100],
       [DateTime.from_unix!(1510928576), 100],
     ]
-    assert ComputeMovements.compute_notifications([{"Project", prices}], 5) == []
+    assert ComputeMovements.build_notification("Project", prices, 5) == nil
   end
 
   test "computing the notifications when the change is below the threshold" do
@@ -24,7 +24,7 @@ defmodule Sanbase.Notifications.CheckPrices.ComputeMovementsTest do
       [DateTime.from_unix!(1510928575), 100],
       [DateTime.from_unix!(1510928576), 104],
     ]
-    assert ComputeMovements.compute_notifications([{"Project", prices}], 5) == []
+    assert ComputeMovements.build_notification("Project", prices, 5) == nil
   end
 
   test "computing the notifications when the change is above the threshold" do
@@ -35,7 +35,7 @@ defmodule Sanbase.Notifications.CheckPrices.ComputeMovementsTest do
     ]
     project = %Project{id: 1}
 
-    [{%Notification{}, 5.0, %Project{}}] = ComputeMovements.compute_notifications([{project, prices}], 5)
+    {%Notification{}, 5.0, %Project{}} = ComputeMovements.build_notification(project, prices, 5)
   end
 
   test "computing the notifications when the change is negative and above threshold" do
@@ -46,6 +46,6 @@ defmodule Sanbase.Notifications.CheckPrices.ComputeMovementsTest do
     ]
     project = %Project{id: 1}
 
-    [{%Notification{}, -5.0, %Project{}}] = ComputeMovements.compute_notifications([{project, prices}], 5)
+    {%Notification{}, -5.0, %Project{}} = ComputeMovements.build_notification(project, prices, 5)
   end
 end


### PR DESCRIPTION
This should provide much better performance when we have some new
projects for which we want to catch up with prices. The rate limiting
will ensure that we don't overload the CMC serves and the price alerts
won't stop happening. The alerts will just become a bit slower. Let's
test this approach and see how it perform compared to the old linear approach.