### PR TITLE
Handle missing twitter links and bad GH activity data

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project_resolver.ex
@@ -293,8 +293,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
     async(fn ->
       month_ago = Timex.shift(Timex.now(), days: -30)
 
-      case Github.Store.fetch_total_activity!(ticker, month_ago, Timex.now()) do
-        {_dt, total_activity} ->
+      case Github.Store.fetch_total_activity(ticker, month_ago, Timex.now()) do
+        {:ok, {_dt, total_activity}} ->
           {:ok, total_activity / 30}
 
         _ ->

--- a/lib/sanbase_web/graphql/resolvers/twitter_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/twitter_resolver.ex
@@ -64,6 +64,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.TwitterResolver do
 
   defp extract_twitter_name(_), do: {:error, "Can't parse twitter link"}
 
+  defp get_twitter_link(nil), do: nil
+
   defp get_twitter_link(ticker) do
     query =
       from(


### PR DESCRIPTION
We should not be using bang methods in the GQL resolvers. All the errors
should be handled properly.

Also fixed a missing pattern match for the twitter data.