### PR TITLE
Refactor parts of Store modules. Replace fetching last datetime from using LAST to using ORDER BY LIMIT 1

### DIFF
--- a/lib/sanbase/etherbi/store.ex
+++ b/lib/sanbase/etherbi/store.ex
@@ -4,32 +4,6 @@ defmodule Sanbase.Etherbi.Store do
   alias Sanbase.Influxdb.Measurement
   alias Sanbase.Etherbi.Store
 
-  def last_datetime(measurement) do
-    ~s/SELECT LAST(*) FROM "#{measurement}"/
-    |> Store.query()
-    |> parse_measurement_datetime()
-  end
-
-  def last_datetime_with_tag(measurement, tag_name, tag_value) when is_binary(tag_value) do
-    ~s/SELECT LAST(*) FROM "#{measurement}"
-    WHERE "#{tag_name}" = "#{tag_value}"/
-    |> Store.query()
-    |> parse_measurement_datetime()
-  end
-
-  def last_datetime_with_tag(measurement, tag_name, tag_value) do
-    ~s/SELECT LAST(*) FROM "#{measurement}"
-    WHERE "#{tag_name}" = #{tag_value}/
-    |> Store.query()
-    |> parse_measurement_datetime()
-  end
-
-  def first_datetime(measurement) do
-    ~s/SELECT FIRST(*) FROM "#{measurement}"/
-    |> Store.query()
-    |> parse_measurement_datetime()
-  end
-
   def transactions(measurement, from, to, transaction_type) do
     transactions_from_to_query(measurement, from, to, transaction_type)
     |> Store.query()
@@ -84,27 +58,4 @@ defmodule Sanbase.Etherbi.Store do
     {:ok, []}
   end
 
-  defp parse_measurement_datetime(%{results: [%{error: error}]}) do
-    {:error, error}
-  end
-
-  defp parse_measurement_datetime(%{
-         results: [
-           %{
-             series: [
-               %{
-                 values: [[iso8601_datetime|_]|_rest]
-               }
-             ]
-           }
-         ]
-       }) do
-    {:ok, datetime, _} = DateTime.from_iso8601(iso8601_datetime)
-
-    {:ok, datetime}
-  end
-
-  defp parse_measurement_datetime(_) do
-    {:ok, nil}
-  end
 end

--- a/lib/sanbase/external_services/coinmarketcap.ex
+++ b/lib/sanbase/external_services/coinmarketcap.ex
@@ -170,7 +170,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap do
   end
 
   defp last_price_datetime(pair, %Project{coinmarketcap_id: coinmarketcap_id}) do
-    case Store.last_price_datetime(pair) do
+    case Store.last_datetime!(pair) do
       nil ->
         GraphData.fetch_first_price_datetime(coinmarketcap_id)
 

--- a/lib/sanbase/github/scheduler.ex
+++ b/lib/sanbase/github/scheduler.ex
@@ -66,10 +66,10 @@ defmodule Sanbase.Github.Scheduler do
   end
 
   defp get_initial_scrape_datetime(%Project{ticker: ticker}) do
-    if Github.Store.first_activity_datetime(ticker) do
-      Github.Store.last_activity_datetime(ticker)
+    if Github.Store.first_datetime!(ticker) do
+      Github.Store.last_datetime!(ticker)
     else
-      Prices.Store.first_price_datetime(ticker <> "_USD")
+      Prices.Store.first_datetime!(ticker <> "_USD")
     end
   end
 

--- a/lib/sanbase/github/store.ex
+++ b/lib/sanbase/github/store.ex
@@ -8,18 +8,6 @@ defmodule Sanbase.Github.Store do
   alias Sanbase.Influxdb.Measurement
   alias Sanbase.Github.Store
 
-  def first_activity_datetime(ticker) do
-    ~s/SELECT FIRST(activity) FROM "#{ticker}"/
-    |> Store.query()
-    |> parse_measurement_datetime()
-  end
-
-  def last_activity_datetime(ticker) do
-    ~s/SELECT LAST(activity) FROM "#{ticker}"/
-    |> Store.query()
-    |> parse_measurement_datetime()
-  end
-
   def fetch_activity_with_resolution!(ticker, from, to, resolution) do
     activity_with_resolution_query(ticker, from, to, resolution)
     |> Store.query()
@@ -101,21 +89,4 @@ defmodule Sanbase.Github.Store do
 
   defp parse_moving_average_series!(_), do: []
 
-  defp parse_measurement_datetime(%{
-         results: [
-           %{
-             series: [
-               %{
-                 values: [[iso8601_datetime, _activity]]
-               }
-             ]
-           }
-         ]
-       }) do
-    {:ok, datetime, _} = DateTime.from_iso8601(iso8601_datetime)
-
-    datetime
-  end
-
-  defp parse_measurement_datetime(_), do: nil
 end

--- a/lib/sanbase/influxdb/store.ex
+++ b/lib/sanbase/influxdb/store.ex
@@ -32,25 +32,26 @@ defmodule Sanbase.Influxdb.Store do
         |> Stream.reject(&is_nil/1)
         |> Stream.chunk_every(288)
         |> Stream.map(fn data_for_import ->
-             :ok = __MODULE__.write(data_for_import)
-            end)
+          :ok = __MODULE__.write(data_for_import)
+        end)
         |> Stream.run()
       end
 
-      def list_measurements!() do
-        "SHOW MEASUREMENTS"
-        |> __MODULE__.query()
-        |> parse_measurements_list!()
-      end
-
       def list_measurements() do
