### PR TITLE
Fix the link to etherscan for the top ETH transactions

### DIFF
--- a/app/src/pages/Detailed/Detailed.js
+++ b/app/src/pages/Detailed/Detailed.js
@@ -248,7 +248,7 @@ export const Detailed = ({
             project.ethTopTransactions.map((transaction, index) => (
               <div className='top-eth-transaction' key={index}>
                 <div className='top-eth-transaction__hash'>
-                  <a href={`https://etherscan.io/address/${transaction.trxHash}`}>{transaction.trxHash}</a>
+                  <a href={`https://etherscan.io/tx/${transaction.trxHash}`}>{transaction.trxHash}</a>
                 </div>
                 <div>
                   {millify(parseFloat(parseFloat(transaction.trxValue).toFixed(2)))}


### PR DESCRIPTION
#### Summary
<!-- (What does this pull request do in general terms?) -->

The links to the transactions are not correct

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
