### PR TITLE
Add githubActivity new argument 'transform'. Implement movingAverage …

### DIFF
--- a/app/src/components/ProjectChart/ProjectChartContainer.js
+++ b/app/src/components/ProjectChart/ProjectChartContainer.js
@@ -67,19 +67,21 @@ const fetchGithubActivityHistoryFromStartToEndDate = (
   return new Promise((resolve, reject) => {
     client.query({
       query: gql`
-        query githubActivityQuery($repository: String, $from: DateTime, $to: DateTime, $interval: String) {
+        query githubActivityQuery($ticker: String, $from: DateTime, $to: DateTime, $interval: String) {
           githubActivity(
-            repository: $repository,
+            ticker: $ticker,
             from: $from,
             to: $to,
             interval: $interval
+            movingAverageInterval: "3h"
+            transform: "movingAverage"
           ) {
             datetime,
             activity
           }
       }`,
       variables: {
-        'repository': ticker.toUpperCase(),
+        'ticker': ticker.toUpperCase(),
         'from': startDate,
         'to': endDate,
         'interval': minInterval

--- a/app/src/components/ProjectChart/ProjectChartContainer.js
+++ b/app/src/components/ProjectChart/ProjectChartContainer.js
@@ -73,7 +73,7 @@ const fetchGithubActivityHistoryFromStartToEndDate = (
             from: $from,
             to: $to,
             interval: $interval
-            movingAverageInterval: "3h"
+            movingAverageInterval: 7
             transform: "movingAverage"
           ) {
             datetime,

--- a/lib/sanbase/date_time_utils.ex
+++ b/lib/sanbase/date_time_utils.ex
@@ -17,4 +17,24 @@ defmodule Sanbase.DateTimeUtils do
   def days_ago(days) do
     seconds_ago(days * 60 * 60 * 24)
   end
+
+  # Interval should be an integer followed by one of: s, m, h, d or w
+  def str_to_sec(interval) do
+    interval_type = String.last(interval)
+
+    interval_seconds =
+      String.slice(interval, 0..-2)
+      |> String.to_integer()
+      |> str_to_sec(interval_type)
+  end
+
+  def str_to_hours(interval) do
+    str_to_sec(interval) |> Integer.floor_div(3600)
+  end
+
+  defp str_to_sec(seconds, "s"), do: seconds
+  defp str_to_sec(minutes, "m"), do: minutes * 60
+  defp str_to_sec(hours, "h"), do: hours * 60 * 60
+  defp str_to_sec(days, "d"), do: days * 60 * 60 * 24
+  defp str_to_sec(weeks, "w"), do: weeks * 60 * 60 * 24 * 7
 end

--- a/lib/sanbase/github/store.ex
+++ b/lib/sanbase/github/store.ex
@@ -26,20 +26,21 @@ defmodule Sanbase.Github.Store do
     |> parse_activity_series!()
   end
 
-  def fetch_moving_average_for_hours!(ticker, from, to, interval) do
-    interval_in_hours = Sanbase.DateTimeUtils.str_to_hours(interval)
+  def fetch_moving_average_for_hours!(ticker, from, to, interval, ma_interval) do
+    ma_interval_in_hours = Sanbase.DateTimeUtils.str_to_hours(ma_interval)
 
-    moving_average_activity(ticker, from, to, interval_in_hours)
+    moving_average_activity(ticker, from, to, interval, ma_interval_in_hours)
     |> Store.query()
     |> parse_moving_average_series!()
   end
 
   # The subsequent fields are 1 hour apart, so the interval must be in hours
-  defp moving_average_activity(ticker, from, to, interval_in_hours) do
-    ~s/SELECT MOVING_AVERAGE(activity, #{interval_in_hours})
+  defp moving_average_activity(ticker, from, to, interval, ma_interval_in_hours) do
+    ~s/SELECT MOVING_AVERAGE(SUM(activity), #{ma_interval_in_hours})
     FROM "#{ticker}"
     WHERE time >= #{DateTime.to_unix(from, :nanoseconds)}
-    AND time <= #{DateTime.to_unix(to, :nanoseconds)}/
+    AND time <= #{DateTime.to_unix(to, :nanoseconds)}
+    GROUP BY time(#{interval})/
   end
 
   defp activity_with_resolution_query(ticker, from, to, resolution) do

--- a/lib/sanbase/github/store.ex
+++ b/lib/sanbase/github/store.ex
@@ -20,15 +20,31 @@ defmodule Sanbase.Github.Store do
     |> parse_measurement_datetime()
   end
 
-  def fetch_activity_with_resolution!(repo, from, to, resolution) do
-    activity_with_resolution_query(repo, from, to, resolution)
+  def fetch_activity_with_resolution!(ticker, from, to, resolution) do
+    activity_with_resolution_query(ticker, from, to, resolution)
     |> Store.query()
     |> parse_activity_series!()
   end
 
-  defp activity_with_resolution_query(repo, from, to, resolution) do
+  def fetch_moving_average_for_hours!(ticker, from, to, interval) do
+    interval_in_hours = Sanbase.DateTimeUtils.str_to_hours(interval)
+
+    moving_average_activity(ticker, from, to, interval_in_hours)
+    |> Store.query()
+    |> parse_moving_average_series!()
+  end
+
+  # The subsequent fields are 1 hour apart, so the interval must be in hours
+  defp moving_average_activity(ticker, from, to, interval_in_hours) do
+    ~s/SELECT MOVING_AVERAGE(activity, #{interval_in_hours})
+    FROM "#{ticker}"
+    WHERE time >= #{DateTime.to_unix(from, :nanoseconds)}
+    AND time <= #{DateTime.to_unix(to, :nanoseconds)}/
+  end
+
+  defp activity_with_resolution_query(ticker, from, to, resolution) do
     ~s/SELECT SUM(activity)
-    FROM "#{repo}"
+    FROM "#{ticker}"
     WHERE time >= #{DateTime.to_unix(from, :nanoseconds)}
     AND time <= #{DateTime.to_unix(to, :nanoseconds)}
     GROUP BY time(#{resolution}) fill(none)/
@@ -49,12 +65,40 @@ defmodule Sanbase.Github.Store do
        }) do
     activity_series
     |> Enum.map(fn [iso8601_datetime, activity] ->
-         {:ok, datetime, _} = DateTime.from_iso8601(iso8601_datetime)
-         {datetime, activity}
-       end)
+      {:ok, datetime, _} = DateTime.from_iso8601(iso8601_datetime)
+      {datetime, activity}
+    end)
   end
 
   defp parse_activity_series!(_), do: []
+
+  defp parse_moving_average_series!(%{results: [%{error: error}]}), do: raise(error)
+
+  defp parse_moving_average_series!(%{
+         results: [
+           %{
+             series: [
+               %{
+                 values: activity_series
+               }
+             ]
+           }
+         ]
+       }) do
+    activity_series
+    |> Enum.map(fn [iso8601_datetime, activity] ->
+      {:ok, datetime, _} = DateTime.from_iso8601(iso8601_datetime)
+
+      activity =
+        activity
+        |> Float.ceil()
+        |> Kernel.trunc()
+
+      {datetime, activity}
+    end)
+  end
+
+  defp parse_moving_average_series!(_), do: []
 
   defp parse_measurement_datetime(%{
          results: [

--- a/lib/sanbase_web/graphql/complexity/price_complexity.ex
+++ b/lib/sanbase_web/graphql/complexity/price_complexity.ex
@@ -37,21 +37,10 @@ defmodule SanbaseWeb.Graphql.Complexity.PriceComplexity do
     from_unix = DateTime.to_unix(from, :second)
     to_unix = DateTime.to_unix(to, :second)
 
-    interval_type = String.last(interval)
-
-    interval_seconds =
-      String.slice(interval, 0..-2)
-      |> String.to_integer()
-      |> str_to_sec(interval_type)
+    interval_seconds = Sanbase.DateTimeUtils.str_to_sec(interval)
 
     (child_complexity * ((to_unix - from_unix) / interval_seconds))
     |> Float.floor()
     |> Kernel.trunc()
   end
-
-  defp str_to_sec(seconds, "s"), do: seconds
-  defp str_to_sec(minutes, "m"), do: minutes * 60
-  defp str_to_sec(hours, "h"), do: hours * 60 * 60
-  defp str_to_sec(days, "d"), do: days * 60 * 60 * 24
-  defp str_to_sec(weeks, "w"), do: weeks * 60 * 60 * 24 * 7
 end

--- a/lib/sanbase_web/graphql/resolvers/github_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/github_resolver.ex
@@ -5,11 +5,23 @@ defmodule SanbaseWeb.Graphql.Resolvers.GithubResolver do
 
   def activity(
         _root,
-        %{repository: repository, from: from, to: to, interval: interval},
+        %{ticker: ticker, from: from, to: to, interval: interval, transform: "None"},
         _resolution
       ) do
     result =
-    Store.fetch_activity_with_resolution!(repository, from, to, interval)
+    Store.fetch_activity_with_resolution!(ticker, from, to, interval)
+    |> Enum.map(fn {datetime, activity} -> %{datetime: datetime, activity: activity} end)
+
+    {:ok, result}
+  end
+
+  def activity(
+        _root,
+        %{ticker: ticker, from: from, to: to, interval: interval, transform: "movingAverage"},
+        _resolution
+      ) do
+    result =
+    Store.fetch_moving_average_for_hours!(ticker, from, to, interval)
     |> Enum.map(fn {datetime, activity} -> %{datetime: datetime, activity: activity} end)
 
     {:ok, result}

--- a/lib/sanbase_web/graphql/resolvers/github_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/github_resolver.ex
@@ -9,25 +9,33 @@ defmodule SanbaseWeb.Graphql.Resolvers.GithubResolver do
         _resolution
       ) do
     result =
-    Store.fetch_activity_with_resolution!(ticker, from, to, interval)
-    |> Enum.map(fn {datetime, activity} -> %{datetime: datetime, activity: activity} end)
+      Store.fetch_activity_with_resolution!(ticker, from, to, interval)
+      |> Enum.map(fn {datetime, activity} -> %{datetime: datetime, activity: activity} end)
 
     {:ok, result}
   end
 
   def activity(
         _root,
-        %{ticker: ticker, from: from, to: to, interval: interval, transform: "movingAverage"},
+        %{
+          ticker: ticker,
+          from: from,
+          to: to,
+          interval: interval,
+          transform: "movingAverage",
+          moving_average_interval: ma_interval
+        },
         _resolution
       ) do
     result =
-    Store.fetch_moving_average_for_hours!(ticker, from, to, interval)
-    |> Enum.map(fn {datetime, activity} -> %{datetime: datetime, activity: activity} end)
+      Store.fetch_moving_average_for_hours!(ticker, from, to, interval, ma_interval)
+      |> Enum.map(fn {datetime, activity} -> %{datetime: datetime, activity: activity} end)
 
     {:ok, result}
   end
 
   def available_repos(_root, _args, _resolution) do
-    Store.list_measurements() # returns {:ok, result} | {:error, error}
+    # returns {:ok, result} | {:error, error}
+    Store.list_measurements()
   end
 end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -80,10 +80,11 @@ defmodule SanbaseWeb.Graphql.Schema do
 
     @desc "Returns a list of github activities"
     field :github_activity, list_of(:activity_point) do
-      arg(:repository, non_null(:string))
+      arg(:ticker, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, :datetime, default_value: DateTime.utc_now())
       arg(:interval, :string, default_value: "1h")
+      arg(:transform, :string, default_value: "None")
 
       resolve(&GithubResolver.activity/3)
     end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -84,7 +84,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:from, non_null(:datetime))
       arg(:to, :datetime, default_value: DateTime.utc_now())
       arg(:interval, :string, default_value: "1h")
-      arg(:moving_average_interval, :string, default_value: "1d")
+      arg(:moving_average_interval, :integer, default_value: 10)
       arg(:transform, :string, default_value: "None")
 
       resolve(&GithubResolver.activity/3)

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -84,6 +84,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:from, non_null(:datetime))
       arg(:to, :datetime, default_value: DateTime.utc_now())
       arg(:interval, :string, default_value: "1h")
+      arg(:moving_average_interval, :string, default_value: "1d")
       arg(:transform, :string, default_value: "None")
 
       resolve(&GithubResolver.activity/3)

--- a/test/sanbase_web/graphql/github_api_test.exs
+++ b/test/sanbase_web/graphql/github_api_test.exs
@@ -169,7 +169,7 @@ defmodule Sanbase.Github.GithubApiTest do
         from: "#{context.datetime1}",
         to: "#{context.datetime6}",
         transform: "movingAverage",
-        interval: "3h") {
+        moving_average_interval: "3h") {
           activity
         }
     }

--- a/test/sanbase_web/graphql/github_api_test.exs
+++ b/test/sanbase_web/graphql/github_api_test.exs
@@ -169,7 +169,7 @@ defmodule Sanbase.Github.GithubApiTest do
         from: "#{context.datetime1}",
         to: "#{context.datetime6}",
         transform: "movingAverage",
-        moving_average_interval: "3h") {
+        moving_average_interval: 3) {
           activity
         }
     }


### PR DESCRIPTION
Added importing of 500 records with random github activity (in the range [0;100]) for SAN ticker in `seeds.exs` for easier local testing

Old queries will work as they did before. The new feature is exposed via the `transform` query argument

Example query:
```
{
  githubActivity(
    ticker: "SAN",
    from: "2017-05-13 12:00:00Z",
    to: "2017-12-17 17:00:00Z",
    transform: "movingAverage",
    moving_average_interval: "3h"){
       datetime
       activity
     }
}
```

Example response:
```
{
  "data": {
    "githubActivity": [
      {
        "datetime": "2017-05-13T17:00:00Z",
        "activity": 7
      },
      {
        "datetime": "2017-05-13T18:00:00Z",
        "activity": 9
      },
      {
        "datetime": "2017-05-13T19:00:00Z",
        "activity": 12
      },
      {
        "datetime": "2017-05-13T20:00:00Z",
        "activity": 14
      }
    ]
  }
}
```
  
  
  