### PR TITLE
Use floats for the etherbi data

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
@@ -82,7 +82,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
         |> Enum.map(fn {datetime, volume, address} ->
           %{
             datetime: datetime,
-            transaction_volume: volume |> Decimal.new(),
+            transaction_volume: volume,
             address: address
           }
         end)

--- a/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
@@ -17,7 +17,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
         |> Enum.map(fn {datetime, burn_rate} ->
           %{
             datetime: datetime,
-            burn_rate: burn_rate |> Decimal.new()
+            burn_rate: burn_rate
           }
         end)
 
@@ -44,7 +44,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
         |> Enum.map(fn {datetime, trx_volume} ->
           %{
             datetime: datetime,
-            transaction_volume: trx_volume |> Decimal.new()
+            transaction_volume: trx_volume
           }
         end)
 

--- a/lib/sanbase_web/graphql/schema/etherbi_types.ex
+++ b/lib/sanbase_web/graphql/schema/etherbi_types.ex
@@ -3,11 +3,11 @@ defmodule SanbaseWeb.Graphql.EtherbiTypes do
 
   object :burn_rate_data do
     field(:datetime, non_null(:datetime))
-    field(:burn_rate, :decimal)
+    field(:burn_rate, :float)
   end
 
   object :transaction_volume do
     field(:datetime, non_null(:datetime))
-    field(:transaction_volume, :decimal)
+    field(:transaction_volume, :float)
   end
 end

--- a/lib/sanbase_web/graphql/schema/transaction_types.ex
+++ b/lib/sanbase_web/graphql/schema/transaction_types.ex
@@ -17,7 +17,7 @@ defmodule SanbaseWeb.Graphql.TransactionTypes do
 
   object :exchange_transaction do
     field(:datetime, non_null(:datetime))
-    field(:transaction_volume, :decimal)
+    field(:transaction_volume, :float)
     field(:address, :string)
   end
 end

--- a/test/sanbase_web/graphql/etherbi_burn_rate_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_burn_rate_api_test.exs
@@ -118,42 +118,42 @@ defmodule Sanbase.Etherbi.BurnRateApiTest do
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime1),
-             "burnRate" => 5000
+             "burnRate" => 5000.0
            } in burn_rates
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime2),
-             "burnRate" => 1000
+             "burnRate" => 1000.0
            } in burn_rates
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime3),
-             "burnRate" => 500
+             "burnRate" => 500.0
            } in burn_rates
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime4),
-             "burnRate" => 15000
+             "burnRate" => 15000.0
            } in burn_rates
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime5),
-             "burnRate" => 65000
+             "burnRate" => 65000.0
            } in burn_rates
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime6),
-             "burnRate" => 50
+             "burnRate" => 50.0
            } in burn_rates
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime7),
-             "burnRate" => 5
+             "burnRate" => 5.0
            } in burn_rates
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime8),
-             "burnRate" => 5000
+             "burnRate" => 5000.0
            } in burn_rates
   end
 
@@ -179,17 +179,17 @@ defmodule Sanbase.Etherbi.BurnRateApiTest do
 
     assert %{
              "datetime" => "2017-05-13T21:30:00Z",
-             "burnRate" => 6000
+             "burnRate" => 6000.0
            } in burn_rates
 
     assert %{
              "datetime" => "2017-05-13T22:00:00Z",
-             "burnRate" => 80500
+             "burnRate" => 80500.0
            } in burn_rates
 
     assert %{
              "datetime" => "2017-05-13T22:30:00Z",
-             "burnRate" => 5055
+             "burnRate" => 5055.0
            } in burn_rates
   end
 end

