### PR TITLE
Add empty map on error

### DIFF
--- a/lib/sanbase/external_services/twitter_data/historical_data.ex
+++ b/lib/sanbase/external_services/twitter_data/historical_data.ex
@@ -114,9 +114,12 @@ defmodule Sanbase.ExternalServices.TwitterData.HistoricalData do
 
       %Tesla.Env{status: 401} ->
         Logger.warn("Twittercounter API credentials are missing or incorrect")
+        %{}
 
       %Tesla.Env{status: 403} ->
         Logger.info("Twittercounter API limit has been reached")
+        %{}
+
     end
   end
 


### PR DESCRIPTION
The next function in the pipeline receieves `:ok` as a paramter from `Logger` and the process crashes with pattern match fail.
Providing empty map fixes that