### PR TITLE
The available github projects should exclude non-github repos

### DIFF
--- a/lib/sanbase/github.ex
+++ b/lib/sanbase/github.ex
@@ -8,5 +8,20 @@ defmodule Sanbase.Github do
     Project
     |> where([p], not is_nil(p.github_link) and not is_nil(p.coinmarketcap_id) and not is_nil(p.ticker))
     |> Repo.all
+    |> Enum.filter(&get_project_org/1)
+  end
+
+  def get_project_org(%Project{github_link: github_link} = project) do
+    case Regex.run(~r{https://(?:www.)?github.com/(.+)}, github_link) do
+      [_, github_path] ->
+        org = github_path
+        |> String.downcase
+        |> String.split("/")
+        |> hd
+
+        org
+      nil ->
+        nil
+    end
   end
 end

--- a/lib/sanbase_workers/import_github_activity.ex
+++ b/lib/sanbase_workers/import_github_activity.ex
@@ -24,7 +24,9 @@ defmodule SanbaseWorkers.ImportGithubActivity do
     |> Timex.to_datetime
 
     orgs = Github.available_projects
-    |> Enum.map(&get_project_org/1)
+    |> Enum.map(fn project ->
+      {Github.get_project_org(project), project}
+    end)
     |> Enum.reject(&is_nil/1)
     |> Map.new()
 
@@ -118,20 +120,6 @@ defmodule SanbaseWorkers.ImportGithubActivity do
     |> Enum.reduce(%{}, fn repo, counts ->
       reduce_repos_to_counts(repo, counts, orgs)
     end)
-  end
-
-  defp get_project_org(%Project{github_link: github_link} = project) do
-    case Regex.run(~r{https://(?:www.)?github.com/(.+)}, github_link) do
-      [_, github_path] ->
-        org = github_path
-        |> String.downcase
-        |> String.split("/")
-        |> hd
-
-        {org, project}
-      nil ->
-        nil
-    end
   end
 
   defp reduce_repos_to_counts(repo, counts, orgs) do

--- a/lib/sanbase_workers/import_github_activity.ex
+++ b/lib/sanbase_workers/import_github_activity.ex
@@ -27,7 +27,6 @@ defmodule SanbaseWorkers.ImportGithubActivity do
     |> Enum.map(fn project ->
       {Github.get_project_org(project), project}
     end)
-    |> Enum.reject(&is_nil/1)
     |> Map.new()
 
     Logger.info("Scanning activity for github users #{Map.keys(orgs) |> inspect}")

--- a/test/sanbase/github_test.exs
+++ b/test/sanbase/github_test.exs
@@ -1,0 +1,38 @@
+defmodule Sanbase.GithubTest do
+  use Sanbase.DataCase, async: false
+
+  alias Sanbase.Repo
+  alias Sanbase.Github
+  alias Sanbase.Model.Project
+
+  test "available_projects returns projects with github link" do
+    project = %Project{github_link: "https://github.com/santiment", ticker: "SAN", coinmarketcap_id: "santiment", name: "Santiment"}
+    |> Repo.insert!
+
+     %Project{github_link: "https://bitbucket.com/random", ticker: "RAN", coinmarketcap_id: "random", name: "Random"}
+    |> Repo.insert!
+
+    %Project{github_link: "", name: "No Source code"}
+    |> Repo.insert!
+
+    assert Github.available_projects == [project]
+  end
+
+  test "get_project_org parsing the github organization" do
+    project = %Project{github_link: "https://github.com/santiment", ticker: "SAN", coinmarketcap_id: "santiment", name: "Santiment"}
+
+    assert Github.get_project_org(project) == "santiment"
+
+    project = %Project{github_link: "https://github.com/Santiment/sanbase2", ticker: "SAN", coinmarketcap_id: "santiment", name: "Santiment"}
+
+    assert Github.get_project_org(project) == "santiment"
+
+    project = %Project{github_link: "https://bitbucket.com/random", ticker: "RAN", coinmarketcap_id: "random", name: "Random"}
+
+    assert Github.get_project_org(project) == nil
+
+    project = %Project{github_link: "", name: "No Source code"}
+
+    assert Github.get_project_org(project) == nil
+  end
+end


### PR DESCRIPTION
We should not try to parse the non-github projects as we don't have the
history of these.