--- a/test/sanbase_web/graphql/etherbi_burn_rate_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_burn_rate_api_test.exs
@@ -118,42 +118,42 @@ defmodule Sanbase.Etherbi.BurnRateApiTest do
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime1),
-             "burnRate" => "5000"
+             "burnRate" => 5000
            } in burn_rates
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime2),
-             "burnRate" => "1000"
+             "burnRate" => 1000
            } in burn_rates
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime3),
-             "burnRate" => "500"
+             "burnRate" => 500
            } in burn_rates
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime4),
-             "burnRate" => "15000"
+             "burnRate" => 15000
            } in burn_rates
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime5),
-             "burnRate" => "65000"
+             "burnRate" => 65000
            } in burn_rates
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime6),
-             "burnRate" => "50"
+             "burnRate" => 50
            } in burn_rates
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime7),
-             "burnRate" => "5"
+             "burnRate" => 5
            } in burn_rates
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime8),
-             "burnRate" => "5000"
+             "burnRate" => 5000
            } in burn_rates
   end
 
@@ -179,17 +179,17 @@ defmodule Sanbase.Etherbi.BurnRateApiTest do
 
     assert %{
              "datetime" => "2017-05-13T21:30:00Z",
-             "burnRate" => "6000"
+             "burnRate" => 6000
            } in burn_rates
 
     assert %{
              "datetime" => "2017-05-13T22:00:00Z",
-             "burnRate" => "80500"
+             "burnRate" => 80500
            } in burn_rates
 
     assert %{
              "datetime" => "2017-05-13T22:30:00Z",
-             "burnRate" => "5055"
+             "burnRate" => 5055
            } in burn_rates
   end
 end

--- a/test/sanbase_web/graphql/etherbi_transactions_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_transactions_api_test.exs
@@ -134,31 +134,31 @@ defmodule Sanbase.Etherbi.TransactionsApiTest do
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime1),
              "address" => context.exchange_address,
-             "transactionVolume" => 5000
+             "transactionVolume" => 5000.0
            } in transactions_in
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime2),
              "address" => context.exchange_address,
-             "transactionVolume" => 6000
+             "transactionVolume" => 6000.0
            } in transactions_in
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime3),
              "address" => context.exchange_address,
-             "transactionVolume" => 9000
+             "transactionVolume" => 9000.0
            } in transactions_in
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime4),
              "address" => context.exchange_address,
-             "transactionVolume" => 15000
+             "transactionVolume" => 15000.0
            } in transactions_in
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime6),
              "address" => context.exchange_address,
-             "transactionVolume" => 1000
+             "transactionVolume" => 1000.0
            } in transactions_in
   end
 
@@ -186,25 +186,25 @@ defmodule Sanbase.Etherbi.TransactionsApiTest do
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime1),
              "address" => context.exchange_address,
-             "transactionVolume" => 3000
+             "transactionVolume" => 3000.0
            } in transactions_out
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime2),
              "address" => context.exchange_address,
-             "transactionVolume" => 4000
+             "transactionVolume" => 4000.0
            } in transactions_out
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime5),
              "address" => context.exchange_address,
-             "transactionVolume" => 18000
+             "transactionVolume" => 18000.0
            } in transactions_out
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime7),
              "address" => context.exchange_address,
-             "transactionVolume" => 10000
+             "transactionVolume" => 10000.0
            } in transactions_out
   end
 end

