### PR TITLE
Fix the etherscan response parsing

### DIFF
--- a/lib/sanbase/external_services/etherscan/requests/balance.ex
+++ b/lib/sanbase/external_services/etherscan/requests/balance.ex
@@ -17,7 +17,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.Balance do
   def get(address) do
     Requests.get("/", query: get_query(address))
     |> case do
-         %{status: 200, body: body} -> Poison.decode!(body, as: %Balance{})
+         %{status: 200, body: body} -> Poison.Decode.decode(body, as: %Balance{})
        end
   end
 

--- a/lib/sanbase/external_services/etherscan/requests/internal_tx.ex
+++ b/lib/sanbase/external_services/etherscan/requests/internal_tx.ex
@@ -34,7 +34,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.InternalTx do
     Requests.get("/", query: get_query(address))
     |> case do
          %{status: 200, body: body} ->
-           response = Poison.decode!(body, as: %{result: [%InternalTx{}]})
+           response = Poison.Decode.decode(body, as: %{result: [%InternalTx{}]})
            response.result
        end
     end

--- a/lib/sanbase/external_services/etherscan/requests/tx.ex
+++ b/lib/sanbase/external_services/etherscan/requests/tx.ex
@@ -43,7 +43,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.Tx do
   end
 
   defp parse_tx_json(body) do
-    response = Poison.decode!(body, as: %{"result" => [%Tx{}]})
+    response = Poison.Decode.decode(body, as: %{"result" => [%Tx{}]})
     response["result"]
     |> Enum.map( fn(tx)->
       {ts, ""} = Integer.parse(tx.timeStamp)


### PR DESCRIPTION
After a change in the Requests module, all the return values changed
from strings to maps, so the logic that depends on this should be
changed. I think we might need to just remove these modules and define
the structs in the Requests module, so that everything around the
requests could be in one place.