### PR TITLE
Add the faktory_worker_ex to the release

### DIFF
--- a/rel/config.exs
+++ b/rel/config.exs
@@ -51,7 +51,8 @@ release :sanbase do
     :sanbase,
     :exactor,
     :phoenix_html,
-    :inets
+    :inets,
+    :faktory_worker_ex
   ]
   set pre_start_hook: "rel/commands/migrate.sh"
 end


### PR DESCRIPTION
I think that because of the `runtime: false` parameter of the `faktory_worker_ex` dependency, this library is not included in the final release. Trying to include it in the explicit list of app.