### PR TITLE
Added middlewares for defining access control

### DIFF
--- a/lib/sanbase/auth/eth_account.ex
+++ b/lib/sanbase/auth/eth_account.ex
@@ -1,7 +1,7 @@
 defmodule Sanbase.Auth.EthAccount do
   use Ecto.Schema
 
-  alias Sanbase.Auth.User
+  alias Sanbase.Auth.{User, EthAccount}
   alias Sanbase.InternalServices.Ethauth
 
   schema "eth_accounts" do
@@ -11,7 +11,7 @@ defmodule Sanbase.Auth.EthAccount do
     timestamps()
   end
 
-  def san_balance(%{address: address}, _, _) do
-    {:ok, Ethauth.san_balance(address)}
+  def san_balance(%EthAccount{address: address}) do
+    Ethauth.san_balance(address)
   end
 end

--- a/lib/sanbase/auth/user.ex
+++ b/lib/sanbase/auth/user.ex
@@ -25,4 +25,10 @@ defmodule Sanbase.Auth.User do
     |> cast(attrs, [:email, :username, :salt])
     |> unique_constraint(:email)
   end
+
+  def san_balance(%User{eth_accounts: eth_accounts}) do
+    eth_accounts
+    |> EthAccount.san_balance()
+    |> Enum.sum()
+  end
 end

--- a/lib/sanbase_web/graphql/complexity/price_complexity.ex
+++ b/lib/sanbase_web/graphql/complexity/price_complexity.ex
@@ -1,4 +1,4 @@
-defmodule SanbaseWeb.Graphql.PriceComplexity do
+defmodule SanbaseWeb.Graphql.Complexity.PriceComplexity do
   require Logger
 
   @doc ~S"""

--- a/lib/sanbase_web/graphql/middlewares/basic_auth.ex
+++ b/lib/sanbase_web/graphql/middlewares/basic_auth.ex
@@ -1,0 +1,14 @@
+defmodule SanbaseWeb.Graphql.Middlewares.BasicAuth do
+  @behavior Absinthe.Middleware
+
+  alias Absinthe.Resolution
+
+  def call(%Resolution{context: %{auth: %{auth_method: :basic}}} = resolution, _) do
+    resolution
+  end
+
+  def call(resolution, _) do
+    resolution
+    |> Resolution.put_result({:error, :unauthorized})
+  end
+end

--- a/lib/sanbase_web/graphql/middlewares/jwt_auth.ex
+++ b/lib/sanbase_web/graphql/middlewares/jwt_auth.ex
@@ -1,0 +1,33 @@
+defmodule SanbaseWeb.Graphql.Middlewares.JWTAuth do
+  @moduledoc """
+  Authenticate that the request contains a valid JWT token and that the user has
+  enough san tokens to access the data. If the san tokens are not specified
+  it is assumed that 0 tokens are required.
+  """
+  @behavior Absinthe.Middleware
+
+  alias Absinthe.Resolution
+  alias Sanbase.Auth.User
+
+  def call(%Resolution{context: %{auth: %{auth_method: :user_token, current_user: current_user}}} = resolution, config) do
+    required_san_tokens = Keyword.get(config, :san_tokens, 0)
+
+    if has_enough_san_tokens?(current_user, required_san_tokens) do
+      resolution
+    else
+      resolution
+      |> Resolution.put_result({:error, :unauthorized})
+    end
+  end
+
+  def call(resolution, _) do
+    resolution
+    |> Resolution.put_result({:error, :unauthorized})
+  end
+
+  defp has_enough_san_tokens?(_, 0), do: true
+
+  defp has_enough_san_tokens?(current_user, san_tokens) do
+    User.san_balance(current_user) >= san_tokens
+  end
+end

--- a/lib/sanbase_web/graphql/middlewares/jwt_auth.ex
+++ b/lib/sanbase_web/graphql/middlewares/jwt_auth.ex
@@ -3,6 +3,20 @@ defmodule SanbaseWeb.Graphql.Middlewares.JWTAuth do
   Authenticate that the request contains a valid JWT token and that the user has
   enough san tokens to access the data. If the san tokens are not specified
   it is assumed that 0 tokens are required.
+
+  Example:
+
+      query do
+        field :project, :project do
+          arg :id, non_null(:id)
+
+          middleware SanbaseWeb.Graphql.Middlewares.JWTAuth, san_tokens: 200
+
+          resolve &ProjectResolver.project/3
+        end
+      end
+
+  This is going to require 200 SAN tokens to access the project query.
   """
   @behavior Absinthe.Middleware
 

--- a/lib/sanbase_web/graphql/middlewares/multiple_auth.ex
+++ b/lib/sanbase_web/graphql/middlewares/multiple_auth.ex
@@ -1,10 +1,10 @@
 defmodule SanbaseWeb.Graphql.Middlewares.MultipleAuth do
-  @behavior Absinthe.Middleware
   @moduledoc """
   Authentication middleware, which allows to specify multiple auth methods. If
   one of them works, the request will continue to the resolver. Otherwise the
   response will be terminated and an unauthorized error will be returned.
   """
+  @behavior Absinthe.Middleware
 
   alias Absinthe.Resolution
 

