### PR TITLE
Improve the query for fetching the last price from influxDB

### DIFF
--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -64,7 +64,7 @@ defmodule Sanbase.Prices.Store do
   defp parse_price_series(_), do: []
 
   def last_price_datetime(pair) do
-    ~s/SELECT time, price FROM "#{pair}" ORDER BY time DESC LIMIT 1/
+    ~s/SELECT LAST(price) FROM "#{pair}"/
     |> Store.query(database: price_database())
     |> parse_last_price_datetime
   end


### PR DESCRIPTION
Using ORDER BY and LIMIT seems to be much slower than using LAST. This
should reduce the load on the influxdb server and reduce timeouts.