### PR TITLE
Use unnamed queries, so that we can connect to pgbouncer

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -11,7 +11,8 @@ config :sanbase,
 
 config :sanbase, Sanbase.Repo,
   adapter: Ecto.Adapters.Postgres,
-  pool_size: 5
+  pool_size: 5,
+  prepare: :unnamed
 
 # Configures the endpoint
 config :sanbase, SanbaseWeb.Endpoint,


### PR DESCRIPTION
pgbouncer does not allow using named queries. More info:
https://github.com/elixir-ecto/postgrex#pgbouncer