--- a/lib/sanbase_web/graphql/middlewares/multiple_auth.ex
+++ b/lib/sanbase_web/graphql/middlewares/multiple_auth.ex
@@ -1,0 +1,26 @@
+defmodule SanbaseWeb.Graphql.Middlewares.MultipleAuth do
+  @behavior Absinthe.Middleware
+  @moduledoc """
+  Authentication middleware, which allows to specify multiple auth methods. If
+  one of them works, the request will continue to the resolver. Otherwise the
+  response will be terminated and an unauthorized error will be returned.
+  """
+
+  alias Absinthe.Resolution
+
+  def call(resolution, auths) do
+    auths
+    |> Enum.map(fn
+      {middleware, config} -> middleware.call(resolution, config)
+      middleware -> middleware.call(resolution, nil)
+    end)
+    |> Enum.find(&(&1.state == :unresolved))
+    |> case do
+      nil ->
+        resolution
+        |> Resolution.put_result({:error, :unauthorized})
+      resolution ->
+        resolution
+    end
+  end
+end

--- a/lib/sanbase_web/graphql/resolvers/account_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/account_resolver.ex
@@ -1,7 +1,7 @@
-defmodule SanbaseWeb.Graphql.AccountResolver do
+defmodule SanbaseWeb.Graphql.Resolvers.AccountResolver do
   require Logger
 
-  alias SanbaseWeb.Graphql.ResolverHelpers
+  alias SanbaseWeb.Graphql.Resolvers.Helpers
   alias Sanbase.Auth.{User, EthAccount}
   alias Sanbase.InternalServices.Ethauth
   alias Sanbase.Model.{Project, UserFollowedProject}
@@ -48,7 +48,7 @@ defmodule SanbaseWeb.Graphql.AccountResolver do
            {
              :error,
              message: "Cannot update current user's email to #{new_email}",
-             details: ResolverHelpers.error_details(changeset)
+             details: Helpers.error_details(changeset)
            }
        end
   end
@@ -76,7 +76,7 @@ defmodule SanbaseWeb.Graphql.AccountResolver do
              {
                :error,
                message: "Cannot follow project with id #{project_id}",
-               details: ResolverHelpers.error_details(changeset)
+               details: Helpers.error_details(changeset)
              }
          end
     else

--- a/lib/sanbase_web/graphql/resolvers/eth_account_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/eth_account_resolver.ex
@@ -1,0 +1,7 @@
+defmodule SanbaseWeb.Graphql.Resolvers.EthAccountResolver do
+  alias Sanbase.Auth.EthAccount
+
+  def san_balance(eth_account, _, _) do
+    {:ok, EthAccount.san_balance(eth_account)}
+  end
+end

--- a/lib/sanbase_web/graphql/resolvers/price_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/price_resolver.ex
@@ -1,4 +1,4 @@
-defmodule SanbaseWeb.Graphql.PriceResolver do
+defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
   require Logger
 
   alias Sanbase.Prices.Store

--- a/lib/sanbase_web/graphql/resolvers/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project_resolver.ex
@@ -1,4 +1,4 @@
-defmodule SanbaseWeb.Graphql.ProjectResolver do
+defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
   require Logger
 
   import Ecto.Query, warn: false
@@ -15,13 +15,7 @@ defmodule SanbaseWeb.Graphql.ProjectResolver do
   alias Sanbase.Repo
   alias Ecto.Multi
 
-  def all_projects(parent, args, %{context: %{auth: %{auth_method: :basic}}}), do: all_projects(parent, args)
-
-  def all_projects(parent, args, %{context: %{auth: %{auth_method: :user_token}}}), do: all_projects(parent, args)
-
-  def all_projects(_parent, _args, _context), do: {:error, :unauthorized}
-
-  defp all_projects(parent, args) do
+  def all_projects(parent, args, _) do
     only_project_transparency = Map.get(args, :only_project_transparency, false)
 
     query = from p in Project,
@@ -32,13 +26,7 @@ defmodule SanbaseWeb.Graphql.ProjectResolver do
     {:ok, projects}
   end
 
-  def project(parent, args, %{context: %{auth: %{auth_method: :basic}}}), do: project(parent, args)
-
-  def project(parent, args, %{context: %{auth: %{auth_method: :user_token}}}), do: project(parent, args)
-
-  def project(_parent, _args, _context), do: {:error, :unauthorized}
-
-  defp project(parent, args) do
+  def project(parent, args, _) do
     id = Map.get(args, :id)
 
     project = Repo.get(Project, id)

--- a/lib/sanbase_web/graphql/resolvers/resolver_helpers.ex
+++ b/lib/sanbase_web/graphql/resolvers/resolver_helpers.ex
@@ -1,4 +1,4 @@
-defmodule SanbaseWeb.Graphql.ResolverHelpers do
+defmodule SanbaseWeb.Graphql.Resolvers.Helpers do
   def error_details(changeset) do
     changeset
     |> Ecto.Changeset.traverse_errors(fn {msg, _} -> msg end)

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -3,8 +3,9 @@ defmodule SanbaseWeb.Graphql.Schema do
   use Absinthe.Ecto, repo: Sanbase.Repo
 
   alias Sanbase.Auth.{User, EthAccount}