-        "SHOW MEASUREMENTS"
+        ~s/SHOW MEASUREMENTS/
         |> __MODULE__.query()
         |> parse_measurements_list()
       end
 
+      def list_measurements!() do
+        case list_measurements() do
+          {:ok, measurements} -> measurements
+          {:error, error} -> raise(error)
+        end
+      end
+
       def drop_measurement(measurement_name) do
-        "DROP MEASUREMENT \"#{measurement_name}\""
+        ~s/DROP MEASUREMENT "#{measurement_name}"/
         |> __MODULE__.execute()
       end
 
@@ -60,24 +61,54 @@ defmodule Sanbase.Influxdb.Store do
         |> __MODULE__.execute()
       end
 
-      # Private functions
-
-      defp parse_measurements_list!(%{results: [%{error: error}]}), do: raise(error)
-
-      defp parse_measurements_list!(%{
-             results: [
-               %{
-                 series: [
-                   %{
-                     values: measurements
-                   }
-                 ]
-               }
-             ]
-           }) do
-        measurements
-        |> Enum.map(&Kernel.hd/1)
+      def last_datetime(measurement) do
+        ~s/SELECT * FROM "#{measurement}" ORDER BY time DESC LIMIT 1/
+        |> __MODULE__.query()
+        |> parse_measurement_datetime()
       end
+
+      def last_datetime!(measurement) do
+        case last_datetime(measurement) do
+          {:ok, datetime} -> datetime
+          {:error, error} -> raise(error)
+        end
+      end
+
+      def last_datetime_with_tag(measurement, tag_name, tag_value) when is_binary(tag_value) do
+        ~s/SELECT * FROM "#{measurement}" ORDER BY time DESC LIMIT 1
+        WHERE "#{tag_name}" = '#{tag_value}'/
+        |> __MODULE__.query()
+        |> parse_measurement_datetime()
+      end
+
+      def last_datetime_with_tag(measurement, tag_name, tag_value) do
+        ~s/SELECT * FROM "#{measurement}" ORDER BY time DESC LIMIT 1
+        WHERE "#{tag_name}" = #{tag_value}/
+        |> __MODULE__.query()
+        |> parse_measurement_datetime()
+      end
+
+      def last_datetime_with_tag!(measurement, tag_name, tag_value) do
+        case last_datetime_with_tag(measurement, tag_name, tag_value) do
+          {:ok, datetime} -> datetime
+          {:error, error} -> raise(error)
+        end
+      end
+
+      def first_datetime(measurement) do
+        ~s/SELECT * FROM "#{measurement}" ORDER BY time ASC LIMIT 1/
+        |> __MODULE__.query()
+        |> parse_measurement_datetime()
+      end
+
+      def first_datetime!(measurement) do
+        case first_datetime(measurement) do
+          {:ok, datetime} -> datetime
+          {:error, error} -> raise(error)
+        end
+      end
+
+      # Private functions
 
       defp parse_measurements_list(%{results: [%{error: error}]}), do: {:error, error}
 
@@ -93,7 +124,31 @@ defmodule Sanbase.Influxdb.Store do
              ]
            }) do
         {:ok, measurements |> Enum.map(&Kernel.hd/1)}
-           end
+      end
+
+      defp parse_measurement_datetime(%{results: [%{error: error}]}) do
+        {:error, error}
+      end
+
+      defp parse_measurement_datetime(%{
+             results: [
+               %{
+                 series: [
+                   %{
+                     values: [[iso8601_datetime | _] | _rest]
+                   }
+                 ]
+               }
+             ]
+           }) do
+        {:ok, datetime, _} = DateTime.from_iso8601(iso8601_datetime)
+
+        {:ok, datetime}
+      end
+
+      defp parse_measurement_datetime(_) do
+        {:ok, nil}
+      end
     end
   end
 end

--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -62,22 +62,10 @@ defmodule Sanbase.Prices.Store do
 
   defp parse_price_series(_), do: []
 
-  def first_price_datetime(pair) do
-    ~s/SELECT FIRST(price) FROM "#{pair}"/
-    |> Store.query()
-    |> parse_price_datetime
-  end
-
   def last_record(pair) do
     ~s/SELECT LAST(price), marketcap, volume from "#{pair}"/
     |> Store.query()
     |> parse_record
-  end
-
-  def last_price_datetime(pair) do
-    ~s/SELECT LAST(price) FROM "#{pair}"/
-    |> Store.query()
-    |> parse_price_datetime
   end
 
   def fetch_last_price_point_before(pair, timestamp) do
@@ -87,23 +75,6 @@ defmodule Sanbase.Prices.Store do
     |> Store.query()
     |> parse_record
   end
-
-  defp parse_price_datetime(%{
-         results: [
-           %{
-             series: [
-               %{
-                 values: [[iso8601_datetime, _price]]
-               }
-             ]
-           }
-         ]
-       }) do
-    {:ok, datetime, _} = DateTime.from_iso8601(iso8601_datetime)
-    datetime
-  end
-
-  defp parse_price_datetime(_), do: nil
 
   defp parse_record(%{
          results: [


### PR DESCRIPTION
Refactor the `Store` modules. Make generic `first_datetime` and `last_datetime` functions to be applicable to all db layouts.

Note: https://github.com/influxdata/docs.influxdata.com/issues/1095
When using wildcard inside a selector, the time is not picked but showed as beginning of epoch (0 unix). A workaround to be able to select the last/first datetime without knowing the field/tag names is to use `ORDER BY ... LIMIT 1`