### PR TITLE
Add fetching prices for multiple tickers

### DIFF
--- a/lib/sanbase_web/graphql/complexity/price_complexity.ex
+++ b/lib/sanbase_web/graphql/complexity/price_complexity.ex
@@ -5,6 +5,23 @@ defmodule SanbaseWeb.Graphql.Complexity.PriceComplexity do
   Internal services use basic authentication. Return complexity = 0 to allow them
   to access everything without limits.
   """
+  def current_prices(_,_, %Absinthe.Complexity{context: %{auth: %{auth_method: :basic}}}) do
+    0
+  end
+
+  @doc ~S"""
+  Returns the complexity of the query. It is the number of returned fields multiplied by 100.
+  The multiplier is big because the current implementation makes a separate DB query for
+  each ticker
+  """
+  def current_prices(%{tickers: tickers}, child_complexity, _) do
+    Enum.count(tickers) * child_complexity * 100
+  end
+
+  @doc ~S"""
+  Internal services use basic authentication. Return complexity = 0 to allow them
+  to access everything without limits.
+  """
   def history_price(_,_, %Absinthe.Complexity{context: %{auth: %{auth_method: :basic}}}) do
     0
   end

--- a/lib/sanbase_web/graphql/resolvers/price_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/price_resolver.ex
@@ -24,7 +24,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
         price_btc: Decimal.new(price_btc),
         price_usd: Decimal.new(price_usd),
         marketcap: Decimal.new(marketcap),
-        volume: Decimal.new(volume)
+        volume: Decimal.new(volume),
+        ticker: ticker
       }}
     else
       {:error, reason} ->
@@ -33,6 +34,17 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
       _ ->
         {:error, "Cannot fetch price for ticker #{ticker}"}
     end
+  end
+
+  def current_prices(_root, %{tickers: tickers}, _resolution) do
+    prices =
+    tickers
+    |> Enum.map(fn ticker ->
+      {:ok, price_point} = current_price(nil, %{ticker: ticker}, nil)
+      price_point
+    end)
+
+    {:ok, prices}
   end
 
   def available_prices(_root, _args, _resolutions) do

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -50,7 +50,6 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:interval, :string, default_value: "1h")
 
       complexity(&PriceComplexity.history_price/3)
-
       resolve(&PriceResolver.history_price/3)
     end
 
@@ -65,7 +64,7 @@ defmodule SanbaseWeb.Graphql.Schema do
     field :prices, list_of(:price_point) do
       arg(:tickers, non_null(list_of(:string)))
 
-      middleware(BasicAuth)
+      complexity(&PriceComplexity.current_prices/3)
       resolve(&PriceResolver.current_prices/3)
     end
 

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -61,6 +61,14 @@ defmodule SanbaseWeb.Graphql.Schema do
       resolve(&PriceResolver.current_price/3)
     end
 
+    @desc "Current price for a list of tickers"
+    field :prices, list_of(:price_point) do
+      arg(:tickers, non_null(list_of(:string)))
+
+      middleware(BasicAuth)
+      resolve(&PriceResolver.current_prices/3)
+    end
+
     @desc "Returns a list of available tickers"
     field :available_prices, list_of(:string) do
       resolve(&PriceResolver.available_prices/3)

--- a/lib/sanbase_web/graphql/schema/price_types.ex
+++ b/lib/sanbase_web/graphql/schema/price_types.ex
@@ -7,5 +7,6 @@ defmodule SanbaseWeb.Graphql.PriceTypes do
     field(:price_usd, :decimal)
     field(:price_btc, :decimal)
     field(:volume, :decimal)
+    field(:ticker, :string)
   end
 end

--- a/test/sanbase_web/graphql/prices_api_test.exs
+++ b/test/sanbase_web/graphql/prices_api_test.exs
@@ -215,6 +215,28 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
     assert "XYZ" in resp_data
   end
 
+  test "fetch price for a list of tickers", context do
+    query = """
+    {
+      prices(tickers: ["TEST", "XYZ"]){
+        ticker
+        priceUsd
+        priceBtc
+      }
+    }
+    """
+
+    result =
+      context.conn
+      |> put_req_header("authorization", "Basic " <> basic_auth())
+      |> post("/graphql", query_skeleton(query, "prices"))
+
+    resp_data = json_response(result, 200)["data"]["prices"]
+
+    assert %{"priceBtc" => "1200", "priceUsd" => "22", "ticker" => "TEST"} in resp_data
+    assert %{"priceBtc" => "1", "priceUsd" => "20", "ticker" => "XYZ"} in resp_data
+  end
+
   defp basic_auth() do
     username =
       Application.fetch_env!(:sanbase, SanbaseWeb.Graphql.ContextPlug)


### PR DESCRIPTION
Note: To determine which ticker each chunk of the data is, `ticker` should also be queried for.
Query:
```
{
  prices(tickers: ["SNT", "XRP"]){
    ticker
    priceBtc
    priceUsd
  }
}
```

Result:
```
{
  "data": {
    "prices": [
      {
        "ticker": "SNT",
        "priceUsd": "0.136804",
        "priceBtc": "0.00000903092"
      },
      {
        "ticker": "XRP",
        "priceUsd": "1.11625",
        "priceBtc": "0.0000736873"
      }
    ]
  }
}
```