### PR TITLE
Fix the volume caclulations to not rely on resultion quries

### DIFF
--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -27,12 +27,11 @@ defmodule Sanbase.Prices.Store do
     |> q()
   end
 
-  def fetch_mean_volume_with_resolution(pair, from, to, resolution) do
+  def fetch_mean_volume(pair, from, to) do
     ~s/SELECT MEAN(volume)
     FROM "#{pair}"
     WHERE time >= #{DateTime.to_unix(from, :nanoseconds)}
-    AND time <= #{DateTime.to_unix(to, :nanoseconds)}
-    GROUP BY time(#{resolution}) fill(none)/
+    AND time <= #{DateTime.to_unix(to, :nanoseconds)}/
     |> q()
   end
 


### PR DESCRIPTION
The resultion queries in influxDB has unpredictable number of results
coming back, so making regular range queries and aggretaion on them
should be much more reliable.