### PR TITLE
Do not raise an error if the queried period has no github activity. 

### DIFF
--- a/lib/sanbase/github/store.ex
+++ b/lib/sanbase/github/store.ex
@@ -54,6 +54,8 @@ defmodule Sanbase.Github.Store do
        end)
   end
 
+  defp parse_activity_series!(_), do: []
+
   defp parse_measurement_datetime(%{
          results: [
            %{


### PR DESCRIPTION
If the queried interval does not have any github activity, the return from influxdb does not match the two function clauses present - error or some data. In that third case we should return just an empty list.