### PR TITLE
Price-volume diff - change indicator calculation

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -163,7 +163,7 @@ config :sanbase, Sanbase.Notifications.PriceVolumeDiff,
   window_type: {:system, "PRICE_VOLUME_DIFF_WINDOW_TYPE"},
   approximation_window: {:system, "PRICE_VOLUME_DIFF_APPROXIMATION_WINDOW", "14"},
   comparison_window: {:system, "PRICE_VOLUME_DIFF_COMPARISON_WINDOW", "7"},
-  notification_threshold: {:system, "PRICE_VOLUME_DIFF_NOTIFICATION_THRESHOLD", "0.1"},
+  notification_threshold: {:system, "PRICE_VOLUME_DIFF_NOTIFICATION_THRESHOLD", "0.01"},
   notifications_cooldown: {:system, "PRICE_VOLUME_DIFF_NOTIFICATIONS_COOLDOWN", "86400"},
   debug_url: {:system, "PRICE_VOLUME_DIFF_DEBUG_URL"},
   notifications_enabled: {:system, "PRICE_VOLUME_DIFF_NOTIFICATIONS_ENABLED", false}

--- a/lib/sanbase/external_services/coinmarketcap.ex
+++ b/lib/sanbase/external_services/coinmarketcap.ex
@@ -145,7 +145,6 @@ defmodule Sanbase.ExternalServices.Coinmarketcap do
     CheckPrices.exec(project, "btc")
 
     PriceVolumeDiff.exec(project, "usd")
-    PriceVolumeDiff.exec(project, "btc")
   end
 
   defp convert_to_measurement(%PricePoint{datetime: datetime} = point, suffix, name) do


### PR DESCRIPTION
Related to: https://github.com/santiment/tech_indicators/pull/10 (should be applied first)

Devops PR: https://github.com/santiment/devops/pull/152

Also left only the calculations for USD - we have volume in USD only