### PR TITLE
Address compile time warnings

### DIFF
--- a/lib/sanbase/date_time_utils.ex
+++ b/lib/sanbase/date_time_utils.ex
@@ -48,10 +48,8 @@ defmodule Sanbase.DateTimeUtils do
   defp str_to_sec(days, "d"), do: days * 60 * 60 * 24
   defp str_to_sec(weeks, "w"), do: weeks * 60 * 60 * 24 * 7
 
-  def ecto_date_to_datetime(ecto_date) do
-    {:ok, datetime, _} =
-      (Ecto.Date.to_iso8601(ecto_date) <> "T00:00:00Z") |> DateTime.from_iso8601()
-
-    datetime
+  def datetime_from_date(%Date{} = date, time \\ ~T[00:00:00]) do
+    {:ok, naive_datetime} = NaiveDateTime.new(date, time)
+    datetime = DateTime.from_naive!(naive_datetime, "Etc/UTC")
   end
 end

--- a/lib/sanbase/external_services/coinmarketcap/ticker_fetcher.ex
+++ b/lib/sanbase/external_services/coinmarketcap/ticker_fetcher.ex
@@ -41,7 +41,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcher do
     |> Enum.each(&store_ticker/1)
 
     tickers
-    |> Enum.take(top_projects_to_follow)
+    |> Enum.take(top_projects_to_follow())
     |> Enum.each(&insert_or_create_project/1)
 
     Process.send_after(self(), {:"$gen_cast", :sync}, update_interval)

--- a/lib/sanbase/model/ico.ex
+++ b/lib/sanbase/model/ico.ex
@@ -80,11 +80,7 @@ defmodule Sanbase.Model.Ico do
   end
 
   defp funds_raised_ico_end_price_from_currencies(ico, target_ticker, date) do
