### PR TITLE
Make the FileStore.filename() function pure by removing the timestamp from it, otherwise FileStore.url() returns not correct url

### DIFF
--- a/lib/sanbase/file_store/store.ex
+++ b/lib/sanbase/file_store/store.ex
@@ -18,7 +18,6 @@ defmodule Sanbase.FileStore do
   """
   def filename(_version, {file, scope}) do
     file_name = Path.basename(file.file_name, Path.extname(file.file_name))
-    timestamp = DateTime.utc_now() |> DateTime.to_unix(:milliseconds)
-    "#{scope}_#{timestamp}_#{file_name}"
+    "#{scope}_#{file_name}"
   end
 end

--- a/lib/sanbase_web/graphql/resolvers/file_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/file_resolver.ex
@@ -14,9 +14,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.FileResolver do
     hash_algorithm = :sha256
 
     image_data =
-      for arg <- images, into: [] do
+      for %{filename: file_name} = arg <- images, into: [] do
+        arg = %{arg | filename: milliseconds_str() <> "_" <> file_name}
         content_hash = image_content_hash!(arg, hash_algorithm)
+
         {:ok, file_name} = FileStore.store({arg, content_hash})
+
         image_url = FileStore.url({file_name, content_hash})
 
         %{
@@ -51,5 +54,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.FileResolver do
       |> PostImage.changeset(Map.put(image, :post_id, nil))
       |> Sanbase.Repo.insert!()
     end)
+  end
+
+  defp milliseconds_str() do
+    DateTime.utc_now()
+    |> DateTime.to_unix(:milliseconds)
+    |> Integer.to_string()
   end
 end

--- a/test/sanbase_web/graphql/assets/image.png
+++ b/test/sanbase_web/graphql/assets/image.png
@@ -1,0 +1,4 @@
+Do not change the content of this file. It's hash is used in test
+
+not a real png image
+just for tests

--- a/test/sanbase_web/graphql/file_upload_test.exs
+++ b/test/sanbase_web/graphql/file_upload_test.exs
@@ -1,0 +1,59 @@
+defmodule SanbaseWeb.Graphql.FileUploadTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  alias Sanbase.Auth.User
+  alias Sanbase.Repo
+  alias Sanbase.InternalServices.Ethauth
+
+  import SanbaseWeb.Graphql.TestHelpers
+
+  setup do
+    user =
+      %User{
+        salt: User.generate_salt(),
+        san_balance:
+          Decimal.mult(Decimal.new("10.000000000000000000"), Ethauth.san_token_decimals()),
+        san_balance_updated_at: Timex.now()
+      }
+      |> Repo.insert!()
+
+    conn = setup_jwt_auth(build_conn(), user)
+
+    {:ok, conn: conn, user: user}
+  end
+
+  @test_file_path "#{System.cwd()}/test/sanbase_web/graphql/assets/image.png"
+
+  test "upload an image", %{conn: conn} do
+    mutation = """
+      mutation {
+        uploadImage(images: ["img"]){
+          fileName
+          contentHash,
+          imageUrl
+        }
+      }
+    """
+
+    upload = %Plug.Upload{
+      content_type: "application/octet-stream",
+      filename: "image.png",
+      path: @test_file_path
+    }
+
+    result =
+      conn
+      |> post("/graphql", %{"query" => mutation, "img" => upload})
+
+    [imageData] = json_response(result, 200)["data"]["uploadImage"]
+
+    test_file_content = File.read!(@test_file_path)
+    saved_file_content = File.read!(imageData["imageUrl"])
+
+    assert imageData["contentHash"] ==
+             "15e9f3c52e8c7f2444c5074f3db2049707d4c9ff927a00ddb8609bfae5925399"
+
+    assert imageData["fileName"] != nil
+    assert test_file_content == saved_file_content
+  end
+end


### PR DESCRIPTION
Make the `FileStore.filename` function pure. Subsequent calls to `store` and `url` return different results based on how quickly the code is executed.

Add a test for the image upload