### PR TITLE
Use the window.location.origin if there is nothing set in the ENV

### DIFF
--- a/app/src/index.js
+++ b/app/src/index.js
@@ -22,7 +22,7 @@ import './index.css'
 
 Raven.config(process.env.RAVEN_DSN).install()
 
-const origin = process.env.WEBSITE_URL || 'http://localhost:4000'
+const origin = process.env.WEBSITE_URL || window.location.origin
 
 const httpLink = createHttpLink({ uri: `${origin}/graphql` })
 const authLink = setContext((_, { headers }) => {

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -22,7 +22,10 @@ import './index.css'
 
 Raven.config(process.env.RAVEN_DSN).install()
 
-const origin = process.env.WEBSITE_URL || window.location.origin
+let origin = process.env.WEBSITE_URL || ''
+if (process.env.production) {
+  origin = window.location.origin
+}
 
 const httpLink = createHttpLink({ uri: `${origin}/graphql` })
 const authLink = setContext((_, { headers }) => {


### PR DESCRIPTION
On staging and production we use the same image and the WEBSITE_URL
varialbe is used on compile time, so we can't use this variable when
building the production images. The origin should be computed on
runtime.