### PR TITLE
Reduce the pool size from 10 to 5

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,6 +9,10 @@ use Mix.Config
 config :sanbase,
   ecto_repos: [Sanbase.Repo]
 
+config :sanbase, Sanbase.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  pool_size: 5
+
 # Configures the endpoint
 config :sanbase, SanbaseWeb.Endpoint,
   url: [host: "localhost"],

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -48,12 +48,10 @@ config :phoenix, :stacktrace_depth, 20
 
 # Configure your database
 config :sanbase, Sanbase.Repo,
-  adapter: Ecto.Adapters.Postgres,
   username: "postgres",
   password: "postgres",
   database: "sanbase_dev",
-  hostname: "localhost",
-  pool_size: 10
+  hostname: "localhost"
 
 config :ex_admin,
   basic_auth: [

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -64,10 +64,6 @@ config :logger, level: :info
 #
 #     config :sanbase, SanbaseWeb.Endpoint, server: true
 #
-
-config :sanbase, Sanbase.Repo,
-  adapter: Ecto.Adapters.Postgres
-
 config :sanbase, Sanbase.ExternalServices.Etherscan.RateLimiter,
   scale: 1000,
   limit: 5,


### PR DESCRIPTION
This will allow to run more machines against a smaller DB. Having more
machines will allow us to parallelize our processing more.