-  alias SanbaseWeb.Graphql.AccountResolver
-  alias SanbaseWeb.Graphql.ProjectResolver
+  alias SanbaseWeb.Graphql.Resolvers.AccountResolver
+  alias SanbaseWeb.Graphql.Resolvers.ProjectResolver
+  alias SanbaseWeb.Graphql.Middlewares.{MultipleAuth, BasicAuth, JWTAuth}
 
   import_types SanbaseWeb.Graphql.AccountTypes
   import_types SanbaseWeb.Graphql.ProjectTypes
@@ -17,6 +18,7 @@ defmodule SanbaseWeb.Graphql.Schema do
     field :all_projects, list_of(:project) do
       arg :only_project_transparency, :boolean
 
+      middleware MultipleAuth, [BasicAuth, JWTAuth]
       resolve &ProjectResolver.all_projects/3
     end
 
@@ -24,6 +26,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg :id, non_null(:id)
       arg :only_project_transparency, :boolean # this is to filter the wallets
 
+      middleware MultipleAuth, [BasicAuth, JWTAuth]
       resolve &ProjectResolver.project/3
     end
   end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -3,7 +3,8 @@ defmodule SanbaseWeb.Graphql.Schema do
   use Absinthe.Ecto, repo: Sanbase.Repo
 
   alias Sanbase.Auth.{User, EthAccount}
-  alias SanbaseWeb.Graphql.{AccountResolver, PriceResolver, ProjectResolver, PriceComplexity}
+  alias SanbaseWeb.Graphql.Resolvers.{AccountResolver, PriceResolver, ProjectResolver}
+  alias SanbaseWeb.Graphql.Complexity.PriceComplexity
   alias SanbaseWeb.Graphql.Middlewares.{MultipleAuth, BasicAuth, JWTAuth}
 
   import_types Absinthe.Type.Custom

--- a/lib/sanbase_web/graphql/schema/account_types.ex
+++ b/lib/sanbase_web/graphql/schema/account_types.ex
@@ -3,7 +3,7 @@ defmodule SanbaseWeb.Graphql.AccountTypes do
   use Absinthe.Ecto, repo: Sanbase.Repo
 
   alias Sanbase.Auth.{User, EthAccount}
-  alias SanbaseWeb.Graphql.AccountResolver
+  alias SanbaseWeb.Graphql.Resolvers.{AccountResolver, EthAccountResolver}
 
   object :user do
     field :id, non_null(:id)
@@ -19,7 +19,7 @@ defmodule SanbaseWeb.Graphql.AccountTypes do
   object :eth_account do
     field :address, non_null(:string)
     field :san_balance, non_null(:integer) do
-      resolve &EthAccount.san_balance/3
+      resolve &EthAccountResolver.san_balance/3
     end
   end
 

--- a/lib/sanbase_web/graphql/schema/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/project_types.ex
@@ -5,7 +5,8 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
   import_types Absinthe.Type.Custom
   import_types SanbaseWeb.Graphql.CustomTypes
 
-  alias SanbaseWeb.Graphql.ProjectResolver
+  alias SanbaseWeb.Graphql.Resolvers.ProjectResolver
+  alias SanbaseWeb.Graphql.Middleware.BasicAuth
 
   object :project do
     field :id, non_null(:id)

--- a/test/sanbase_web/graphql/middlewares/multiple_auth_test.exs
+++ b/test/sanbase_web/graphql/middlewares/multiple_auth_test.exs
@@ -1,0 +1,34 @@
+defmodule SanbaseWeb.Graphql.Middlewares.MultipleAuthTest do
+  use ExUnit.Case
+
+  alias SanbaseWeb.Graphql.Middlewares.MultipleAuth
+
+  defmodule TestResolvingAuth do
+    def call(resolution, _), do: Absinthe.Resolution.put_result(resolution, {:error, :you_shall_not_pass})
+  end
+
+  defmodule TestNotResolvingAuth do
+    def call(resolution, _), do: resolution
+  end
+
+  test "when no auth methods are specified, access should be denied" do
+    result = MultipleAuth.call(%Absinthe.Resolution{}, [])
+
+    assert result.state == :resolved
+    assert result.errors == [:unauthorized]
+  end
+
+  test "when all auth methods resolves, access denied should be returned" do
+    result = MultipleAuth.call(%Absinthe.Resolution{}, [TestResolvingAuth])
+
+    assert result.state == :resolved
+    assert result.errors == [:unauthorized]
+  end
+
+  test "when an auth methods do not resolve, that resolution should be returned" do
+    result = MultipleAuth.call(%Absinthe.Resolution{}, [TestResolvingAuth, TestNotResolvingAuth])
+
+    assert result.state == :unresolved
+    assert result.errors == []
+  end
+end


### PR DESCRIPTION
For now we have 3 middlewares:
* BasicAuth for internal APIs
* JWTAuth for frontend authenticated requests that also checks SAN
  balance
* MultipleAuth for specifying several auth methods. If one of the
  methods pass, the request is permited