### PR TITLE
Introduce a new internal DB and fix fetching of the datetime needed for the queries

### DIFF
--- a/lib/sanbase/etherbi/etherbi_api.ex
+++ b/lib/sanbase/etherbi/etherbi_api.ex
@@ -38,7 +38,7 @@ defmodule Sanbase.Etherbi.EtherbiApi do
 
       {:error, %HTTPoison.Error{reason: :timeout}} ->
         Logger.warn("Timeout trying to fetch the first burn rate timestamp for #{ticker}")
-        {:ok, nil}
+        {:ok, []}
 
       {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
         {:error,
@@ -67,7 +67,7 @@ defmodule Sanbase.Etherbi.EtherbiApi do
 
       {:error, %HTTPoison.Error{reason: :timeout}} ->
         Logger.warn("Timeout trying to fetch the first transaction timestamp for #{address}")
-        {:ok, nil}
+        {:ok, []}
 
       {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
         {:error,
@@ -99,7 +99,7 @@ defmodule Sanbase.Etherbi.EtherbiApi do
 
       {:error, %HTTPoison.Error{reason: :timeout}} ->
         Logger.warn("Timeout trying to fetch the first transaction timestamp for #{ticker}")
-        {:ok, nil}
+        {:ok, []}
 
       {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
         {:error,
@@ -236,7 +236,7 @@ defmodule Sanbase.Etherbi.EtherbiApi do
   end
 
   # Body is a string in the format `[[timestamp,volume,address,token], [timestamp,...]]
-  defp convert_transactions_response("[]"), do: {:ok, nil}
+  defp convert_transactions_response("[]"), do: {:ok, []}
 
   defp convert_transactions_response(body) do
     with {:ok, decoded_body} <- Poison.decode(body) do
@@ -251,7 +251,7 @@ defmodule Sanbase.Etherbi.EtherbiApi do
   end
 
   # Body is a string in the format `[[timestamp, integer], [timestamp, integer], ...]
-  defp convert_timestamp_integer_response("[]"), do: {:ok, nil}
+  defp convert_timestamp_integer_response("[]"), do: {:ok, []}
 
   defp convert_timestamp_integer_response(body) do
     with {:ok, decoded_body} <- Poison.decode(body) do

--- a/lib/sanbase/etherbi/transactions.ex
+++ b/lib/sanbase/etherbi/transactions.ex
@@ -70,12 +70,14 @@ defmodule Sanbase.Etherbi.Transactions do
        ) do
     transactions_data
     |> Enum.map(fn {datetime, volume, address, token} ->
-      %Sanbase.Influxdb.Measurement{
-        timestamp: datetime |> DateTime.to_unix(:nanoseconds),
-        fields: %{volume: volume / Map.get(token_decimals, token)},
-        tags: [transaction_type: transaction_type, address: address],
-        name: token
-      }
+      if decimals = Map.get(token_decimals, token) do
+        %Sanbase.Influxdb.Measurement{
+          timestamp: datetime |> DateTime.to_unix(:nanoseconds),
+          fields: %{volume: volume / Map.get(token_decimals, token)},
+          tags: [transaction_type: transaction_type, address: address],
+          name: token
+        }
+      end
     end)
   end
 end

--- a/lib/sanbase/etherbi/transactions.ex
+++ b/lib/sanbase/etherbi/transactions.ex
@@ -73,7 +73,7 @@ defmodule Sanbase.Etherbi.Transactions do
       if decimals = Map.get(token_decimals, token) do
         %Sanbase.Influxdb.Measurement{
           timestamp: datetime |> DateTime.to_unix(:nanoseconds),
-          fields: %{volume: volume / Map.get(token_decimals, token)},
+          fields: %{volume: volume / decimals},
           tags: [transaction_type: transaction_type, address: address],
           name: token
         }

--- a/lib/sanbase/etherbi/transactions/fetcher.ex
+++ b/lib/sanbase/etherbi/transactions/fetcher.ex
@@ -44,7 +44,15 @@ defmodule Sanbase.Etherbi.Transactions.Fetcher do
     case Utils.generate_from_to_interval_unix(from_datetime) do
       {from, to} ->
         Logger.info("Getting #{transaction_type} transactions for #{address}")
-        @etherbi_api.get_transactions(address, from, to, transaction_type)
+
+        case @etherbi_api.get_transactions(address, from, to, transaction_type) do
+          {:ok, result} ->
+            Store.import_last_address_time(address, transaction_type, to)
+            {:ok, result}
+
+          {:error, error} ->
+            {:error, error}
+        end
 
       _ ->
         {:ok, []}

--- a/lib/sanbase/etherbi/transactions/store.ex
+++ b/lib/sanbase/etherbi/transactions/store.ex
@@ -6,6 +6,39 @@ defmodule Sanbase.Etherbi.Transactions.Store do
 
   alias Sanbase.Etherbi.Transactions.Store
 
+  @last_address_measurement "_sanbase-internal-last-address-measurement"
+
+  @doc ~s"""
+    Updates the point for `address` in the special measurement used for saving
+    the last queried timestamp for a given address
+  """
+  @spec import_last_address_time(String.t(), String.t(), %DateTime{}) :: :ok | no_return()
+  def import_last_address_time(_, _, nil), do: :ok
+
+  def import_last_address_time(address, trx_type, last_datetime) do
+    Store.delete_by_tag(@last_address_measurement, "address", address)
+
+    %Sanbase.Influxdb.Measurement{
+      timestamp: DateTime.utc_now() |> DateTime.to_unix(:nanoseconds),
+      fields: %{last_datetime: last_datetime |> DateTime.to_unix(:nanoseconds)},
+      tags: [address: address, transaction_type: trx_type],
+      name: @last_address_measurement
+    }
+    |> Store.import()
+  end
+
+  @doc ~s"""
+    Returns the last datetime that was quried for that particular address.
+    Returns `{:ok, datetime}` on successs, `{:error, reason}` otherwise
+  """
+  @spec last_address_datetime(String.t(), String.t()) ::
+          {:ok, %DateTime{}} | {:ok, nil} | {:error, String.t()}
+  def last_address_datetime(address, trx_type) do
+    select_last_address_datetime(address, trx_type)
+    |> Store.query()
+    |> parse_last_address_datetime()
+  end
+
   @doc ~S"""
     Get all in and/or out transactions that happened with a given address.
     Returns a tuple `{:ok, result}` on success, `{:error, error}` otherwise
@@ -31,6 +64,13 @@ defmodule Sanbase.Etherbi.Transactions.Store do
   end
 
   # Private functions
+
+  defp select_last_address_datetime(address, trx_type) do
+    ~s/SELECT LAST(address)
+    FROM "#{@last_address_measurement}"
+    WHERE address='#{address}'
+    AND transaction_type='#{trx_type}/
+  end
 
   defp transactions_from_to_query(measurement, from, to, "all") do
     ~s/SELECT volume, address
@@ -79,4 +119,26 @@ defmodule Sanbase.Etherbi.Transactions.Store do
   defp parse_transactions_time_series(_) do
     {:ok, []}
   end
+
+  defp parse_last_address_datetime(%{results: [%{error: error}]}) do
+    {:error, error}
+  end
+
+  defp parse_last_address_datetime(%{
+         results: [
+           %{
+             series: [
+               %{
+                 values: last_address
+               }
+             ]
+           }
+         ]
+       }) do
+    [[iso8601_datetime, _]] = last_address
+    {:ok, datetime, _} = DateTime.from_iso8601(iso8601_datetime)
+    {:ok, datetime}
+  end
+
+  defp parse_last_address_datetime(_), do: {:ok, nil}
 end

--- a/lib/sanbase/external_services/etherscan/store.ex
+++ b/lib/sanbase/external_services/etherscan/store.ex
@@ -82,7 +82,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
   # Private functions
 
   defp select_last_block_number(address) do
-    ~s/SELECT block_number from "sanbase-internal-last-blocks-measurement"
+    ~s/SELECT block_number from "#{@last_block_measurement}"
     WHERE address = '#{address}'/
   end
 

--- a/lib/sanbase/influxdb/store.ex
+++ b/lib/sanbase/influxdb/store.ex
@@ -36,7 +36,7 @@ defmodule Sanbase.Influxdb.Store do
         measurements
         |> Stream.map(&Measurement.convert_measurement_for_import/1)
         |> Stream.reject(&is_nil/1)
-        |> Stream.chunk_every(288)
+        |> Stream.chunk_every(2500)
         |> Stream.map(fn data_for_import ->
           :ok = __MODULE__.write(data_for_import)
         end)

--- a/test/sanbase/auth/user_test.exs
+++ b/test/sanbase/auth/user_test.exs
@@ -31,7 +31,13 @@ defmodule Sanbase.Auth.UserTest do
     changeset = User.update_san_balance_changeset(user)
 
     assert changeset.changes[:san_balance] == Decimal.new(5)
-    assert Timex.diff(Timex.now(), changeset.changes[:san_balance_updated_at], :seconds) == 0
+    #
+    assert Sanbase.TestUtils.date_close_to(
+             Timex.now(),
+             changeset.changes[:san_balance_updated_at],
+             2,
+             :seconds
+           )
   end
 
   test "san_balance! does not update the balance if the balance cache is not stale" do
@@ -60,7 +66,8 @@ defmodule Sanbase.Auth.UserTest do
     assert User.san_balance!(user) == Decimal.new(10)
 
     user = Repo.get(User, user.id)
-    assert Timex.diff(Timex.now(), user.san_balance_updated_at, :seconds) == 0
+
+    assert Sanbase.TestUtils.date_close_to(Timex.now(), user.san_balance_updated_at, 2, :seconds)
   end
 
   test "find_or_insert_by_email when the user does not exist" do
@@ -90,7 +97,13 @@ defmodule Sanbase.Auth.UserTest do
     {:ok, user} = User.update_email_token(user)
 
     assert user.email_token != nil
-    assert Timex.diff(Timex.now(), user.email_token_generated_at, :seconds) == 0
+
+    assert Sanbase.TestUtils.date_close_to(
+             Timex.now(),
+             user.email_token_generated_at,
+             2,
+             :seconds
+           )
   end
 
   test "mark_email_token_as_validated updates the email_token_validated_at" do
@@ -100,7 +113,12 @@ defmodule Sanbase.Auth.UserTest do
 
     {:ok, user} = User.mark_email_token_as_validated(user)
 
-    assert Timex.diff(Timex.now(), user.email_token_validated_at, :seconds) == 0
+    assert Sanbase.TestUtils.date_close_to(
+             Timex.now(),
+             user.email_token_validated_at,
+             2,
+             :seconds
+           )
   end
 
   test "email_token_valid? validates the token properly" do

--- a/test/sanbase_web/graphql/account_test.exs
+++ b/test/sanbase_web/graphql/account_test.exs
@@ -128,7 +128,14 @@ defmodule SanbaseWeb.Graphql.AccountTest do
 
     assert loginData["token"] != nil
     assert loginData["user"]["email"] == user.email
-    assert Timex.diff(Timex.now(), user.email_token_validated_at, :seconds) == 0
+
+    # Assert that now() and validated_at do not differ by more than 2 seconds
+    assert Sanbase.TestUtils.date_close_to(
+             Timex.now(),
+             user.email_token_validated_at,
+             2,
+             :seconds
+           )
   end
 
   test "trying to login with a valid email token after more than 1 day", %{conn: conn} do

--- a/test/sanbase_web/graphql/voting_test.exs
+++ b/test/sanbase_web/graphql/voting_test.exs
@@ -235,7 +235,9 @@ defmodule SanbaseWeb.Graphql.VotingTest do
     assert sanbasePost["totalSanVotes"] == "0.000000000000000000"
 
     createdAt = Timex.parse!(sanbasePost["createdAt"], "{ISO:Extended}")
-    assert Timex.diff(Timex.now(), createdAt, :seconds) == 0
+
+    # Assert that now() and createdAt do not differ by more than 2 seconds.
+    assert Sanbase.TestUtils.date_close_to(Timex.now(), createdAt, 2, :seconds)
   end
 
   test "adding a new post with a very long title", %{conn: conn} do

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -1,0 +1,29 @@
+defmodule Sanbase.TestUtils do
+  @doc ~s"""
+    Return `true` if the distance between the two numbers `a` and `b` is less than
+    or equal to `distance`. Return `false` otherwise.
+  """
+  @spec close_to(number(), number(), number()) :: boolean()
+  def close_to(a, b, distance) when is_number(a) and is_number(b) and is_number(distance) do
+    if abs(a - b) <= distance do
+      true
+    else
+      false
+    end
+  end
+
+  @doc ~s"""
+    Return `true` if two dates `a` and `b` are closer than `distance` measured in `granularity`.
+    Return `false` otherwise.
+  """
+  @spec date_close_to(%DateTime{}, %DateTime{}, number(), atom()) :: boolean()
+  def date_close_to(a, b, distance, granularity \\ :seconds) do
+    diff = abs(Timex.diff(a, b, granularity))
+
+    if diff <= distance do
+      true
+    else
+      false
+    end
+  end
+end


### PR DESCRIPTION
Note: The k8s job for clearing the transactions influxdb database must be executed.

Use a separate table for saving the last datetime we have data for `address_in` and `address_out`