### PR TITLE
Reduce the number of points returned by the TBR API

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
@@ -4,6 +4,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
 
   @http_client Mockery.of("HTTPoison")
   @recv_timeout 15_000
+  @max_result_size 500
 
   def burn_rate(_root, %{ticker: ticker, from: from, to: to}, _resolution) do
     from_unix = DateTime.to_unix(from, :seconds)
@@ -18,6 +19,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
         {:ok, result} = Poison.decode(body)
         result =
           result
+          |> reduce_result_size(&average/1)
           |> Enum.map(fn [timestamp, br] ->
             %{datetime: DateTime.from_unix!(timestamp), burn_rate: Decimal.new(br)}
           end)
@@ -38,6 +40,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
 
     etherbi_url = Config.get(:url)
     url = "#{etherbi_url}/transaction_volume?ticker=#{ticker}&from_timestamp=#{from_unix}&to_timestamp=#{to_unix}"
+
     options = [recv_timeout: @recv_timeout]
     case @http_client.get(url, options) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
@@ -45,6 +48,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
 
         result =
           result
+          |> reduce_result_size(&Enum.sum/1)
           |> Enum.map(fn [timestamp, trx_volume] ->
             %{datetime: DateTime.from_unix!(timestamp), transaction_volume: Decimal.new(trx_volume)}
           end)
@@ -57,5 +61,37 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
       _ ->
         {:error, "Cannot fetch burn transaction volume for ticker #{ticker}"}
     end
+  end
+
+  defp reduce_result_size(list, _) when length(list) < 2 * @max_result_size, do: list
+
+  defp reduce_result_size(list, reduce_function) do
+    chunk_size = trunc(length(list) / @max_result_size)
+
+    list
+    |> Enum.chunk_every(chunk_size)
+    |> Enum.map(fn chunk ->
+      [
+        min_timestamp(chunk),
+        reduced_value(chunk, reduce_function)
+      ]
+    end)
+  end
+
+  defp min_timestamp(chunk) do
+    chunk
+    |> Enum.map(&hd/1)
+    |> Enum.min
+  end
+
+  defp reduced_value(chunk, reduce_function) do
+    chunk
+    |> Enum.map(&tl/1)
+    |> Enum.map(&hd/1)
+    |> reduce_function.()
+  end
+
+  defp average(list) do
+    Enum.sum(list) / length(list)
   end
 end

--- a/test/sanbase_web/graphql/etherbi_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_api_test.exs
@@ -5,12 +5,16 @@ defmodule Sanbase.Github.EtherbiApiTest do
   import Mockery
 
   test "fetch burn rate", context do
+    burn_rate = [
+      [1514766000, 91716892495405965698400256],
+      [1514770144, 359319706108516227858038784],
+      [1514778068, 31034050000000001245184]
+    ]
+
     mock HTTPoison, :get,
         {:ok, %HTTPoison.Response{
           status_code: 200,
-          body: "[[1514766000, 91716892495405965698400256],\
-              [1514770144, 359319706108516227858038784],\
-              [1514778068, 31034050000000001245184]]"
+          body: Poison.encode!(burn_rate)
         }}
 
       ticker = "SAN"
@@ -42,11 +46,57 @@ defmodule Sanbase.Github.EtherbiApiTest do
       assert %{"burnRate" => "31034050000000001245184"} in burn_rates
   end
 
-  test "fetch transaction volume", context do
+  test "fetch big response for the burn rate", context do
+    burn_rate = Stream.cycle([
+      [1514766000, 91716892495405965698400256],
+      [1514770144, 359319706108516227858038784],
+      [1514778068, 31034050000000001245184]
+    ])
+    |> Enum.take(20000)
+
     mock HTTPoison, :get,
-        {:ok, %HTTPoison.Response{status_code: 200, body: "[[1514765863, 5810803200000000000],
-              [1514766007, 700000000000001803841],
-              [1514770144, 1749612781540000000000]]"}}
+        {:ok, %HTTPoison.Response{
+          status_code: 200,
+          body: Poison.encode!(burn_rate)
+        }}
+
+      ticker = "SAN"
+      datetime1 = DateTime.from_naive!(~N[2018-01-01 12:00:00], "Etc/UTC")
+      datetime2 = DateTime.from_naive!(~N[2017-01-01 21:45:00], "Etc/UTC")
+      datetime1_unix = DateTime.to_unix(datetime1, :second)
+      datetime2_unix = DateTime.to_unix(datetime2, :second)
+
+      query = """
+      {
+        burnRate(
+          ticker: "#{ticker}",
+          from: "#{datetime1}",
+          to: "#{datetime2}")
+          {
+            burnRate
+          }
+        }
+      """
+
+      result =
+        context.conn
+        |> post("/graphql", query_skeleton(query, "burnRate"))
+
+      burn_rates = json_response(result, 200)["data"]["burnRate"]
+
+      assert length(burn_rates) == 500
+  end
+
+  test "fetch transaction volume", context do
+    transaction_volume = Stream.cycle([
+      [1514765863, 5810803200000000000],
+      [1514766007, 700000000000001803841],
+      [1514770144, 1749612781540000000000]
+    ])
+    |> Enum.take(21000)
+
+    mock HTTPoison, :get,
+        {:ok, %HTTPoison.Response{status_code: 200, body: Poison.encode!(transaction_volume)}}
 
       ticker = "SAN"
       datetime1 = DateTime.from_naive!(~N[2018-01-01 12:00:00], "Etc/UTC")
@@ -72,9 +122,7 @@ defmodule Sanbase.Github.EtherbiApiTest do
 
       transaction_volumes = json_response(result, 200)["data"]["transactionVolume"]
 
-      assert %{"transactionVolume" => "5810803200000000000"} in transaction_volumes
-      assert %{"transactionVolume" => "700000000000001803841"} in transaction_volumes
-      assert %{"transactionVolume" => "1749612781540000000000"} in transaction_volumes
+      assert length(transaction_volumes) == 500
   end
 
   defp query_skeleton(query, query_name) do


### PR DESCRIPTION
The limit is 500, but the exact number of points returned might be a bit
higher, as the response is chunked into equal chunks and each is
averaged/sumed.

The TBR is using average for the reduction. The transaction volume is
using sum.