### PR TITLE
Fix eth_login mutation field name

### DIFF
--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -17,7 +17,7 @@ defmodule SanbaseWeb.Graphql.Schema do
     field :eth_login, :login do
       arg :signature, non_null(:string)
       arg :address, non_null(:string)
-      arg :messageHash, non_null(:string)
+      arg :message_hash, non_null(:string)
 
       resolve &AccountResolver.eth_login/2
     end


### PR DESCRIPTION
Absinthe itself transforms `:message_hash` to be used as `messageHash`.
For an unknown (for now) reason `:messageHash `cannot be used as `messageHash`