### PR TITLE
Add createdAt to the Post object

### DIFF
--- a/lib/sanbase_web/graphql/schema/voting_types.ex
+++ b/lib/sanbase_web/graphql/schema/voting_types.ex
@@ -18,6 +18,12 @@ defmodule SanbaseWeb.Graphql.VotingTypes do
     field(:state, :string)
     field(:moderation_comment, :string)
 
+    field :created_at, non_null(:datetime) do
+      resolve(fn %{inserted_at: inserted_at}, _, _ ->
+        {:ok, inserted_at}
+      end)
+    end
+
     field :voted_at, :datetime do
       resolve(&VotingResolver.voted_at/3)
     end

--- a/test/sanbase_web/graphql/voting_test.exs
+++ b/test/sanbase_web/graphql/voting_test.exs
@@ -216,7 +216,8 @@ defmodule SanbaseWeb.Graphql.VotingTest do
           id
         },
         totalSanVotes,
-        state
+        state,
+        createdAt
       }
     }
     """
@@ -232,6 +233,9 @@ defmodule SanbaseWeb.Graphql.VotingTest do
     assert sanbasePost["state"] == nil
     assert sanbasePost["user"]["id"] == Integer.to_string(user.id)
     assert sanbasePost["totalSanVotes"] == "0.000000000000000000"
+
+    createdAt = Timex.parse!(sanbasePost["createdAt"], "{ISO:Extended}")
+    assert Timex.diff(Timex.now(), createdAt, :seconds) == 0
   end
 
   test "adding a new post with a very long title", %{conn: conn} do


### PR DESCRIPTION
The createdAt is an alias for insertedAt. We might created a helper for
such aliases in the future, so that we have a better DSL for defining
them.