### PR TITLE
Fetch all normal and internal transactions from etherscan

### DIFF
--- a/lib/sanbase/external_services/etherscan/requests/balance.ex
+++ b/lib/sanbase/external_services/etherscan/requests/balance.ex
@@ -6,20 +6,18 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.Balance do
 
   defstruct [:status, :message, :result]
 
-  defp get_query(address) do
-    [
-      module: "account",
-      action: "balance",
-      address: address,
-      tag: "latest"
-    ]
+  def get_balance!(address) do
+    case get_balance(address) do
+      {:ok, result} -> result
+      {:error, error} -> raise(error)
+    end
   end
 
-  def get(address) do
+  def get_balance(address) do
     Requests.get("/", query: get_query(address))
     |> case do
       %{status: 200, body: body} ->
-        Poison.Decode.decode(body, as: %Balance{})
+        {:ok, Poison.Decode.decode(body, as: %Balance{})}
 
       %{status: status, body: body} ->
         error = "Error fetching transactions for #{address}. Status code: #{status}: #{body}"
@@ -31,5 +29,16 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.Balance do
         Logger.warn(error)
         {:error, error}
     end
+  end
+
+  # Helper functions
+
+  defp get_query(address) do
+    [
+      module: "account",
+      action: "balance",
+      address: address,
+      tag: "latest"
+    ]
   end
 end

--- a/lib/sanbase/external_services/etherscan/requests/internal_tx.ex
+++ b/lib/sanbase/external_services/etherscan/requests/internal_tx.ex
@@ -2,40 +2,53 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.InternalTx do
   alias Sanbase.ExternalServices.Etherscan.Requests
   alias __MODULE__
 
+  require Logger
+
   defstruct [
     :blockNumber,
     :timeStamp,
-    :hash,
     :from,
     :to,
     :value,
-    :contractAddress,
-    :input,
-    :type,
-    :gas,
-    :gasUsed,
-    :traceId,
     :isError,
     :errCode
   ]
 
-  defp get_query(address) do
+  def get(address, startblock, endblock) do
+    Requests.get("/", query: get_query(address, startblock, endblock))
+    |> case do
+      %{status: 200, body: body} ->
+        {:ok, parse_tx_json(body)}
+
+      %{status: status, body: body} ->
+        error = "Error fetching transactions for #{address}. Status code: #{status}: #{body}"
+        Logger.warn(error)
+        {:error, error}
+    end
+  end
+
+  # Private functions
+
+  defp get_query(address, startblock, endblock) do
     [
       module: "account",
       action: "txlistinternal",
       address: address,
-      startblock: 0,
-      endblock: 99_999_999,
-      sort: "asc"
+      startblock: startblock,
+      endblock: endblock,
+      sort: "desc",
+      page: 1,
+      offset: 2500
     ]
   end
 
-  def get(address) do
-    Requests.get("/", query: get_query(address))
-    |> case do
-      %{status: 200, body: body} ->
-        response = Poison.Decode.decode(body, as: %{result: [%InternalTx{}]})
-        response.result
-    end
+  defp parse_tx_json(body) do
+    response = Poison.Decode.decode(body, as: %{"result" => [%InternalTx{}]})
+
+    response["result"]
+    |> Enum.map(fn tx ->
+      {ts, ""} = Integer.parse(tx.timeStamp)
+      %{tx | timeStamp: ts}
+    end)
   end
 end

--- a/lib/sanbase/external_services/etherscan/requests/internal_tx.ex
+++ b/lib/sanbase/external_services/etherscan/requests/internal_tx.ex
@@ -36,7 +36,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.InternalTx do
       address: address,
       startblock: startblock,
       endblock: endblock,
-      sort: "desc",
+      sort: "asc",
       page: 1,
       offset: 2500
     ]

--- a/lib/sanbase/external_services/etherscan/requests/tx.ex
+++ b/lib/sanbase/external_services/etherscan/requests/tx.ex
@@ -47,7 +47,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.Tx do
       address: address,
       startblock: startblock,
       endblock: endblock,
-      sort: "desc",
+      sort: "asc",
       page: 1,
       offset: 2500
     ]

