### PR TITLE
Add a private API for fetching the projects

### DIFF
--- a/lib/sanbase/application.ex
+++ b/lib/sanbase/application.ex
@@ -25,9 +25,25 @@ defmodule Sanbase.Application do
         time_between_requests: 100
       ),
 
-      # Coinmarketcap rate limiter
+      # Coinmarketcap graph data rate limiter
       Sanbase.ExternalServices.RateLimiting.Server.child_spec(
-        :coinmarketcap_rate_limiter,
+        :graph_coinmarketcap_rate_limiter,
+        scale: 60_000,
+        limit: 20,
+        time_between_requests: 2000
+      ),
+
+      # Coinmarketcap api rate limiter
+      Sanbase.ExternalServices.RateLimiting.Server.child_spec(
+        :api_coinmarketcap_rate_limiter,
+        scale: 60_000,
+        limit: 5,
+        time_between_requests: 2000
+      ),
+
+      # Coinmarketcap http rate limiter
+      Sanbase.ExternalServices.RateLimiting.Server.child_spec(
+        :http_coinmarketcap_rate_limiter,
         scale: 60_000,
         limit: 20,
         time_between_requests: 2000

--- a/lib/sanbase/external_services/coinmarketcap/graph_data.ex
+++ b/lib/sanbase/external_services/coinmarketcap/graph_data.ex
@@ -8,7 +8,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData do
   alias Sanbase.ExternalServices.Coinmarketcap.RateLimiter
   alias Sanbase.ExternalServices.Coinmarketcap.PricePoint
 
-  plug RateLimiting.Middleware, name: :coinmarketcap_rate_limiter
+  plug RateLimiting.Middleware, name: :graph_coinmarketcap_rate_limiter
   plug Tesla.Middleware.BaseUrl, "https://graphs.coinmarketcap.com"
   plug Tesla.Middleware.Compression
   plug Tesla.Middleware.Logger

--- a/lib/sanbase/external_services/coinmarketcap/ticker.ex
+++ b/lib/sanbase/external_services/coinmarketcap/ticker.ex
@@ -6,7 +6,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.Ticker do
 
   use Tesla
 
-  plug RateLimiting.Middleware, name: :coinmarketcap_rate_limiter
+  plug RateLimiting.Middleware, name: :api_coinmarketcap_rate_limiter
   plug Tesla.Middleware.BaseUrl, "https://api.coinmarketcap.com/v1/ticker"
   plug Tesla.Middleware.Compression
   plug Tesla.Middleware.Logger

--- a/lib/sanbase/model/project.ex
+++ b/lib/sanbase/model/project.ex
@@ -1,14 +1,13 @@
 defmodule Sanbase.Model.Project do
   use Ecto.Schema
   import Ecto.Changeset
-  alias Sanbase.Model.{Project, ProjectEthAddress, ProjectBtcAddress, Ico, MarketSegment, Infrastructure}
+  alias Sanbase.Model.{Project, ProjectEthAddress, ProjectBtcAddress, Ico, MarketSegment, Infrastructure, LatestCoinmarketcapData}
 
 
   schema "project" do
     field :name, :string
     field :ticker, :string
     field :logo_url, :string
-    field :coinmarketcap_id, :string
     field :website_link, :string
     field :btt_link, :string
     field :facebook_link, :string
@@ -27,6 +26,7 @@ defmodule Sanbase.Model.Project do
     has_many :btc_addresses, ProjectBtcAddress
     belongs_to :market_segment, MarketSegment, on_replace: :nilify
     belongs_to :infrastructure, Infrastructure, on_replace: :nilify
+    belongs_to :latest_coinmarketcap_data, LatestCoinmarketcapData, foreign_key: :coinmarketcap_id, references: :coinmarketcap_id, type: :string, on_replace: :nilify
     has_one :ico, Ico
   end
 

--- a/lib/sanbase_web/controllers/projects_controller.ex
+++ b/lib/sanbase_web/controllers/projects_controller.ex
@@ -1,0 +1,17 @@
+defmodule SanbaseWeb.ProjectsController do
+  use SanbaseWeb, :controller
+
+  alias Sanbase.Model.Project
+  alias Sanbase.Repo
+
+  import Ecto.Query
+
+  def index(conn, _params) do
+    projects = Project
+    |> where([p], not is_nil(p.coinmarketcap_id) and not is_nil(p.ticker))
+    |> preload(:latest_coinmarketcap_data)
+    |> Repo.all
+
+    render conn, "index.json", projects: projects
+  end
+end

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -35,6 +35,12 @@ defmodule SanbaseWeb.Router do
     resources "/daily_prices", DailyPricesController, only: [:index]
   end
 
+  scope "/api", SanbaseWeb do
+    pipe_through [:api, :basic_auth]
+
+    resources "/projects", ProjectsController, only: [:index]
+  end
+
   scope "/" do
     pipe_through [:nextjs]
 

--- a/lib/sanbase_web/views/projects_view.ex
+++ b/lib/sanbase_web/views/projects_view.ex
@@ -1,0 +1,18 @@
+defmodule SanbaseWeb.ProjectsView do
+  use SanbaseWeb, :view
+
+  def render("index.json", %{projects: projects}) do
+    projects
+    |> Enum.filter(&(&1.latest_coinmarketcap_data))
+    |> Enum.map(fn project ->
+      %{
+        name: project.name,
+        coinmarketcap_id: project.coinmarketcap_id,
+        ticker: project.ticker,
+        website_link: project.website_link,
+        price_usd: project.latest_coinmarketcap_data.price_usd,
+        market_cap_usd: project.latest_coinmarketcap_data.market_cap_usd
+      }
+    end)
+  end
+end


### PR DESCRIPTION
Added an API which is behind basic auth for fetching the current
projects we track. Only projects which are successfully updated from CMC
will be returned. There will be more data coming out of this API as we
scrape more information about the projects.

Also separated the rate limiting for CMC into several separate buckets,
as we are making requests to different domains.