### PR TITLE
 Add env var switch for etherbi

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -198,7 +198,9 @@ config :ex_aws,
   secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role],
   region: "eu-central-1"
 
-config :sanbase, Sanbase.Etherbi, url: {:system, "ETHERBI_URL"}
+config :sanbase, Sanbase.Etherbi,
+  url: {:system, "ETHERBI_URL"},
+  use_cache: {:system, "ETHERBI_USE_CACHE", false}
 
 config :sanbase, Sanbase.MandrillApi,
   apikey: {:system, "MANDRILL_APIKEY"},

--- a/config/test.exs
+++ b/config/test.exs
@@ -45,8 +45,6 @@ config :sanbase, Sanbase.Github.Store, database: "github_activity_test"
 config :sanbase, Sanbase.ExternalServices.TwitterData.Store,
   database: "twitter_followers_data_test"
 
-config :sanbase, Sanbase.Etherbi, use_cache: true
-
 config :sanbase, Sanbase.Etherbi.Transactions.Store, database: "transactions_test"
 
 config :sanbase, Sanbase.Etherbi.BurnRate.Store, database: "burn_rate_test"

--- a/config/test.exs
+++ b/config/test.exs
@@ -45,6 +45,8 @@ config :sanbase, Sanbase.Github.Store, database: "github_activity_test"
 config :sanbase, Sanbase.ExternalServices.TwitterData.Store,
   database: "twitter_followers_data_test"
 
+config :sanbase, Sanbase.Etherbi, use_cache: true
+
 config :sanbase, Sanbase.Etherbi.Transactions.Store, database: "transactions_test"
 
 config :sanbase, Sanbase.Etherbi.BurnRate.Store, database: "burn_rate_test"

--- a/lib/sanbase_web/graphql/resolvers/etherbi_api_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_api_resolver.ex
@@ -145,7 +145,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiApiResolver do
   defp get_token_decimals(ticker) do
     query =
       from(
-        p in Sanbase.Model.Project,
+        p in subquery(Sanbase.Model.Project.all_projects_with_eth_contract_query()),
         where: p.ticker == ^ticker and not is_nil(p.token_decimals),
         select: p.token_decimals
       )

