### PR TITLE
Fix the github scheduling script

### DIFF
--- a/lib/sanbase/external_services/github.ex
+++ b/lib/sanbase/external_services/github.ex
@@ -41,7 +41,7 @@ defmodule Sanbase.ExternalServices.Github do
     {:noreply, state}
   end
 
-  defp schedule_jobs_if_free(%{"faktory" => %{"tasks" => %{"total_enqueued" => total_enqueued}}}) do
+  defp schedule_jobs_if_free(%{"faktory" => %{"total_enqueued" => total_enqueued}}) do
     if total_enqueued > 0 do
       :ok
     else

--- a/lib/sanbase/github/scheduler.ex
+++ b/lib/sanbase/github/scheduler.ex
@@ -12,6 +12,7 @@ defmodule Sanbase.Github.Scheduler do
     Github.available_projects
     |> log_scheduler_info
     |> Enum.map(&get_initial_scrape_datetime/1)
+    |> Enum.reject(&is_nil/1)
     |> reduce_initial_scrape_datetime
     |> schedule_scrape_for_datetime(yesterday())
   end


### PR DESCRIPTION
The scheduling script had a bug in the pattern matching. Also fixed a
case when we don't have the prices for a given token, to exclude this
project from the GH activity scraping.