### PR TITLE
Price API and collection improvements and fixes

### DIFF
--- a/lib/sanbase/influxdb/store.ex
+++ b/lib/sanbase/influxdb/store.ex
@@ -26,7 +26,7 @@ defmodule Sanbase.Influxdb.Store do
           |> __MODULE__.write()
       end
 
-      def import(measurements) when is_list(measurements) do
+      def import(measurements) do
         # 1 day of 5 min resolution data
         measurements
         |> Stream.map(&Measurement.convert_measurement_for_import/1)
@@ -36,11 +36,6 @@ defmodule Sanbase.Influxdb.Store do
           :ok = __MODULE__.write(data_for_import)
         end)
         |> Stream.run()
-      end
-
-      def import(arg) do
-        Logger.warn("Trying to import not valid data in Influxdb: #{inspect(arg)}")
-        :ok
       end
 
       def delete_by_tag(measurement, tag_key, tag_value) do

--- a/lib/sanbase/notifications/check_prices.ex
+++ b/lib/sanbase/notifications/check_prices.ex
@@ -41,7 +41,7 @@ defmodule Sanbase.Notifications.CheckPrices do
   defp fetch_price_points(project, counter_currency) do
     ticker = price_ticker(project, counter_currency)
 
-    Store.fetch_price_points(ticker, seconds_ago(@check_interval_in_sec), DateTime.utc_now())
+    Store.fetch_price_points!(ticker, seconds_ago(@check_interval_in_sec), DateTime.utc_now())
   end
 
   def send_notification({notification, price_difference, project}, counter_currency) do

--- a/lib/sanbase_web/controllers/daily_prices_controller.ex
+++ b/lib/sanbase_web/controllers/daily_prices_controller.ex
@@ -19,7 +19,7 @@ defmodule SanbaseWeb.DailyPricesController do
         acc
         |> Map.put(
           pair,
-          Store.fetch_prices_with_resolution(
+          Store.fetch_prices_with_resolution!(
             pair,
             seconds_ago(@days_limit),
             DateTime.utc_now(),

--- a/lib/sanbase_web/graphql/price_store.ex
+++ b/lib/sanbase_web/graphql/price_store.ex
@@ -11,6 +11,10 @@ defmodule SanbaseWeb.Graphql.PriceStore do
     Decimal.new(price)
   end
 
+  def fetch_price(pair, %{from: from, to: to, interval: interval}) do
+    Prices.Store.fetch_prices_with_resolution(pair, from, to, interval)
+  end
+
   def query(pair, ids) when is_list(ids) do
     ids
     |> Enum.uniq()

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -88,26 +88,6 @@ defmodule SanbaseWeb.Graphql.Schema do
       resolve(&PriceResolver.history_price/3)
     end
 
-    @desc "Current price for a ticker"
-    field :price, :price_point do
-      arg(:ticker, non_null(:string))
-
-      resolve(&PriceResolver.current_price/3)
-    end
-
-    @desc "Current price for a list of tickers"
-    field :prices, list_of(:price_point) do
-      arg(:tickers, non_null(list_of(:string)))
-
-      complexity(&PriceComplexity.current_prices/3)
-      resolve(&PriceResolver.current_prices/3)
-    end
-
-    @desc "Returns a list of available tickers"
-    field :available_prices, list_of(:string) do
-      resolve(&PriceResolver.available_prices/3)
-    end
-
     @desc "Returns a list of available github repositories"
     field :github_availables_repos, list_of(:string) do
       resolve(&GithubResolver.available_repos/3)

--- a/test/sanbase_web/graphql/prices_api_test.exs
+++ b/test/sanbase_web/graphql/prices_api_test.exs
@@ -86,24 +86,6 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
     assert json_response(result, 200)["data"]["historyPrice"] == []
   end
 
-  test "fetch current price for a ticker", context do
-    query = """
-    {
-      price(ticker: "TEST") {
-        priceUsd
-        priceBtc
-      }
-    }
-    """
-
-    result =
-      context.conn
-      |> post("/graphql", query_skeleton(query, "price"))
-
-    assert json_response(result, 200)["data"]["price"]["priceUsd"] == "22"
-    assert json_response(result, 200)["data"]["price"]["priceBtc"] == "1200"
-  end
-
   test "data aggregation for larger intervals", context do
     query = """
     {
@@ -189,45 +171,6 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
       |> post("/graphql", query_skeleton(query, "historyPrice"))
 
     assert json_response(result, 200)["data"] != nil
-  end
-
-  test "fetch all available prices", context do
-    query = """
-    {
-      availablePrices
-    }
-    """
-
-    result =
-      context.conn
-      |> post("/graphql", query_skeleton(query, "availablePrices"))
-
-    resp_data = json_response(result, 200)["data"]["availablePrices"]
-    assert Enum.count(resp_data) == 2
-    assert "TEST" in resp_data
-    assert "XYZ" in resp_data
-  end
-
-  test "fetch price for a list of tickers", context do
-    query = """
-    {
-      prices(tickers: ["TEST", "XYZ"]){
-        ticker
-        priceUsd
-        priceBtc
-      }
-    }
-    """
-
-    result =
-      context.conn
-      |> put_req_header("authorization", "Basic " <> basic_auth())
-      |> post("/graphql", query_skeleton(query, "prices"))
-
-    resp_data = json_response(result, 200)["data"]["prices"]
-
-    assert %{"priceBtc" => "1200", "priceUsd" => "22", "ticker" => "TEST"} in resp_data
-    assert %{"priceBtc" => "1", "priceUsd" => "20", "ticker" => "XYZ"} in resp_data
   end
 
   defp basic_auth() do


### PR DESCRIPTION
Use Dataloader to efficiently get the historical prices from influxDB.

Use success/error tuples in the GQL api, so that we don't have any
exceptions happening while a GQL query is resolved.

Removed some price queries which are not used.

Also fixed a regression in the price collection. The price import have
stopped working after a guard clause was introduced.