--- a/lib/sanbase_web/graphql/resolvers/etherbi_api_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_api_resolver.ex
@@ -1,0 +1,156 @@
+defmodule SanbaseWeb.Graphql.Resolvers.EtherbiApiResolver do
+  require Sanbase.Utils.Config
+  alias Sanbase.Utils.Config
+  alias Sanbase.Etherbi.Store
+
+  import Ecto.Query
+
+  @http_client Mockery.of("HTTPoison")
+  @recv_timeout 15_000
+  @max_result_size 500
+
+  def burn_rate(_root, %{ticker: ticker, from: from, to: to}, _resolution) do
+    from_unix = DateTime.to_unix(from, :seconds)
+    to_unix = DateTime.to_unix(to, :seconds)
+
+    etherbi_url = Config.module_get(Sanbase.Etherbi, :url)
+
+    url =
+      "#{etherbi_url}/burn_rate?ticker=#{ticker}&from_timestamp=#{from_unix}&to_timestamp=#{
+        to_unix
+      }"
+
+    options = [recv_timeout: @recv_timeout]
+
+    case @http_client.get(url, [], options) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        {:ok, result} = Poison.decode(body)
+
+        token_decimals = get_token_decimals(ticker)
+        divide_by = :math.pow(10, token_decimals)
+
+        result =
+          result
+          |> reduce_result_size(&average/1)
+          |> Enum.map(fn [timestamp, br] ->
+            %{datetime: DateTime.from_unix!(timestamp), burn_rate: Decimal.new(br / divide_by)}
+          end)
+
+        {:ok, result}
+
+      {:error, %HTTPoison.Response{status_code: status, body: body}} ->
+        {:error, "Error status #{status} fetching burn rate for ticker #{ticker}: #{body}"}
+
+      _ ->
+        {:error, "Cannot fetch burn rate data for ticker #{ticker}"}
+    end
+  end
+
+  def transaction_volume(_root, %{ticker: ticker, from: from, to: to}, _resolution) do
+    from_unix = DateTime.to_unix(from, :seconds)
+    to_unix = DateTime.to_unix(to, :seconds)
+
+    etherbi_url = Config.module_get(Sanbase.Etherbi, :url)
+
+    url =
+      "#{etherbi_url}/transaction_volume?ticker=#{ticker}&from_timestamp=#{from_unix}&to_timestamp=#{
+        to_unix
+      }"
+
+    options = [recv_timeout: @recv_timeout]
+
+    case @http_client.get(url, [], options) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        {:ok, result} = Poison.decode(body)
+
+        result =
+          result
+          |> reduce_result_size(&Enum.sum/1)
+          |> Enum.map(fn [timestamp, trx_volume] ->
+            %{
+              datetime: DateTime.from_unix!(timestamp),
+              transaction_volume: Decimal.new(trx_volume)
+            }
+          end)
+
+        {:ok, result}
+
+      {:error, %HTTPoison.Response{status_code: status, body: body}} ->
+        {:error,
+         "Error status #{status} fetching transaction volume for ticker #{ticker}: #{body}"}
+
+      _ ->
+        {:error, "Cannot fetch burn transaction volume for ticker #{ticker}"}
+    end
+  end
+
+  def exchange_fund_flow(
+        _root,
+        %{
+          ticker: ticker,
+          from: from,
+          to: to,
+          transaction_type: transaction_type
+        },
+        _resolution
+      ) do
+    with {:ok, transactions} <- Store.transactions(ticker, from, to, transaction_type) do
+      result =
+        transactions
+        |> Enum.map(fn {datetime, volume, address} ->
+          %{
+            datetime: datetime,
+            transaction_volume: volume |> Decimal.new(),
+            address: address
+          }
+        end)
+
+      {:ok, result}
+    end
+  end
+
+  # Private functions
+
+  defp reduce_result_size(list, _) when length(list) < 2 * @max_result_size, do: list
+
+  defp reduce_result_size(list, reduce_function) do
+    chunk_size = trunc(length(list) / @max_result_size)
+
+    list
+    |> Enum.chunk_every(chunk_size)
+    |> Enum.map(fn chunk ->
+      [
+        min_timestamp(chunk),
+        reduced_value(chunk, reduce_function)
+      ]
+    end)
+  end
+
+  defp min_timestamp(chunk) do
+    chunk
+    |> Enum.map(&hd/1)
+    |> Enum.min()
+  end
+
+  defp reduced_value(chunk, reduce_function) do
+    chunk
+    |> Enum.map(&tl/1)
+    |> Enum.map(&hd/1)
+    |> reduce_function.()
+  end
+
+  defp average(list) do
+    Enum.sum(list) / length(list)
+  end
+
+  defp get_token_decimals(ticker) do
+    query =
+      from(
+        p in Sanbase.Model.Project,
+        where: p.ticker == ^ticker and not is_nil(p.token_decimals),
+        select: p.token_decimals
+      )
+
+    Sanbase.Repo.all(query) |> hd
+  end
+end

