### PR TITLE
Fetch all transactions from etherscan and save them in time series. Keep saving the latest data to the pg table

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ podTemplate(label: 'sanbase-builder', containers: [
         sh "docker build -t sanbase-test:${scmVars.GIT_COMMIT} -f Dockerfile-test ."
         sh "docker build -t sanbase-frontend-test:${scmVars.GIT_COMMIT} -f app/Dockerfile-test app"
         sh "docker run --rm --name test_postgres_${scmVars.GIT_COMMIT} -d postgres:9.6-alpine"
-        sh "docker run --rm --name test_influxdb_${scmVars.GIT_COMMIT} -d influxdb:1.3-alpine"
+        sh "docker run --rm --name test_influxdb_${scmVars.GIT_COMMIT} -d influxdb:1.4-alpine"
         try {
           sh "docker run --rm --link test_postgres_${scmVars.GIT_COMMIT}:test_db --link test_influxdb_${scmVars.GIT_COMMIT}:test_influxdb --env DATABASE_URL=postgres://postgres:password@test_db:5432/postgres --env INFLUXDB_HOST=test_influxdb -t sanbase-test:${scmVars.GIT_COMMIT}"
           sh "docker run --rm -t sanbase-frontend-test:${scmVars.GIT_COMMIT} yarn test --ci"

--- a/config/config.exs
+++ b/config/config.exs
@@ -115,7 +115,7 @@ config :ex_admin,
 
 config :xain, :after_callback, {Phoenix.HTML, :raw}
 
-config :tesla, adapter: :hackney
+config :tesla, adapter: :hackney, recv_timeout: 30_000
 
 config :sanbase, Sanbase.ExternalServices.Coinmarketcap,
   # 5 minutes

--- a/config/config.exs
+++ b/config/config.exs
@@ -75,6 +75,12 @@ config :sanbase, Sanbase.Etherbi.TransactionVolume.Store,
   pool: [max_overflow: 10, size: 20],
   database: "transaction_volume"
 
+config :sanbase, Sanbase.ExternalServices.Etherscan.Store,
+  host: {:system, "INFLUXDB_HOST", "localhost"},
+  port: {:system, "INFLUXDB_PORT", 8086},
+  pool: [max_overflow: 10, size: 20],
+  database: "etherscan_transactions"
+
 config :hammer,
   backend: {Hammer.Backend.ETS, [expiry_ms: 60_000 * 60 * 4, cleanup_interval_ms: 60_000 * 10]}
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -57,6 +57,8 @@ config :sanbase, SanbaseWeb.Graphql.ContextPlug,
 
 config :sanbase, Sanbase.Prices.Store, database: "prices_test"
 
+config :sanbase, Sanbase.ExternalServices.Etherscan.Store, database: "etherscan_transactions_test"
+
 if File.exists?("config/test.secret.exs") do
   import_config "test.secret.exs"
 end

--- a/lib/sanbase/application.ex
+++ b/lib/sanbase/application.ex
@@ -39,6 +39,9 @@ defmodule Sanbase.Application do
         # Time series transaction volume DB connection
         Sanbase.Etherbi.TransactionVolume.Store.child_spec(),
 
+        # Time series ethscan team wallet transactions DB connection
+        Sanbase.ExternalServices.Etherscan.Store.child_spec(),
+
         # Etherscan rate limiter
         Sanbase.ExternalServices.RateLimiting.Server.child_spec(
           :etherscan_rate_limiter,

--- a/lib/sanbase/external_services/etherscan/requests.ex
+++ b/lib/sanbase/external_services/etherscan/requests.ex
@@ -1,4 +1,7 @@
 defmodule Sanbase.ExternalServices.Etherscan.Requests do
+  @moduledoc ~s"""
+    Module which is used to send requests to etherscan.io
+  """
   use Tesla
 
   require Sanbase.Utils.Config

--- a/lib/sanbase/external_services/etherscan/requests/balance.ex
+++ b/lib/sanbase/external_services/etherscan/requests/balance.ex
@@ -2,6 +2,8 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.Balance do
   alias Sanbase.ExternalServices.Etherscan.Requests
   alias __MODULE__
 
+  require Logger
+
   defstruct [:status, :message, :result]
 
   defp get_query(address) do
@@ -16,7 +18,18 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.Balance do
   def get(address) do
     Requests.get("/", query: get_query(address))
     |> case do
-      %{status: 200, body: body} -> Poison.Decode.decode(body, as: %Balance{})
+      %{status: 200, body: body} ->
+        Poison.Decode.decode(body, as: %Balance{})
+
+      %{status: status, body: body} ->
+        error = "Error fetching transactions for #{address}. Status code: #{status}: #{body}"
+        Logger.warn(error)
+        {:error, error}
+
+      _ ->
+        error = "Error fetching transactions for #{address}"
+        Logger.warn(error)
+        {:error, error}
     end
   end
 end

--- a/lib/sanbase/external_services/etherscan/requests/internal_tx.ex
+++ b/lib/sanbase/external_services/etherscan/requests/internal_tx.ex
@@ -26,7 +26,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.InternalTx do
       address: address,
       startblock: 0,
       endblock: 99_999_999,
-      sort: "desc"
+      sort: "asc"
     ]
   end
 

--- a/lib/sanbase/external_services/etherscan/requests/internal_tx.ex
+++ b/lib/sanbase/external_services/etherscan/requests/internal_tx.ex
@@ -26,7 +26,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.InternalTx do
       address: address,
       startblock: 0,
       endblock: 99_999_999,
-      sort: "asc"
+      sort: "desc"
     ]
   end
 

--- a/lib/sanbase/external_services/etherscan/requests/tx.ex
+++ b/lib/sanbase/external_services/etherscan/requests/tx.ex
@@ -30,7 +30,9 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.Tx do
       address: address,
       startblock: startblock,
       endblock: endblock,
-      sort: "desc"
+      sort: "asc",
+      page: 1,
+      offset: 2500
     ]
   end
 

--- a/lib/sanbase/external_services/etherscan/requests/tx.ex
+++ b/lib/sanbase/external_services/etherscan/requests/tx.ex
@@ -60,4 +60,9 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.Tx do
       String.downcase(tx.from) == normalized_address
     end)
   end
