### PR TITLE
Rework coinmarketcap fetching

### DIFF
--- a/lib/sanbase/external_services/coinmarketcap.ex
+++ b/lib/sanbase/external_services/coinmarketcap.ex
@@ -15,7 +15,6 @@ defmodule Sanbase.ExternalServices.Coinmarketcap do
 
   alias Sanbase.Model.{Project, Ico}
   alias Sanbase.Repo
-  alias Sanbase.Prices.Store
   alias Sanbase.Influxdb.Measurement
   alias Sanbase.Prices.Store
   alias Sanbase.ExternalServices.ProjectInfo
@@ -33,16 +32,12 @@ defmodule Sanbase.ExternalServices.Coinmarketcap do
   end
 
   def init(:ok) do
-    update_interval = Config.get(:update_interval, @default_update_interval)
-
     if Config.get(:sync_enabled, false) do
-      Application.fetch_env!(:sanbase, Sanbase.Prices.Store)
-      |> Keyword.get(:database)
-      |> Instream.Admin.Database.create()
-      |> Store.execute()
+      Store.create_db()
 
       GenServer.cast(self(), :sync)
 
+      update_interval = Config.get(:update_interval, @default_update_interval)
       {:ok, %{update_interval: update_interval}}
     else
       :ignore
@@ -68,7 +63,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap do
     Task.Supervisor.async_stream_nolink(
       Sanbase.TaskSupervisor,
       projects,
-      &fetch_price_data/1,
+      &fetch_and_process_price_data/1,
       ordered: false,
       max_concurrency: 5,
       timeout: :infinity
@@ -133,58 +128,49 @@ defmodule Sanbase.ExternalServices.Coinmarketcap do
     !main_contract_address or !contract_abi or !contract_block_number
   end
 
-  defp fetch_price_data(%Project{coinmarketcap_id: coinmarketcap_id, ticker: ticker} = project) do
+  defp fetch_and_process_price_data(%Project{coinmarketcap_id: coinmarketcap_id} = project) do
+    last_price_datetime = last_price_datetime(project)
+
+    prices = fetch_prices(project, last_price_datetime)
+
+    prices |> Store.import()
+
+    last_price_datetime_updated =
+      prices
+      |> Enum.max_by(&Measurement.get_timestamp/1)
+      |> Measurement.get_datetime()
+
+    Store.update_last_history_datetime_cmc(coinmarketcap_id, last_price_datetime_updated)
+
+    process_notifications(project)
+  end
+
+  defp fetch_prices(
+         %Project{coinmarketcap_id: coinmarketcap_id, ticker: ticker},
+         last_price_datetime
+       ) do
     GraphData.fetch_prices(
       coinmarketcap_id,
-      last_price_datetime(project),
+      last_price_datetime,
       DateTime.utc_now()
     )
     |> Stream.flat_map(fn price_point ->
       [
-        convert_to_measurement(price_point, "_usd", "#{ticker}_USD"),
-        convert_to_measurement(price_point, "_btc", "#{ticker}_BTC")
+        PricePoint.convert_to_measurement(price_point, "USD", ticker),
+        PricePoint.convert_to_measurement(price_point, "BTC", ticker)
       ]
     end)
-    |> Store.import()
+  end
 
+  defp process_notifications(%Project{} = project) do
     CheckPrices.exec(project, "usd")
     CheckPrices.exec(project, "btc")
 
     PriceVolumeDiff.exec(project, "usd")
   end
 
-  defp convert_to_measurement(%PricePoint{datetime: datetime} = point, suffix, name) do
-    %Measurement{
-      timestamp: DateTime.to_unix(datetime, :nanosecond),
-      fields: price_point_to_fields(point, suffix),
-      tags: [],
-      name: name
-    }
-  end
-
-  defp price_point_to_fields(
-         %PricePoint{marketcap: marketcap, volume_usd: volume} = point,
-         suffix
-       ) do
-    %{
-      price: Map.get(point, String.to_atom("price" <> suffix)),
-      volume: volume,
-      marketcap: marketcap
-    }
-  end
-
-  defp last_price_datetime(%Project{ticker: ticker} = project) do
-    usd_datetime = last_price_datetime(ticker <> "_USD", project)
-    btc_datetime = last_price_datetime(ticker <> "_BTC", project)
-
-    case DateTime.compare(usd_datetime, btc_datetime) do
-      :gt -> btc_datetime
-      _ -> usd_datetime
-    end
-  end
-
-  defp last_price_datetime(pair, %Project{coinmarketcap_id: coinmarketcap_id}) do
-    case Store.last_datetime!(pair) do
+  defp last_price_datetime(%Project{coinmarketcap_id: coinmarketcap_id}) do
+    case Store.last_history_datetime_cmc!(coinmarketcap_id) do
       nil ->
         GraphData.fetch_first_price_datetime(coinmarketcap_id)
 

--- a/lib/sanbase/external_services/coinmarketcap/price_point.ex
+++ b/lib/sanbase/external_services/coinmarketcap/price_point.ex
@@ -1,3 +1,37 @@
 defmodule Sanbase.ExternalServices.Coinmarketcap.PricePoint do
+  alias __MODULE__
+  alias Sanbase.Influxdb.Measurement
+
   defstruct [:datetime, :marketcap, :price_usd, :volume_usd, :price_btc, :volume_btc]
+
+  def convert_to_measurement(%PricePoint{datetime: datetime} = point, suffix, name) do
+    %Measurement{
+      timestamp: DateTime.to_unix(datetime, :nanosecond),
+      fields: price_point_to_fields(point, suffix),
+      tags: [],
+      name: name <> "_#{suffix}"
+    }
+  end
+
+  defp price_point_to_fields(
+         %PricePoint{marketcap: marketcap, volume_usd: volume_usd, price_btc: price_btc},
+         "BTC"
+       ) do
+    %{
+      price: price_btc,
+      volume: volume_usd,
+      marketcap: marketcap
+    }
+  end
+
+  defp price_point_to_fields(
+         %PricePoint{marketcap: marketcap, volume_usd: volume_usd, price_usd: price_usd},
+         "USD"
+       ) do
+    %{
+      price: price_usd,
+      volume: volume_usd,
+      marketcap: marketcap
+    }
+  end
 end

--- a/lib/sanbase/external_services/coinmarketcap/ticker.ex
+++ b/lib/sanbase/external_services/coinmarketcap/ticker.ex
@@ -17,9 +17,10 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.Ticker do
     :percent_change_7d
   ]
 
