### PR TITLE
CMC service - don't update project name

### DIFF
--- a/lib/sanbase/external_services/project_info.ex
+++ b/lib/sanbase/external_services/project_info.ex
@@ -51,8 +51,12 @@ defmodule Sanbase.ExternalServices.ProjectInfo do
       |> Ico.changeset(Map.from_struct(project_info))
       |> Repo.insert_or_update!
 
+      project_attrs = project_info
+      |> Map.from_struct()
+      |> Map.delete(:name)
+
       project
-      |> Project.changeset(Map.from_struct(project_info))
+      |> Project.changeset(project_attrs)
       |> Repo.update!
     end
   end

--- a/lib/sanbase/external_services/project_info.ex
+++ b/lib/sanbase/external_services/project_info.ex
@@ -51,6 +51,7 @@ defmodule Sanbase.ExternalServices.ProjectInfo do
       |> Ico.changeset(Map.from_struct(project_info))
       |> Repo.insert_or_update!
 
+      # Don't automatically update an already existing project's name - it is a UK when importing form other sources
       project_attrs = project_info
       |> Map.from_struct()
       |> Map.delete(:name)


### PR DESCRIPTION
Change coinmarketcap service not to overwrite project's name