### PR TITLE
Add exchange wallets internal api

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
@@ -1,7 +1,7 @@
 defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
   alias Sanbase.Etherbi.{Transactions, BurnRate, TransactionVolume}
   alias Sanbase.Repo
-  alias Sanbase.Model.Project
+  alias Sanbase.Model.{Project, ExchangeEthAddress}
 
   import Ecto.Query
 

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -221,6 +221,13 @@ defmodule SanbaseWeb.Graphql.Schema do
       complexity(&TechIndicatorsComplexity.price_volume_diff/3)
       resolve(&TechIndicatorsResolver.price_volume_diff/3)
     end
+
+    @desc "Returns a list of all exchange wallets. Internal API."
+    field :exchange_wallets, list_of(:wallet) do
+      middleware(BasicAuth)
+
+      resolve(&EtherbiResolver.exchange_wallets/3)
+    end
   end
 
   mutation do

--- a/lib/sanbase_web/graphql/schema/etherbi_types.ex
+++ b/lib/sanbase_web/graphql/schema/etherbi_types.ex
@@ -10,4 +10,9 @@ defmodule SanbaseWeb.Graphql.EtherbiTypes do
     field(:datetime, non_null(:datetime))
     field(:transaction_volume, :decimal)
   end
+
+  object :wallet do
+    field(:name, non_null(:string))
+    field(:address, non_null(:string))
+  end
 end

--- a/test/sanbase_web/graphql/etherbi_exchange_wallets_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_exchange_wallets_api_test.exs
@@ -1,0 +1,77 @@
+defmodule Sanbase.Etherbi.ExchangeWalletsApiTest do
+  use SanbaseWeb.ConnCase
+  use Phoenix.ConnTest
+
+  alias Sanbase.Model.ExchangeEthAddress
+  alias Sanbase.Repo
+
+  import SanbaseWeb.Graphql.TestHelpers
+
+  setup do
+    [
+      conn: setup_basic_auth(build_conn(), "user", "pass")
+    ]
+  end
+
+  test "returning an error when there is no bacis auth" do
+    query = """
+    {
+      exchangeWallets{
+        address,
+        name
+      }
+    }
+    """
+
+    result =
+      build_conn()
+      |> post("/graphql", query_skeleton(query, "exchangeWallets"))
+
+    assert result.status_code == 403
+  end
+
+  test "returning an empty list of wallets if there are none in the DB", context do
+    query = """
+    {
+      exchangeWallets{
+        address,
+        name
+      }
+    }
+    """
+
+    result =
+      context.conn
+      |> post("/graphql", query_skeleton(query, "exchangeWallets"))
+
+    exchange_wallets = json_response(result, 200)["data"]["exchangeWallets"]
+
+    assert exchange_wallets == []
+  end
+
+  test "returning a list of wallets from the DB", context do
+    [
+      %ExchangeEthAddress{name: "Binance", address: "0x12345"},
+      %ExchangeEthAddress{name: "Kraken", address: "0x54321"}
+    ]
+    |> Repo.insert_all()
+
+    query = """
+    {
+      exchangeWallets{
+        address,
+        name
+      }
+    }
+    """
+
+    result =
+      context.conn
+      |> post("/graphql", query_skeleton(query, "exchangeWallets"))
+
+    exchange_wallets = json_response(result, 200)["data"]["exchangeWallets"]
+
+    assert %{name: "Binance", address: "0x12345"} in exchange_wallets
+    assert %{name: "Kraken", address: "0x54321"} in exchange_wallets
+  end
+end

--- a/test/support/graphql_test_helpers.ex
+++ b/test/support/graphql_test_helpers.ex
@@ -26,4 +26,12 @@ defmodule SanbaseWeb.Graphql.TestHelpers do
     |> put_req_header("authorization", "Bearer " <> token)
     |> ContextPlug.call(%{})
   end
+
+  def setup_basic_auth(conn, user, pass) do
+    token = Base.encode64(user <> ":" <> pass)
+
+    conn
+    |> put_req_header("authorization", "Basic " <> token)
+    |> ContextPlug.call(%{})
+  end
 end


### PR DESCRIPTION
Add a GQL api which returns all the exchange wallets we have on track.

This is going to be used by our big data crunching pipeline to generate the exchange flow of funds.