### PR TITLE
Revert "Track zero activity in github"

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -142,10 +142,10 @@ config :faktory_worker_ex,
   host: {:system, "FAKTORY_HOST", "localhost"},
   port: {:system, "FAKTORY_PORT", 7419},
   client: [
-    pool: 1,
+    pool: 5,
   ],
   worker: [
-    concurrency: 1,
+    concurrency: 5,
     queues: ["github_activity", "data_migrations"],
   ],
   start_workers: {:system, "FAKTORY_WORKERS_ENABLED", false}

--- a/lib/sanbase_workers/import_github_activity.ex
+++ b/lib/sanbase_workers/import_github_activity.ex
@@ -157,14 +157,13 @@ defmodule SanbaseWorkers.ImportGithubActivity do
   defp get_repository_name(_), do: nil
 
   defp store_counts(counts, orgs, datetime) do
-    orgs
-    |> Map.values()
-    |> Enum.map(fn project ->
+    counts
+    |> Enum.map(fn {org, count} ->
       %Measurement{
         timestamp: DateTime.to_unix(datetime, :nanosecond),
-        fields: %{activity: Map.get(counts, project.ticker, 0)},
+        fields: %{activity: count},
         tags: [source: "githubarchive"],
-        name: project.ticker
+        name: orgs[org].ticker
       }
     end)
     |> Store.import


### PR DESCRIPTION
Reverts santiment/sanbase2#165

There is a bug in this change, which causes all the github activity to be reported as 0. The problem is that the counts are not indexed by `project.ticker` but by the org name