### PR TITLE
Fetch transaction hash from etherscan

### DIFF
--- a/lib/sanbase/external_services/etherscan/requests/internal_tx.ex
+++ b/lib/sanbase/external_services/etherscan/requests/internal_tx.ex
@@ -5,6 +5,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.InternalTx do
   require Logger
 
   defstruct [
+    :hash,
     :blockNumber,
     :timeStamp,
     :from,

--- a/lib/sanbase/external_services/etherscan/requests/tx.ex
+++ b/lib/sanbase/external_services/etherscan/requests/tx.ex
@@ -8,6 +8,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.Tx do
   require Logger
 
   defstruct [
+    :hash,
     :blockNumber,
     :timeStamp,
     :from,

--- a/lib/sanbase/external_services/etherscan/store.ex
+++ b/lib/sanbase/external_services/etherscan/store.ex
@@ -118,13 +118,13 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
   end
 
   defp select_transactions(measurement, from, to, "all") do
-    ~s/SELECT trx_value, transaction_type, from_addr, to_addr FROM "#{measurement}"
+    ~s/SELECT trx_hash, trx_value, transaction_type, from_addr, to_addr FROM "#{measurement}"
     WHERE time >= #{DateTime.to_unix(from, :nanoseconds)}
     AND time <= #{DateTime.to_unix(to, :nanoseconds)}/
   end
 
   defp select_transactions(measurement, from, to, transaction_type) do
-    ~s/SELECT trx_value, transaction_type, from_addr, to_addr FROM "#{measurement}"
+    ~s/SELECT trx_hash, trx_value, transaction_type, from_addr, to_addr FROM "#{measurement}"
     WHERE transaction_type='#{transaction_type}'
     AND time >= #{DateTime.to_unix(from, :nanoseconds)}
     AND time <= #{DateTime.to_unix(to, :nanoseconds)}/
@@ -190,9 +190,9 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
        }) do
     result =
       transactions