+
+  def get_all_transactions(address, startblock, endblock) do
+    normalized_address = String.downcase(address)
+    {:ok, get(address, startblock, endblock)}
+  end
 end

--- a/lib/sanbase/external_services/etherscan/requests/tx.ex
+++ b/lib/sanbase/external_services/etherscan/requests/tx.ex
@@ -54,6 +54,10 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.Tx do
     end
   end
 
+  # The offset is the max number of transactions that will be returned. As we are
+  # making the next query with a recalculated starblock so we are effectivly
+  # exploiting the offset to be used only for limiting the number of fetched transactions
+  # and not for pagination
   defp get_query(address, startblock, endblock) do
     [
       module: "account",

--- a/lib/sanbase/external_services/etherscan/scraper.ex
+++ b/lib/sanbase/external_services/etherscan/scraper.ex
@@ -13,7 +13,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Scraper do
 
   @max_redirects 10
 
-  def fetch_address_page(address) do
+  def fetch_address_page!(address) do
     case get("/address/#{address}") do
       %Tesla.Env{status: 200, body: body} ->
         body
@@ -29,20 +29,20 @@ defmodule Sanbase.ExternalServices.Etherscan.Scraper do
     end
   end
 
-  def fetch_token_page(token_name, redirects \\ 0)
+  def fetch_token_page!(token_name, redirects \\ 0)
 
-  def fetch_token_page(_, @max_redirects) do
+  def fetch_token_page!(_, @max_redirects) do
     Logger.warn("Too many redirects")
     nil
   end
 
-  def fetch_token_page(token_name, redirects) do
+  def fetch_token_page!(token_name, redirects) do
     case get("/token/#{token_name}") do
       %Tesla.Env{status: 200, body: body} ->
         body
 
       %Tesla.Env{status: 302, headers: %{"location" => "/token/" <> name}} ->
-        fetch_token_page(name, redirects + 1)
+        fetch_token_page!(name, redirects + 1)
 
       %Tesla.Env{status: status, body: body} ->
         Logger.warn(
@@ -55,15 +55,15 @@ defmodule Sanbase.ExternalServices.Etherscan.Scraper do
     end
   end
 
-  def parse_address_page(nil, project_info), do: project_info
+  def parse_address_page!(nil, project_info), do: project_info
 
-  def parse_address_page(html, project_info) do
+  def parse_address_page!(html, project_info) do
     %ProjectInfo{project_info | creation_transaction: creation_transaction(html)}
   end
 
-  def parse_token_page(nil, project_info), do: project_info
+  def parse_token_page!(nil, project_info), do: project_info
 
-  def parse_token_page(html, project_info) do
+  def parse_token_page!(html, project_info) do
     %ProjectInfo{
       project_info
       | total_supply:

--- a/lib/sanbase/external_services/etherscan/store.ex
+++ b/lib/sanbase/external_services/etherscan/store.ex
@@ -1,0 +1,92 @@
+defmodule Sanbase.ExternalServices.Etherscan.Store do
+  @moduledoc ~S"""
+    A module for storing and fetching transactions data from a time series data store
+  """
+
+  use Sanbase.Influxdb.Store
+
+  alias Sanbase.Influxdb.Measurement
+  alias Sanbase.ExternalServices.Etherscan.Store
+
+  def last_block_number(measurement) do
+    select_last_block_number(measurement)
+    |> Store.query()
+    |> parse_last_block_number()
+  end
+
+  def last_block_number!(measurement) do
+    case last_block_number(measurement) do
+      {:ok, result} -> result
+      {:error, error} -> raise(error)
+    end
+  end
+
+  def transactions(measurement, from, to) do
+    select_from_to_query(measurement, from, to)
+    |> Store.query()
+    |> parse_transactions_time_series()
+  end
+
+  # Private functions
+
+  defp select_last_block_number(measurement) do
+    ~s/SELECT LAST(block_number) from "#{measurement}"/
+  end
+
+  defp select_from_to_query(measurement, from, to) do
+    ~s/SELECT time, trx_value, from_addr, to_addr
+    FROM "#{measurement}"
+    WHERE time >= #{DateTime.to_unix(from, :nanoseconds)}
+    AND time <= #{DateTime.to_unix(to, :nanoseconds)}/
+  end
+
+  defp parse_transactions_time_series(%{results: [%{error: error}]}) do
+    {:error, error}
+  end
+
+  defp parse_transactions_time_series(%{
+         results: [
+           %{
+             series: [
+               %{
+                 values: transactions
+               }
+             ]
+           }
+         ]
+       }) do
+    result =
+      transactions
+      |> Enum.map(fn [iso8601_datetime, trx_value, from_addr, to_addr] ->
+        {:ok, datetime, _} = DateTime.from_iso8601(iso8601_datetime)
+        {datetime, trx_value, from_addr, to_addr}
+      end)
+
+    {:ok, result}
+  end
+
+  defp parse_transactions_time_series(_), do: {:ok, []}
+
+  defp parse_last_block_number(%{results: [%{error: error}]}) do
+    {:error, error}
+  end
+
+  defp parse_last_block_number(%{
+         results: [
+           %{
+             series: [
+               %{
+                 values: block_number
+               }
+             ]
+           }
+         ]
+       }) do
+    block_number
+    |> Enum.map(fn [_iso8601_datetime, block_number] ->
+      {:ok, block_number}
+    end)
+  end
+
+  defp parse_last_block_number(_), do: {:ok, nil}
+end

--- a/lib/sanbase/external_services/etherscan/store.ex
+++ b/lib/sanbase/external_services/etherscan/store.ex
@@ -30,7 +30,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
   # Private functions
 
   defp select_last_block_number(measurement) do
-    ~s/SELECT LAST(block_number) from "#{measurement}"/
+    ~s/SELECT MAX(block_number) from "#{measurement}"/
   end
 
   defp select_from_to_query(measurement, from, to) do

--- a/lib/sanbase/external_services/etherscan/worker.ex
+++ b/lib/sanbase/external_services/etherscan/worker.ex
@@ -89,7 +89,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
     |> Store.import()
   end
 
-  defp import_latest_eth_wallet_data(transactions, address, id) do
+  defp import_latest_eth_wallet_data(transactions, address) do
     normalized_address = address |> String.downcase()
 
     last_trx =
@@ -121,7 +121,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
     end
   end
 
-  defp fetch(address, measurement_name, endblock) do
+  defp fetch_all_transactions(address, measurement_name, endblock) do
     last_block_with_data = Store.last_block_number!(address) || 0
 
     case Tx.get_all_transactions(address, last_block_with_data, endblock) do
@@ -140,7 +140,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
   end
 
   defp fetch_and_store(%{address: address, coinmarketcap_id: id}, endblock) do
-    transactions = fetch(address, id, endblock) |> Enum.reverse()
+    transactions = fetch_all_transactions(address, id, endblock)
 
     filtered_transactions =
       transactions
@@ -150,9 +150,9 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
 
     import_all_transactions_influxdb(filtered_transactions, address, id)
 
-    import_latest_eth_wallet_data(filtered_transactions, address, id)
+    import_latest_eth_wallet_data(filtered_transactions, address)
 
-    import_last_block_number(address, List.first(transactions))
+    import_last_block_number(address, List.last(transactions))
   end
 
   defp import_last_block_number(address, %Tx{blockNumber: bn}) do

--- a/lib/sanbase/external_services/etherscan/worker.ex
+++ b/lib/sanbase/external_services/etherscan/worker.ex
@@ -7,6 +7,8 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
 
   require Sanbase.Utils.Config
 
+  import Ecto.Query
+
   alias Sanbase.Model.LatestEthWalletData
   alias Sanbase.Model.ProjectEthAddress
   alias Sanbase.Repo
@@ -14,7 +16,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
   alias Sanbase.ExternalServices.Etherscan.Requests.{Balance, Tx}
   alias Sanbase.Utils.Config
 
-  alias Decimal, as: D
+  alias Sanbase.ExternalServices.Etherscan.Store
 
   @default_update_interval_ms 1000 * 60 * 5
   # Actually it's close to 15s
@@ -22,6 +24,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
   # 30 days
   @default_timespan_ms 30 * 24 * 60 * 60 * 1000
   @confirmations 10
+  @num_18_zeroes 1_000_000_000_000_000_000
 
   def start_link(_state) do
     GenServer.start_link(__MODULE__, :ok)
@@ -30,16 +33,13 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
   def init(:ok) do
     Logger.info("Starting etherscan polling client")
 
-    # Trap exists, so that we don't die when a child dies
-    Process.flag(:trap_exit, true)
-
-    # For calculating balance in eth (to keep functionality same as
-    # old sanbase)
-    D.set_context(%{D.get_context() | precision: 2})
-
-    update_interval_ms = Config.get(:update_interval, @default_update_interval_ms)
-
     if Config.get(:sync_enabled, false) do
+      Store.create_db()
+
+      Decimal.set_context(%{Decimal.get_context() | precision: 2})
+
+      update_interval_ms = Config.get(:update_interval, @default_update_interval_ms)
+
       GenServer.cast(self(), :sync)
 
       {:ok, %{update_interval_ms: update_interval_ms}}
@@ -51,12 +51,20 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
   def handle_cast(:sync, %{update_interval_ms: update_interval_ms} = state) do
     # 1. Get current block number
     endblock = Parity.get_latest_block_number!() - @confirmations
-    startblock = endblock - Float.ceil(@default_timespan_ms / @average_block_time_ms)
+
+    query =
+      from(
+        eth_addr in ProjectEthAddress,
+        inner_join: p in Sanbase.Model.Project,
+        on: eth_addr.project_id == p.id,
+        where: not is_nil(p.coinmarketcap_id),
+        select: %{address: eth_addr.address, coinmarketcap_id: p.coinmarketcap_id}
+      )
 
     Task.Supervisor.async_stream_nolink(
       Sanbase.TaskSupervisor,
-      Repo.all(ProjectEthAddress),
-      &fetch_and_store(&1, startblock, endblock),
+      Repo.all(query),
+      &fetch_and_store(&1, endblock),
       max_concurrency: 5,
       on_timeout: :kill_task,
       ordered: false,
@@ -75,34 +83,68 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
   end
 
   defp convert_to_eth(wei) do
-    D.div(D.new(wei), D.new(1_000_000_000_000_000_000))
+    Decimal.div(Decimal.new(wei), Decimal.new(@num_18_zeroes))
   end
 
-  defp fetch(address, startblock, endblock) do
+  defp import_all_transactions_influxdb(transactions, address, id) do
+    transactions
+    |> Enum.map(&convert_to_measurement(&1, address, id))
+    |> Store.import()
+  end
+
+  defp import_latest_eth_wallet_data(transactions, address) do
+    normalized_address = address |> String.downcase()
+
+    last_trx =
+      transactions
+      |> Enum.find(fn tx -> String.downcase(tx.from) == normalized_address end)
+
+    changeset = latest_eth_wallet_changeset(last_trx, address)
+
+    get_or_create_entry(address)
+    |> LatestEthWalletData.changeset(changeset)
+    |> Repo.insert_or_update!()
+  end
+
+  defp latest_eth_wallet_changeset(last_trx, address) do
     changeset = %{
       update_time: DateTime.utc_now(),
       balance: convert_to_eth(Balance.get(address).result)
     }
 
-    case Tx.get_last_outgoing_transaction(address, startblock, endblock) do
-      %Tx{timeStamp: ts, value: value} ->
-        Map.merge(changeset, %{
-          last_outgoing: DateTime.from_unix!(ts),
-          tx_out: convert_to_eth(value)
-        })
+    changeset =
+      case last_trx do
+        %Tx{timeStamp: ts, value: value} ->
+          Map.merge(changeset, %{
+            last_outgoing: DateTime.from_unix!(ts),
+            tx_out: convert_to_eth(value)
+          })
 
-      nil ->
-        changeset
+        nil ->
+          changeset
+      end
+  end
+
+  defp fetch(address, endblock) do
+    last_block_with_data = Store.last_block_number!(address) || 0
+
+    case Tx.get_all_transactions(address, last_block_with_data, endblock) do
+      {:ok, list} ->
+        list
+        |> Enum.reject(fn %Tx{isError: error} -> error == "1" end)
+
+      error ->
+        Logger.warn("Cannot fetch transactions for #{address}. Reason: #{inspect(error)}")
+        []
     end
   end
 
-  defp fetch_and_store(%ProjectEthAddress{address: address}, startblock, endblock) do
-    Logger.info("Updating transactions of address #{address}")
-    changeset = fetch(address, startblock, endblock)
+  defp fetch_and_store(%{address: address, coinmarketcap_id: id}, endblock) do
+    transactions = fetch(address, endblock)
 
-    get_or_create_entry(address)
-    |> LatestEthWalletData.changeset(changeset)
-    |> Repo.insert_or_update!()
+    import_all_transactions_influxdb(transactions, address, id)
+
+    import_latest_eth_wallet_data(transactions, address)
   end
 
   defp get_or_create_entry(address) do
@@ -110,5 +152,25 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
       nil -> %LatestEthWalletData{address: address}
       entry -> entry
     end
+  end
+
+  defp convert_to_measurement(
+         %Tx{timeStamp: ts, from: from, to: to, value: value, blockNumber: bn},
+         address,
+         measurement_name
+       ) do
+    transaction_type =
+      if from == address do
+        "in"
+      else
+        "out"
+      end
+
+    %Sanbase.Influxdb.Measurement{
+      timestamp: ts * 1_000_000_000,
+      fields: %{trx_value: (value |> String.to_integer()) / @num_18_zeroes, from: from, to: to},
+      tags: [block_number: bn, transaction_type: transaction_type],
+      name: measurement_name
+    }
   end
 end

--- a/lib/sanbase/external_services/etherscan/worker.ex
+++ b/lib/sanbase/external_services/etherscan/worker.ex
@@ -90,11 +90,9 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
   end
 
   defp import_latest_eth_wallet_data(transactions, address) do
-    normalized_address = address |> String.downcase()
-
     last_trx =
       transactions
-      |> Enum.find(fn tx -> String.downcase(tx.from) == normalized_address end)
+      |> Enum.find(fn tx -> String.downcase(tx.from) == address end)
 
     changeset = latest_eth_wallet_changeset(last_trx, address)
 
@@ -141,6 +139,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
 
   defp fetch_and_store(%{address: address, coinmarketcap_id: id}, endblock) do
     transactions = fetch_all_transactions(address, id, endblock)
+    address = address |> String.downcase()
 
     filtered_transactions =
       transactions
@@ -178,6 +177,9 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
          address,
          measurement_name
        ) do
+    from = from |> String.downcase()
+    to = to |> String.downcase()
+
     transaction_type =
       if to == address do
         "in"

--- a/lib/sanbase/external_services/project_info.ex
+++ b/lib/sanbase/external_services/project_info.ex
@@ -50,8 +50,8 @@ defmodule Sanbase.ExternalServices.ProjectInfo do
   def fetch_contract_info(
         %ProjectInfo{main_contract_address: main_contract_address} = project_info
       ) do
-    Etherscan.Scraper.fetch_address_page(main_contract_address)
-    |> Etherscan.Scraper.parse_address_page(project_info)
+    Etherscan.Scraper.fetch_address_page!(main_contract_address)
+    |> Etherscan.Scraper.parse_address_page!(project_info)
     |> fetch_block_number()
     |> fetch_abi()
   end
@@ -62,8 +62,8 @@ defmodule Sanbase.ExternalServices.ProjectInfo do
   def fetch_etherscan_token_summary(
         %ProjectInfo{etherscan_token_name: etherscan_token_name} = project_info
       ) do
-    Etherscan.Scraper.fetch_token_page(etherscan_token_name)
-    |> Etherscan.Scraper.parse_token_page(project_info)
+    Etherscan.Scraper.fetch_token_page!(etherscan_token_name)
+    |> Etherscan.Scraper.parse_token_page!(project_info)
   end
 
   def update_project(project_info, project) do

--- a/lib/sanbase/influxdb/store.ex
+++ b/lib/sanbase/influxdb/store.ex
@@ -67,23 +67,6 @@ defmodule Sanbase.Influxdb.Store do
         |> __MODULE__.execute()
       end
 
-      def create_db_with_retention_policy(
-            name \\ "sanbase_rp",
-            duration \\ "2w",
-            replication \\ 1,
-            default \\ true
-          ) do
-        database = Sanbase.Utils.Config.get(:database)
-
-        database
-        |> Sanbase.Utils.Config.get()
-        |> Instream.Admin.Database.create()
-        |> __MODULE__.execute()
-
-        Instream.Admin.RetentionPolicy.create(name, database, duration, replication, default)
-        |> __MODULE__.execute()
-      end
-
       def last_datetime(measurement) do
         ~s/SELECT * FROM "#{measurement}" ORDER BY time DESC LIMIT 1/
         |> __MODULE__.query()

--- a/lib/sanbase/influxdb/store.ex
+++ b/lib/sanbase/influxdb/store.ex
@@ -61,6 +61,23 @@ defmodule Sanbase.Influxdb.Store do
         |> __MODULE__.execute()
       end
 
+      def create_db_with_retention_policy(
+            name \\ "sanbase_rp",
+            duration \\ "2w",
+            replication \\ 1,
+            default \\ true
+          ) do
+        database = Sanbase.Utils.Config.get(:database)
+
+        database
+        |> Sanbase.Utils.Config.get()
+        |> Instream.Admin.Database.create()
+        |> __MODULE__.execute()
+
+        Instream.Admin.RetentionPolicy.create(name, database, duration, replication, default)
+        |> __MODULE__.execute()
+      end
+
       def last_datetime(measurement) do
         ~s/SELECT * FROM "#{measurement}" ORDER BY time DESC LIMIT 1/
         |> __MODULE__.query()

--- a/lib/sanbase/influxdb/store.ex
+++ b/lib/sanbase/influxdb/store.ex
@@ -25,6 +25,12 @@ defmodule Sanbase.Influxdb.Store do
           |> __MODULE__.write()
       end
 
+      def delete_by_tag(measurement, tag_key, tag_value) do
+        ~s/DELETE from "#{measurement}"
+        WHERE #{tag_key} = '#{tag_value}'/
+        |> __MODULE__.query()
+      end
+
       def import(measurements) do
         # 1 day of 5 min resolution data
         measurements

--- a/lib/sanbase_web/graphql/resolvers/ico_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/ico_resolver.ex
@@ -62,10 +62,4 @@ defmodule SanbaseWeb.Graphql.Resolvers.IcoResolver do
 
     {:ok, result}
   end
-
-  defp requested_fields(resolution) do
-    resolution.definition.selections
-    |> Enum.map(&(Map.get(&1, :name) |> String.to_atom()))
-    |> Enum.into(%{}, fn field -> {field, true} end)
-  end
 end

--- a/lib/sanbase_web/graphql/resolvers/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project_resolver.ex
@@ -93,11 +93,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
     end)
   end
 
-  def eth_spent(%Project{id: id}, %{days: days}, _resolution) do
+  def eth_spent(%Project{coinmarketcap_id: coinmarketcap_id}, %{days: days}, _resolution) do
     async(fn ->
-      coinmarketcap_id =
-        Repo.one(from(p in Project, where: p.id == ^id, select: p.coinmarketcap_id))
-
       today = Timex.now()
       days_ago = Timex.shift(today, days: -days)
 

--- a/lib/sanbase_web/graphql/schema/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/project_types.ex
@@ -120,6 +120,11 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     end
 
     field(:icos, list_of(:ico), resolve: assoc(:icos))
+
+    field :eth_spent, :decimal do
+      arg(:days, :integer, default_value: 30)
+      resolve(&ProjectResolver.eth_spent/3)
+    end
   end
 
   # Used in the project list query (public), so heavy computed fields are omitted
@@ -200,6 +205,11 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
 
     field :percent_change_7d, :decimal, name: "percent_change7d" do
       resolve(&ProjectResolver.percent_change_7d/3)
+    end
+
+    field :eth_spent, :float do
+      arg(:days, :integer, default_value: 30)
+      resolve(&ProjectResolver.eth_spent/3)
     end
   end
 
@@ -295,6 +305,11 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
 
     field :percent_change_7d, :decimal, name: "percent_change7d" do
       resolve(&ProjectResolver.percent_change_7d/3)
+    end
+
+    field :eth_spent, :float do
+      arg(:days, :integer, default_value: 30)
+      resolve(&ProjectResolver.eth_spent/3)
     end
   end
 
@@ -408,10 +423,8 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       resolve(&ProjectResolver.funds_raised_btc_ico_end_price/3)
     end
 
-    field :eth_spent, :decimal do
-      arg(:from, :datetime, default_value: Sanbase.DateTimeUtils.days_ago(30))
-      arg(:to, :datetime, default_value: Timex.now())
-
+    field :eth_spent, :float do
+      arg(:days, :integer, default_value: 30)
       resolve(&ProjectResolver.eth_spent/3)
     end
   end

--- a/lib/sanbase_web/graphql/schema/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/project_types.ex
@@ -407,6 +407,13 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     field :funds_raised_btc_ico_end_price, :decimal do
       resolve(&ProjectResolver.funds_raised_btc_ico_end_price/3)
     end
+
+    field :eth_spent, :decimal do
+      arg(:from, :datetime, default_value: Sanbase.DateTimeUtils.days_ago(30))
+      arg(:to, :datetime, default_value: Timex.now())
+
+      resolve(&ProjectResolver.eth_spent/3)
+    end
   end
 
   object :project_with_eth_contract_info do

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -85,7 +85,8 @@ end
   {"DAO.Casino", "BET", "dao-casino.png", "dao-casino", "ETH"},
   {"Centra", "CTR", "centra.png", "centra", "ETH"},
   {"Tierion", "TNT", "tierion.png", "tierion", "ETH"},
-  {"Matchpool", "GUP", "guppy.png", "guppy", "ETH"}
+  {"Matchpool", "GUP", "guppy.png", "guppy", "ETH"},
+  {"Nebulas", "NAS", "nebulas.png", "nebulas-token", "ETH"}
 ]
 |> Enum.map(make_project)
 |> Enum.each(&Repo.insert!/1)
@@ -118,7 +119,8 @@ end
   {"DAO.Casino", "0x1446bf7AF9dF857b23a725646D94f9Ec49802227"},
   {"Centra", "0x96A65609a7B84E8842732DEB08f56C3E21aC6f8a"},
   {"Tierion", "0x0C4b367e876d18d5c102023D9240DD7e9C11b380"},
-  {"Matchpool", "0x1c10aD0b5f1b4013173f05B4cc05a60cBBAa6536"}
+  {"Matchpool", "0x1c10aD0b5f1b4013173f05B4cc05a60cBBAa6536"},
+  {"Nebulas", "0x5d65D971895Edc438f465c17DB6992698a52318D"}
 ]
 |> Enum.flat_map(make_eth_address)
 |> Enum.each(&Repo.insert!/1)

--- a/test/sanbase/external_services/etherscan/scraper_test.exs
+++ b/test/sanbase/external_services/etherscan/scraper_test.exs
@@ -7,7 +7,7 @@ defmodule Sanbase.ExternalServices.Etherscan.ScraperTest do
   test "parsing the address page" do
     html = File.read!(Path.join(__DIR__, "address_info_page.html"))
 
-    assert Scraper.parse_address_page(html, %ProjectInfo{}) == %ProjectInfo{
+    assert Scraper.parse_address_page!(html, %ProjectInfo{}) == %ProjectInfo{
              creation_transaction:
                "0x83705b4dcaa603d17c2fc642df91b3f7e2f7c2d6fa4844f878602c4f233fe79b"
            }
@@ -16,7 +16,7 @@ defmodule Sanbase.ExternalServices.Etherscan.ScraperTest do
   test "parsing the token summary page" do
     html = File.read!(Path.join(__DIR__, "token_summary_page.html"))
 
-    assert Scraper.parse_token_page(html, %ProjectInfo{}) == %ProjectInfo{
+    assert Scraper.parse_token_page!(html, %ProjectInfo{}) == %ProjectInfo{
              total_supply: 6_804_870_174_878_168_246_198_837_603,
              main_contract_address: "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
              token_decimals: 18

--- a/test/sanbase_web/graphql/project_spent_eth_test.exs
+++ b/test/sanbase_web/graphql/project_spent_eth_test.exs
@@ -1,0 +1,119 @@
+defmodule SanbaseWeb.Graphql.ProjectSpentEthTest do
+  use SanbaseWeb.ConnCase
+
+  alias Sanbase.Influxdb.Measurement
+  alias Sanbase.ExternalServices.Etherscan.Store
+  alias Sanbase.Model.Project
+  alias Sanbase.Repo
+
+  import SanbaseWeb.Graphql.TestHelpers
+
+  setup do
+    Store.create_db()
+
+    name = "santiment"
+    Store.drop_measurement(name)
+
+    p =
+      %Project{}
+      |> Project.changeset(%{name: "Santiment", coinmarketcap_id: name})
+      |> Repo.insert!()
+
+    datetime1 = DateTime.from_naive!(~N[2017-05-13 15:00:00], "Etc/UTC")
+    datetime2 = DateTime.from_naive!(~N[2017-05-10 16:00:00], "Etc/UTC")
+    datetime3 = DateTime.from_naive!(~N[2017-05-05 17:00:00], "Etc/UTC")
+    datetime4 = DateTime.from_naive!(~N[2017-05-01 18:00:00], "Etc/UTC")
+    datetime5 = DateTime.from_naive!(~N[2017-04-25 19:00:00], "Etc/UTC")
+    datetime6 = DateTime.from_naive!(~N[2017-04-14 20:00:00], "Etc/UTC")
+
+    [
+      %Measurement{
+        timestamp: datetime1 |> DateTime.to_unix(:nanoseconds),
+        fields: %{trx_value: 500},
+        tags: [transaction_type: "out"],
+        name: name
+      },
+      %Measurement{
+        timestamp: datetime2 |> DateTime.to_unix(:nanoseconds),
+        fields: %{trx_value: 1500},
+        tags: [transaction_type: "out"],
+        name: name
+      },
+      %Measurement{
+        timestamp: datetime3 |> DateTime.to_unix(:nanoseconds),
+        fields: %{trx_value: 2500},
+        tags: [transaction_type: "out"],
+        name: name
+      },
+      %Measurement{
+        timestamp: datetime4 |> DateTime.to_unix(:nanoseconds),
+        fields: %{trx_value: 3500},
+        tags: [transaction_type: "out"],
+        name: name
+      },
+      %Measurement{
+        timestamp: datetime4 |> DateTime.to_unix(:nanoseconds),
+        fields: %{trx_value: 100_000},
+        tags: [transaction_type: "in"],
+        name: name
+      },
+      %Measurement{
+        timestamp: datetime5 |> DateTime.to_unix(:nanoseconds),
+        fields: %{trx_value: 5500},
+        tags: [transaction_type: "out"],
+        name: name
+      },
+      %Measurement{
+        timestamp: datetime6 |> DateTime.to_unix(:nanoseconds),
+        fields: %{trx_value: 6500},
+        tags: [transaction_type: "out"],
+        name: name
+      }
+    ]
+    |> Store.import()
+
+    [
+      project: p,
+      name: name,
+      datetime_from: datetime6,
+      datetime_mid: datetime4,
+      datetime_to: datetime1
+    ]
+  end
+
+  test "project total eth spent whole interval", context do
+    query = """
+    {
+      project(id: #{context.project.id}) {
+        ethSpent(from: "#{context.datetime_from}", to: "#{context.datetime_to}")
+      }
+    }
+    """
+
+    result =
+      context.conn
+      |> post("/graphql", query_skeleton(query, "project"))
+
+    trx_sum = json_response(result, 200)["data"]["project"]
+
+    assert trx_sum == %{"ethSpent" => "20000"}
+  end
+
+  test "project total eth spent part of interval", context do
+    query = """
+    {
+      project(id: #{context.project.id}) {
+        ethSpent(from: "#{context.datetime_mid}", to: "#{context.datetime_to}")
+      }
+    }
+    """
+
+    result =
+      context.conn
+      |> post("/graphql", query_skeleton(query, "project"))
+
+    trx_sum = json_response(result, 200)["data"]["project"]
+
+    assert trx_sum == %{"ethSpent" => "8000"}
+  end
+end

--- a/test/sanbase_web/graphql/project_spent_eth_test.exs
+++ b/test/sanbase_web/graphql/project_spent_eth_test.exs
@@ -19,12 +19,13 @@ defmodule SanbaseWeb.Graphql.ProjectSpentEthTest do
       |> Project.changeset(%{name: "Santiment", coinmarketcap_id: name})
       |> Repo.insert!()
 
-    datetime1 = DateTime.from_naive!(~N[2017-05-13 15:00:00], "Etc/UTC")
-    datetime2 = DateTime.from_naive!(~N[2017-05-10 16:00:00], "Etc/UTC")
-    datetime3 = DateTime.from_naive!(~N[2017-05-05 17:00:00], "Etc/UTC")
-    datetime4 = DateTime.from_naive!(~N[2017-05-01 18:00:00], "Etc/UTC")
-    datetime5 = DateTime.from_naive!(~N[2017-04-25 19:00:00], "Etc/UTC")
-    datetime6 = DateTime.from_naive!(~N[2017-04-14 20:00:00], "Etc/UTC")
+    today = Timex.now()
+    datetime1 = today
+    datetime2 = Timex.shift(today, days: -5)
+    datetime3 = Timex.shift(today, days: -10)
+    datetime4 = Timex.shift(today, days: -15)
+    datetime5 = Timex.shift(today, days: -20)
+    datetime6 = Timex.shift(today, days: -25)
 
     [
       %Measurement{
@@ -75,9 +76,10 @@ defmodule SanbaseWeb.Graphql.ProjectSpentEthTest do
     [
       project: p,
       name: name,
-      datetime_from: datetime6,
-      datetime_mid: datetime4,
-      datetime_to: datetime1
+      dates_day_diff1: Timex.diff(datetime1, datetime6, :days) + 1,
+      expected_sum1: 20000,
+      dates_day_diff2: Timex.diff(datetime1, datetime3, :days) + 1,
+      expected_sum2: 4500
     ]
   end
 
@@ -85,7 +87,7 @@ defmodule SanbaseWeb.Graphql.ProjectSpentEthTest do
     query = """
     {
       project(id: #{context.project.id}) {
-        ethSpent(from: "#{context.datetime_from}", to: "#{context.datetime_to}")
+        ethSpent(days: #{context.dates_day_diff1})
       }
     }
     """
@@ -96,14 +98,14 @@ defmodule SanbaseWeb.Graphql.ProjectSpentEthTest do
 
     trx_sum = json_response(result, 200)["data"]["project"]
 
-    assert trx_sum == %{"ethSpent" => "20000"}
+    assert trx_sum == %{"ethSpent" => context.expected_sum1}
   end
 
   test "project total eth spent part of interval", context do
     query = """
     {
       project(id: #{context.project.id}) {
-        ethSpent(from: "#{context.datetime_mid}", to: "#{context.datetime_to}")
+        ethSpent(days: #{context.dates_day_diff2})
       }
     }
     """
@@ -114,6 +116,6 @@ defmodule SanbaseWeb.Graphql.ProjectSpentEthTest do
 
     trx_sum = json_response(result, 200)["data"]["project"]
 
-    assert trx_sum == %{"ethSpent" => "8000"}
+    assert trx_sum == %{"ethSpent" => context.expected_sum2}
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
 ExUnit.start()
 
-Ecto.Adapters.SQL.Sandbox.mode(Sanbase.Repo, :auto)
+Ecto.Adapters.SQL.Sandbox.mode(Sanbase.Repo, {:shared, self()})


### PR DESCRIPTION
Save all transactions for wallets with `isError == 1 && trxreception_status == 0 && value > 0` from etherscan to influxdb grouped  by the project they belong to.

Keep the old behaviour, too. Save the latest eth wallet data in the corresponding pg table until(if) its usage is removed. 
Do both things with a single query so the rate limit does not require changes.

Keep a separate measurement for tracking the last checked block number. Implement it this way because if (for example) a contract address is queried it could end up with only transactions with `value = 0` and no points will be inserted in the db. In that case we do not know which starting block to choose for the next query.