### PR TITLE
Address some of the compilation time and test warnings

### DIFF
--- a/lib/sanbase/external_services/etherscan/worker.ex
+++ b/lib/sanbase/external_services/etherscan/worker.ex
@@ -111,7 +111,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
     end
   end
 
-  defp config do
+  defp config() do
     Application.get_env(:sanbase, __MODULE__)
   end
 

--- a/lib/sanbase/external_services/twitter_data/historical_data.ex
+++ b/lib/sanbase/external_services/twitter_data/historical_data.ex
@@ -21,7 +21,7 @@ defmodule Sanbase.ExternalServices.TwitterData.HistoricalData do
   alias Sanbase.Model.Project
   alias Sanbase.Influxdb.Measurement
   alias Sanbase.ExternalServices.RateLimiting
-  alias Sanbase.ExternalServices.TwitterData.{HistoricalData, Store}
+  alias Sanbase.ExternalServices.TwitterData.Store
 
   # 1 day
   @default_update_interval 1000 * 60 * 60 * 24
@@ -86,12 +86,12 @@ defmodule Sanbase.ExternalServices.TwitterData.HistoricalData do
 
   # Twittercounter works only with id, but not with name
   defp fetch_and_store_twittercounter_user_data(
-         %ExTwitter.Model.User{id: twitter_id, id_str: twitter_id_str},
+         %ExTwitter.Model.User{id_str: twitter_id_str},
          twitter_name
        ) do
     case has_scraped_data?(twitter_name) do
       false ->
-        {twitter_id, twitter_id_str}
+        twitter_id_str
         |> fetch_twittercounter_user_data()
         |> convert_to_measurement(twitter_name)
         |> store_twittercounter_user_data()
@@ -101,7 +101,7 @@ defmodule Sanbase.ExternalServices.TwitterData.HistoricalData do
     end
   end
 
-  defp fetch_twittercounter_user_data({twitter_id, twitter_id_str}) do
+  defp fetch_twittercounter_user_data(twitter_id_str) do
     RateLimiting.Server.wait(@rate_limiter_name)
 
     apikey = get_config(:apikey)

--- a/lib/sanbase/external_services/twitter_data/store.ex
+++ b/lib/sanbase/external_services/twitter_data/store.ex
@@ -34,12 +34,12 @@ defmodule Sanbase.ExternalServices.TwitterData.Store do
     AND time <= #{DateTime.to_unix(to, :nanoseconds)}/
   end
 
-  defp select_last_tag_value_query(measurement_name, tag, value) when is_bitstring(value) do
+  defp select_last_tag_value_query(measurement_name, tag_name, tag_value) when is_bitstring(tag_value) do
     ~s/SELECT LAST(followers_count) FROM "#{measurement_name}"
     WHERE #{tag_name} = '#{tag_value}'/
   end
 
-  defp select_last_tag_value_query(measurement_name, tag, value) when is_integer(value) do
+  defp select_last_tag_value_query(measurement_name, tag_name, tag_value) when is_integer(tag_value) do
     ~s/SELECT LAST(followers_count) FROM "#{measurement_name}"
     WHERE #{tag_name} = #{tag_value}/
   end

--- a/lib/sanbase/external_services/twitter_data/worker.ex
+++ b/lib/sanbase/external_services/twitter_data/worker.ex
@@ -17,7 +17,7 @@ defmodule Sanbase.ExternalServices.TwitterData.Worker do
   alias Sanbase.Model.Project
   alias Sanbase.Influxdb.Measurement
   alias Sanbase.ExternalServices.RateLimiting.Server
-  alias Sanbase.ExternalServices.TwitterData.{Worker, Store}
+  alias Sanbase.ExternalServices.TwitterData.Store
 
   @default_update_interval 1000 * 60 * 60 * 6
 
