### PR TITLE
Fetch current user followed projects

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/account_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/account_resolver.ex
@@ -12,7 +12,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.AccountResolver do
 
   import Ecto.Query
 
-  def current_user(_root, _args, %{context: %{auth: %{auth_method: :user_token, current_user: user}}}) do
+  def current_user(_root, _args, %{
+        context: %{auth: %{auth_method: :user_token, current_user: user}}
+      }) do
     {:ok, user}
   end
 
@@ -38,7 +40,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.AccountResolver do
     end
   end
 
-  def change_email(_root, %{email: new_email}, %{context: %{auth: %{auth_method: :user_token, current_user: user}}}) do
+  def change_email(_root, %{email: new_email}, %{
+        context: %{auth: %{auth_method: :user_token, current_user: user}}
+      }) do
     Repo.get!(User, user.id)
     |> User.changeset(%{email: new_email})
     |> Repo.update()
@@ -55,7 +59,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.AccountResolver do
        end
   end
 
-  def unfollow_project(_root, %{project_id: project_id}, %{context: %{auth: %{auth_method: :user_token, current_user: user}}}) do
+  def unfollow_project(_root, %{project_id: project_id}, %{
+        context: %{auth: %{auth_method: :user_token, current_user: user}}
+      }) do
     from(
       pair in UserFollowedProject,
       where: pair.project_id == ^project_id and pair.user_id == ^user.id
@@ -65,7 +71,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.AccountResolver do
     {:ok, user}
   end
 
-  def follow_project(_root, %{project_id: project_id}, %{context: %{auth: %{auth_method: :user_token, current_user: user}}}) do
+  def follow_project(_root, %{project_id: project_id}, %{
+        context: %{auth: %{auth_method: :user_token, current_user: user}}
+      }) do
     with %Project{} <- Repo.get(Project, project_id) do
       %UserFollowedProject{project_id: project_id, user_id: user.id}
       |> UserFollowedProject.changeset(%{project_id: project_id, user_id: user.id})
@@ -87,19 +95,25 @@ defmodule SanbaseWeb.Graphql.Resolvers.AccountResolver do
     end
   end
 
-  def followed_projects(%User{} = user, _args, %{context: %{auth: %{auth_method: :user_token, current_user: user}}}) do
+  def followed_projects(%User{} = user, _args, %{
+        context: %{auth: %{auth_method: :user_token, current_user: user}}
+      }) do
     query =
-    from(
-      p in Project,
-      inner_join: ufp in UserFollowedProject, on: p.id == ufp.project_id,
-      where: ufp.user_id == ^user.id
-    )
+      from(
+        p in Project,
+        inner_join: ufp in UserFollowedProject,
+        on: p.id == ufp.project_id,
+        where: ufp.user_id == ^user.id
+      )
 
     {:ok, Repo.all(query)}
   end
 
   # No eth account and there is a user logged in
-  defp fetch_user(%{address: address, context: %{auth: %{auth_method: :user_token, current_user: user}}}, nil) do
+  defp fetch_user(
+         %{address: address, context: %{auth: %{auth_method: :user_token, current_user: user}}},
+         nil
+       ) do
     %EthAccount{user_id: user.id, address: address}
     |> Repo.insert!()
 

--- a/lib/sanbase_web/graphql/resolvers/account_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/account_resolver.ex
@@ -89,11 +89,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.AccountResolver do
 
   def followed_projects(%User{} = user, _args, %{context: %{auth: %{auth_method: :user_token, current_user: user}}}) do
     query =
-      from(
-        pair in UserFollowedProject,
-        select: pair.project_id,
-        where: pair.user_id == ^user.id
-      )
+    from(
+      p in Project,
+      inner_join: ufp in UserFollowedProject, on: p.id == ufp.project_id,
+      where: ufp.user_id == ^user.id
+    )
 
     {:ok, Repo.all(query)}
   end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -69,19 +69,22 @@ defmodule SanbaseWeb.Graphql.Schema do
     field :change_email, :user do
       arg :email, non_null(:string)
 
-      resolve &AccountResolver.change_email/3
+      middleware(JWTAuth)
+      resolve(&AccountResolver.change_email/3)
     end
 
     field :follow_project, :user do
       arg :project_id, non_null(:integer)
 
-      resolve &AccountResolver.follow_project/3
+      middleware(JWTAuth)
+      resolve(&AccountResolver.follow_project/3)
     end
 
     field :unfollow_project, :user do
       arg :project_id, non_null(:integer)
 
-      resolve &AccountResolver.unfollow_project/3
+      middleware(JWTAuth)
+      resolve(&AccountResolver.unfollow_project/3)
     end
   end
 end

--- a/lib/sanbase_web/graphql/schema/account_types.ex
+++ b/lib/sanbase_web/graphql/schema/account_types.ex
@@ -4,13 +4,14 @@ defmodule SanbaseWeb.Graphql.AccountTypes do
 
   alias Sanbase.Auth.{User, EthAccount}
   alias SanbaseWeb.Graphql.Resolvers.{AccountResolver, EthAccountResolver}
+  alias SanbaseWeb.Graphql.ProjectTypes
 
   object :user do
     field :id, non_null(:id)
     field :email, :string
     field :username, :string
     field :eth_accounts, list_of(:eth_account), resolve: assoc(:eth_accounts)
-    field :followed_projects, list_of(:integer) do
+    field :followed_projects, list_of(:project) do
       #TODO Redo to return list_of(:project) when there's an API for that?
       resolve &AccountResolver.followed_projects/3
     end

--- a/lib/sanbase_web/graphql/schema/account_types.ex
+++ b/lib/sanbase_web/graphql/schema/account_types.ex
@@ -12,7 +12,6 @@ defmodule SanbaseWeb.Graphql.AccountTypes do
     field :username, :string
     field :eth_accounts, list_of(:eth_account), resolve: assoc(:eth_accounts)
     field :followed_projects, list_of(:project) do
-      #TODO Redo to return list_of(:project) when there's an API for that?
       resolve &AccountResolver.followed_projects/3
     end
   end

--- a/test/sanbase_web/graphql/account_test.exs
+++ b/test/sanbase_web/graphql/account_test.exs
@@ -70,7 +70,9 @@ defmodule SanbaseWeb.Graphql.AccountTest do
     follow_mutation = """
     mutation {
       followProject(projectId: #{project.id}){
-        followedProjects
+        followedProjects{
+          ticker
+        }
       }
     }
     """
@@ -78,6 +80,8 @@ defmodule SanbaseWeb.Graphql.AccountTest do
     follow_result =
       context.conn
       |> post("/graphql", mutation_skeleton(follow_mutation))
+
+      json_response(follow_result,200)["data"]["followProject"]["followedProjects"] |> IO.inspect()
 
     assert project.id in json_response(follow_result, 200)["data"]["followProject"][
              "followedProjects"
@@ -98,6 +102,6 @@ defmodule SanbaseWeb.Graphql.AccountTest do
     followed_projects =
       json_response(unfollow_result, 200)["data"]["followProject"]["followedProjects"]
 
-    assert followed_projects == nil || project.id not in followed_projects
+    assert followed_projects == nil# || project.id not in followed_projects
   end
 end

--- a/test/sanbase_web/graphql/account_test.exs
+++ b/test/sanbase_web/graphql/account_test.exs
@@ -39,7 +39,10 @@ defmodule SanbaseWeb.Graphql.AccountTest do
       |> put_req_header("authorization", "Bearer " <> token)
 
     conn = ContextPlug.call(conn, %{})
-    assert conn.private[:absinthe] == %{context: %{auth: %{auth_method: :user_token, current_user: user}}}
+
+    assert conn.private[:absinthe] == %{
+             context: %{auth: %{auth_method: :user_token, current_user: user}}
+           }
 
     {:ok, conn: conn}
   end
@@ -70,8 +73,8 @@ defmodule SanbaseWeb.Graphql.AccountTest do
     follow_mutation = """
     mutation {
       followProject(projectId: #{project.id}){
-        followedProjects{
-          ticker
+        followedProjects {
+          id
         }
       }
     }
@@ -81,16 +84,15 @@ defmodule SanbaseWeb.Graphql.AccountTest do
       context.conn
       |> post("/graphql", mutation_skeleton(follow_mutation))
 
-      json_response(follow_result,200)["data"]["followProject"]["followedProjects"] |> IO.inspect()
-
-    assert project.id in json_response(follow_result, 200)["data"]["followProject"][
-             "followedProjects"
-           ]
+    assert [%{"id" => "#{project.id}"}] ==
+             json_response(follow_result, 200)["data"]["followProject"]["followedProjects"]
 
     unfollow_mutation = """
     mutation {
       unfollowProject(projectId: #{project.id}){
-        followedProjects
+        followedProjects {
+          id
+        }
       }
     }
     """
@@ -102,6 +104,6 @@ defmodule SanbaseWeb.Graphql.AccountTest do
     followed_projects =
       json_response(unfollow_result, 200)["data"]["followProject"]["followedProjects"]
 
-    assert followed_projects == nil# || project.id not in followed_projects
+    assert followed_projects == nil || [%{"ticker" => "#{project.id}"}] not in followed_projects
   end
 end


### PR DESCRIPTION
1. Add custom resolver to `followedProjects` field in the `:user` field. It now returns basic information about every project. Note that, as with `all_projects` query, here the following fields cannot be fetched:
- `fundsRaisedIcos`
- `ethBalance`
- `btcBalance`

2. Run elixir formatter to fix some long lines

3. Add middleware JWT auth to user mutations to return `unauthorized` error instead of pattern match fail