### PR TITLE
Switch the CMC pricing domain to the new one

### DIFF
--- a/lib/sanbase/external_services/coinmarketcap.ex
+++ b/lib/sanbase/external_services/coinmarketcap.ex
@@ -16,10 +16,9 @@ defmodule Sanbase.ExternalServices.Coinmarketcap do
   alias Sanbase.Model.{Project, Ico}
   alias Sanbase.Repo
   alias Sanbase.Prices.Store
-  alias Sanbase.ExternalServices.Coinmarketcap.{GraphData, PricePoint}
-  alias Sanbase.ExternalServices.ProjectInfo
   alias Sanbase.Influxdb.Measurement
   alias Sanbase.Prices.Store
+  alias Sanbase.ExternalServices.ProjectInfo
   alias Sanbase.ExternalServices.Coinmarketcap.GraphData
   alias Sanbase.ExternalServices.Coinmarketcap.PricePoint
   alias Sanbase.Notifications.CheckPrices

--- a/lib/sanbase/external_services/coinmarketcap/graph_data.ex
+++ b/lib/sanbase/external_services/coinmarketcap/graph_data.ex
@@ -8,7 +8,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData do
   alias Sanbase.ExternalServices.Coinmarketcap.PricePoint
 
   plug RateLimiting.Middleware, name: :graph_coinmarketcap_rate_limiter
-  plug Tesla.Middleware.BaseUrl, "https://graphs.coinmarketcap.com"
+  plug Tesla.Middleware.BaseUrl, "https://graphs2.coinmarketcap.com"
   plug Tesla.Middleware.Compression
   plug Tesla.Middleware.Logger
 

--- a/test/sanbase/external_services/coinmarketcap/graph_data_test.exs
+++ b/test/sanbase/external_services/coinmarketcap/graph_data_test.exs
@@ -5,7 +5,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphDataTest do
 
   test "fetching the first price datetime of a token" do
     Tesla.Mock.mock fn
-      %{method: :get, url: "https://graphs.coinmarketcap.com/currencies/santiment/"} ->
+      %{method: :get, url: "https://graphs2.coinmarketcap.com/currencies/santiment/"} ->
         %Tesla.Env{status: 200, body: File.read!(Path.join(__DIR__, "btc_graph_data.json"))}
     end
 
@@ -14,7 +14,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphDataTest do
 
   test "fetching prices of a token" do
     Tesla.Mock.mock fn
-      %{method: :get, url: "https://graphs.coinmarketcap.com/currencies/santiment/1507991665000/1508078065000/"} ->
+      %{method: :get, url: "https://graphs2.coinmarketcap.com/currencies/santiment/1507991665000/1508078065000/"} ->
         %Tesla.Env{status: 200, body: File.read!(Path.join(__DIR__, "btc_graph_data.json"))}
     end
 


### PR DESCRIPTION
CMC switched their pricing endpoint to graph2 a few hours ago.