### PR TITLE
Track zero activity in github

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -141,10 +141,10 @@ config :faktory_worker_ex,
   host: {:system, "FAKTORY_HOST", "localhost"},
   port: {:system, "FAKTORY_PORT", 7419},
   client: [
-    pool: 5,
+    pool: 1,
   ],
   worker: [
-    concurrency: 5,
+    concurrency: 1,
     queues: ["github_activity"],
   ],
   start_workers: {:system, "FAKTORY_WORKERS_ENABLED", false}

--- a/lib/sanbase_workers/import_github_activity.ex
+++ b/lib/sanbase_workers/import_github_activity.ex
@@ -157,13 +157,14 @@ defmodule SanbaseWorkers.ImportGithubActivity do
   defp get_repository_name(_), do: nil
 
   defp store_counts(counts, orgs, datetime) do
-    counts
-    |> Enum.map(fn {org, count} ->
+    orgs
+    |> Map.values()
+    |> Enum.map(fn project ->
       %Measurement{
         timestamp: DateTime.to_unix(datetime, :nanosecond),
-        fields: %{activity: count},
+        fields: %{activity: Map.get(counts, project.ticker, 0)},
         tags: [source: "githubarchive"],
-        name: orgs[org].ticker
+        name: project.ticker
       }
     end)
     |> Store.import


### PR DESCRIPTION
Track when a project had zero activity, so that we know we scraped the
activity upto that point. This used by the work scheduler.