### PR TITLE
Rename GQL query transactions to exchnage_funds_flow

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
@@ -79,7 +79,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
     end
   end
 
-  def transactions(
+  def exchange_fund_flow(
         _root,
         %{
           ticker: ticker,

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -151,13 +151,13 @@ defmodule SanbaseWeb.Graphql.Schema do
     end
 
     @desc "Shows the flow of funds in an exchange wallet"
-    field :transactions, list_of(:transaction) do
+    field :exchange_fund_flow, list_of(:transaction) do
       arg(:ticker, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, :datetime, default_value: DateTime.utc_now())
       arg(:transaction_type, :transaction_type, default_value: :all)
 
-      resolve(&EtherbiResolver.transactions/3)
+      resolve(&EtherbiResolver.exchange_fund_flow/3)
 
     end
   end

--- a/test/sanbase_web/graphql/etherbi_transactions_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_transactions_api_test.exs
@@ -103,7 +103,7 @@ defmodule Sanbase.Github.EtherbiTransactionsApiTest do
   test "fetch in transactions", context do
     query = """
     {
-      transactions(
+      exchangeFundFlow(
         ticker: "#{context.ticker}",
         from: "#{context.datetime1}",
         to: "#{context.datetime8}",
@@ -117,9 +117,9 @@ defmodule Sanbase.Github.EtherbiTransactionsApiTest do
 
     result =
       context.conn
-      |> post("/graphql", query_skeleton(query, "transactions"))
+      |> post("/graphql", query_skeleton(query, "exchangeFundFlow"))
 
-    transactions_in = json_response(result, 200)["data"]["transactions"]
+    transactions_in = json_response(result, 200)["data"]["exchangeFundFlow"]
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime1),
@@ -155,7 +155,7 @@ defmodule Sanbase.Github.EtherbiTransactionsApiTest do
   test "fetch out transactions", context do
     query = """
     {
-      transactions(
+      exchangeFundFlow(
         ticker: "#{context.ticker}",
         from: "#{context.datetime1}",
         to: "#{context.datetime8}",
@@ -169,9 +169,9 @@ defmodule Sanbase.Github.EtherbiTransactionsApiTest do
 
     result =
       context.conn
-      |> post("/graphql", query_skeleton(query, "transactions"))
+      |> post("/graphql", query_skeleton(query, "exchangeFundFlow"))
 
-    transactions_out = json_response(result, 200)["data"]["transactions"]
+    transactions_out = json_response(result, 200)["data"]["exchangeFundFlow"]
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime1),


### PR DESCRIPTION
This GQL query retrieves only transactions of a given token that happened in/out of an exchange wallet. Rename it to better specify what it does.