### PR TITLE
Change the exchange funds flow name to the correct one. Return and log better error message in case the exchange fund flow API call fails

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -61,7 +61,7 @@ config :sanbase, Sanbase.Etherbi.Transactions.Store,
   host: {:system, "ETHERBI_INFLUXDB_HOST", "localhost"},
   port: {:system, "ETHERBI_INFLUXDB_PORT", 8086},
   pool: [max_overflow: 10, size: 20],
-  database: "erc20_exchange_transactions"
+  database: "erc20_exchange_funds_flow"
 
 config :sanbase, Sanbase.Etherbi.BurnRate.Store,
   host: {:system, "ETHERBI_INFLUXDB_HOST", "localhost"},

--- a/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
@@ -5,6 +5,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
 
   import Ecto.Query
 
+  require Logger
+
   @doc ~S"""
     Return the token burn rate for the given ticker and time period.
     Uses the influxdb cached values instead of issuing a GET request to etherbi
@@ -89,7 +91,13 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
 
       {:ok, result}
     else
-      _ -> {:error, "Can't fetch the exchange funds for #{ticker}"}
+      error ->
+        error_message =
+          "Can't fetch the exchange fund flow for #{ticker}. Reason: #{inspect(error)}"
+
+        Logger.warn(error_message)
+
+        {:error, error_message}
     end
   end
 


### PR DESCRIPTION
#### Summary
When the etherbi changed the db names it uses the change was not correctly made in the Elixir configuration. Change the db name to `erc20_exchange_funds_flows`