### PR TITLE
Add voted_at field for each post

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/voting_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/voting_resolver.ex
@@ -18,7 +18,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.VotingResolver do
   def total_san_votes(%Post{} = post, _args, _context) do
     total_san_votes =
       post
-      |> Repo.preload(votes: [:user])
+      |> Repo.preload(votes: [user: :eth_accounts])
       |> Map.get(:votes)
       |> Enum.map(&Map.get(&1, :user))
       |> Enum.map(&User.san_balance!/1)
@@ -26,6 +26,17 @@ defmodule SanbaseWeb.Graphql.Resolvers.VotingResolver do
 
     {:ok, Decimal.div(total_san_votes, Ethauth.san_token_decimals())}
   end
+
+  def voted_at(%Post{} = post, _args, %{
+        context: %{auth: %{current_user: user}}
+      }) do
+    case Repo.get_by(Vote, post_id: post.id, user_id: user.id) do
+      nil -> {:ok, nil}
+      vote -> {:ok, vote.inserted_at}
+    end
+  end
+
+  def voted_at(%Post{}, _args, _context), do: {:ok, nil}
 
   def vote(_root, %{post_id: post_id}, %{
         context: %{auth: %{current_user: user}}

--- a/lib/sanbase_web/graphql/schema/voting_types.ex
+++ b/lib/sanbase_web/graphql/schema/voting_types.ex
@@ -17,6 +17,10 @@ defmodule SanbaseWeb.Graphql.VotingTypes do
     field(:link, non_null(:string))
     field(:approved_at, :datetime)
 
+    field :voted_at, :datetime do
+      resolve(&VotingResolver.voted_at/3)
+    end
+
     field :total_san_votes, :integer do
       resolve(&VotingResolver.total_san_votes/3)
     end


### PR DESCRIPTION
The `voted_at` field gives the datetime when the current user voted for
a given post.

Also fixed the total_san_votes to preload the eth_accounts of the user,
so that the san balance can be calculated of the users.