--- a/lib/sanbase/external_services/etherscan/requests/tx.ex
+++ b/lib/sanbase/external_services/etherscan/requests/tx.ex
@@ -10,22 +10,11 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.Tx do
   defstruct [
     :blockNumber,
     :timeStamp,
-    :hash,
-    :nonce,
-    :blockHash,
-    :transactionIndex,
     :from,
     :to,
     :value,
-    :gas,
-    :gasPrice,
     :isError,
-    :txreceipt_status,
-    :input,
-    :contractAddress,
-    :cumulativeGasUsed,
-    :gasUsed,
-    :confirmations
+    :txreceipt_status
   ]
 
   @doc ~s"""
@@ -33,15 +22,8 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.Tx do
     `startblock` to `endblock` in ascending order.
     Returns `{:ok, list()}` on success, `{:error, String.t}` otherwise
   """
-  @spec get_all_transactions(String.t(), Integer.t(), Integer.t()) ::
-          {:ok, list()} | {:error, String.t()}
-  def get_all_transactions(address, startblock, endblock) do
-    String.downcase(address) |> get(startblock, endblock)
-  end
-
-  # Private functions
-
-  defp get(address, startblock, endblock) do
+  @spec get(String.t(), Integer.t(), Integer.t()) :: {:ok, list()} | {:error, String.t()}
+  def get(address, startblock, endblock) do
     Requests.get("/", query: get_query(address, startblock, endblock))
     |> case do
       %{status: 200, body: body} ->
@@ -65,7 +47,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.Tx do
       address: address,
       startblock: startblock,
       endblock: endblock,
-      sort: "asc",
+      sort: "desc",
       page: 1,
       offset: 2500
     ]

--- a/lib/sanbase/external_services/etherscan/worker.ex
+++ b/lib/sanbase/external_services/etherscan/worker.ex
@@ -114,7 +114,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
   defp latest_eth_wallet_changeset(last_trx, address) do
     changeset = %{
       update_time: DateTime.utc_now(),
-      balance: convert_to_eth(Balance.get(address).result)
+      balance: convert_to_eth(Balance.get_balance!(address).result)
     }
 
     case last_trx do

--- a/lib/sanbase/external_services/etherscan/worker.ex
+++ b/lib/sanbase/external_services/etherscan/worker.ex
@@ -74,13 +74,19 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
     {:noreply, state}
   end
 
-  def fetch_and_store(%{address: address, ticker: ticker} = wallet, endblock) do
+  def fetch_and_store(%{address: address, ticker: ticker}, endblock) do
     address = address |> String.downcase()
 
-    transactions = fetch_transactions(address, ticker, endblock)
+    transactions =
+      fetch_transactions(address, ticker, endblock)
+      |> Enum.reverse()
+
     store_transactions(transactions, address, ticker)
 
-    internal_transactions = fetch_internal_transactions(address, ticker, endblock)
+    internal_transactions =
+      fetch_internal_transactions(address, ticker, endblock)
+      |> Enum.reverse()
+
     store_transactions(internal_transactions, address, ticker)
 
     process_last_out_transactions(address, transactions, internal_transactions)

