### PR TITLE
Allow 5 restarts every second

### DIFF
--- a/lib/sanbase/application.ex
+++ b/lib/sanbase/application.ex
@@ -61,7 +61,7 @@ defmodule Sanbase.Application do
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
-    opts = [strategy: :one_for_one, name: Sanbase.Supervisor]
+    opts = [strategy: :one_for_one, name: Sanbase.Supervisor, max_restarts: 5, max_seconds: 1]
     Supervisor.start_link(children, opts)
   end
 


### PR DESCRIPTION
This makes the app more resilient to API errors. We should install error
monitoring to the app and start getting alerts when there are too many
GenServer errors and restarts.