@@ -120,7 +120,7 @@ defmodule Sanbase.ExternalServices.TwitterData.Worker do
   end
 
   defp convert_to_measurement(
-         %ExTwitter.Model.User{followers_count: followers_count} = user_data,
+         %ExTwitter.Model.User{followers_count: followers_count},
          measurement_name
        ) do
     %Measurement{

--- a/lib/sanbase/influxdb/store.ex
+++ b/lib/sanbase/influxdb/store.ex
@@ -7,7 +7,7 @@ defmodule Sanbase.Influxdb.Store do
     ```
   """
 
-  defmacro __using__(options \\ []) do
+  defmacro __using__(_options \\ []) do
     quote do
       use Instream.Connection, otp_app: :sanbase
       alias Sanbase.Influxdb.Measurement

--- a/lib/sanbase/model/ico.ex
+++ b/lib/sanbase/model/ico.ex
@@ -1,7 +1,6 @@
 defmodule Sanbase.Model.Ico do
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query
   alias Sanbase.Model.ModelUtils
   alias Sanbase.Model.Ico
   alias Sanbase.Model.Project
@@ -79,7 +78,7 @@ defmodule Sanbase.Model.Ico do
     put_change(changeset, key, value)
   end
 
-  defp add_change(changeset, key, :error) do
+  defp add_change(changeset, _key, :error) do
     changeset
   end
 

--- a/lib/sanbase/model/project.ex
+++ b/lib/sanbase/model/project.ex
@@ -11,13 +11,9 @@ defmodule Sanbase.Model.Project do
     MarketSegment,
     Infrastructure,
     LatestCoinmarketcapData,
-    UserFollowedProject,
     ProjectTransparencyStatus
   }
   import Ecto.Query
-
-  alias Sanbase.Auth.{User, EthAccount}
-  alias Sanbase.InternalServices.Ethauth
 
   schema "project" do
     field(:name, :string)

--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -113,7 +113,7 @@ defmodule Sanbase.Prices.Store do
     {datetime, price, marketcap, volume}
   end
 
-  defp parse_record(x) do
+  defp parse_record(_) do
     nil
   end
 end

--- a/lib/sanbase_web/controllers/daily_prices_controller.ex
+++ b/lib/sanbase_web/controllers/daily_prices_controller.ex
@@ -10,7 +10,7 @@ defmodule SanbaseWeb.DailyPricesController do
 
   def index(conn, %{"tickers" => tickers}) do
     prices = String.split(tickers, ",")
-    |> Enum.map(&String.strip/1)
+    |> Enum.map(&String.trim/1)
     |> Enum.take(@max_assets_to_return)
     |> Enum.map(fn ticker -> "#{ticker}_USD" end)
     |> Enum.reduce(%{}, fn pair, acc ->

--- a/lib/sanbase_web/graphql/context_plug.ex
+++ b/lib/sanbase_web/graphql/context_plug.ex
@@ -1,5 +1,5 @@
 defmodule SanbaseWeb.Graphql.ContextPlug do
-  @behavior Plug
+  @behaviour Plug
 
   import Plug.Conn
 
@@ -27,7 +27,7 @@ defmodule SanbaseWeb.Graphql.ContextPlug do
     end
   end
 
-  defp build_context(conn, []), do: %{}
+  defp build_context(_conn, []), do: %{}
 
   def bearer_authentication(conn) do
     with ["Bearer " <> token] <- get_req_header(conn, "authorization"),

--- a/lib/sanbase_web/graphql/middlewares/basic_auth.ex
+++ b/lib/sanbase_web/graphql/middlewares/basic_auth.ex
@@ -1,5 +1,5 @@
 defmodule SanbaseWeb.Graphql.Middlewares.BasicAuth do
-  @behavior Absinthe.Middleware
+  @behaviour Absinthe.Middleware
 
   alias Absinthe.Resolution
 

--- a/lib/sanbase_web/graphql/middlewares/jwt_auth.ex
+++ b/lib/sanbase_web/graphql/middlewares/jwt_auth.ex
@@ -18,7 +18,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.JWTAuth do
 
   This is going to require 200 SAN tokens to access the project query.
   """
-  @behavior Absinthe.Middleware
+  @behaviour Absinthe.Middleware
 
   alias Absinthe.Resolution
   alias Sanbase.Auth.User

--- a/lib/sanbase_web/graphql/middlewares/multiple_auth.ex
+++ b/lib/sanbase_web/graphql/middlewares/multiple_auth.ex
@@ -4,7 +4,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.MultipleAuth do
   one of them works, the request will continue to the resolver. Otherwise the
   response will be terminated and an unauthorized error will be returned.
   """
-  @behavior Absinthe.Middleware
+  @behaviour Absinthe.Middleware
 
   alias Absinthe.Resolution
 

--- a/lib/sanbase_web/graphql/resolvers/account_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/account_resolver.ex
@@ -5,7 +5,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.AccountResolver do
   alias Sanbase.Auth.{User, EthAccount}
   alias Sanbase.InternalServices.Ethauth
   alias Sanbase.Model.{Project, UserFollowedProject}
-  alias Sanbase.Prices.Store
   alias Sanbase.Auth.{User, EthAccount}
   alias Sanbase.Repo
   alias Ecto.Multi

--- a/lib/sanbase_web/graphql/resolvers/github_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/github_resolver.ex
@@ -5,7 +5,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.GithubResolver do
 
   def activity(
         _root,
-        %{repository: repository, from: from, to: to, interval: interval} = args,
+        %{repository: repository, from: from, to: to, interval: interval},
         _resolution
       ) do
     result =

--- a/lib/sanbase_web/graphql/resolvers/price_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/price_resolver.ex
@@ -2,7 +2,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
   require Logger
 
   alias Sanbase.Prices.Store
-  alias SanbaseWeb.Graphql.PriceTypes
 
   @doc """
   Returns a list of price points for the given ticker. Optimizes the number of queries
@@ -10,7 +9,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
   """
   def history_price(
         _root,
-        %{ticker: ticker, from: from, to: to, interval: interval} = args,
+        %{ticker: _ticker, from: _from, to: _to, interval: _interval} = args,
         resolution
       ) do
     history_price(args, requested_fields(resolution))
@@ -95,7 +94,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
     {:ok, result}
   end
 
-  defp history_price(args, fields) do
+  defp history_price(_args, _fields) do
     Logger.warn("Unexpected arguments passed to history_price")
   end
 

--- a/lib/sanbase_web/graphql/resolvers/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project_resolver.ex
@@ -9,14 +9,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
   alias Sanbase.Model.LatestBtcWalletData
   alias Sanbase.Model.LatestEthWalletData
   alias Sanbase.Model.Ico
-  alias Sanbase.Model.IcoCurrencies
   alias Sanbase.Model.Currency
   alias Sanbase.Model.MarketSegment
   alias Sanbase.Model.Infrastructure
   alias Sanbase.Model.ProjectTransparencyStatus
 
   alias Sanbase.Repo
-  alias Ecto.Multi
 
   def all_projects(_parent, args, _context) do
     only_project_transparency = Map.get(args, :only_project_transparency, false)
@@ -58,7 +56,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
     {:ok, projects}
   end
 
-  def eth_balance(%Project{id: id}, args, context) do
+  def eth_balance(%Project{id: id}, _args, context) do
     only_project_transparency = get_parent_args(context)
     |> Map.get(:only_project_transparency, false)
 
@@ -73,7 +71,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
     {:ok, balance}
   end
 
-  def btc_balance(%Project{id: id}, args, context) do
+  def btc_balance(%Project{id: id}, _args, context) do
     only_project_transparency = get_parent_args(context)
     |> Map.get(:only_project_transparency, false)
 

--- a/lib/sanbase_web/graphql/resolvers/resolver_helpers.ex
+++ b/lib/sanbase_web/graphql/resolvers/resolver_helpers.ex
@@ -1,7 +1,7 @@
 defmodule SanbaseWeb.Graphql.Resolvers.Helpers do
   def error_details(changeset) do
     changeset
-    |> Ecto.Changeset.traverse_errors(fn {msg, _} -> msg end)
+    |> Ecto.Changeset.traverse_errors(&format_error/1)
   end
 
   @spec format_error(Ecto.Changeset.error()) :: String.t()

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -2,7 +2,6 @@ defmodule SanbaseWeb.Graphql.Schema do
   use Absinthe.Schema
   use Absinthe.Ecto, repo: Sanbase.Repo
 
-  alias Sanbase.Auth.{User, EthAccount}
   alias SanbaseWeb.Graphql.Resolvers.{
     AccountResolver,
     PriceResolver,

--- a/lib/sanbase_web/graphql/schema/account_types.ex
+++ b/lib/sanbase_web/graphql/schema/account_types.ex
@@ -2,9 +2,7 @@ defmodule SanbaseWeb.Graphql.AccountTypes do
   use Absinthe.Schema.Notation
   use Absinthe.Ecto, repo: Sanbase.Repo
 
-  alias Sanbase.Auth.{User, EthAccount}
   alias SanbaseWeb.Graphql.Resolvers.{AccountResolver, EthAccountResolver}
-  alias SanbaseWeb.Graphql.ProjectTypes
 
   object :user do
     field :id, non_null(:id)

--- a/lib/sanbase_web/graphql/schema/price_types.ex
+++ b/lib/sanbase_web/graphql/schema/price_types.ex
@@ -1,6 +1,4 @@
 defmodule SanbaseWeb.Graphql.PriceTypes do
-  alias SanbaseWeb.Graphql.PriceResolver
-
   use Absinthe.Schema.Notation
 
   object :price_point do

--- a/lib/sanbase_web/graphql/schema/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/project_types.ex
@@ -5,7 +5,6 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
   import_types SanbaseWeb.Graphql.CustomTypes
 
   alias SanbaseWeb.Graphql.Resolvers.ProjectResolver
-  alias SanbaseWeb.Graphql.Middleware.BasicAuth
 
   object :project do
     field :id, non_null(:id)

--- a/lib/sanbase_workers/import_github_activity.ex
+++ b/lib/sanbase_workers/import_github_activity.ex
@@ -95,7 +95,7 @@ defmodule SanbaseWorkers.ImportGithubActivity do
   end
 
   defp s3_path(archive) do
-    [year, month | rest] = String.split(archive, "-")
+    [year, month | _rest] = String.split(archive, "-")
 
     "#{year}/#{month}/#{archive}.json.gz"
   end

--- a/test/sanbase_web/graphql/account_test.exs
+++ b/test/sanbase_web/graphql/account_test.exs
@@ -3,27 +3,17 @@ defmodule SanbaseWeb.Graphql.AccountTest do
   use Phoenix.ConnTest
 
   import Plug.Conn
-  import ExUnit.CaptureLog
 
   alias Sanbase.Model.Project
   alias Sanbase.Auth.User
   alias Sanbase.Repo
   alias SanbaseWeb.Graphql.ContextPlug
-  alias SanbaseWeb.Graphql.{AccountTypes, AccountResolver}
 
   defp mutation_skeleton(query) do
     %{
       "operationName" => "",
       "query" => "#{query}",
       "variables" => ""
-    }
-  end
-
-  defp query_skeleton(query, query_name) do
-    %{
-      "operationName" => "#{query_name}",
-      "query" => "query #{query_name} #{query}",
-      "variables" => "{}"
     }
   end
 

--- a/test/sanbase_web/graphql/prices_api_test.exs
+++ b/test/sanbase_web/graphql/prices_api_test.exs
@@ -2,12 +2,10 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
   use SanbaseWeb.ConnCase
   use Phoenix.ConnTest
 
-  alias SanbaseWeb.Graphql.{PriceResolver, PriceTypes}
   alias Sanbase.Prices.Store
   alias Sanbase.Influxdb.Measurement
 
   import Plug.Conn
-  import ExUnit.CaptureLog
 
   defp query_skeleton(query, query_name) do
     %{

--- a/test/sanbase_web/graphql/project_api_test.exs
+++ b/test/sanbase_web/graphql/project_api_test.exs
@@ -4,8 +4,6 @@ defmodule Sanbase.Graphql.ProjectApiTest do
 
   import Sanbase.Utils, only: [parse_config_value: 1]
 
-  alias Ecto.Changeset
-  alias Sanbase.Graphql.ProjectInfo
   alias Sanbase.Model.Project
   alias Sanbase.Model.Ico
   alias Sanbase.Model.Currency
@@ -15,7 +13,6 @@ defmodule Sanbase.Graphql.ProjectApiTest do
   alias Sanbase.Repo
 
   import Plug.Conn
-  import ExUnit.CaptureLog
 
   defp query_skeleton(query, query_name) do
     %{
@@ -30,19 +27,19 @@ defmodule Sanbase.Graphql.ProjectApiTest do
     |> Project.changeset(%{name: "Project1", project_transparency: true})
     |> Repo.insert!
 
-    addr1_1 = %ProjectEthAddress{}
+    %ProjectEthAddress{}
     |> ProjectEthAddress.changeset(%{project_id: project1.id, address: "abcdefg", project_transparency: true})
     |> Repo.insert!
 
-    addr1_1_data = %LatestEthWalletData{}
+    %LatestEthWalletData{}
     |> LatestEthWalletData.changeset(%{address: "abcdefg", update_time: Ecto.DateTime.utc(), balance: 500})
     |> Repo.insert!
 
-    addr1_2 = %ProjectEthAddress{}
+    %ProjectEthAddress{}
     |> ProjectEthAddress.changeset(%{project_id: project1.id, address: "rrrrr"})
     |> Repo.insert!
 
-    addr1_2_data = %LatestEthWalletData{}
+    %LatestEthWalletData{}
     |> LatestEthWalletData.changeset(%{address: "rrrrr", update_time: Ecto.DateTime.utc(), balance: 800})
     |> Repo.insert!
 
@@ -77,7 +74,7 @@ defmodule Sanbase.Graphql.ProjectApiTest do
     |> Project.changeset(%{name: "Project1"})
     |> Repo.insert!
 
-    ico1 = %Ico{}
+    %Ico{}
     |> Ico.changeset(%{project_id: project1.id, funds_raised_usd: 123.45})
     |> Repo.insert!
 
@@ -89,15 +86,15 @@ defmodule Sanbase.Graphql.ProjectApiTest do
     |> Ico.changeset(%{project_id: project2.id, funds_raised_usd: 100})
     |> Repo.insert!
 
-    ico2_2 = %Ico{}
+    %Ico{}
     |> Ico.changeset(%{project_id: project2.id, funds_raised_usd: 200})
     |> Repo.insert!
 
-    ico_currency_2_1 = %IcoCurrencies{}
+    %IcoCurrencies{}
     |> IcoCurrencies.changeset(%{ico_id: ico2_1.id, currency_id: currency1.id, amount: 50})
     |> Repo.insert!
 
-    ico_currency_2_2 = %IcoCurrencies{}
+    %IcoCurrencies{}
     |> IcoCurrencies.changeset(%{ico_id: ico2_1.id, currency_id: currency2.id, amount: 300})
     |> Repo.insert!
 


### PR DESCRIPTION
Reduce the number of warnings. Some of the warnings are not that much harmful (unused alias) but some of them are more critical and should in no case be ignored and lost in all other warnings - misspelling tag names, wrong file extension, etc.