--- a/test/sanbase_web/graphql/etherbi_transactions_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_transactions_api_test.exs
@@ -36,61 +36,61 @@ defmodule Sanbase.Etherbi.TransactionsApiTest do
     Store.import([
       %Measurement{
         timestamp: datetime1 |> DateTime.to_unix(:nanoseconds),
-        fields: %{volume: "5000", ticker: ticker},
+        fields: %{volume: 5000, ticker: ticker},
         tags: [transaction_type: "in", address: exchange_address],
         name: contract_address
       },
       %Measurement{
         timestamp: datetime1 |> DateTime.to_unix(:nanoseconds),
-        fields: %{volume: "3000", ticker: ticker},
+        fields: %{volume: 3000, ticker: ticker},
         tags: [transaction_type: "out", address: exchange_address],
         name: contract_address
       },
       %Measurement{
         timestamp: datetime2 |> DateTime.to_unix(:nanoseconds),
-        fields: %{volume: "6000", ticker: ticker},
+        fields: %{volume: 6000, ticker: ticker},
         tags: [transaction_type: "in", address: exchange_address],
         name: contract_address
       },
       %Measurement{
         timestamp: datetime2 |> DateTime.to_unix(:nanoseconds),
-        fields: %{volume: "4000", ticker: ticker},
+        fields: %{volume: 4000, ticker: ticker},
         tags: [transaction_type: "out", address: exchange_address],
         name: contract_address
       },
       %Measurement{
         timestamp: datetime3 |> DateTime.to_unix(:nanoseconds),
-        fields: %{volume: "9000", ticker: ticker},
+        fields: %{volume: 9000, ticker: ticker},
         tags: [transaction_type: "in", address: exchange_address],
         name: contract_address
       },
       %Measurement{
         timestamp: datetime4 |> DateTime.to_unix(:nanoseconds),
-        fields: %{volume: "15000", ticker: ticker},
+        fields: %{volume: 15000, ticker: ticker},
         tags: [transaction_type: "in", address: exchange_address],
         name: contract_address
       },
       %Measurement{
         timestamp: datetime5 |> DateTime.to_unix(:nanoseconds),
-        fields: %{volume: "18000", ticker: ticker},
+        fields: %{volume: 18000, ticker: ticker},
         tags: [transaction_type: "out", address: exchange_address],
         name: contract_address
       },
       %Measurement{
         timestamp: datetime6 |> DateTime.to_unix(:nanoseconds),
-        fields: %{volume: "1000", ticker: ticker},
+        fields: %{volume: 1000, ticker: ticker},
         tags: [transaction_type: "in", address: exchange_address],
         name: contract_address
       },
       %Measurement{
         timestamp: datetime7 |> DateTime.to_unix(:nanoseconds),
-        fields: %{volume: "10000", ticker: ticker},
+        fields: %{volume: 10000, ticker: ticker},
         tags: [transaction_type: "out", address: exchange_address],
         name: contract_address
       },
       %Measurement{
         timestamp: datetime8 |> DateTime.to_unix(:nanoseconds),
-        fields: %{volume: "50000", ticker: ticker},
+        fields: %{volume: 50000, ticker: ticker},
         tags: [transaction_type: "in", address: exchange_address],
         name: contract_address
       }
@@ -134,31 +134,31 @@ defmodule Sanbase.Etherbi.TransactionsApiTest do
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime1),
              "address" => context.exchange_address,
-             "transactionVolume" => "5000"
+             "transactionVolume" => 5000
            } in transactions_in
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime2),
              "address" => context.exchange_address,
-             "transactionVolume" => "6000"
+             "transactionVolume" => 6000
            } in transactions_in
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime3),
              "address" => context.exchange_address,
-             "transactionVolume" => "9000"
+             "transactionVolume" => 9000
            } in transactions_in
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime4),
              "address" => context.exchange_address,
-             "transactionVolume" => "15000"
+             "transactionVolume" => 15000
            } in transactions_in
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime6),
              "address" => context.exchange_address,
-             "transactionVolume" => "1000"
+             "transactionVolume" => 1000
            } in transactions_in
   end
 
@@ -186,25 +186,25 @@ defmodule Sanbase.Etherbi.TransactionsApiTest do
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime1),
              "address" => context.exchange_address,
-             "transactionVolume" => "3000"
+             "transactionVolume" => 3000
            } in transactions_out
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime2),
              "address" => context.exchange_address,
-             "transactionVolume" => "4000"
+             "transactionVolume" => 4000
            } in transactions_out
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime5),
              "address" => context.exchange_address,
-             "transactionVolume" => "18000"
+             "transactionVolume" => 18000
            } in transactions_out
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime7),
              "address" => context.exchange_address,
-             "transactionVolume" => "10000"
+             "transactionVolume" => 10000
            } in transactions_out
   end
 end

