### PR TITLE
Do not try to send slack notification if there is no webhook url

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -123,7 +123,8 @@ config :sanbase, Sanbase.ExternalServices.TwitterData.HistoricalData,
 
 config :sanbase, Sanbase.Notifications.CheckPrices,
   webhook_url: {:system, "NOTIFICATIONS_WEBHOOK_URL"},
-  notification_channel: {:system, "NOTIFICATIONS_CHANNEL", "#signals-stage"}
+  notification_channel: {:system, "NOTIFICATIONS_CHANNEL", "#signals-stage"},
+  slack_notifications_enabled: {:system, "SLACK_NOTIFICATIONS_ENABLED", false}
 
 config :sanbase, SanbaseWeb.Guardian,
   issuer: "santiment",

--- a/config/test.exs
+++ b/config/test.exs
@@ -41,7 +41,8 @@ config :faktory_worker_ex,
   start_workers: false
 
 config :sanbase, Sanbase.Notifications.CheckPrices,
-  webhook_url: "http://example.com/webhook_url"
+  webhook_url: "http://example.com/webhook_url",
+  slack_notifications_enabled: true
 
 config :sanbase, Sanbase.Github.Store,
   database: "github_activity_test"

--- a/config/test.exs
+++ b/config/test.exs
@@ -40,6 +40,9 @@ config :faktory_worker_ex,
   ],
   start_workers: false
 
+config :sanbase, Sanbase.Notifications.CheckPrices,
+  webhook_url: "http://example.com/webhook_url"
+
 config :sanbase, Sanbase.Github.Store,
   database: "github_activity_test"
 

--- a/lib/sanbase/notifications/check_prices.ex
+++ b/lib/sanbase/notifications/check_prices.ex
@@ -33,18 +33,18 @@ defmodule Sanbase.Notifications.CheckPrices do
   end
 
   def send_notification({notification, price_difference, project}, counter_currency) do
-    send_slack_notification(Config.get(:webhook_url), price_difference, project, counter_currency)
+    if slack_notifications_enabled?() do
+      send_slack_notification(price_difference, project, counter_currency)
+    end
 
     Repo.insert!(notification)
   end
 
   def send_notification(_, _), do: false
 
-  def send_slack_notification(nil, _, _, _), do: :ok
-
-  def send_slack_notification(webhook_url, price_difference, project, counter_currency) do
+  def send_slack_notification(price_difference, project, counter_currency) do
     %{status: 200} = @http_service.post(
-      webhook_url,
+      webhook_url(),
       notification_payload(price_difference, project, counter_currency),
       headers: %{"Content-Type" => "application/json"}
     )
@@ -72,5 +72,13 @@ defmodule Sanbase.Notifications.CheckPrices do
 
   defp notification_emoji(price_difference) when price_difference > 0, do: ":signal_up:"
   defp notification_emoji(price_difference) when price_difference < 0, do: ":signal_down:"
+
+  defp webhook_url() do
+    Config.get(:webhook_url)
+  end
+
+  defp slack_notifications_enabled?() do
+    Config.get(:slack_notifications_enabled)
+  end
 
 end

--- a/lib/sanbase/notifications/check_prices.ex
+++ b/lib/sanbase/notifications/check_prices.ex
@@ -33,16 +33,22 @@ defmodule Sanbase.Notifications.CheckPrices do
   end
 
   def send_notification({notification, price_difference, project}, counter_currency) do
-    %{status: 200} = @http_service.post(
-      Config.get(:webhook_url),
-      notification_payload(price_difference, project, counter_currency),
-      headers: %{"Content-Type" => "application/json"}
-    )
+    send_slack_notification(Config.get(:webhook_url), price_difference, project, counter_currency)
 
     Repo.insert!(notification)
   end
 
   def send_notification(_, _), do: false
+
+  def send_slack_notification(nil, _, _, _), do: :ok
+
+  def send_slack_notification(webhook_url, price_difference, project, counter_currency) do
+    %{status: 200} = @http_service.post(
+      webhook_url,
+      notification_payload(price_difference, project, counter_currency),
+      headers: %{"Content-Type" => "application/json"}
+    )
+  end
 
   defp price_ticker(%Project{ticker: ticker}, counter_currency) do
     "#{ticker}_#{String.upcase(counter_currency)}"


### PR DESCRIPTION
If the webhook URL is not set, don't send notifications to slack.