### PR TITLE
Increase timeout for http requests to tech-indicators service

### DIFF
--- a/lib/sanbase/internal_services/tech_indicators.ex
+++ b/lib/sanbase/internal_services/tech_indicators.ex
@@ -4,7 +4,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
   alias Sanbase.Utils.Config
 
   @http_client Mockery.of("HTTPoison")
-  @recv_timeout 15_000
+  @recv_timeout 45_000
 
   def macd(
         ticker,


### PR DESCRIPTION
Hopefully this will resolve that in prod `sanbase-scrapers` fail with a :connect_timeout error when trying to access `tech-indicators` for the price-volume diff notification:
![image](https://user-images.githubusercontent.com/15890495/37824586-cbcb6f14-2e95-11e8-90d8-b2b8d343d73e.png)
(for two hours between 05:20 and 07:00 it worked and before & after that it failed)

The funny thing is the GQL api on prod works well (`sanbase-web`), and also on staging there are no timeout problems whatsoever.