### PR TITLE
Price-volume diff notification - increase threshold

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -172,6 +172,7 @@ config :sanbase, Sanbase.Notifications.CheckPrices,
 
 config :sanbase, Sanbase.Notifications.PriceVolumeDiff,
   webhook_url: {:system, "PRICE_VOLUME_DIFF_WEBHOOK_URL"},
+  notification_threshold: {:system, "PRICE_VOLUME_DIFF_NOTIFICATION_THRESHOLD"},
   notifications_enabled: {:system, "PRICE_VOLUME_DIFF_NOTIFICATIONS_ENABLED", false}
 
 config :sanbase, SanbaseWeb.Guardian,

--- a/config/config.exs
+++ b/config/config.exs
@@ -172,7 +172,8 @@ config :sanbase, Sanbase.Notifications.CheckPrices,
 
 config :sanbase, Sanbase.Notifications.PriceVolumeDiff,
   webhook_url: {:system, "PRICE_VOLUME_DIFF_WEBHOOK_URL"},
-  notification_threshold: {:system, "PRICE_VOLUME_DIFF_NOTIFICATION_THRESHOLD"},
+  notification_threshold: {:system, "PRICE_VOLUME_DIFF_NOTIFICATION_THRESHOLD", "0.1"},
+  notifications_cooldown: {:system, "PRICE_VOLUME_DIFF_NOTIFICATIONS_COOLDOWN", "86400"},
   notifications_enabled: {:system, "PRICE_VOLUME_DIFF_NOTIFICATIONS_ENABLED", false}
 
 config :sanbase, SanbaseWeb.Guardian,

--- a/config/config.exs
+++ b/config/config.exs
@@ -174,6 +174,7 @@ config :sanbase, Sanbase.Notifications.PriceVolumeDiff,
   webhook_url: {:system, "PRICE_VOLUME_DIFF_WEBHOOK_URL"},
   notification_threshold: {:system, "PRICE_VOLUME_DIFF_NOTIFICATION_THRESHOLD", "0.1"},
   notifications_cooldown: {:system, "PRICE_VOLUME_DIFF_NOTIFICATIONS_COOLDOWN", "86400"},
+  debug_url: {:system, "PRICE_VOLUME_DIFF_DEBUG_URL"},
   notifications_enabled: {:system, "PRICE_VOLUME_DIFF_NOTIFICATIONS_ENABLED", false}
 
 config :sanbase, SanbaseWeb.Guardian,

--- a/config/test.exs
+++ b/config/test.exs
@@ -42,6 +42,7 @@ config :sanbase, Sanbase.Notifications.CheckPrices,
 
 config :sanbase, Sanbase.Notifications.PriceVolumeDiff,
   webhook_url: "http://example.com/webhook_url",
+  notification_threshold: "0.1",
   notifications_enabled: true
 
 config :sanbase, Sanbase.Github.Store, database: "github_activity_test"

--- a/config/test.exs
+++ b/config/test.exs
@@ -42,7 +42,6 @@ config :sanbase, Sanbase.Notifications.CheckPrices,
 
 config :sanbase, Sanbase.Notifications.PriceVolumeDiff,
   webhook_url: "http://example.com/webhook_url",
-  notification_threshold: "0.1",
   notifications_enabled: true
 
 config :sanbase, Sanbase.Github.Store, database: "github_activity_test"

--- a/lib/sanbase/notifications/price_volume_diff.ex
+++ b/lib/sanbase/notifications/price_volume_diff.ex
@@ -16,7 +16,7 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
 
   @approximation_window 14
   @comparison_window 7
-  @price_volume_diff_threshold 0.1
+  @price_volume_diff_threshold 0.2
 
   def exec(project, currency) do
     currency = String.upcase(currency)
@@ -107,7 +107,7 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
       content:
         "#{name}: #{ticker}/#{String.upcase(currency)} #{notification_emoji(price_change)} Price #{
           notification_emoji(volume_change)
-        } Volume. https://coinmarketcap.com/currencies/#{coinmarketcap_id}",
+        } Volume opposite trends. https://coinmarketcap.com/currencies/#{coinmarketcap_id}",
       username: "Price-Volume Difference"
     })
   end

--- a/lib/sanbase/notifications/price_volume_diff.ex
+++ b/lib/sanbase/notifications/price_volume_diff.ex
@@ -16,12 +16,11 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
 
   @approximation_window 14
   @comparison_window 7
-  @price_volume_diff_threshold 0.2
 
   def exec(project, currency) do
     currency = String.upcase(currency)
 
-    if notifications_enabled?() &&
+    if notifications_enabled?() && notification_threshold() &&
          not Utils.recent_notification?(
            project,
            seconds_ago(@cooldown_period_in_sec),
@@ -73,7 +72,7 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
   end
 
   defp check_notification(%{price_volume_diff: price_volume_diff}) do
-    Decimal.cmp(price_volume_diff, Decimal.new(@price_volume_diff_threshold))
+    Decimal.cmp(price_volume_diff, notification_threshold())
     |> case do
       :lt -> false
       _ -> true
@@ -126,6 +125,14 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
 
   defp webhook_url() do
     Config.get(:webhook_url)
+  end
+
+  defp notification_threshold() do
+    Config.get(:notification_threshold)
+    |> case do
+      nil -> nil
+      threshold -> Decimal.new(threshold)
+    end
   end
 
   defp notifications_enabled?() do

--- a/lib/sanbase/notifications/price_volume_diff.ex
+++ b/lib/sanbase/notifications/price_volume_diff.ex
@@ -24,10 +24,10 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
            seconds_ago(notifications_cooldown()),
            notification_type_name(currency)
          ) do