-  alias Sanbase.ExternalServices.RateLimiting
-
   use Tesla
+
+  alias Sanbase.ExternalServices.RateLimiting
+  alias Sanbase.ExternalServices.Coinmarketcap.PricePoint
 
   plug(RateLimiting.Middleware, name: :api_coinmarketcap_rate_limiter)
   plug(Tesla.Middleware.BaseUrl, "https://api.coinmarketcap.com/v1/ticker")
@@ -43,8 +44,48 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.Ticker do
     |> Enum.map(&make_timestamp_integer/1)
   end
 
+  def convert_for_importing(%Ticker{
+        symbol: ticker,
+        last_updated: last_updated,
+        price_btc: price_btc,
+        price_usd: price_usd,
+        "24h_volume_usd": volume_usd,
+        market_cap_usd: marketcap_usd
+      }) do
+    price_point = %PricePoint{
+      marketcap: marketcap_usd,
+      volume_usd: volume_usd |> to_integer(),
+      price_btc: price_btc |> to_float(),
+      price_usd: price_usd |> to_float(),
+      datetime: DateTime.from_unix!(last_updated)
+    }
+
+    [
+      PricePoint.convert_to_measurement(price_point, "USD", ticker),
+      PricePoint.convert_to_measurement(price_point, "BTC", ticker)
+    ]
+  end
+
+  # Helper functions
+
   defp make_timestamp_integer(ticker) do
     {ts, ""} = Integer.parse(ticker.last_updated)
     %{ticker | last_updated: ts}
