### PR TITLE
Add BTC price movement alerts

### DIFF
--- a/lib/sanbase/external_services/coinmarketcap.ex
+++ b/lib/sanbase/external_services/coinmarketcap.ex
@@ -70,7 +70,8 @@ defmodule Sanbase.ExternalServices.Coinmarketcap do
     end)
     |> Store.import()
 
-    CheckPrices.exec(project)
+    CheckPrices.exec(project, "usd")
+    CheckPrices.exec(project, "btc")
   end
 
   defp convert_to_measurement(%PricePoint{datetime: datetime} = point, suffix, name) do

--- a/lib/sanbase/notifications/check_prices.ex
+++ b/lib/sanbase/notifications/check_prices.ex
@@ -14,39 +14,41 @@ defmodule Sanbase.Notifications.CheckPrices do
   @check_interval_in_sec 60 * 60 # 60 minutes
   @price_change_threshold 5 # percent
 
-  def exec(project) do
-    unless ComputeMovements.recent_notification?(project, seconds_ago(@cooldown_period_in_sec)) do
-      prices = fetch_price_points(project)
+  def exec(project, counter_currency) do
+    unless ComputeMovements.recent_notification?(project, seconds_ago(@cooldown_period_in_sec), counter_currency) do
+      prices = fetch_price_points(project, counter_currency)
 
-      ComputeMovements.build_notification(project, prices, @price_change_threshold)
-      |> send_notification()
+      ComputeMovements.build_notification(project, counter_currency, prices, @price_change_threshold)
+      |> send_notification(counter_currency)
     end
   end
 
-  defp fetch_price_points(project) do
-    Store.fetch_price_points(price_ticker(project), seconds_ago(@check_interval_in_sec), DateTime.utc_now())
+  defp fetch_price_points(project, counter_currency) do
+    ticker = price_ticker(project, counter_currency)
+
+    Store.fetch_price_points(ticker, seconds_ago(@check_interval_in_sec), DateTime.utc_now())
   end
 
-  def send_notification({notification, price_difference, project}) do
+  def send_notification({notification, price_difference, project}, counter_currency) do
     %{status: 200} = @http_service.post(
       webhook_url(),
-      notification_payload(price_difference, project),
+      notification_payload(price_difference, project, counter_currency),
       headers: %{"Content-Type" => "application/json"}
     )
 
     Repo.insert!(notification)
   end
 
-  def send_notification(_), do: false
+  def send_notification(_, _), do: false
 
-  defp price_ticker(%Project{ticker: ticker}) do
-    "#{ticker}_USD"
+  defp price_ticker(%Project{ticker: ticker}, counter_currency) do
+    "#{ticker}_#{String.upcase(counter_currency)}"
   end
 
-  defp notification_payload(price_difference, %Project{name: name, coinmarketcap_id: coinmarketcap_id}) do
+  defp notification_payload(price_difference, %Project{name: name, coinmarketcap_id: coinmarketcap_id}, counter_currency) do
     Poison.encode!(%{
-      text: "#{name}: #{notification_emoji(price_difference)} #{Float.round(price_difference, 2)}% in last hour. <https://coinmarketcap.com/currencies/#{coinmarketcap_id}/|price graph>",
-      channel: notification_channel()
+      text: "#{name}: #{notification_emoji(price_difference)} #{Float.round(price_difference, 2)}% #{String.upcase(counter_currency)} in last hour. <https://coinmarketcap.com/currencies/#{coinmarketcap_id}/|price graph>",
+      channel: notification_channel(counter_currency)
     })
   end
 
@@ -56,7 +58,14 @@ defmodule Sanbase.Notifications.CheckPrices do
     |> parse_config_value()
   end
 
-  defp notification_channel() do
+  defp notification_channel("btc") do
+    Application.fetch_env!(:sanbase, Sanbase.Notifications.CheckPrice)
+    |> Keyword.get(:notification_channel)
+    |> parse_config_value()
+    |> Kernel.<>("-btc")
+  end
+
+  defp notification_channel(_) do
     Application.fetch_env!(:sanbase, Sanbase.Notifications.CheckPrice)
     |> Keyword.get(:notification_channel)
     |> parse_config_value()

--- a/test/sanbase/notifications/check_price_test.exs
+++ b/test/sanbase/notifications/check_price_test.exs
@@ -20,7 +20,7 @@ defmodule Sanbase.Notifications.CheckPricesTest do
     Store.drop_pair("SAN_USD")
     project = Repo.insert!(%Project{name: "Santiment", ticker: "SAN", coinmarketcap_id: "santiment"})
 
-    assert CheckPrices.exec(project) == false
+    assert CheckPrices.exec(project, "usd") == false
   end
 
   test "running the checks for a project with some prices" do
@@ -35,7 +35,7 @@ defmodule Sanbase.Notifications.CheckPricesTest do
 
     mock Tesla, [post: 3], %{status: 200}
 
-    %Notification{project_id: project_id} = CheckPrices.exec(project)
+    %Notification{project_id: project_id} = CheckPrices.exec(project, "usd")
 
     assert project_id == project.id
     assert_called Tesla, post: 3

--- a/test/sanbase/notifications/check_prices/compute_movements_test.exs
+++ b/test/sanbase/notifications/check_prices/compute_movements_test.exs
@@ -6,7 +6,7 @@ defmodule Sanbase.Notifications.CheckPrices.ComputeMovementsTest do
   alias Sanbase.Model.Project
 
   test "computing the movements when there are no prices for the project" do
-    assert ComputeMovements.build_notification("Project", [], 5) == nil
+    assert ComputeMovements.build_notification("Project", "usd", [], 5) == nil
   end
 
   test "computing the notifications when there are no changes in the price" do
@@ -15,7 +15,7 @@ defmodule Sanbase.Notifications.CheckPrices.ComputeMovementsTest do
       [DateTime.from_unix!(1510928575), 100],
       [DateTime.from_unix!(1510928576), 100],
     ]
-    assert ComputeMovements.build_notification("Project", prices, 5) == nil
+    assert ComputeMovements.build_notification("Project", "usd", prices, 5) == nil
   end
 
   test "computing the notifications when the change is below the threshold" do
@@ -24,7 +24,7 @@ defmodule Sanbase.Notifications.CheckPrices.ComputeMovementsTest do
       [DateTime.from_unix!(1510928575), 100],
       [DateTime.from_unix!(1510928576), 104],
     ]
-    assert ComputeMovements.build_notification("Project", prices, 5) == nil
+    assert ComputeMovements.build_notification("Project", "usd", prices, 5) == nil
   end
 
   test "computing the notifications when the change is above the threshold" do
@@ -35,7 +35,7 @@ defmodule Sanbase.Notifications.CheckPrices.ComputeMovementsTest do
     ]
     project = %Project{id: 1}
 
-    {%Notification{}, 5.0, %Project{}} = ComputeMovements.build_notification(project, prices, 5)
+    {%Notification{}, 5.0, %Project{}} = ComputeMovements.build_notification(project, "usd", prices, 5)
   end
 
   test "computing the notifications when the change is negative and above threshold" do
@@ -46,6 +46,6 @@ defmodule Sanbase.Notifications.CheckPrices.ComputeMovementsTest do
     ]
     project = %Project{id: 1}
 
-    {%Notification{}, -5.0, %Project{}} = ComputeMovements.build_notification(project, prices, 5)
+    {%Notification{}, -5.0, %Project{}} = ComputeMovements.build_notification(project, "usd", prices, 5)
   end
 end


### PR DESCRIPTION
The BTC price movements are posted in a separate slack channel and have
a separate cooldown periods.