--- a/lib/sanbase_web/graphql/resolvers/etherbi_cache_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_cache_resolver.ex
@@ -1,0 +1,79 @@
+defmodule SanbaseWeb.Graphql.Resolvers.EtherbiCacheResolver do
+  require Sanbase.Utils.Config
+  alias Sanbase.Utils.Config
+  alias Sanbase.Etherbi.{Transactions, BurnRate, TransactionVolume}
+
+  @doc ~S"""
+    Return the token burn rate for the given ticker and time period.
+    Uses the influxdb cached values instead of issuing a GET request to etherbi
+  """
+  def burn_rate(_root, %{ticker: ticker, from: from, to: to, interval: interval}, _resolution) do
+    with {:ok, burn_rates} <- BurnRate.Store.burn_rate(ticker, from, to, interval) do
+      result =
+        burn_rates
+        |> Enum.map(fn {datetime, burn_rate} ->
+          %{
+            datetime: datetime,
+            burn_rate: burn_rate |> Decimal.new()
+          }
+        end)
+
+      {:ok, result}
+    end
+  end
+
+  @doc ~S"""
+    Return the transaction volume for the given ticker and time period.
+    Uses the influxdb cached values instead of issuing a GET request to etherbi
+  """
+  def transaction_volume(
+        _root,
+        %{ticker: ticker, from: from, to: to, interval: interval},
+        _resolution
+      ) do
+    with {:ok, trx_volumes} <-
+           TransactionVolume.Store.transaction_volume(ticker, from, to, interval) do
+      result =
+        trx_volumes
+        |> Enum.map(fn {datetime, trx_volume} ->
+          %{
+            datetime: datetime,
+            transaction_volume: trx_volume |> Decimal.new()
+          }
+        end)
+
+      {:ok, result}
+    end
+  end
+
+  @doc ~S"""
+    Return the transactions that happend in or out of an exchange wallet for a given ticker
+    and time period.
+    Uses the influxdb cached values instead of issuing a GET request to etherbi
+  """
+  def exchange_fund_flow(
+        _root,
+        %{
+          ticker: ticker,
+          from: from,
+          to: to,
+          transaction_type: transaction_type
+        },
+        _resolution
+      ) do
+    with {:ok, transactions} <-
+           Transactions.Store.transactions(ticker, from, to, transaction_type) do
+      result =
+        transactions
+        |> Enum.map(fn {datetime, volume, address} ->
+          %{
+            datetime: datetime,
+            transaction_volume: volume |> Decimal.new(),
+            address: address
+          }
+        end)
+
+      {:ok, result}
+    end
+  end
+end

--- a/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
@@ -1,79 +1,47 @@
 defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
   require Sanbase.Utils.Config
   alias Sanbase.Utils.Config
-  alias Sanbase.Etherbi.{Transactions, BurnRate, TransactionVolume}
+
+  alias SanbaseWeb.Graphql.Resolvers.EtherbiApiResolver
+  alias SanbaseWeb.Graphql.Resolvers.EtherbiCacheResolver
 
   @doc ~S"""
     Return the token burn rate for the given ticker and time period.
-    Uses the influxdb cached values instead of issuing a GET request to etherbi
   """
-  def burn_rate(_root, %{ticker: ticker, from: from, to: to, interval: interval}, _resolution) do
-    with {:ok, burn_rates} <- BurnRate.Store.burn_rate(ticker, from, to, interval) do
-      result =
-        burn_rates
-        |> Enum.map(fn {datetime, burn_rate} ->
-          %{
-            datetime: datetime,
-            burn_rate: burn_rate |> Decimal.new()
-          }
-        end)
-
-      {:ok, result}
+  def burn_rate(root, args, resolution) do
+    if use_cache?() do
+      EtherbiCacheResolver.burn_rate(root, args, resolution)
+    else
+      EtherbiApiResolver.burn_rate(root, args, resolution)
     end
   end
 
   @doc ~S"""
     Return the transaction volume for the given ticker and time period.
-    Uses the influxdb cached values instead of issuing a GET request to etherbi
   """
-  def transaction_volume(
-        _root,
-        %{ticker: ticker, from: from, to: to, interval: interval},
-        _resolution
-      ) do
-    with {:ok, trx_volumes} <-
-           TransactionVolume.Store.transaction_volume(ticker, from, to, interval) do
-      result =
-        trx_volumes
-        |> Enum.map(fn {datetime, trx_volume} ->
-          %{
-            datetime: datetime,
-            transaction_volume: trx_volume |> Decimal.new()
-          }
-        end)
-
-      {:ok, result}
+  def transaction_volume(root, args, resolution) do
+    if use_cache?() do
+      EtherbiCacheResolver.transaction_volume(root, args, resolution)
+    else
+      EtherbiApiResolver.transaction_volume(root, args, resolution)
     end
   end
 
   @doc ~S"""
     Return the transactions that happend in or out of an exchange wallet for a given ticker
     and time period.
-    Uses the influxdb cached values instead of issuing a GET request to etherbi
   """
