### PR TITLE
Graphql prices api

### DIFF
--- a/app/src/components/ProjectIcon.js
+++ b/app/src/components/ProjectIcon.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { setDisplayName } from 'recompose'
 import './ProjectIcon.css'
 
 export const DefaultIcon = ({size}) => (
@@ -40,4 +41,4 @@ ProjectIcon.defaultProps = {
   size: 16
 }
 
-export default ProjectIcon
+export default setDisplayName('ProjectIcon')(ProjectIcon)

--- a/app/src/components/__snapshots__/ProjectIcon.spec.js.snap
+++ b/app/src/components/__snapshots__/ProjectIcon.spec.js.snap
@@ -19,7 +19,7 @@ exports[`ProjectIcon component DAO.Casino icon should render correctly 1`] = `
 `;
 
 exports[`ProjectIcon component DefaultIcon should render correctly 1`] = `
-<Component
+<ProjectIcon
   name="Any Not Available Name"
   size={16}
 >
@@ -31,7 +31,7 @@ exports[`ProjectIcon component DefaultIcon should render correctly 1`] = `
       width={16}
     />
   </Component>
-</Component>
+</ProjectIcon>
 `;
 
 exports[`ProjectIcon component SAN icon should render correctly 1`] = `

--- a/config/test.exs
+++ b/config/test.exs
@@ -24,7 +24,6 @@ config :sanbase, Sanbase.Repo,
 config :hound, driver: "chrome_driver"
 
 config :sanbase, Sanbase.ExternalServices.Coinmarketcap,
-  database: "prices_test",
   sync_enabled: false
 
 config :sanbase, Sanbase.ExternalServices.Etherscan.RateLimiter,
@@ -53,6 +52,9 @@ config :sanbase, Sanbase.Github.Store,
 config :sanbase, SanbaseWeb.Graphql.ContextPlug,
   basic_auth_username: "user",
   basic_auth_password: "pass"
+
+config :sanbase, Sanbase.Prices.Store,
+  database: "prices_test"
 
 if File.exists?("config/test.secret.exs") do
   import_config "test.secret.exs"

--- a/lib/sanbase/date_time_utils.ex
+++ b/lib/sanbase/date_time_utils.ex
@@ -5,4 +5,16 @@ defmodule Sanbase.DateTimeUtils do
     |> Kernel.-(seconds)
     |> DateTime.from_unix!
   end
+
+  def minutes_ago(minutes) do
+    seconds_ago(minutes * 60)
+  end
+
+  def hours_ago(hours) do
+    seconds_ago(hours * 60 * 60)
+  end
+
+  def days_ago(days) do
+    seconds_ago(days * 60 * 60 * 24)
+  end
 end

--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -33,7 +33,7 @@ defmodule Sanbase.Prices.Store do
     FROM "#{pair}"
     WHERE time >= #{DateTime.to_unix(from, :nanoseconds)}
     AND time <= #{DateTime.to_unix(to, :nanoseconds)}
-    GROUP BY time(#{resolution})/
+    GROUP BY time(#{resolution}) fill(none)/
     |> q()
   end
 

--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -37,6 +37,12 @@ defmodule Sanbase.Prices.Store do
     |> q()
   end
 
+  def list_measurements() do
+    "SHOW MEASUREMENTS"
+    |> Store.query()
+    |> parse_measurements_list()
+  end
+
   def q(query) do
     Store.query(query)
     |> parse_price_series
@@ -48,6 +54,25 @@ defmodule Sanbase.Prices.Store do
     WHERE time >= #{DateTime.to_unix(from, :nanoseconds)}
     AND time <= #{DateTime.to_unix(to, :nanoseconds)
     }/
+  end
+
+
+  defp parse_measurements_list(%{results: [%{error: error}]}), do: raise(error)
+
+  defp parse_measurements_list(%{
+    results: [
+      %{
+        series: [
+          %{
+            values: measurements
+          }
+        ]
+      }
+    ]
+  }) do
+
+    measurements
+    |> Enum.map(&Kernel.hd/1)
   end
 
   defp parse_price_series(%{results: [%{error: error}]}), do: raise(error)

--- a/lib/sanbase_web/graphql/complexity/price_complexity.ex
+++ b/lib/sanbase_web/graphql/complexity/price_complexity.ex
@@ -2,13 +2,21 @@ defmodule SanbaseWeb.Graphql.PriceComplexity do
   require Logger
 
   @doc ~S"""
+  Internal services use basic authentication. Return complexity = 0 to allow them
+  to access everything without limits.
+  """
+  def history_price(_,_, %Absinthe.Complexity{context: %{basic_auth: true}}) do
+    0
+  end
+
+  @doc ~S"""
   Returns the complexity of the query. It is the number of intervals in the period
   'from-to' multiplied by the child complexity. The child complexity is the number
   of fields that will be returned for a single price point. The calculation is done
   based only on the supplied arguments and avoids accessing the DB if the query
   is rejected.
   """
-  def history_price(%{from: from, to: to, interval: interval}, child_complexity) do
+  def history_price(%{from: from, to: to, interval: interval}, child_complexity, _) do
     from_unix = DateTime.to_unix(from, :second)
     to_unix = DateTime.to_unix(to, :second)
 

--- a/lib/sanbase_web/graphql/complexity/price_complexity.ex
+++ b/lib/sanbase_web/graphql/complexity/price_complexity.ex
@@ -1,0 +1,26 @@
+defmodule SanbaseWeb.Graphql.PriceComplexity do
+  require Logger
+
+  @doc "Returns the number of intervals in the period 'from-to'"
+  def history_price(%{from: from, to: to, interval: interval}, child_complexity) do
+    from_unix = DateTime.to_unix(from, :second)
+    to_unix = DateTime.to_unix(to, :second)
+
+    interval_type = String.last(interval)
+
+    interval_seconds =
+      String.slice(interval, 0..-2)
+      |> String.to_integer()
+      |> str_to_sec(interval_type)
+
+    (child_complexity * ((to_unix - from_unix) / interval_seconds))
+    |> Float.floor()
+    |> Kernel.trunc()
+  end
+
+  defp str_to_sec(seconds, "s"), do: seconds
+  defp str_to_sec(hours, "h"), do: hours * 60 * 60
+  defp str_to_sec(minutes, "m"), do: minutes * 60
+  defp str_to_sec(days, "d"), do: days * 60 * 60 * 24
+  defp str_to_sec(weeks, "w"), do: weeks * 60 * 60 * 24 * 7
+end

--- a/lib/sanbase_web/graphql/complexity/price_complexity.ex
+++ b/lib/sanbase_web/graphql/complexity/price_complexity.ex
@@ -1,7 +1,13 @@
 defmodule SanbaseWeb.Graphql.PriceComplexity do
   require Logger
 
-  @doc "Returns the number of intervals in the period 'from-to'"
+  @doc ~S"""
+  Returns the complexity of the query. It is the number of intervals in the period
+  'from-to' multiplied by the child complexity. The child complexity is the number
+  of fields that will be returned for a single price point. The calculation is done
+  based only on the supplied arguments and avoids accessing the DB if the query
+  is rejected.
+  """
   def history_price(%{from: from, to: to, interval: interval}, child_complexity) do
     from_unix = DateTime.to_unix(from, :second)
     to_unix = DateTime.to_unix(to, :second)
@@ -19,8 +25,8 @@ defmodule SanbaseWeb.Graphql.PriceComplexity do
   end
 
   defp str_to_sec(seconds, "s"), do: seconds
-  defp str_to_sec(hours, "h"), do: hours * 60 * 60
   defp str_to_sec(minutes, "m"), do: minutes * 60
+  defp str_to_sec(hours, "h"), do: hours * 60 * 60
   defp str_to_sec(days, "d"), do: days * 60 * 60 * 24
   defp str_to_sec(weeks, "w"), do: weeks * 60 * 60 * 24 * 7
 end

--- a/lib/sanbase_web/graphql/complexity/price_complexity.ex
+++ b/lib/sanbase_web/graphql/complexity/price_complexity.ex
@@ -5,7 +5,7 @@ defmodule SanbaseWeb.Graphql.PriceComplexity do
   Internal services use basic authentication. Return complexity = 0 to allow them
   to access everything without limits.
   """
-  def history_price(_,_, %Absinthe.Complexity{context: %{basic_auth: true}}) do
+  def history_price(_,_, %Absinthe.Complexity{context: %{auth: %{auth_method: :basic}}}) do
     0
   end
 

--- a/lib/sanbase_web/graphql/resolvers/account_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/account_resolver.ex
@@ -5,6 +5,8 @@ defmodule SanbaseWeb.Graphql.AccountResolver do
   alias Sanbase.Auth.{User, EthAccount}
   alias Sanbase.InternalServices.Ethauth
   alias Sanbase.Model.{Project, UserFollowedProject}
+  alias Sanbase.Prices.Store
+  alias Sanbase.Auth.{User, EthAccount}
   alias Sanbase.Repo
   alias Ecto.Multi
 

--- a/lib/sanbase_web/graphql/resolvers/price_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/price_resolver.ex
@@ -11,9 +11,9 @@ defmodule SanbaseWeb.Graphql.PriceResolver do
   def history_price(
         _root,
         %{ticker: ticker, from: from, to: to, interval: interval} = args,
-        context
+        resolution
       ) do
-    hist_price(args, requested_fields(context))
+        history_price(args, requested_fields(resolution))
   end
 
   def current_price(_root, %{ticker: ticker}, _context) do
@@ -22,10 +22,10 @@ defmodule SanbaseWeb.Graphql.PriceResolver do
          {_, price_btc, _, _} <- Store.last_record(String.upcase(ticker) <> "_BTC") do
       {:ok, %{
         datetime: datetime,
-        price_btc: price_btc,
-        price_usd: price_usd,
-        marketcap: marketcap,
-        volume: volume
+        price_btc: Decimal.new(price_btc),
+        price_usd: Decimal.new(price_usd),
+        marketcap: Decimal.new(marketcap),
+        volume: Decimal.new(volume)
       }}
     else
       {:error, reason} ->
@@ -36,67 +36,70 @@ defmodule SanbaseWeb.Graphql.PriceResolver do
     end
   end
 
-  defp hist_price(%{ticker: ticker, from: from, to: to, interval: interval}, %{
+  defp history_price(%{ticker: ticker, from: from, to: to, interval: interval}, %{
          priceBtc: true,
          priceUsd: true
        }) do
-    pair_btc = String.upcase(ticker) <> "_BTC"
-    pair_usd = String.upcase(ticker) <> "_USD"
+    result_usd =
+      (String.upcase(ticker) <> "_USD")
+      |> get_price_points(from, to, interval)
 
-    result_btc = get_price_points(pair_btc, from, to, interval)
-    result_usd = get_price_points(pair_usd, from, to, interval)
+    result_btc =
+      (String.upcase(ticker) <> "_BTC")
+      |> get_price_points(from, to, interval)
 
-    # The data is always in _USD and _BTC measurements, but with a slightly different
-    # timestamp. Zip combines corresponding results
+    # Zip the price in USD and BTC so they are shown as a single point
     result =
       Enum.zip(result_btc, result_usd)
-      |> Enum.map(fn {%{datetime: ltime} = btc_map, %{datetime: rtime, price_usd: price_usd}} ->
-           IO.inspect(DateTime.to_unix(ltime) - DateTime.to_unix(rtime))
+      |> Enum.map(fn {btc_map, %{price_usd: price_usd}} ->
            Map.put(btc_map, :price_usd, price_usd)
          end)
 
     {:ok, result}
   end
 
-  defp hist_price(%{ticker: ticker, from: from, to: to, interval: interval}, %{
+  defp history_price(%{ticker: ticker, from: from, to: to, interval: interval}, %{
          priceBtc: true
        }) do
-    pair = String.upcase(ticker) <> "_BTC"
-    result = get_price_points(pair, from, to, interval)
+    result =
+      (String.upcase(ticker) <> "_BTC")
+      |> get_price_points(from, to, interval)
+
     {:ok, result}
   end
 
-  defp hist_price(%{ticker: ticker, from: from, to: to, interval: interval}, %{
+  defp history_price(%{ticker: ticker, from: from, to: to, interval: interval}, %{
          priceUsd: true
        }) do
-    pair = String.upcase(ticker) <> "_USD"
-    result = get_price_points(pair, from, to, interval)
+    result =
+      (String.upcase(ticker) <> "_USD")
+      |> get_price_points(from, to, interval)
+
     {:ok, result}
   end
 
-  defp hist_price(args, fields) do
-    Logger.warn("Unexpected arguments passed to hist_price")
+  defp history_price(args, fields) do
+    Logger.warn("Unexpected arguments passed to history_price")
   end
 
   defp requested_fields(context) do
-    fields =
-      context.definition.selections
-      |> Enum.map(&(Map.get(&1, :name) |> String.to_atom()))
-      |> Enum.into(%{}, fn field -> {field, true} end)
+    context.definition.selections
+    |> Enum.map(&(Map.get(&1, :name) |> String.to_atom()))
+    |> Enum.into(%{}, fn field -> {field, true} end)
   end
 
   defp to_price_point([datetime, price, volume, marketcap]) do
     %{
       datetime: datetime,
-      price_btc: price,
-      price_usd: price,
-      marketcap: marketcap,
-      volume: volume
+      price_btc: Decimal.new(price),
+      price_usd: Decimal.new(price),
+      marketcap: Decimal.new(marketcap),
+      volume: Decimal.new(volume)
     }
   end
 
   defp get_price_points(pair, from, to, interval) do
-    Sanbase.Prices.Store.fetch_prices_with_resolution(
+    Store.fetch_prices_with_resolution(
       pair,
       from,
       to,

--- a/lib/sanbase_web/graphql/resolvers/price_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/price_resolver.ex
@@ -44,6 +44,8 @@ defmodule SanbaseWeb.Graphql.PriceResolver do
     {:ok, data}
   end
 
+  # Measurements are always stored with _BTC and _USD suffixes. Add only one of them
+  # to avoid filtering the list for duplicates afterwards
   defp trim_measurement(name) do
     case String.ends_with?(name, "_BTC") do
       true -> String.slice(name, 0..-5)

--- a/lib/sanbase_web/graphql/resolvers/price_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/price_resolver.ex
@@ -40,15 +40,10 @@ defmodule SanbaseWeb.Graphql.PriceResolver do
          priceBtc: true,
          priceUsd: true
        }) do
-    result_usd =
-      (String.upcase(ticker) <> "_USD")
-      |> get_price_points(from, to, interval)
+    result_usd = String.upcase(ticker) <> "_USD" |> get_price_points(from, to, interval)
+    result_btc = String.upcase(ticker) <> "_BTC" |> get_price_points(from, to, interval)
 
-    result_btc =
-      (String.upcase(ticker) <> "_BTC")
-      |> get_price_points(from, to, interval)
-
-    # Zip the price in USD and BTC so they are shown as a single point
+    # Zip the price in USD and BTC so they are shown as a single price point
     result =
       Enum.zip(result_btc, result_usd)
       |> Enum.map(fn {btc_map, %{price_usd: price_usd}} ->
@@ -88,6 +83,8 @@ defmodule SanbaseWeb.Graphql.PriceResolver do
     |> Enum.into(%{}, fn field -> {field, true} end)
   end
 
+  # Set the same price for BTC and USD. Function is only used when zipping the time series
+  # where the right price is set as appropriate
   defp to_price_point([datetime, price, volume, marketcap]) do
     %{
       datetime: datetime,
@@ -105,7 +102,6 @@ defmodule SanbaseWeb.Graphql.PriceResolver do
       to,
       interval
     )
-    |> IO.inspect()
     |> Enum.map(&to_price_point/1)
   end
 end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -3,10 +3,11 @@ defmodule SanbaseWeb.Graphql.Schema do
   use Absinthe.Ecto, repo: Sanbase.Repo
 
   alias Sanbase.Auth.{User, EthAccount}
-  alias SanbaseWeb.Graphql.AccountResolver
-  alias SanbaseWeb.Graphql.ProjectResolver
+  alias SanbaseWeb.Graphql.{AccountResolver, PriceResolver, ProjectResolver}
 
+  import_types Absinthe.Type.Custom
   import_types SanbaseWeb.Graphql.AccountTypes
+  import_types SanbaseWeb.Graphql.PriceTypes
   import_types SanbaseWeb.Graphql.ProjectTypes
 
   query do
@@ -25,6 +26,23 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg :only_project_transparency, :boolean # this is to filter the wallets
 
       resolve &ProjectResolver.project/3
+    end
+
+    @desc "Historical information for the price"
+    field :history_price, list_of(:price_point) do
+      arg :ticker, non_null(:string)
+      arg :from, non_null(:datetime)
+      arg :to, non_null(:datetime)
+      arg :interval, :string
+
+      resolve &PriceResolver.history_price/3
+    end
+
+    @desc "Current price for a ticker"
+    field :price, :price_point do
+      arg :ticker, non_null(:string)
+
+      resolve &PriceResolver.current_price/3
     end
   end
 

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -35,7 +35,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:to, :datetime, default_value: DateTime.utc_now())
       arg(:interval, :string, default_value: "1h")
 
-      complexity(&PriceComplexity.history_price/2)
+      complexity(&PriceComplexity.history_price/3)
 
       resolve(&PriceResolver.history_price/3)
     end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -3,7 +3,7 @@ defmodule SanbaseWeb.Graphql.Schema do
   use Absinthe.Ecto, repo: Sanbase.Repo
 
   alias Sanbase.Auth.{User, EthAccount}
-  alias SanbaseWeb.Graphql.{AccountResolver, PriceResolver, ProjectResolver}
+  alias SanbaseWeb.Graphql.{AccountResolver, PriceResolver, ProjectResolver, PriceComplexity}
 
   import_types Absinthe.Type.Custom
   import_types SanbaseWeb.Graphql.AccountTypes
@@ -12,7 +12,7 @@ defmodule SanbaseWeb.Graphql.Schema do
 
   query do
     field :current_user, :user do
-      resolve &AccountResolver.current_user/3
+      resolve(&AccountResolver.current_user/3)
     end
 
     field :all_projects, list_of(:project) do
@@ -30,29 +30,31 @@ defmodule SanbaseWeb.Graphql.Schema do
 
     @desc "Historical information for the price"
     field :history_price, list_of(:price_point) do
-      arg :ticker, non_null(:string)
-      arg :from, non_null(:datetime)
-      arg :to, :datetime, default_value: DateTime.utc_now()
-      arg :interval, :string, default_value: "1h"
+      arg(:ticker, non_null(:string))
+      arg(:from, non_null(:datetime))
+      arg(:to, :datetime, default_value: DateTime.utc_now())
+      arg(:interval, :string, default_value: "1h")
 
-      resolve &PriceResolver.history_price/3
+      complexity(&PriceComplexity.history_price/2)
+
+      resolve(&PriceResolver.history_price/3)
     end
 
     @desc "Current price for a ticker"
     field :price, :price_point do
-      arg :ticker, non_null(:string)
+      arg(:ticker, non_null(:string))
 
-      resolve &PriceResolver.current_price/3
+      resolve(&PriceResolver.current_price/3)
     end
   end
 
   mutation do
     field :eth_login, :login do
-      arg :signature, non_null(:string)
-      arg :address, non_null(:string)
-      arg :message_hash, non_null(:string)
+      arg(:signature, non_null(:string))
+      arg(:address, non_null(:string))
+      arg(:message_hash, non_null(:string))
 
-      resolve &AccountResolver.eth_login/2
+      resolve(&AccountResolver.eth_login/2)
     end
 
     field :change_email, :user do

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -32,8 +32,8 @@ defmodule SanbaseWeb.Graphql.Schema do
     field :history_price, list_of(:price_point) do
       arg :ticker, non_null(:string)
       arg :from, non_null(:datetime)
-      arg :to, non_null(:datetime)
-      arg :interval, :string
+      arg :to, :datetime, default_value: DateTime.utc_now()
+      arg :interval, :string, default_value: "1h"
 
       resolve &PriceResolver.history_price/3
     end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -46,6 +46,11 @@ defmodule SanbaseWeb.Graphql.Schema do
 
       resolve(&PriceResolver.current_price/3)
     end
+
+    @desc "Returns a list of available tickers"
+    field :available_prices, list_of(:string) do
+      resolve(&PriceResolver.available_prices/3)
+    end
   end
 
   mutation do

--- a/lib/sanbase_web/graphql/schema/price_types.ex
+++ b/lib/sanbase_web/graphql/schema/price_types.ex
@@ -5,10 +5,10 @@ defmodule SanbaseWeb.Graphql.PriceTypes do
 
   object :price_point do
     field :datetime, non_null(:datetime)
-    field :marketcap, :integer
+    field :marketcap, :decimal
     field :price_usd, :decimal
     field :price_btc, :decimal
-    field :volume, :integer
+    field :volume, :decimal
   end
 
 end

--- a/lib/sanbase_web/graphql/schema/price_types.ex
+++ b/lib/sanbase_web/graphql/schema/price_types.ex
@@ -6,8 +6,8 @@ defmodule SanbaseWeb.Graphql.PriceTypes do
   object :price_point do
     field :datetime, non_null(:datetime)
     field :marketcap, :integer
-    field :price_usd, :string
-    field :price_btc, :string
+    field :price_usd, :decimal
+    field :price_btc, :decimal
     field :volume, :integer
   end
 

--- a/lib/sanbase_web/graphql/schema/price_types.ex
+++ b/lib/sanbase_web/graphql/schema/price_types.ex
@@ -4,11 +4,10 @@ defmodule SanbaseWeb.Graphql.PriceTypes do
   use Absinthe.Schema.Notation
 
   object :price_point do
-    field :datetime, non_null(:datetime)
-    field :marketcap, :decimal
-    field :price_usd, :decimal
-    field :price_btc, :decimal
-    field :volume, :decimal
+    field(:datetime, non_null(:datetime))
+    field(:marketcap, :decimal)
+    field(:price_usd, :decimal)
+    field(:price_btc, :decimal)
+    field(:volume, :decimal)
   end
-
 end

--- a/lib/sanbase_web/graphql/schema/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/project_types.ex
@@ -2,7 +2,6 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
   use Absinthe.Schema.Notation
   use Absinthe.Ecto, repo: Sanbase.Repo
 
-  import_types Absinthe.Type.Custom
   import_types SanbaseWeb.Graphql.CustomTypes
 
   alias SanbaseWeb.Graphql.ProjectResolver

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -28,11 +28,15 @@ defmodule SanbaseWeb.Router do
     pipe_through :api
 
     forward "/graphql", Absinthe.Plug,
-      schema: SanbaseWeb.Graphql.Schema
+      schema: SanbaseWeb.Graphql.Schema,
+      analyze_complexity: true,
+      max_complexity: 500
 
     if Mix.env == :dev do
       forward "/graphiql", Absinthe.Plug.GraphiQL,
-        schema: SanbaseWeb.Graphql.Schema
+        schema: SanbaseWeb.Graphql.Schema,
+        analyze_complexity: true,
+        max_complexity: 500
     end
   end
 

--- a/test/sanbase_web/graphql/prices_api_test.exs
+++ b/test/sanbase_web/graphql/prices_api_test.exs
@@ -163,7 +163,7 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
     context.conn
     |> post("/graphql", query_skeleton(query, "historyPrice"))
 
-    history_price  = json_response(result, 200)["data"]["historyPrice"]
+    history_price = json_response(result, 200)["data"]["historyPrice"]
     assert Enum.count(history_price) == 2
     assert Enum.at(history_price,0)["priceUsd"] == "20"
     assert Enum.at(history_price,1)["priceUsd"] == "22"

--- a/test/sanbase_web/graphql/prices_api_test.exs
+++ b/test/sanbase_web/graphql/prices_api_test.exs
@@ -147,4 +147,25 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
     [error | _] = json_response(result, 400)["errors"]
     assert String.contains?(error["message"], "too complex")
   end
+
+  test "default arguments are correctly set", context do
+    yesterday = Sanbase.DateTimeUtils.days_ago(1)
+
+    query = """
+    {
+      historyPrice(ticker: "TEST", from: "#{yesterday}"){
+        priceUsd
+      }
+    }
+    """
+
+    result =
+    context.conn
+    |> post("/graphql", query_skeleton(query, "historyPrice"))
+
+    history_price  = json_response(result, 200)["data"]["historyPrice"]
+    assert Enum.count(history_price) == 2
+    assert Enum.at(history_price,0)["priceUsd"] == "20"
+    assert Enum.at(history_price,1)["priceUsd"] == "22"
+  end
 end

--- a/test/sanbase_web/graphql/prices_api_test.exs
+++ b/test/sanbase_web/graphql/prices_api_test.exs
@@ -3,7 +3,8 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
   use Phoenix.ConnTest
 
   alias SanbaseWeb.Graphql.{PriceResolver, PriceTypes}
-  alias Sanbase.Prices.{Store, Measurement}
+  alias Sanbase.Prices.Store
+  alias Sanbase.Influxdb.Measurement
 
   import Plug.Conn
   import ExUnit.CaptureLog

--- a/test/sanbase_web/graphql/prices_api_test.exs
+++ b/test/sanbase_web/graphql/prices_api_test.exs
@@ -202,4 +202,37 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
 
     assert json_response(result, 200)["data"] != nil
   end
+
+  test "fetch all available prices", context do
+    now = DateTime.utc_now() |> DateTime.to_unix(:nanoseconds)
+
+    Store.import([
+      # older
+      %Measurement{
+        timestamp: now,
+        fields: %{price: 1, volume: 5, marketcap: 500},
+        name: "XYZ_BTC"
+      },
+      %Measurement{
+        timestamp: now,
+        fields: %{price: 20, volume: 200, marketcap: 500},
+        name: "XYZ_USD"
+      }
+    ])
+
+    query = """
+    {
+      availablePrices
+    }
+    """
+
+    result =
+      context.conn
+      |> post("/graphql", query_skeleton(query, "availablePrices"))
+
+    resp_data = json_response(result,200)["data"]["availablePrices"]
+    assert Enum.count(resp_data) == 2
+    assert "TEST" in resp_data
+    assert "XYZ" in resp_data
+  end
 end

--- a/test/sanbase_web/graphql/prices_api_test.exs
+++ b/test/sanbase_web/graphql/prices_api_test.exs
@@ -103,7 +103,7 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
 
     query = """
     {
-      historyPrice(ticker: "TEST", from: "#{two_days_ago}", to: "#{now}", interval: "1w") {
+      historyPrice(ticker: "TEST", from: "#{two_days_ago}", to: "#{now}", interval: "10w") {
         priceUsd
         priceBtc
         marketcap


### PR DESCRIPTION
- Important note: This PR introduces complexity analysis of all queries/mutations. Allowing internal services and/or anyone authorized as needed to avoid this complexity can be done with an explicit `complexity` macro.
- Internal services using the price API should use basic authentication to have full access without complexity limitation. For dev and test purposes `username:  user` and `password: pass` are used.
- Fetching the current price via the "price" query
- Fetching aggregated historical information for a ticker via the "historyPrice" query
Example usage
```
{
historyPrice(
    ticker: "SNT",
    from: "2017-11-16 17:00:00Z",
    to:   "2017-12-16 17:00:00Z",
    interval:"2h"){
    	   datetime
  	    priceBtc
            priceUsd
    	    marketcap
   	    volume
	}
}
```

Example result:

```
{
  "data": {
    "historyPrice": [
      {
        "volume": "34671610",
        "priceUsd": "0.03035625",
        "priceBtc": "0.000004031670000000001",
        "marketcap": "105350872.83333333",
        "datetime": "2017-11-16T16:00:00Z"
      }
...
      ]
   }
}
```

The current price of a ticker can be queried as follows:
```
{
price(
    ticker: "SAN"){
    	datetime
  	priceUsd
    	priceBtc
    }
}
```

The result is:
```
{
  "data": {
      "price": {
          "priceUsd": "4",
          "priceBtc": "0.000224688",
          "datetime": "2017-12-21T08:43:05Z"
    }
  }
}
```