### PR TITLE
Filter the transactions with no hash out of the result

### DIFF
--- a/lib/sanbase/external_services/etherscan/store.ex
+++ b/lib/sanbase/external_services/etherscan/store.ex
@@ -369,6 +369,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
        }) do
     result =
       transactions
+      |> Stream.reject(fn [_, trx_hash, _, _, _, _] -> trx_hash == nil end)
       |> Enum.map(fn [iso8601_datetime, trx_hash, trx_value, trx_type, from_addr, to_addr] ->
         {:ok, datetime, _} = DateTime.from_iso8601(iso8601_datetime)
         {datetime, trx_hash, trx_value, trx_type, from_addr, to_addr}

--- a/test/sanbase_web/graphql/project_api_wallet_transactions_test.exs
+++ b/test/sanbase_web/graphql/project_api_wallet_transactions_test.exs
@@ -29,49 +29,49 @@ defmodule SanbaseWeb.Graphql.ProjectApiWalletTransactionsTest do
     [
       %Measurement{
         timestamp: datetime1 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 500, from_addr: "0x1", to_addr: "0x2"},
+        fields: %{trx_value: 500, from_addr: "0x1", to_addr: "0x2", trx_hash: "0x123"},
         tags: [transaction_type: "out"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime2 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 1500, from_addr: "0x1", to_addr: "0x2"},
+        fields: %{trx_value: 1500, from_addr: "0x1", to_addr: "0x2", trx_hash: "0x123b"},
         tags: [transaction_type: "out"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime3 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 2500, from_addr: "0x1", to_addr: "0x2"},
+        fields: %{trx_value: 2500, from_addr: "0x1", to_addr: "0x2", trx_hash: "0x123c"},
         tags: [transaction_type: "out"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime4 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 3500, from_addr: "0x1", to_addr: "0x2"},
+        fields: %{trx_value: 3500, from_addr: "0x1", to_addr: "0x2", trx_hash: "0x123d"},
         tags: [transaction_type: "out"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime4 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 100_000, from_addr: "0x2", to_addr: "0x1"},
+        fields: %{trx_value: 100_000, from_addr: "0x2", to_addr: "0x1", trx_hash: "0x123e"},
         tags: [transaction_type: "in"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime5 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 5500, from_addr: "0x1", to_addr: "0x2"},
+        fields: %{trx_value: 5500, from_addr: "0x1", to_addr: "0x2", trx_hash: "0x123f"},
         tags: [transaction_type: "out"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime5 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 45000, from_addr: "0x2", to_addr: "0x1"},
+        fields: %{trx_value: 45000, from_addr: "0x2", to_addr: "0x1", trx_hash: "0x123g"},
         tags: [transaction_type: "in"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime6 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 6500, from_addr: "0x1", to_addr: "0x2"},
+        fields: %{trx_value: 6500, from_addr: "0x1", to_addr: "0x2", trx_hash: "0x123h"},
         tags: [transaction_type: "out"],
         name: ticker
       }


### PR DESCRIPTION
#### Summary
Filter the transactions with no hash as they are old data that is wrong and should be cleared.

[//]: # (#### Screenshots)
Before fix (request against staging):
![](https://i.imgur.com/5A1T2j0.png):

After fix (localhost with port-forward to staging influxdb - same trx records as before fix)
![](https://i.imgur.com/W5Ijqmj.png)