-      indicator = get_indicator(project.ticker, currency)
+      {indicator, debug_info} = get_indicator(project.ticker, currency)
 
       if check_notification(indicator) do
-        send_notification(project, currency, indicator)
+        send_notification(project, currency, indicator, debug_info)
       end
     end
   end
@@ -35,38 +35,52 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
   defp get_indicator(ticker, currency) do
     %{from_datetime: from_datetime, to_datetime: to_datetime} = get_calculation_interval()
 
-    TechIndicators.price_volume_diff_ma(
-      ticker,
-      currency,
-      from_datetime,
-      to_datetime,
-      "1d",
-      @approximation_window,
-      @comparison_window,
-      1
-    )
-    |> case do
-      {:ok,
-       [
-         %{
-           price_volume_diff: price_volume_diff,
-           price_change: price_change,
-           volume_change: volume_change
-         }
-       ]} ->
-        %{
-          price_volume_diff: nil_to_zero(price_volume_diff),
-          price_change: nil_to_zero(price_change),
-          volume_change: nil_to_zero(volume_change)
-        }
+    indicator =
+      TechIndicators.price_volume_diff_ma(
+        ticker,
+        currency,
+        from_datetime,
+        to_datetime,
+        "1d",
+        @approximation_window,
+        @comparison_window,
+        1
+      )
+      |> case do
+        {:ok,
+         [
+           %{
+             price_volume_diff: price_volume_diff,
+             price_change: price_change,
+             volume_change: volume_change
+           }
+         ]} ->
+          %{
+            price_volume_diff: nil_to_zero(price_volume_diff),
+            price_change: nil_to_zero(price_change),
+            volume_change: nil_to_zero(volume_change)
+          }
 
-      _ ->
-        %{
-          price_volume_diff: Decimal.new(0),
-          price_change: Decimal.new(0),
-          volume_change: Decimal.new(0)
-        }
-    end
+        _ ->
+          %{
+            price_volume_diff: Decimal.new(0),
+            price_change: Decimal.new(0),
+            volume_change: Decimal.new(0)
+          }
+      end
+
+    debug_info =
+      debug_info(
+        ticker,
+        currency,
+        from_datetime,
+        to_datetime,
+        "1d",
+        @approximation_window,
+        @comparison_window
+      )
+
+    {indicator, debug_info}
   end
 
   defp check_notification(%{price_volume_diff: price_volume_diff}) do
@@ -86,11 +100,15 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
     %{from_datetime: from_datetime, to_datetime: to_datetime}
   end
 
-  defp send_notification(project, currency, indicator) do
+  defp send_notification(project, currency, indicator, debug_info) do
     {:ok, %HTTPoison.Response{status_code: 204}} =
-      @http_service.post(webhook_url(), notification_payload(project, currency, indicator), [
-        {"Content-Type", "application/json"}
-      ])
+      @http_service.post(
+        webhook_url(),
+        notification_payload(project, currency, indicator, debug_info),
+        [
+          {"Content-Type", "application/json"}
+        ]
+      )
 
     Utils.insert_notification(project, notification_type_name(currency))
   end
@@ -98,13 +116,16 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
   defp notification_payload(
          %Project{name: name, ticker: ticker, coinmarketcap_id: coinmarketcap_id},
          currency,
-         %{price_change: price_change, volume_change: volume_change}
+         %{price_change: price_change, volume_change: volume_change},
+         debug_info
        ) do
     Poison.encode!(%{
       content:
         "#{name}: #{ticker}/#{String.upcase(currency)} #{notification_emoji(price_change)} Price #{
           notification_emoji(volume_change)
-        } Volume opposite trends. https://coinmarketcap.com/currencies/#{coinmarketcap_id}",
+        } Volume opposite trends. https://coinmarketcap.com/currencies/#{coinmarketcap_id} #{
+          debug_info
+        }",
       username: "Price-Volume Difference"
     })
   end
@@ -115,6 +136,34 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
       :lt -> ":small_red_triangle_down:"
       :gt -> ":small_red_triangle:"
       :eq -> " "
+    end
+  end
+
+  def debug_info(
+        ticker,
+        currency,
+        from_datetime,
+        to_datetime,
+        aggregate_interval,
+        approximation_window,
+        comparison_window
+      ) do
+    case debug_url() do
+      nil ->
+        nil
+
+      debug_url ->
+        from_unix = DateTime.to_unix(from_datetime)
+        to_unix = DateTime.to_unix(to_datetime)
+
+        debug_url =
+          "#{debug_url}?ticker=#{ticker}&currency=#{currency}&from_timestamp=#{from_unix}&to_timestamp=#{
+            to_unix
+          }&aggregate_interval=#{aggregate_interval}&approximation_window=#{approximation_window}&comparison_window=#{
+            comparison_window
+          }"
+
+        "[DEBUG INFO: #{debug_url}]"
     end
   end
 
@@ -136,6 +185,10 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
       |> Integer.parse()
 
     res
+  end
+
+  defp debug_url() do
+    Config.get(:debug_url)
   end
 
   defp notifications_enabled?() do


### PR DESCRIPTION
Hopefully this will decrease the spam on `#signals-stage`
Also added env var for the cooldown period

Also added debug info for stage: redirects to a jupyter notebook with the appropriate params

Threshold & debug url added to env vars: https://github.com/santiment/devops/pull/141