### PR TITLE
Increase the influxDB pool size because of timeouts

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -32,7 +32,8 @@ config :logger, :console,
 
 config :sanbase, Sanbase.Prices.Store,
   host: {:system, "INFLUXDB_HOST", "localhost"},
-  port: {:system, "INFLUXDB_PORT", 8086}
+  port: {:system, "INFLUXDB_PORT", 8086},
+  pool: [ max_overflow: 10, size: 20 ]
 
 config :hammer,
   backend: {Hammer.Backend.ETS, [expiry_ms: 60_000 * 60 * 4,


### PR DESCRIPTION
There are some timeouts happening on staging and I hope that increaseing
the pool size of the influxdb connector will fix these.