### PR TITLE
Catch get balance errors

### DIFF
--- a/lib/sanbase/external_services/etherscan/requests/balance.ex
+++ b/lib/sanbase/external_services/etherscan/requests/balance.ex
@@ -6,28 +6,21 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.Balance do
 
   defstruct [:status, :message, :result]
 
-  def get_balance!(address) do
-    case get_balance(address) do
-      {:ok, result} -> result
-      {:error, error} -> raise(error)
-    end
-  end
-
   def get_balance(address) do
     Requests.get("/", query: get_query(address))
     |> case do
       %{status: 200, body: body} ->
-        {:ok, Poison.Decode.decode(body, as: %Balance{})}
+        Poison.Decode.decode(body, as: %Balance{})
 
       %{status: status, body: body} ->
         error = "Error fetching transactions for #{address}. Status code: #{status}: #{body}"
         Logger.warn(error)
-        {:error, error}
+        nil
 
       _ ->
         error = "Error fetching transactions for #{address}"
         Logger.warn(error)
-        {:error, error}
+        nil
     end
   end
 

--- a/lib/sanbase/external_services/etherscan/requests/balance.ex
+++ b/lib/sanbase/external_services/etherscan/requests/balance.ex
@@ -10,17 +10,17 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests.Balance do
     Requests.get("/", query: get_query(address))
     |> case do
       %{status: 200, body: body} ->
-        Poison.Decode.decode(body, as: %Balance{})
+        {:ok, Poison.Decode.decode(body, as: %Balance{})}
 
       %{status: status, body: body} ->
         error = "Error fetching transactions for #{address}. Status code: #{status}: #{body}"
         Logger.warn(error)
-        nil
+        {:error, error}
 
       _ ->
         error = "Error fetching transactions for #{address}"
         Logger.warn(error)
-        nil
+        {:error, error}
     end
   end
 

--- a/lib/sanbase/external_services/etherscan/worker.ex
+++ b/lib/sanbase/external_services/etherscan/worker.ex
@@ -106,16 +106,18 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
   end
 
   defp import_latest_eth_wallet_data(last_trx, address) do
-    with {:ok, balance} <- Balance.get_balance(address) do
-      changeset =
-        last_trx
-        |> get_last_trx_changeset
-        |> build_latest_eth_wallet_changeset(balance)
+    case Balance.get_balance(address) do
+      {:ok, balance} ->
+        changeset =
+          last_trx
+          |> get_last_trx_changeset
+          |> build_latest_eth_wallet_changeset(balance)
 
-      address
-      |> get_or_create_entry()
-      |> LatestEthWalletData.changeset(changeset)
-      |> Repo.insert_or_update!()
+        address
+        |> get_or_create_entry()
+        |> LatestEthWalletData.changeset(changeset)
+        |> Repo.insert_or_update!()
+      {:error, _error} -> nil
     end
   end
 

--- a/lib/sanbase/external_services/etherscan/worker.ex
+++ b/lib/sanbase/external_services/etherscan/worker.ex
@@ -106,48 +106,39 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
   end
 
   defp import_latest_eth_wallet_data(last_trx, address) do
-    case latest_eth_wallet_changeset(last_trx, address) do
-      nil ->
-        nil
+    with {:ok, balance} <- Balance.get_balance(address) do
+      changeset =
+        last_trx
+        |> get_last_trx_changeset
+        |> build_latest_eth_wallet_changeset(balance)
 
-      changeset ->
-        get_or_create_entry(address)
-        |> LatestEthWalletData.changeset(changeset)
-        |> Repo.insert_or_update!()
+      address
+      |> get_or_create_entry()
+      |> LatestEthWalletData.changeset(changeset)
+      |> Repo.insert_or_update!()
     end
   end
 
-  defp latest_eth_wallet_changeset(last_trx, address) do
-    Balance.get_balance(address)
-    |> build_latest_eth_wallet_changeset(last_trx |> get_last_trx)
-  end
-
-  defp build_latest_eth_wallet_changeset(nil, nil), do: nil
-  defp build_latest_eth_wallet_changeset(nil, _last_trx_changeset), do: nil
-  defp build_latest_eth_wallet_changeset(balance, nil) do
-    %{
-      update_time: DateTime.utc_now(),
-      balance: convert_to_eth(balance.result)
-    }
-  end
-
-  defp build_latest_eth_wallet_changeset(balance, last_trx_changeset) do
+  defp build_latest_eth_wallet_changeset(last_trx_changeset, balance) do
     Map.merge(
-      build_latest_eth_wallet_changeset(balance, nil),
+      %{
+        update_time: DateTime.utc_now(),
+        balance: convert_to_eth(balance.result)
+      },
       last_trx_changeset
     )
   end
 
-  defp get_last_trx(nil), do: nil
+  defp get_last_trx_changeset(nil), do: %{}
 
-  defp get_last_trx(%Tx{timeStamp: ts, value: value}) do
+  defp get_last_trx_changeset(%Tx{timeStamp: ts, value: value}) do
     %{
       last_outgoing: DateTime.from_unix!(ts),
       tx_out: convert_to_eth(value)
     }
   end
 
-  defp get_last_trx(%InternalTx{timeStamp: ts, value: value}) do
+  defp get_last_trx_changeset(%InternalTx{timeStamp: ts, value: value}) do
     %{
       last_outgoing: DateTime.from_unix!(ts),
       tx_out: convert_to_eth(value)

--- a/lib/sanbase/external_services/etherscan/worker.ex
+++ b/lib/sanbase/external_services/etherscan/worker.ex
@@ -117,7 +117,9 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
         |> get_or_create_entry()
         |> LatestEthWalletData.changeset(changeset)
         |> Repo.insert_or_update!()
-      {:error, _error} -> nil
+
+      {:error, _error} ->
+        nil
     end
   end
 


### PR DESCRIPTION


#### Summary
<!-- (What does this pull request do in general terms?) -->

Remove `get_balance!` bang function and return nil when we can't get balance. Insert/update only when we have balance.
This should fix: https://sentry.stage.internal.santiment.net/sentry/sanbase/issues/210/

card: https://favro.com/organization/bdbb4f24afc48b29c74f4fa4/9ff267872fcd8b7925f1d7c7

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