-      |> Enum.map(fn [iso8601_datetime, trx_volume, trx_type, from_addr, to_addr] ->
+      |> Enum.map(fn [iso8601_datetime, trx_hash, trx_value, trx_type, from_addr, to_addr] ->
         {:ok, datetime, _} = DateTime.from_iso8601(iso8601_datetime)
-        {datetime, trx_volume, trx_type, from_addr, to_addr}
+        {datetime, trx_hash, trx_value, trx_type, from_addr, to_addr}
       end)
 
     {:ok, result}

--- a/lib/sanbase/external_services/etherscan/worker.ex
+++ b/lib/sanbase/external_services/etherscan/worker.ex
@@ -239,6 +239,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
        ) do
     # Extract the fields from either %Tx{} or %InternalTx{}
     %{
+      hash: hash,
       timeStamp: ts,
       from: from,
       to: to,
@@ -259,6 +260,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
     %Sanbase.Influxdb.Measurement{
       timestamp: ts * 1_000_000_000,
       fields: %{
+        trx_hash: hash,
         trx_value: (value |> String.to_integer()) / @num_18_zeroes,
         block_number: bn |> String.to_integer(),
         from_addr: from,

--- a/lib/sanbase_web/graphql/resolvers/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project_resolver.ex
@@ -106,10 +106,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
            {:ok, eth_transactions} <- Etherscan.Store.transactions(ticker, from, to, trx_type) do
         result =
           eth_transactions
-          |> Enum.map(fn {datetime, trx_volume, trx_type, from_addr, to_addr} ->
+          |> Enum.map(fn {datetime, trx_hash, trx_value, trx_type, from_addr, to_addr} ->
             %{
               datetime: datetime,
-              transaction_volume: trx_volume |> Decimal.new(),
+              trx_hash: trx_hash,
+              trx_value: trx_value |> Decimal.new(),
               transaction_type: trx_type,
               from_address: from_addr,
               to_address: to_addr

--- a/lib/sanbase_web/graphql/schema/transaction_types.ex
+++ b/lib/sanbase_web/graphql/schema/transaction_types.ex
@@ -9,7 +9,8 @@ defmodule SanbaseWeb.Graphql.TransactionTypes do
 
   object :wallet_transaction do
     field(:datetime, non_null(:datetime))
-    field(:transaction_volume, :decimal)
+    field(:trx_hash, :string)
+    field(:trx_value, :decimal)
     field(:transaction_type, :string)
     field(:from_address, :string)
     field(:to_address, :string)

--- a/test/sanbase_web/graphql/project_api_wallet_transactions_test.exs
+++ b/test/sanbase_web/graphql/project_api_wallet_transactions_test.exs
@@ -95,7 +95,7 @@ defmodule SanbaseWeb.Graphql.ProjectApiWalletTransactionsTest do
           to: "#{context.datetime_to}",
           transaction_type: IN){
             datetime,
-            transaction_volume,
+            trxValue,
             fromAddress,
             toAddress
         }
@@ -113,14 +113,14 @@ defmodule SanbaseWeb.Graphql.ProjectApiWalletTransactionsTest do
              "datetime" => "2017-05-16T18:00:00Z",
              "fromAddress" => "0x2",
              "toAddress" => "0x1",
-             "transaction_volume" => "100000"
+             "trxValue" => "100000"
            } in trx_in
 
     assert %{
              "datetime" => "2017-05-17T19:00:00Z",
              "fromAddress" => "0x2",
              "toAddress" => "0x1",
-             "transaction_volume" => "45000"
+             "trxValue" => "45000"
            } in trx_in
   end
 
@@ -133,7 +133,7 @@ defmodule SanbaseWeb.Graphql.ProjectApiWalletTransactionsTest do
           to: "#{context.datetime_to}",
           transaction_type: OUT){
             datetime,
-            transaction_volume,
+            trxValue,
             fromAddress,
             toAddress
         }
@@ -151,42 +151,42 @@ defmodule SanbaseWeb.Graphql.ProjectApiWalletTransactionsTest do
              "datetime" => "2017-05-13T15:00:00Z",
              "fromAddress" => "0x1",
              "toAddress" => "0x2",
-             "transaction_volume" => "500"
+             "trxValue" => "500"
            } in trx_out
 
     assert %{
              "datetime" => "2017-05-14T16:00:00Z",
              "fromAddress" => "0x1",
              "toAddress" => "0x2",
-             "transaction_volume" => "1500"
+             "trxValue" => "1500"
            } in trx_out
 
     assert %{
              "datetime" => "2017-05-15T17:00:00Z",
              "fromAddress" => "0x1",
              "toAddress" => "0x2",
-             "transaction_volume" => "2500"
+             "trxValue" => "2500"
            } in trx_out
 
     assert %{
              "datetime" => "2017-05-16T18:00:00Z",
              "fromAddress" => "0x1",
              "toAddress" => "0x2",
-             "transaction_volume" => "3500"
+             "trxValue" => "3500"
            } in trx_out
 
     assert %{
              "datetime" => "2017-05-17T19:00:00Z",
              "fromAddress" => "0x1",
              "toAddress" => "0x2",
-             "transaction_volume" => "5500"
+             "trxValue" => "5500"
            } in trx_out
 
     assert %{
              "datetime" => "2017-05-18T20:00:00Z",
              "fromAddress" => "0x1",
              "toAddress" => "0x2",
-             "transaction_volume" => "6500"
+             "trxValue" => "6500"
            } in trx_out
   end
 
@@ -199,7 +199,7 @@ defmodule SanbaseWeb.Graphql.ProjectApiWalletTransactionsTest do
           to: "#{context.datetime_to}",
           transaction_type: ALL){
             datetime,
-            transaction_volume,
+            trxValue,
             fromAddress,
             toAddress
         }
@@ -217,56 +217,56 @@ defmodule SanbaseWeb.Graphql.ProjectApiWalletTransactionsTest do
              "datetime" => "2017-05-13T15:00:00Z",
              "fromAddress" => "0x1",
              "toAddress" => "0x2",
-             "transaction_volume" => "500"
+             "trxValue" => "500"
            } in trx_all
 
     assert %{
              "datetime" => "2017-05-14T16:00:00Z",
              "fromAddress" => "0x1",
              "toAddress" => "0x2",
-             "transaction_volume" => "1500"
+             "trxValue" => "1500"
            } in trx_all
 
     assert %{
              "datetime" => "2017-05-15T17:00:00Z",
              "fromAddress" => "0x1",
              "toAddress" => "0x2",
-             "transaction_volume" => "2500"
+             "trxValue" => "2500"
            } in trx_all
 
     assert %{
              "datetime" => "2017-05-16T18:00:00Z",
              "fromAddress" => "0x1",
              "toAddress" => "0x2",
-             "transaction_volume" => "3500"
+             "trxValue" => "3500"
            } in trx_all
 
     assert %{
              "datetime" => "2017-05-17T19:00:00Z",
              "fromAddress" => "0x1",
              "toAddress" => "0x2",
-             "transaction_volume" => "5500"
+             "trxValue" => "5500"
            } in trx_all
 
     assert %{
              "datetime" => "2017-05-18T20:00:00Z",
              "fromAddress" => "0x1",
              "toAddress" => "0x2",
-             "transaction_volume" => "6500"
+             "trxValue" => "6500"
            } in trx_all
 
     assert %{
              "datetime" => "2017-05-16T18:00:00Z",
              "fromAddress" => "0x2",
              "toAddress" => "0x1",
-             "transaction_volume" => "100000"
+             "trxValue" => "100000"
            } in trx_all
 
     assert %{
              "datetime" => "2017-05-17T19:00:00Z",
              "fromAddress" => "0x2",
              "toAddress" => "0x1",
-             "transaction_volume" => "45000"
+             "trxValue" => "45000"
            } in trx_all
   end
 end


### PR DESCRIPTION
Left to do: Better tests

Note: Just by dropping the table `sanbase-internal-last-blocks-measurement` the fetching is re-run and the points are overwritten with the new field `trx_hash` added without dropping the records first:

![](https://imgur.com/yqKZJmx.png)