-    erl_date = date |> Date.to_erl()
-
-    datetime =
-      NaiveDateTime.from_erl!({erl_date, {0, 0, 0}})
-      |> DateTime.from_naive!("Etc/UTC")
+    datetime = Sanbase.DateTimeUtils.datetime_from_date(date)
 
     Repo.preload(ico, ico_currencies: [:currency]).ico_currencies
     |> Enum.map(fn ic ->

--- a/lib/sanbase/model/ico.ex
+++ b/lib/sanbase/model/ico.ex
@@ -10,8 +10,8 @@ defmodule Sanbase.Model.Ico do
 
   schema "icos" do
     belongs_to(:project, Project)
-    field(:start_date, Ecto.Date)
-    field(:end_date, Ecto.Date)
+    field(:start_date, :date)
+    field(:end_date, :date)
     field(:token_usd_ico_price, :decimal)
     field(:token_eth_ico_price, :decimal)
     field(:token_btc_ico_price, :decimal)
@@ -80,11 +80,15 @@ defmodule Sanbase.Model.Ico do
   end
 
   defp funds_raised_ico_end_price_from_currencies(ico, target_ticker, date) do
-    timestamp = Sanbase.DateTimeUtils.ecto_date_to_datetime(date)
+    erl_date = date |> Date.to_erl()
+
+    datetime =
+      NaiveDateTime.from_erl!({erl_date, {0, 0, 0}})
+      |> DateTime.from_naive!("Etc/UTC")
 
     Repo.preload(ico, ico_currencies: [:currency]).ico_currencies
     |> Enum.map(fn ic ->
-      Sanbase.Prices.Utils.convert_amount(ic.amount, ic.currency.code, target_ticker, timestamp)
+      Sanbase.Prices.Utils.convert_amount(ic.amount, ic.currency.code, target_ticker, datetime)
     end)
     |> Enum.reject(&is_nil/1)
     |> case do

--- a/lib/sanbase/model/latest_btc_wallet_data.ex
+++ b/lib/sanbase/model/latest_btc_wallet_data.ex
@@ -6,7 +6,7 @@ defmodule Sanbase.Model.LatestBtcWalletData do
   schema "latest_btc_wallet_data" do
     field(:address, :string)
     field(:satoshi_balance, :decimal)
-    field(:update_time, Ecto.DateTime)
+    field(:update_time, :naive_datetime)
   end
 
   @doc false

--- a/lib/sanbase/model/latest_coinmarketcap_data.ex
+++ b/lib/sanbase/model/latest_coinmarketcap_data.ex
@@ -17,7 +17,7 @@ defmodule Sanbase.Model.LatestCoinmarketcapData do
     field(:percent_change_1h, :decimal)
     field(:percent_change_24h, :decimal)
     field(:percent_change_7d, :decimal)
-    field(:update_time, Ecto.DateTime)
+    field(:update_time, :naive_datetime)
   end
 
   @doc false

--- a/lib/sanbase/model/latest_eth_wallet_data.ex
+++ b/lib/sanbase/model/latest_eth_wallet_data.ex
@@ -6,11 +6,11 @@ defmodule Sanbase.Model.LatestEthWalletData do
   schema "latest_eth_wallet_data" do
     field(:address, :string)
     field(:balance, :decimal)
-    field(:last_incoming, Ecto.DateTime)
-    field(:last_outgoing, Ecto.DateTime)
+    field(:last_incoming, :naive_datetime)
+    field(:last_outgoing, :naive_datetime)
     field(:tx_in, :decimal)
     field(:tx_out, :decimal)
-    field(:update_time, Ecto.DateTime)
+    field(:update_time, :naive_datetime)
   end
 
   @doc false

--- a/lib/sanbase/model/project.ex
+++ b/lib/sanbase/model/project.ex
@@ -248,9 +248,15 @@ defmodule Sanbase.Model.Project do
   defp token_usd_ico_price(_price_from, _currency_from, nil, _current_datetime), do: nil
 
   defp token_usd_ico_price(price_from, currency_from, ico_start_date, current_datetime) do
-    with :gt <- Ecto.DateTime.compare(current_datetime, Ecto.DateTime.from_date(ico_start_date)),
-         timestamp <- Sanbase.DateTimeUtils.ecto_date_to_datetime(ico_start_date),
-         price <- Sanbase.Prices.Utils.fetch_last_price_before(currency_from, "USD", timestamp) do
+    erl_date = ico_start_date |> Date.to_erl()
+
+    ico_start_datetime =
+      NaiveDateTime.from_erl!({erl_date, {0, 0, 0}})
+      |> DateTime.from_naive!("Etc/UTC")
+
+    with :gt <- Date.compare(NaiveDateTime.to_date(current_datetime), ico_start_date),
+         price <-
+           Sanbase.Prices.Utils.fetch_last_price_before(currency_from, "USD", ico_start_datetime) do
       Decimal.mult(price_from, price)
     else
       _ -> nil

--- a/lib/sanbase/model/project.ex
+++ b/lib/sanbase/model/project.ex
@@ -248,11 +248,7 @@ defmodule Sanbase.Model.Project do
   defp token_usd_ico_price(_price_from, _currency_from, nil, _current_datetime), do: nil
 
   defp token_usd_ico_price(price_from, currency_from, ico_start_date, current_datetime) do
-    erl_date = ico_start_date |> Date.to_erl()
-
-    ico_start_datetime =
-      NaiveDateTime.from_erl!({erl_date, {0, 0, 0}})
-      |> DateTime.from_naive!("Etc/UTC")
+    ico_start_datetime = Sanbase.DateTimeUtils.datetime_from_date(ico_start_date)
 
     with :gt <- Date.compare(NaiveDateTime.to_date(current_datetime), ico_start_date),
          price <-

--- a/lib/sanbase_web/admin/model/ico.ex
+++ b/lib/sanbase_web/admin/model/ico.ex
@@ -174,13 +174,13 @@ defmodule Sanbase.ExAdmin.Model.Ico do
   defp set_cap_currency_default(%Ico{} = ico), do: ico
 
   defp set_start_date_default(%Ico{start_date: nil} = ico) do
-    Map.put(ico, :start_date, Ecto.Date.utc())
+    Map.put(ico, :start_date, Date.utc_today())
   end
 
   defp set_start_date_default(%Ico{} = ico), do: ico
 
   defp set_end_date_default(%Ico{end_date: nil} = ico) do
-    Map.put(ico, :end_date, Ecto.Date.utc())
+    Map.put(ico, :end_date, Date.utc_today())
   end
 
   defp set_end_date_default(%Ico{} = ico), do: ico

--- a/lib/sanbase_web/graphql/resolvers/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project_resolver.ex
@@ -54,20 +54,19 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
   end
 
   def project_by_slug(_parent, %{slug: slug}, _resolution) do
-    project =
-      Project
-      |> Repo.get_by(coinmarketcap_id: slug)
-      |> case do
-        nil ->
-          {:error, "Project with slug '#{slug}' not found."}
+    Project
+    |> Repo.get_by(coinmarketcap_id: slug)
+    |> case do
+      nil ->
+        {:error, "Project with slug '#{slug}' not found."}
 
-        project ->
-          project =
-            project
-            |> Repo.preload([:latest_coinmarketcap_data, icos: [ico_currencies: [:currency]]])
+      project ->
+        project =
+          project
+          |> Repo.preload([:latest_coinmarketcap_data, icos: [ico_currencies: [:currency]]])
 
-          {:ok, project}
-      end
+        {:ok, project}
+    end
   end
 
   def all_projects_with_eth_contract_info(_parent, _args, _resolution) do

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -16,7 +16,7 @@ defmodule SanbaseWeb.Graphql.Schema do
 
   alias SanbaseWeb.Graphql.Complexity.PriceComplexity
   alias SanbaseWeb.Graphql.Complexity.TechIndicatorsComplexity
-  alias SanbaseWeb.Graphql.Middlewares.{MultipleAuth, BasicAuth, JWTAuth, ProjectPermissions}
+  alias SanbaseWeb.Graphql.Middlewares.{BasicAuth, JWTAuth, ProjectPermissions}
   alias SanbaseWeb.Graphql.SanbaseRepo
   alias SanbaseWeb.Graphql.PriceStore
 

--- a/lib/sanbase_web/graphql/schema/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/project_types.ex
@@ -179,8 +179,8 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
 
   object :ico do
     field(:id, non_null(:id))
-    field(:start_date, :ecto_date)
-    field(:end_date, :ecto_date)
+    field(:start_date, :date)
+    field(:end_date, :date)
     field(:token_usd_ico_price, :decimal)
     field(:token_eth_ico_price, :decimal)
     field(:token_btc_ico_price, :decimal)
@@ -217,8 +217,8 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
 
   object :ico_with_eth_contract_info do
     field(:id, non_null(:id))
-    field(:start_date, :ecto_date)
-    field(:end_date, :ecto_date)
+    field(:start_date, :date)
+    field(:end_date, :date)
     field(:main_contract_address, :string)
     field(:contract_block_number, :integer)
     field(:contract_abi, :string)

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -10,10 +10,14 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
-alias Sanbase.Model.Project
-alias Sanbase.Model.ProjectEthAddress
-alias Sanbase.Model.ProjectBtcAddress
-alias Sanbase.Model.Infrastructure
+alias Sanbase.Model.{
+  Project,
+  ProjectEthAddress,
+  ProjectBtcAddress,
+  Infrastructure,
+  LatestEthWalletData
+}
+
 alias Sanbase.Repo
 alias Sanbase.Auth.{User, EthAccount}
 
@@ -299,3 +303,20 @@ defmodule InsertExchangeEthAddresses do
 end
 
 InsertExchangeEthAddresses.run()
+
+# Import some LatestEthWalletData
+%LatestEthWalletData{}
+|> LatestEthWalletData.changeset(%{
+  address: "0x123123123123123",
+  update_time: NaiveDateTime.utc_now(),
+  balance: 500
+})
+|> Repo.insert!()
+
+%LatestEthWalletData{}
+|> LatestEthWalletData.changeset(%{
+  address: "0x9876543210",
+  update_time: NaiveDateTime.utc_now(),
+  balance: 5000
+})
+|> Repo.insert!()

--- a/test/sanbase_web/graphql/project_api_funds_raised_test.exs
+++ b/test/sanbase_web/graphql/project_api_funds_raised_test.exs
@@ -25,11 +25,11 @@ defmodule SanbaseWeb.Graphql.ProjectApiFundsRaisedTest do
     Store.drop_measurement("BTC_USD")
     Store.drop_measurement("ETH_USD")
 
-    date1 = "2017-08-19"
-    date1_unix = 1_503_100_800_000_000_000
+    date1 = DateTime.from_naive!(~N[2017-08-19 00:00:00], "Etc/UTC")
+    date1_unix = DateTime.to_unix(date1, :nanoseconds)
 
-    date2 = "2017-10-17"
-    date2_unix = 1_508_198_400_000_000_000
+    date2 = DateTime.from_naive!(~N[2017-10-17 00:00:00], "Etc/UTC")
+    date2_unix = DateTime.to_unix(date2, :nanoseconds)
 
     Store.import([
       %Measurement{

--- a/test/sanbase_web/graphql/project_api_roi_test.exs
+++ b/test/sanbase_web/graphql/project_api_roi_test.exs
@@ -20,13 +20,14 @@ defmodule SanbaseWeb.Graphql.ProjectApiRoiTest do
     |> Instream.Admin.Database.create()
     |> Store.execute()
 
-    date1 = "2017-08-19"
-    date1_unix = 1_503_100_800_000_000_000
+    date1 = DateTime.from_naive!(~N[2017-08-19 00:00:00], "Etc/UTC")
 
-    date2 = "2017-10-17"
-    date2_unix = 1_508_198_400_000_000_000
+    date1_unix = DateTime.to_unix(date1, :nanoseconds)
 
-    now = Ecto.DateTime.utc()
+    date2 = DateTime.from_naive!(~N[2017-10-17 00:00:00], "Etc/UTC")
+    date2_unix = DateTime.to_unix(date2, :nanoseconds)
+
+    now = NaiveDateTime.utc_now()
 
     Store.import([
       %Measurement{

--- a/test/sanbase_web/graphql/project_api_test.exs
+++ b/test/sanbase_web/graphql/project_api_test.exs
@@ -32,7 +32,7 @@ defmodule Sanbase.Graphql.ProjectApiTest do
     %LatestEthWalletData{}
     |> LatestEthWalletData.changeset(%{
       address: "abcdefg",
-      update_time: Ecto.DateTime.utc(),
+      update_time: NaiveDateTime.utc_now(),
       balance: 500
     })
     |> Repo.insert!()
@@ -44,7 +44,7 @@ defmodule Sanbase.Graphql.ProjectApiTest do
     %LatestEthWalletData{}
     |> LatestEthWalletData.changeset(%{
       address: "rrrrr",
-      update_time: Ecto.DateTime.utc(),
+      update_time: NaiveDateTime.utc_now(),
       balance: 800
     })
     |> Repo.insert!()


### PR DESCRIPTION
Address some compile time warnings.

NOTE: This PR is **potentially dangerous**. Should be tested really well because of previous attempts to replace Ecto.Date and Ecto.DateTime led to timezone issues.