### PR TITLE
Add filering on trx_hash in the transaction queries. add trx_hash to all erc20 transactions tests

### DIFF
--- a/lib/sanbase/external_services/etherscan/store.ex
+++ b/lib/sanbase/external_services/etherscan/store.ex
@@ -246,6 +246,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
 
     ~s/SELECT SUM(trx_value) from #{measurements_string}
     WHERE transaction_type = 'out'
+    AND trx_hash != ''
     AND time >= #{DateTime.to_unix(from, :nanoseconds)}
     AND time <= #{DateTime.to_unix(to, :nanoseconds)}/
   end
@@ -258,6 +259,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
 
     ~s/SELECT SUM(trx_value) from #{measurements_string}
     WHERE transaction_type = 'out'
+    AND trx_hash != ''
     AND time >= #{DateTime.to_unix(from, :nanoseconds)}
     AND time <= #{DateTime.to_unix(to, :nanoseconds)}
     GROUP BY TIME(#{resolution}) fill(0)/
@@ -272,6 +274,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
     ~s/SELECT time, SUM(trx_value)
     FROM "#{measurement}"
     WHERE transaction_type = '#{transaction_type}'
+    AND trx_hash != ''
     AND time >= #{DateTime.to_unix(from, :nanoseconds)}
     AND time <= #{DateTime.to_unix(to, :nanoseconds)}/
   end
@@ -280,6 +283,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
     ~s/SELECT time, SUM(trx_value)
     FROM "#{measurement}"
     WHERE transaction_type = '#{transaction_type}'
+    AND trx_hash != ''
     AND time >= #{DateTime.to_unix(from, :nanoseconds)}
     AND time <= #{DateTime.to_unix(to, :nanoseconds)}
     GROUP BY TIME(#{resolution}) fill(0)/
@@ -288,7 +292,8 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
   defp select_top_transactions(measurement, from, to, "all", limit) do
     ~s/SELECT trx_hash, TOP(trx_value, #{limit}) as trx_value, transaction_type, from_addr, to_addr
     FROM "#{measurement}"
-    WHERE time >= #{DateTime.to_unix(from, :nanoseconds)}
+    WHERE trx_hash != ''
+    AND time >= #{DateTime.to_unix(from, :nanoseconds)}
     AND time <= #{DateTime.to_unix(to, :nanoseconds)}/
   end
 
@@ -296,6 +301,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
     ~s/SELECT trx_hash, TOP(trx_value, #{limit}) as trx_value, transaction_type, from_addr, to_addr
     FROM "#{measurement}"
     WHERE transaction_type='#{transaction_type}'
+    AND trx_hash != ''
     AND time >= #{DateTime.to_unix(from, :nanoseconds)}
     AND time <= #{DateTime.to_unix(to, :nanoseconds)}/
   end
@@ -369,7 +375,6 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
        }) do
     result =
       transactions
-      |> Stream.reject(fn [_, trx_hash, _, _, _, _] -> trx_hash == nil end)
       |> Enum.map(fn [iso8601_datetime, trx_hash, trx_value, trx_type, from_addr, to_addr] ->
         {:ok, datetime, _} = DateTime.from_iso8601(iso8601_datetime)
         {datetime, trx_hash, trx_value, trx_type, from_addr, to_addr}

--- a/test/sanbase/external_services/etherscan/fetch_transactions_test.exs
+++ b/test/sanbase/external_services/etherscan/fetch_transactions_test.exs
@@ -44,6 +44,7 @@ defmodule Sanbase.ExternalServices.Etherscan.FetchTransactions do
       {:ok,
        [
          %Tx{
+           hash: "0x123456788c",
            blockNumber: "4470352",
            from: "0x123245678910",
            isError: "0",
@@ -53,6 +54,7 @@ defmodule Sanbase.ExternalServices.Etherscan.FetchTransactions do
            value: 10 |> ether_to_wei_str()
          },
          %Tx{
+           hash: "0x123456788b",
            blockNumber: "4463670",
            from: "0x123245678910",
            isError: "0",
@@ -62,6 +64,7 @@ defmodule Sanbase.ExternalServices.Etherscan.FetchTransactions do
            value: 10 |> ether_to_wei_str()
          },
          %Tx{
+           hash: "0x123456788a",
            blockNumber: "4463588",
            from: "0x8e473843fd546bf203f8b96cce310bb8740a4cec",
            isError: "0",
@@ -79,6 +82,7 @@ defmodule Sanbase.ExternalServices.Etherscan.FetchTransactions do
       {:ok,
        [
          %InternalTx{
+           hash: "0x123456789c",
            blockNumber: "4557084",
            errCode: "",
            from: "0x123245678910",
@@ -88,6 +92,7 @@ defmodule Sanbase.ExternalServices.Etherscan.FetchTransactions do
            value: 50 |> ether_to_wei_str()
          },
          %InternalTx{
+           hash: "0x123456789a",
            blockNumber: "4379313",
            errCode: "",
            from: "0x7da82c7ab4771ff031b66538d2fb9b0b047f6cf9",
@@ -97,6 +102,7 @@ defmodule Sanbase.ExternalServices.Etherscan.FetchTransactions do
            value: 1000 |> ether_to_wei_str()
          },
          %Sanbase.ExternalServices.Etherscan.Requests.InternalTx{
+           hash: "0x123456789b",
            blockNumber: "4173006",
            errCode: "",
            from: "0x7da82c7ab4771ff031b66538d2fb9b0b047f6cf9",

--- a/test/sanbase_web/graphql/project_api_eth_spent_over_time_test.exs
+++ b/test/sanbase_web/graphql/project_api_eth_spent_over_time_test.exs
@@ -29,49 +29,49 @@ defmodule SanbaseWeb.Graphql.ProjectApiEthSpentOverTimeTest do
     [
       %Measurement{
         timestamp: datetime1 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 500, from_addr: "0x1", to_addr: "0x2"},
+        fields: %{trx_value: 500, from_addr: "0x1", to_addr: "0x2", trx_hash: "0x321"},
         tags: [transaction_type: "out"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime2 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 1500, from_addr: "0x1", to_addr: "0x2"},
+        fields: %{trx_value: 1500, from_addr: "0x1", to_addr: "0x2", trx_hash: "0x321a"},
         tags: [transaction_type: "out"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime3 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 2500, from_addr: "0x1", to_addr: "0x2"},
+        fields: %{trx_value: 2500, from_addr: "0x1", to_addr: "0x2", trx_hash: "0x321b"},
         tags: [transaction_type: "out"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime4 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 3500, from_addr: "0x1", to_addr: "0x2"},
+        fields: %{trx_value: 3500, from_addr: "0x1", to_addr: "0x2", trx_hash: "0x321c"},
         tags: [transaction_type: "out"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime4 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 100_000, from_addr: "0x2", to_addr: "0x1"},
+        fields: %{trx_value: 100_000, from_addr: "0x2", to_addr: "0x1", trx_hash: "0x321d"},
         tags: [transaction_type: "in"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime5 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 5500, from_addr: "0x1", to_addr: "0x2"},
+        fields: %{trx_value: 5500, from_addr: "0x1", to_addr: "0x2", trx_hash: "0x321e"},
         tags: [transaction_type: "in"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime5 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 45000, from_addr: "0x2", to_addr: "0x1"},
+        fields: %{trx_value: 45000, from_addr: "0x2", to_addr: "0x1", trx_hash: "0x321f"},
         tags: [transaction_type: "in"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime6 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 6500, from_addr: "0x1", to_addr: "0x2"},
+        fields: %{trx_value: 6500, from_addr: "0x1", to_addr: "0x2", trx_hash: "0x321g"},
         tags: [transaction_type: "out"],
         name: ticker
       }

--- a/test/sanbase_web/graphql/project_api_spent_eth_test.exs
+++ b/test/sanbase_web/graphql/project_api_spent_eth_test.exs
@@ -14,6 +14,7 @@ defmodule SanbaseWeb.Graphql.ProjecApiEthSpentTest do
     ticker = "SAN"
     ticker2 = "TESTTEST"
     ticker3 = "XYZ"
+
     Store.drop_measurement(ticker)
     Store.drop_measurement(ticker2)
     Store.drop_measurement(ticker3)
@@ -34,55 +35,55 @@ defmodule SanbaseWeb.Graphql.ProjecApiEthSpentTest do
     [
       %Measurement{
         timestamp: datetime1 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 500},
+        fields: %{trx_value: 500, trx_hash: "0x123a"},
         tags: [transaction_type: "out"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime2 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 1500},
+        fields: %{trx_value: 1500, trx_hash: "0x123b"},
         tags: [transaction_type: "out"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime3 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 2500},
+        fields: %{trx_value: 2500, trx_hash: "0x123c"},
         tags: [transaction_type: "out"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime4 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 3500},
+        fields: %{trx_value: 3500, trx_hash: "0x123d"},
         tags: [transaction_type: "out"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime4 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 100_000},
+        fields: %{trx_value: 100_000, trx_hash: "0x123e"},
         tags: [transaction_type: "in"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime5 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 5500},
+        fields: %{trx_value: 5500, trx_hash: "0x123f"},
         tags: [transaction_type: "out"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime6 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 6500},
+        fields: %{trx_value: 6500, trx_hash: "0x123g"},
         tags: [transaction_type: "out"],
         name: ticker
       },
       %Measurement{
         timestamp: datetime6 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 5000},
+        fields: %{trx_value: 5000, trx_hash: "0x123h"},
         tags: [transaction_type: "out"],
         name: ticker2
       },
       %Measurement{
         timestamp: datetime6 |> DateTime.to_unix(:nanoseconds),
-        fields: %{trx_value: 5000},
+        fields: %{trx_value: 5000, trx_hash: "0x123i"},
         tags: [transaction_type: "out"],
         name: ticker3
       }


### PR DESCRIPTION
The trx_hash checks must be added to all queries until we clean the influxdb