### PR TITLE
Twitter ignore non existent accounts

### DIFF
--- a/lib/sanbase/external_services/twitter_data/historical_data.ex
+++ b/lib/sanbase/external_services/twitter_data/historical_data.ex
@@ -75,17 +75,17 @@ defmodule Sanbase.ExternalServices.TwitterData.HistoricalData do
 
     twitter_name
     |> Sanbase.ExternalServices.TwitterData.Worker.fetch_twitter_user_data()
-    |> fetch_twittercounter_and_store(twitter_name)
+    |> fetch_and_store_twittercounter_user_data(twitter_name)
   end
 
   defp fetch_and_store(args) do
     Logger.warn("Invalid twitter link format: " <> inspect(args))
   end
 
-  defp fetch_twittercounter_and_store(nil, _), do: :ok
+  defp fetch_and_store_twittercounter_user_data(nil, _), do: :ok
 
   # Twittercounter works only with id, but not with name
-  defp fetch_twittercounter_and_store(
+  defp fetch_and_store_twittercounter_user_data(
          %ExTwitter.Model.User{id: twitter_id, id_str: twitter_id_str},
          twitter_name
        ) do
@@ -94,7 +94,7 @@ defmodule Sanbase.ExternalServices.TwitterData.HistoricalData do
         {twitter_id, twitter_id_str}
         |> fetch_twittercounter_user_data()
         |> convert_to_measurement(twitter_name)
-        |> store_twitter_user_data()
+        |> store_twittercounter_user_data()
 
       true ->
         :ok
@@ -120,9 +120,9 @@ defmodule Sanbase.ExternalServices.TwitterData.HistoricalData do
     end
   end
 
-  defp store_twitter_user_data([]), do: :ok
+  defp store_twittercounter_user_data([]), do: :ok
 
-  defp store_twitter_user_data(user_data_measurement) do
+  defp store_twittercounter_user_data(user_data_measurement) do
     user_data_measurement
     |> Store.import()
   end

--- a/lib/sanbase/external_services/twitter_data/worker.ex
+++ b/lib/sanbase/external_services/twitter_data/worker.ex
@@ -81,7 +81,20 @@ defmodule Sanbase.ExternalServices.TwitterData.Worker do
     try do
       ExTwitter.user(twitter_name, include_entities: false)
     rescue
-      _ -> nil
+      e in ExTwitter.RateLimitExceededError ->
+        Logger.info("Rate limit to twitter exceeded.")
+        nil
+
+      e in ExTwitter.ConnectionError ->
+        Logger.warn("Connection error while trying to fetch twitter user data: #{e.reason}")
+        nil
+
+      e in ExTwitter.Error ->
+        Logger.warn("Error trying to fetch twitter user data for #{twitter_name}: #{e.message}")
+        nil
+
+      _ ->
+        nil
     end
   end
 


### PR DESCRIPTION
We chose to avoid crashing the processes when non existing account is fetched to avoid too flooding the logs.
Some  little fixes are added - there is no `Logger.msg` function - `Logger.info` should be used.