-  def exchange_fund_flow(
-        _root,
-        %{
-          ticker: ticker,
-          from: from,
-          to: to,
-          transaction_type: transaction_type
-        },
-        _resolution
-      ) do
-    with {:ok, transactions} <-
-           Transactions.Store.transactions(ticker, from, to, transaction_type) do
-      result =
-        transactions
-        |> Enum.map(fn {datetime, volume, address} ->
-          %{
-            datetime: datetime,
-            transaction_volume: volume |> Decimal.new(),
-            address: address
-          }
-        end)
-
-      {:ok, result}
+  def exchange_fund_flow(root, args, resolution) do
+    if use_cache?() do
+      EtherbiCacheResolver.exchange_fund_flow(root, args, resolution)
+    else
+      EtherbiApiResolver.exchange_fund_flow(root, args, resolution)
     end
+  end
+
+  # Private functions
+
+  defp use_cache?() do
+    Config.module_get(Sanbase.Etherbi, :use_cache)
   end
 end

--- a/test/sanbase_web/graphql/etherbi_burn_rate_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_burn_rate_api_test.exs
@@ -8,6 +8,8 @@ defmodule Sanbase.Etherbi.BurnRateApiTest do
   import SanbaseWeb.Graphql.TestHelpers
 
   setup do
+    Application.put_env(:sanbase, Sanbase.Etherbi, use_cache: true)
+
     Store.create_db()
 
     ticker = "SAN"

--- a/test/sanbase_web/graphql/etherbi_fetch_from_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_fetch_from_api_test.exs
@@ -4,7 +4,7 @@ defmodule Sanbase.Github.EtherbiApiTest do
   import Mockery
   import SanbaseWeb.Graphql.TestHelpers
 
-  alias Sanbase.Model.Project
+  alias Sanbase.Model.{Project, Ico}
   alias Sanbase.Repo
 
   setup do
@@ -14,12 +14,23 @@ defmodule Sanbase.Github.EtherbiApiTest do
     datetime1 = DateTime.from_naive!(~N[2018-01-01 12:00:00], "Etc/UTC")
     datetime2 = DateTime.from_naive!(~N[2017-01-01 21:45:00], "Etc/UTC")
 
