### PR TITLE
The san token balance should use only Decimal numbers

### DIFF
--- a/lib/sanbase/auth/user.ex
+++ b/lib/sanbase/auth/user.ex
@@ -61,6 +61,6 @@ defmodule Sanbase.Auth.User do
   defp san_balance_for_eth_accounts(eth_accounts) do
     eth_accounts
     |> Enum.map(&EthAccount.san_balance/1)
-    |> Enum.sum()
+    |> Enum.reduce(Decimal.new(0), &Decimal.add/2)
   end
 end


### PR DESCRIPTION
Fixed the tests and the way the API calls to ethauth are mocked.