### PR TITLE
Return the last 24h volume instead of doing a SUM

### DIFF
--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -19,7 +19,7 @@ defmodule Sanbase.Prices.Store do
 
   def fetch_prices_with_resolution(pair, from, to, resolution) do
     # fill(none) skips intervals with no data to report instead of returning null
-    ~s/SELECT MEAN(price), SUM(volume), MEAN(marketcap)
+    ~s/SELECT MEAN(price), LAST(volume), MEAN(marketcap)
     FROM "#{pair}"
     WHERE time >= #{DateTime.to_unix(from, :nanoseconds)}
     AND time <= #{DateTime.to_unix(to, :nanoseconds)}

--- a/test/sanbase_web/graphql/prices_api_test.exs
+++ b/test/sanbase_web/graphql/prices_api_test.exs
@@ -134,7 +134,7 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
     [history_price | _] = history_price
     assert history_price["priceUsd"] == "21"
     assert history_price["priceBtc"] == "1100"
-    assert history_price["volume"] == "500"
+    assert history_price["volume"] == "300"
     assert history_price["marketcap"] == "650"
   end
 


### PR DESCRIPTION
`volume` is the volume for the last 24 hours at this point in time. We cannot just `SUM` it.