### PR TITLE
Filter also on coinmarketcap_id when returning twitter followers

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/twitter_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/twitter_resolver.ex
@@ -61,7 +61,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.TwitterResolver do
     query =
       from(
         p in Project,
-        where: p.ticker == ^ticker and not is_nil(p.twitter_link),
+        where: p.ticker == ^ticker and not is_nil(p.twitter_link) and not is_nil(p.coinmarketcap_id),
         select: p.twitter_link
       )
 

--- a/test/sanbase_web/graphql/twitter_api_test.exs
+++ b/test/sanbase_web/graphql/twitter_api_test.exs
@@ -25,7 +25,8 @@ defmodule Sanbase.Github.TwitterApiTest do
     |> Project.changeset(%{
       name: "Santiment",
       ticker: "SAN",
-      twitter_link: "https://twitter.com/santimentfeed"
+      twitter_link: "https://twitter.com/santimentfeed",
+      coinmarketcap_id: "santiment"
     })
     |> Repo.insert!()
 


### PR DESCRIPTION
When we have a duplicated ticker that both have twitter links, the project shown on PDP always gets the twitter followers for the ticker with smaller id. Add filter for coinmarketcap_id too