--- a/test/sanbase/external_services/etherscan/fetch_transactions_test.exs
+++ b/test/sanbase/external_services/etherscan/fetch_transactions_test.exs
@@ -1,0 +1,167 @@
+defmodule Sanbase.ExternalServices.Etherscan.FetchTransactions do
+  use SanbaseWeb.ConnCase
+
+  import Mockery
+
+  alias Sanbase.ExternalServices.Etherscan.{Worker, Store}
+  alias Sanbase.ExternalServices.Etherscan.Requests.{Tx, InternalTx}
+  alias Sanbase.Model.{Project, ProjectEthAddress}
+  alias Sanbase.Repo
+
+  setup do
+    Store.create_db()
+
+    ticker = "SAN"
+    address = "0x123245678910"
+    cmc_id = "santiment"
+
+    p =
+      %Project{}
+      |> Project.changeset(%{
+        name: "Santiment",
+        ticker: ticker,
+        token_decimals: 18,
+        coinmarketcap_id: cmc_id
+      })
+      |> Repo.insert!()
+
+    %ProjectEthAddress{}
+    |> ProjectEthAddress.changeset(%{project_id: p.id, address: address})
+    |> Repo.insert!()
+
+    [
+      ticker: ticker,
+      address: address,
+      cmc_id: cmc_id
+    ]
+  end
+
+  test "fetch internal transactions", context do
+    mock(
+      Sanbase.ExternalServices.Etherscan.Requests.Tx,
+      :get,
+      {:ok,
+       [
+         %Tx{
+           blockNumber: "4470352",
+           from: "0x123245678910",
+           isError: "0",
+           timeStamp: 1_509_541_164,
+           to: "0xd1ea8853619aaad66f3f6c14ca22430ce6954476",
+           txreceipt_status: "1",
+           value: "0"
+         },
+         %Tx{
+           blockNumber: "4463670",
+           from: "0x123245678910",
+           isError: "0",
+           timeStamp: 1_509_448_322,
+           to: "0xd1ea8853619aaad66f3f6c14ca22430ce6954476",
+           txreceipt_status: "1",
+           value: "1000000000000000000"
+         },
+         %Tx{
+           blockNumber: "4463588",
+           from: "0x8e473843fd546bf203f8b96cce310bb8740a4cec",
+           isError: "0",
+           timeStamp: 1_509_447_419,
+           to: "0x123245678910",
+           txreceipt_status: "1",
+           value: "680000000000000000"
+         }
+       ]}
+    )
+
+    mock(
+      Sanbase.ExternalServices.Etherscan.Requests.InternalTx,
+      :get,
+      {:ok,
+       [
+         %InternalTx{
+           blockNumber: "4557084",
+           errCode: "",
+           from: "0x123245678910",
+           isError: "0",
+           timeStamp: 1_510_746_716,
+           to: "0x949342479c00fccd65fee93a6b5a4fbd9b4abcea",
+           value: "4000000000000000000000"
+         },
+         %InternalTx{
+           blockNumber: "4379313",
+           errCode: "",
+           from: "0x7da82c7ab4771ff031b66538d2fb9b0b047f6cf9",
+           isError: "0",
+           timeStamp: 1_508_276_361,
+           to: "0x123245678910",
+           value: "3000000000000000000000"
+         },
+         %Sanbase.ExternalServices.Etherscan.Requests.InternalTx{
+           blockNumber: "4173006",
+           errCode: "",
+           from: "0x7da82c7ab4771ff031b66538d2fb9b0b047f6cf9",
+           isError: "0",
+           timeStamp: 1_503_053_188,
+           to: "0x123245678910",
+           value: "10000000000000000000000"
+         }
+       ]}
+    )
+
+    Tesla.Mock.mock(fn %{method: :get} ->
+      %Tesla.Env{
+        __client__: nil,
+        __module__: Sanbase.ExternalServices.Etherscan.Requests,
+        body: %{
+          "message" => "OK",
+          "result" => "198474700000000000000000",
+          "status" => "1"
+        },
+        headers: %{
+          "access-control-allow-headers" => "Content-Type",
+          "access-control-allow-methods" => "GET, POST, OPTIONS",
+          "access-control-allow-origin" => "*",
+          "cache-control" => "private",
+          "content-length" => "65",
+          "content-type" => "application/json; charset=utf-8",
+          "date" => "Wed, 14 Feb 2018 14:28:40 GMT",
+          "server" => "Microsoft-IIS/10.0",
+          "x-frame-options" => "SAMEORIGIN"
+        },
+        method: :get,
+        opts: [],
+        query: [
+          module: "account",
+          action: "balance",
+          address: "0x123245678910",
+          tag: "latest",
+          apikey: nil
+        ],
+        status: 200,
+        url: "https://api.etherscan.io/api/"
+      }
+    end)
+
+    endblock = 999_999_999
+
+    Worker.fetch_and_store(
+      %{address: context.address, coinmarketcap_id: context.cmc_id},
+      endblock
+    )
+
+    assert {:ok, 113_000.68} =
+             Store.trx_sum_in_interval(
+               context.cmc_id,
+               DateTime.from_unix!(0),
+               DateTime.utc_now(),
+               "in"
+             )
+
+    assert {:ok, 24001} =
+             Store.trx_sum_in_interval(
+               context.cmc_id,
+               DateTime.from_unix!(0),
+               DateTime.utc_now(),
+               "out"
+             )
+  end
+end

--- a/test/sanbase/external_services/etherscan/fetch_transactions_test.exs
+++ b/test/sanbase/external_services/etherscan/fetch_transactions_test.exs
@@ -37,7 +37,7 @@ defmodule Sanbase.ExternalServices.Etherscan.FetchTransactions do
     ]
   end
 
-  test "fetch internal transactions", context do
+  test "fetch transactions", context do
     mock(
       Sanbase.ExternalServices.Etherscan.Requests.Tx,
       :get,


### PR DESCRIPTION
Rework the etherscan worker. Now fetch all transactions and save them in time series db

Note: Revisit the code once the new overview page is deployed and remove all stuff related to `LatestEthWalletData`