### PR TITLE
Change the percent change fields back to decimals

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project_resolver.ex
@@ -345,7 +345,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
         _args,
         _resolution
       ) do
-    {:ok, percent_change_1h |> Decimal.to_float()}
+    {:ok, percent_change_1h}
   end
 
   def percent_change_1h(_parent, _args, _resolution), do: {:ok, nil}
@@ -359,7 +359,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
         _args,
         _resolution
       ) do
-    {:ok, percent_change_24h |> Decimal.to_float()}
+    {:ok, percent_change_24h}
   end
 
   def percent_change_24h(_parent, _args, _resolution), do: {:ok, nil}
@@ -373,7 +373,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
         _args,
         _resolution
       ) do
-    {:ok, percent_change_7d |> Decimal.to_float()}
+    {:ok, percent_change_7d}
   end
 
   def percent_change_7d(_parent, _args, _resolution), do: {:ok, nil}

--- a/lib/sanbase_web/graphql/schema/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/project_types.ex
@@ -112,15 +112,15 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       resolve(&ProjectResolver.total_supply/3)
     end
 
-    field :percent_change_1h, :float, name: "percent_change1h" do
+    field :percent_change_1h, :decimal, name: "percent_change1h" do
       resolve(&ProjectResolver.percent_change_1h/3)
     end
 
-    field :percent_change_24h, :float, name: "percent_change24h" do
+    field :percent_change_24h, :decimal, name: "percent_change24h" do
       resolve(&ProjectResolver.percent_change_24h/3)
     end
 
-    field :percent_change_7d, :float, name: "percent_change7d" do
+    field :percent_change_7d, :decimal, name: "percent_change7d" do
       resolve(&ProjectResolver.percent_change_7d/3)
     end
 
@@ -247,15 +247,15 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       resolve(&ProjectResolver.total_supply/3)
     end
 
-    field :percent_change_1h, :float, name: "percent_change1h" do
+    field :percent_change_1h, :decimal, name: "percent_change1h" do
       resolve(&ProjectResolver.percent_change_1h/3)
     end
 
-    field :percent_change_24h, :float, name: "percent_change24h" do
+    field :percent_change_24h, :decimal, name: "percent_change24h" do
       resolve(&ProjectResolver.percent_change_24h/3)
     end
 
-    field :percent_change_7d, :float, name: "percent_change7d" do
+    field :percent_change_7d, :decimal, name: "percent_change7d" do
       resolve(&ProjectResolver.percent_change_7d/3)
     end
 
@@ -356,22 +356,22 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       resolve(&ProjectResolver.total_supply/3)
     end
 
-    field :percent_change_1h, :float, name: "percent_change1h" do
+    field :percent_change_1h, :decimal, name: "percent_change1h" do
       resolve(&ProjectResolver.percent_change_1h/3)
     end
 
-    field :percent_change_24h, :float, name: "percent_change24h" do
+    field :percent_change_24h, :decimal, name: "percent_change24h" do
       resolve(&ProjectResolver.percent_change_24h/3)
     end
 
-    field :percent_change_7d, :float, name: "percent_change7d" do
+    field :percent_change_7d, :decimal, name: "percent_change7d" do
       resolve(&ProjectResolver.percent_change_7d/3)
     end
 
     field :signals, list_of(:signal) do
       resolve(&ProjectResolver.signals/3)
     end
-    
+
     field :eth_spent, :float do
       arg(:days, :integer, default_value: 30)
 
@@ -482,15 +482,15 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       resolve(&ProjectResolver.total_supply/3)
     end
 
-    field :percent_change_1h, :float, name: "percent_change1h" do
+    field :percent_change_1h, :decimal, name: "percent_change1h" do
       resolve(&ProjectResolver.percent_change_1h/3)
     end
 
-    field :percent_change_24h, :float, name: "percent_change24h" do
+    field :percent_change_24h, :decimal, name: "percent_change24h" do
       resolve(&ProjectResolver.percent_change_24h/3)
     end
 
-    field :percent_change_7d, :float, name: "percent_change7d" do
+    field :percent_change_7d, :decimal, name: "percent_change7d" do
       resolve(&ProjectResolver.percent_change_7d/3)
     end
 
@@ -509,7 +509,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     field :signals, list_of(:signal) do
       resolve(&ProjectResolver.signals/3)
     end
-    
+
     field :eth_spent, :float do
       arg(:days, :integer, default_value: 30)
 


### PR DESCRIPTION
This is because these fields are missing their values sometimes and
can't be converted to float properly. The long term solution will be to
remove the LatestCoinmarketcapData table and calculate the data from our
pricing data, but that will happen later.