+  end
+
+  defp to_float(nil), do: nil
+  defp to_float(fl) when is_float(fl), do: fl
+
+  defp to_float(str) when is_binary(str) do
+    {num, _} = str |> Float.parse()
+    num
+  end
+
+  defp to_integer(nil), do: nil
+  defp to_integer(int) when is_integer(int), do: int
+
+  defp to_integer(str) when is_binary(str) do
+    {num, _} = str |> Integer.parse()
+    num
   end
 end

--- a/lib/sanbase/external_services/coinmarketcap/ticker.ex
+++ b/lib/sanbase/external_services/coinmarketcap/ticker.ex
@@ -53,7 +53,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.Ticker do
         market_cap_usd: marketcap_usd
       }) do
     price_point = %PricePoint{
-      marketcap: marketcap_usd,
+      marketcap: marketcap_usd |> to_integer(),
       volume_usd: volume_usd |> to_integer(),
       price_btc: price_btc |> to_float(),
       price_usd: price_usd |> to_float(),

--- a/lib/sanbase/external_services/coinmarketcap/ticker_fetcher.ex
+++ b/lib/sanbase/external_services/coinmarketcap/ticker_fetcher.ex
@@ -12,7 +12,6 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcher do
   alias Sanbase.Model.Project
   alias Sanbase.Repo
   alias Sanbase.ExternalServices.Coinmarketcap.Ticker
-  alias Sanbase.ExternalServices.Coinmarketcap.PricePoint
   alias Sanbase.Utils.Config
   alias Sanbase.Prices.Store
 
@@ -24,11 +23,12 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcher do
   end
 
   def init(:ok) do
-    update_interval = Config.get(:update_interval, @default_update_interval)
-
     if Config.get(:sync_enabled, false) do
+      Store.create_db()
+
       GenServer.cast(self(), :sync)
 
+      update_interval = Config.get(:update_interval, @default_update_interval)
       {:ok, %{update_interval: update_interval}}
     else
       :ignore

--- a/lib/sanbase/external_services/project_info.ex
+++ b/lib/sanbase/external_services/project_info.ex
@@ -1,13 +1,13 @@
 defmodule Sanbase.ExternalServices.ProjectInfo do
   @moduledoc """
-  # Fetch information about a project
+    Fetch information about a project
 
-  This module combies the logic from several external and internal services
-  in order to scrape as much information about a project as possible. All the
-  fields that are scraped can be seen in the struct that the module defines.
+    This module combies the logic from several external and internal services
+    in order to scrape as much information about a project as possible. All the
+    fields that are scraped can be seen in the struct that the module defines.
 
-  There is also a function, which allows to update the project with the
-  collected information.
+    There is also a function, which allows to update the project with the
+    collected information.
   """
   defstruct [
     :coinmarketcap_id,

--- a/lib/sanbase/influxdb/measurement.ex
+++ b/lib/sanbase/influxdb/measurement.ex
@@ -4,7 +4,7 @@ defmodule Sanbase.Influxdb.Measurement do
   """
   defstruct [:timestamp, :fields, :tags, :name]
 
-  alias Sanbase.Influxdb.Measurement
+  alias __MODULE__
 
   def convert_measurement_for_import(nil), do: nil
 
@@ -24,5 +24,11 @@ defmodule Sanbase.Influxdb.Measurement do
         }
       ]
     }
+  end
+
+  def get_timestamp(%Measurement{timestamp: ts}), do: ts
+
+  def get_datetime(%Measurement{timestamp: ts}) do
+    DateTime.from_unix!(ts, :nanoseconds)
   end
 end

--- a/lib/sanbase/influxdb/store.ex
+++ b/lib/sanbase/influxdb/store.ex
@@ -31,7 +31,6 @@ defmodule Sanbase.Influxdb.Store do
       end
 
       def import(measurements) do
-        # 1 day of 5 min resolution data
         measurements
         |> Stream.map(&Measurement.convert_measurement_for_import/1)
         |> Stream.reject(&is_nil/1)
@@ -63,13 +62,13 @@ defmodule Sanbase.Influxdb.Store do
 
       def drop_measurement(measurement_name) do
         ~s/DROP MEASUREMENT "#{measurement_name}"/
-        |> __MODULE__.execute()
+        |> __MODULE__.execute(method: :post)
       end
 
       def create_db() do
         Sanbase.Utils.Config.get(:database)
         |> Instream.Admin.Database.create()
-        |> __MODULE__.execute()
+        |> __MODULE__.execute(method: :post)
       end
 
       def last_datetime(measurement) do

--- a/priv/repo/migrations/20180319041803_populate_influxdb_last_cmc_datetime.exs
+++ b/priv/repo/migrations/20180319041803_populate_influxdb_last_cmc_datetime.exs
@@ -1,0 +1,63 @@
+defmodule Sanbase.Repo.Migrations.PopulateInfluxdbLastCmcDatetime do
+  @moduledoc """
+    Builds the last CMC history datetime measurement(db table).
+    It should be built before running the new version because otherwise the
+    fetching of history price will begin from `GraphData.fetch_first_price_datetime(coinmarketcap_id)`
+  """
+  use Ecto.Migration
+
+  import Ecto.Query
+
+  alias Sanbase.Prices.Store
+  alias Sanbase.Repo
+  alias Sanbase.Model.Project
+
+  def up do
+    Application.ensure_all_started(:hackney)
+    start_store()
+
+    projects()
+    |> Enum.map(&import_last_datetime/1)
+  end
+
+  def down, do: :ok
+
+  # Helper functions
+
+  defp projects() do
+    projects =
+      Project
+      |> where([p], not is_nil(p.coinmarketcap_id) and not is_nil(p.ticker))
+      |> Repo.all()
+  end
+
+  defp start_store() do
+    opts = [strategy: :one_for_one, max_restarts: 5, max_seconds: 1]
+    Supervisor.start_link([Store.child_spec()], opts)
+  end
+
+  defp import_last_datetime(%Project{coinmarketcap_id: coinmarketcap_id, ticker: ticker}) do
+    last_datetime_unix = last_datetime_unix(ticker)
+
+    if last_datetime_unix > 0 do
+      Store.update_last_history_datetime_cmc(
+        coinmarketcap_id,
+        last_datetime_unix |> DateTime.from_unix!()
+      )
+    end
+  end
+
+  defp last_datetime_unix(ticker) do
+    last_dt_usd = do_last_datetime(ticker <> "_USD")
+    last_dt_btc = do_last_datetime(ticker <> "_BTC")
+
+    if last_dt_btc > last_dt_usd, do: last_dt_btc, else: last_dt_usd
+  end
+
+  defp do_last_datetime(pair) do
+    case Store.last_datetime!(pair) do
+      nil -> 0
+      datetime -> datetime |> DateTime.to_unix()
+    end
+  end
+end

--- a/test/sanbase/external_services/coinmarketcap/graph_data_test.exs
+++ b/test/sanbase/external_services/coinmarketcap/graph_data_test.exs
@@ -16,18 +16,15 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphDataTest do
   end
 
   test "fetching prices of a token" do
-    Tesla.Mock.mock(fn %{
-                         method: :get,
-                         url:
-                           "https://graphs2.coinmarketcap.com/currencies/santiment/1507991665000/1508078065000/"
-                       } ->
+    Tesla.Mock.mock(fn %{method: :get} ->
       %Tesla.Env{status: 200, body: File.read!(Path.join(__DIR__, "btc_graph_data.json"))}
     end)
 
     from_datetime = DateTime.from_unix!(1_507_991_665_000, :millisecond)
     to_datetime = DateTime.from_unix!(1_508_078_065_000, :millisecond)
 
-    GraphData.fetch_prices("santiment", from_datetime, to_datetime)
+    GraphData.fetch_price_stream("santiment", from_datetime, to_datetime)
+    |> Stream.flat_map(fn x -> x end)
     |> Stream.take(1)
     |> Enum.map(fn %PricePoint{datetime: datetime, price_usd: price_usd} ->
       assert datetime == from_datetime


### PR DESCRIPTION
Start saving the latest price data returned by `https://api.coinmarketcap.com/v1/ticker/limit=1000`. This requires the history data `last_datetime` to be saved in a separate measurement.

Additionally do some refactoring and move functions to more appropriate modules