--- a/test/sanbase_web/graphql/etherbi_trx_volume_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_trx_volume_api_test.exs
@@ -118,42 +118,42 @@ defmodule Sanbase.Etherbi.TransactionVolumeApiTest do
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime1),
-             "transactionVolume" => "1000"
+             "transactionVolume" => 1000
            } in trx_volumes
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime2),
-             "transactionVolume" => "555"
+             "transactionVolume" => 555
            } in trx_volumes
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime3),
-             "transactionVolume" => "123"
+             "transactionVolume" => 123
            } in trx_volumes
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime4),
-             "transactionVolume" => "6643"
+             "transactionVolume" => 6643
            } in trx_volumes
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime5),
-             "transactionVolume" => "64123"
+             "transactionVolume" => 64123
            } in trx_volumes
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime6),
-             "transactionVolume" => "1232"
+             "transactionVolume" => 1232
            } in trx_volumes
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime7),
-             "transactionVolume" => "555"
+             "transactionVolume" => 555
            } in trx_volumes
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime8),
-             "transactionVolume" => "12111"
+             "transactionVolume" => 12111
            } in trx_volumes
   end
 
@@ -179,27 +179,27 @@ defmodule Sanbase.Etherbi.TransactionVolumeApiTest do
 
     assert %{
              "datetime" => "2017-05-13T21:45:00Z",
-             "transactionVolume" => "1555"
+             "transactionVolume" => 1555
            } in trx_volumes
 
     assert %{
              "datetime" => "2017-05-13T22:00:00Z",
-             "transactionVolume" => "123"
+             "transactionVolume" => 123
            } in trx_volumes
 
     assert %{
              "datetime" => "2017-05-13T22:15:00Z",
-             "transactionVolume" => "70766"
+             "transactionVolume" => 70766
            } in trx_volumes
 
     assert %{
              "datetime" => "2017-05-13T22:30:00Z",
-             "transactionVolume" => "1232"
+             "transactionVolume" => 1232
            } in trx_volumes
 
     assert %{
              "datetime" => "2017-05-13T22:45:00Z",
-             "transactionVolume" => "12666"
+             "transactionVolume" => 12666
            } in trx_volumes
   end
 end

--- a/test/sanbase_web/graphql/etherbi_trx_volume_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_trx_volume_api_test.exs
@@ -118,42 +118,42 @@ defmodule Sanbase.Etherbi.TransactionVolumeApiTest do
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime1),
-             "transactionVolume" => 1000
+             "transactionVolume" => 1000.0
            } in trx_volumes
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime2),
-             "transactionVolume" => 555
+             "transactionVolume" => 555.0
            } in trx_volumes
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime3),
-             "transactionVolume" => 123
+             "transactionVolume" => 123.0
            } in trx_volumes
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime4),
-             "transactionVolume" => 6643
+             "transactionVolume" => 6643.0
            } in trx_volumes
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime5),
-             "transactionVolume" => 64123
+             "transactionVolume" => 64123.0
            } in trx_volumes
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime6),
-             "transactionVolume" => 1232
+             "transactionVolume" => 1232.0
            } in trx_volumes
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime7),
-             "transactionVolume" => 555
+             "transactionVolume" => 555.0
            } in trx_volumes
 
     assert %{
              "datetime" => DateTime.to_iso8601(context.datetime8),
-             "transactionVolume" => 12111
+             "transactionVolume" => 12111.0
            } in trx_volumes
   end
 
@@ -179,27 +179,27 @@ defmodule Sanbase.Etherbi.TransactionVolumeApiTest do
 
     assert %{
              "datetime" => "2017-05-13T21:45:00Z",
-             "transactionVolume" => 1555
+             "transactionVolume" => 1555.0
            } in trx_volumes
 
     assert %{
              "datetime" => "2017-05-13T22:00:00Z",
-             "transactionVolume" => 123
+             "transactionVolume" => 123.0
            } in trx_volumes
 
     assert %{
              "datetime" => "2017-05-13T22:15:00Z",
-             "transactionVolume" => 70766
+             "transactionVolume" => 70766.0
            } in trx_volumes
 
     assert %{
              "datetime" => "2017-05-13T22:30:00Z",
-             "transactionVolume" => 1232
+             "transactionVolume" => 1232.0
            } in trx_volumes
 
     assert %{
              "datetime" => "2017-05-13T22:45:00Z",
-             "transactionVolume" => 12666
+             "transactionVolume" => 12666.0
            } in trx_volumes
   end
 end


### PR DESCRIPTION
This makes the GQL serializer render the numbers properly and not use
scientific notation.