### PR TITLE
Select the first record with matching ticker and not empty twitter link

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/twitter_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/twitter_resolver.ex
@@ -3,22 +3,31 @@ defmodule SanbaseWeb.Graphql.Resolvers.TwitterResolver do
   alias Sanbase.Model.Project
   alias Sanbase.ExternalServices.TwitterData.Store
 
+  import Ecto.Query
+
   def twitter_data(_root, %{ticker: ticker}, _resolution) do
-    with %Project{twitter_link: twitter_link} <- Repo.get_by(Project, ticker: ticker),
+    with query <-
+           from(
+             p in Project,
+             where: p.ticker == ^ticker and not is_nil(p.twitter_link),
+             select: p.twitter_link
+           ),
+         [twitter_link|_] <- Repo.all(query),
          twitter_name <- extract_twitter_name(twitter_link),
          {datetime, followers_count} <- Store.last_record_for_measurement(twitter_name) do
-      {:ok, %{
-        ticker: ticker,
-        datetime: datetime,
-        twitter_name: twitter_name,
-        followers_count: followers_count
-      }}
+      {:ok,
+       %{
+         ticker: ticker,
+         datetime: datetime,
+         twitter_name: twitter_name,
+         followers_count: followers_count
+       }}
     else
       {:error, reason} ->
         {:error, "Cannot fetch twitter data for ticker #{ticker}: #{reason}"}
 
-      _ ->
-        {:error, "Cannot fetch twitter data for ticker #{ticker}"}
+      error ->
+        {:error, "Cannot fetch twitter data for ticker #{ticker}: #{inspect(error)}"}
     end
   end
 
@@ -27,7 +36,13 @@ defmodule SanbaseWeb.Graphql.Resolvers.TwitterResolver do
         %{ticker: ticker, from: from, to: to, interval: interval},
         _resolution
       ) do
-    with %Project{twitter_link: twitter_link} <- Repo.get_by(Project, ticker: ticker),
+    with query <-
+           from(
+             p in Project,
+             where: p.ticker == ^ticker and not is_nil(p.twitter_link),
+             select: p.twitter_link
+           ),
+         [twitter_link|_] <- Repo.all(query),
          twitter_name <- extract_twitter_name(twitter_link),
          twitter_historical_data <-
            Store.all_records_for_measurement!(twitter_name, from, to, interval) do
@@ -42,8 +57,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.TwitterResolver do
       {:error, reason} ->
         {:error, "Cannot fetch twitter history data for ticker #{ticker}: #{reason}"}
 
-      _ ->
-        {:error, "Cannot fetch twitter history data for ticker #{ticker}"}
+      error ->
+        {:error, "Cannot fetch twitter history data for ticker #{ticker}: #{inspect(error)}"}
     end
   end
 

--- a/lib/sanbase_web/graphql/resolvers/twitter_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/twitter_resolver.ex
@@ -6,13 +6,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.TwitterResolver do
   import Ecto.Query
 
   def twitter_data(_root, %{ticker: ticker}, _resolution) do
-    with query <-
-           from(
-             p in Project,
-             where: p.ticker == ^ticker and not is_nil(p.twitter_link),
-             select: p.twitter_link
-           ),
-         [twitter_link|_] <- Repo.all(query),
+    with twitter_link <- get_twitter_link(ticker),
          twitter_name <- extract_twitter_name(twitter_link),
          {datetime, followers_count} <- Store.last_record_for_measurement(twitter_name) do
       {:ok,
@@ -36,13 +30,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.TwitterResolver do
         %{ticker: ticker, from: from, to: to, interval: interval},
         _resolution
       ) do
-    with query <-
-           from(
-             p in Project,
-             where: p.ticker == ^ticker and not is_nil(p.twitter_link),
-             select: p.twitter_link
-           ),
-         [twitter_link|_] <- Repo.all(query),
+    with twitter_link <- get_twitter_link(ticker),
          twitter_name <- extract_twitter_name(twitter_link),
          twitter_historical_data <-
            Store.all_records_for_measurement!(twitter_name, from, to, interval) do
@@ -64,5 +52,18 @@ defmodule SanbaseWeb.Graphql.Resolvers.TwitterResolver do
 
   defp extract_twitter_name("https://twitter.com/" <> twitter_name) do
     String.split(twitter_name, "/") |> hd
+  end
+
+  defp get_twitter_link(ticker) do
+    query =
+      from(
+        p in Project,
+        where: p.ticker == ^ticker and not is_nil(p.twitter_link),
+        select: p.twitter_link
+      )
+
+    [twitter_link | _] = Repo.all(query)
+
+    twitter_link
   end
 end

--- a/test/sanbase_web/graphql/twitter_api_test.exs
+++ b/test/sanbase_web/graphql/twitter_api_test.exs
@@ -28,6 +28,15 @@ defmodule Sanbase.Github.TwitterApiTest do
     })
     |> Repo.insert!()
 
+    # All tests implicitly test for when more than one record has the same ticker
+    %Project{}
+    |> Project.changeset(%{
+      name: "Santiment2",
+      ticker: "SAN",
+      twitter_link: ""
+    })
+    |> Repo.insert!()
+
     %Project{}
     |> Project.changeset(%{
       name: "TestProj",


### PR DESCRIPTION
`Repo.get_by(Project, ticker: ticker)` gets confused when there are more than one record with matching tickers. Change the code to get the first result with matching ticker and not empty twitter link