### PR TITLE
Change arc uploaded files' acl to public-read

### DIFF
--- a/lib/sanbase/file_store/store.ex
+++ b/lib/sanbase/file_store/store.ex
@@ -2,6 +2,7 @@ defmodule Sanbase.FileStore do
   use Arc.Definition
 
   @versions [:original]
+  @acl :public_read
 
   @doc ~s"""
     Whitelist file extensions. Now allowing only images.


### PR DESCRIPTION
Uploads by default have `private` acl, so we are changing them to `public-read`

Reference: https://github.com/stavro/arc#access-control-permissions