### PR TITLE
Fix the pattern matching of the mean volume influx query

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project_resolver.ex
@@ -306,8 +306,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
       yesterday = Timex.shift(Timex.now(), days: -1)
       the_other_day = Timex.shift(Timex.now(), days: -2)
 
-      with [[_dt, today_vol]] <- Prices.Store.fetch_mean_volume(pair, yesterday, Timex.now()),
-           [[_dt, yesterday_vol]] <-
+      with {:ok, [[_dt, today_vol]]} <-
+             Prices.Store.fetch_mean_volume(pair, yesterday, Timex.now()),
+           {:ok, [[_dt, yesterday_vol]]} <-
              Prices.Store.fetch_mean_volume(pair, the_other_day, yesterday),
            true <- yesterday_vol > 0 do
         {:ok, (today_vol - yesterday_vol) * 100 / yesterday_vol}


### PR DESCRIPTION
The influx methods started returning {:ok, result}/{:error, error}
results