### PR TITLE
Improve GitHub activity scheduler

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -142,11 +142,11 @@ config :faktory_worker_ex,
   host: {:system, "FAKTORY_HOST", "localhost"},
   port: {:system, "FAKTORY_PORT", 7419},
   client: [
-    pool: 5,
+    pool: 1,
   ],
   worker: [
-    concurrency: 5,
-    queues: ["github_activity", "data_migrations"],
+    concurrency: 1,
+    queues: ["default", "data_migrations"],
   ],
   start_workers: {:system, "FAKTORY_WORKERS_ENABLED", false}
 

--- a/lib/sanbase/external_services/github.ex
+++ b/lib/sanbase/external_services/github.ex
@@ -41,8 +41,8 @@ defmodule Sanbase.ExternalServices.Github do
     {:noreply, state}
   end
 
-  defp schedule_jobs_if_free(%{"faktory" => %{"total_enqueued" => total_enqueued}}) do
-    if total_enqueued > 0 do
+  defp schedule_jobs_if_free(%{"faktory" => %{"default_size" => default_size}}) do
+    if default_size > 0 do
       :ok
     else
       Sanbase.Github.Scheduler.schedule_scrape

--- a/lib/sanbase/github/scheduler.ex
+++ b/lib/sanbase/github/scheduler.ex
@@ -6,23 +6,19 @@ defmodule Sanbase.Github.Scheduler do
 
   require Logger
 
-  import Ecto.Query
-
   # A dependency injection, so that we can test this module in isolation
   @worker Mockery.of("SanbaseWorkers.ImportGithubActivity")
 
   def schedule_scrape do
     available_projects = Github.available_projects
 
-    processed_archives = available_projects
-    |> fetch_processed_archives()
-
-    available_projects
+    initial_scrape_datetime = available_projects
     |> log_scheduler_info
     |> Enum.map(&get_initial_scrape_datetime/1)
     |> Enum.reject(&is_nil/1)
     |> reduce_initial_scrape_datetime()
-    |> schedule_scrape_for_datetime(yesterday(), processed_archives)
+
+    schedule_scrape_for_datetime(initial_scrape_datetime, available_projects, yesterday())
   end
 
   def archive_name_for(datetime) do
@@ -44,20 +40,29 @@ defmodule Sanbase.Github.Scheduler do
 
   defp schedule_scrape_for_datetime(nil, _last_datetime, _processed_archives), do: :ok
 
-  defp schedule_scrape_for_datetime(datetime, last_datetime, processed_archives) do
-    case DateTime.compare(datetime, last_datetime) do
+  defp schedule_scrape_for_datetime(current_datetime, projects, last_datetime) do
+    case DateTime.compare(current_datetime, last_datetime) do
       :lt ->
-        archive_name = archive_name_for(datetime)
+        need_to_scrape = projects
+        |> Enum.any?(&need_to_scrape_project?(&1, current_datetime))
 
-        unless MapSet.member?(processed_archives, archive_name) do
+        if need_to_scrape do
+          archive_name = archive_name_for(current_datetime)
+
           @worker.perform_async([archive_name])
         end
 
-        datetime
+        current_datetime
         |> Timex.shift(hours: 1)
-        |> schedule_scrape_for_datetime(last_datetime, processed_archives)
+        |> schedule_scrape_for_datetime(projects, last_datetime)
       _ -> :ok
     end
+  end
+
+  defp need_to_scrape_project?(%Project{id: id, name: name}, datetime) do
+    archive_name = archive_name_for(datetime)
+
+    !Repo.get_by(Github.ProcessedGithubArchive, project_id: id, archive: archive_name)
   end
 
   defp get_initial_scrape_datetime(%Project{ticker: ticker}) do
@@ -66,20 +71,6 @@ defmodule Sanbase.Github.Scheduler do
     else
       Prices.Store.first_price_datetime(ticker <> "_USD")
     end
-  end
-
-  defp fetch_processed_archives(projects) do
-    project_ids = projects
-    |> Enum.map(&(&1.id))
-
-    Github.ProcessedGithubArchive
-    |> where([p], p.project_id in ^project_ids)
-    |> group_by(:archive)
-    |> having([p], count(p.project_id) == ^(length(project_ids)))
-    |> select([:archive])
-    |> Repo.all
-    |> Enum.map(&(&1.archive))
-    |> MapSet.new
   end
 
   defp yesterday do

--- a/lib/sanbase/github/scheduler.ex
+++ b/lib/sanbase/github/scheduler.ex
@@ -59,7 +59,7 @@ defmodule Sanbase.Github.Scheduler do
     end
   end
 
-  defp need_to_scrape_project?(%Project{id: id, name: name}, datetime) do
+  defp need_to_scrape_project?(%Project{id: id}, datetime) do
     archive_name = archive_name_for(datetime)
 
     !Repo.get_by(Github.ProcessedGithubArchive, project_id: id, archive: archive_name)

--- a/lib/sanbase_workers/import_github_activity.ex
+++ b/lib/sanbase_workers/import_github_activity.ex
@@ -12,7 +12,7 @@ defmodule SanbaseWorkers.ImportGithubActivity do
   alias ExAws.S3
   @github_archive "http://data.githubarchive.org/"
 
-  faktory_options queue: "github_activity", retry: -1, reserve_for: 900
+  faktory_options queue: "default", retry: -1, reserve_for: 900
 
   def perform(archive) do
     Temp.track!


### PR DESCRIPTION
The current GH activity scheduler is timing out when trying to schedule
jobs. This is because of a very big query, which can't be optimized
without creating a gigantic index on it.

In this PR, the computations are broken down into many smaller queries
to the DB. Given that the scheduling is much faster than the processing,
even a bit slower scheduling will fine.

Also switched to using the `default` queue, which allows to check the
size of the queue before adding more work into it.