-    %Project{}
-    |> Project.changeset(%{
-      name: "Santiment",
-      ticker: ticker,
-      coinmarketcap_id: "santiment",
-      token_decimals: 18
+    p =
+      %Project{}
+      |> Project.changeset(%{
+        name: "Santiment",
+        ticker: ticker,
+        token_decimals: 18,
+        coinmarketcap_id: "santiment"
+      })
+      |> Repo.insert!()
+
+    %Ico{}
+    |> Ico.changeset(%{
+      project_id: p.id,
+      main_contract_address: "0x1232",
+      contract_block_number: 55,
+      contract_abi: "0x321",
+      rank: 1
     })
     |> Repo.insert!()
 

--- a/test/sanbase_web/graphql/etherbi_fetch_from_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_fetch_from_api_test.exs
@@ -1,0 +1,108 @@
+defmodule Sanbase.Github.EtherbiApiTest do
+  use SanbaseWeb.ConnCase
+
+  import Mockery
+  import SanbaseWeb.Graphql.TestHelpers
+
+  alias Sanbase.Model.Project
+  alias Sanbase.Repo
+
+  setup do
+    Application.put_env(:sanbase, Sanbase.Etherbi, use_cache: false)
+
+    ticker = "SAN"
+    datetime1 = DateTime.from_naive!(~N[2018-01-01 12:00:00], "Etc/UTC")
+    datetime2 = DateTime.from_naive!(~N[2017-01-01 21:45:00], "Etc/UTC")
+
+    %Project{}
+    |> Project.changeset(%{
+      name: "Santiment",
+      ticker: ticker,
+      coinmarketcap_id: "santiment",
+      token_decimals: 18
+    })
+    |> Repo.insert!()
+
+    [
+      ticker: ticker,
+      datetime1: datetime1,
+      datetime2: datetime2
+    ]
+  end
+
+  test "fetch burn rate from etherbi API", context do
+    burn_rate = [
+      [1_514_766_000, 91_716_892_495_405_965_698_400_256],
+      [1_514_770_144, 359_319_706_108_516_227_858_038_784],
+      [1_514_778_068, 31_034_050_000_000_001_245_184]
+    ]
+
+    mock(
+      HTTPoison,
+      :get,
+      {:ok,
+       %HTTPoison.Response{
+         status_code: 200,
+         body: Poison.encode!(burn_rate)
+       }}
+    )
+
+    query = """
+    {
+      burnRate(
+        ticker: "#{context.ticker}",
+        from: "#{context.datetime1}",
+        to: "#{context.datetime2}")
+        {
+          burnRate
+        }
+      }
+    """
+
+    result =
+      context.conn
+      |> post("/graphql", query_skeleton(query, "burnRate"))
+
+    burn_rates = json_response(result, 200)["data"]["burnRate"]
+
+    assert %{"burnRate" => "91716892.49540597"} in burn_rates
+    assert %{"burnRate" => "359319706.1085162"} in burn_rates
+    assert %{"burnRate" => "31034.050000000003"} in burn_rates
+  end
+
+  test "fetch transaction volume from Etherbi api", context do
+    transaction_volume =
+      Stream.cycle([
+        [1_514_765_863, 5_810_803_200_000_000_000],
+        [1_514_766_007, 700_000_000_000_001_803_841],
+        [1_514_770_144, 1_749_612_781_540_000_000_000]
+      ])
+      |> Enum.take(21000)
+
+    mock(
+      HTTPoison,
+      :get,
+      {:ok, %HTTPoison.Response{status_code: 200, body: Poison.encode!(transaction_volume)}}
+    )
+
+    query = """
+    {
+      transactionVolume(
+        ticker: "#{context.ticker}",
+        from: "#{context.datetime1}",
+        to: "#{context.datetime2}")
+        {
+          transactionVolume
+        }
+      }
+    """
+
+    result =
+      context.conn
+      |> post("/graphql", query_skeleton(query, "transactionVolume"))
+
+    transaction_volumes = json_response(result, 200)["data"]["transactionVolume"]
+
+    assert length(transaction_volumes) == 500
+  end
+end

--- a/test/sanbase_web/graphql/etherbi_transactions_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_transactions_api_test.exs
@@ -8,6 +8,8 @@ defmodule Sanbase.Etherbi.TransactionsApiTest do
   import SanbaseWeb.Graphql.TestHelpers
 
   setup do
+    Application.put_env(:sanbase, Sanbase.Etherbi, use_cache: true)
+
     Store.create_db()
 
     ticker = "SAN"

--- a/test/sanbase_web/graphql/etherbi_trx_volume_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_trx_volume_api_test.exs
@@ -8,6 +8,8 @@ defmodule Sanbase.Etherbi.TransactionVolumeApiTest do
   import SanbaseWeb.Graphql.TestHelpers
 
   setup do
+    Application.put_env(:sanbase, Sanbase.Etherbi, use_cache: true)
+
     Store.create_db()
 
     ticker = "SAN"


### PR DESCRIPTION
Brings back the old behaviour by default. This is because when deploying on prod there should be no downtime. The scrappers will fill the cache in the background while the GQL api will still fetch from etherbi as before

Depending on the value of `ETHERBI_USE_CACHE` env var:
If true -> The GQL api fetches from influxdb
If false -> The GQL api fetches from etherbi api. The only difference with the old behaviour here is that we are doing the token_decimal divisions in the backend (to keep consistency with the other option). The division is already removed from the frontend