### PR TITLE
Quickfix - Add commas to marketcap

### DIFF
--- a/app/components/projects-table/index.js
+++ b/app/components/projects-table/index.js
@@ -48,8 +48,10 @@ class ProjectsTable extends Component {
   }
 
   formatMarketCapProject = (project) => {
-    if (project.market_cap_usd !== null) {
-      return '$' + project.market_cap_usd.toLocaleString('en-US', { maximumFractionDigits: 0 })
+    if (project.market_cap_usd !== null)
+    {
+      const marketcap = Number(project.market_cap_usd)
+      return '$' + marketcap.toLocaleString('en-US', { maximumFractionDigits: 0 })
     } else {
       return 'No data'
     }


### PR DESCRIPTION
It seems that the marketcap is passed to the frontend as a
string. That's why "toLocaleString" didn't work properly