### PR TITLE
Set the tesla url before the follow redirect middleware, otherwise the e follow redirect does not know the authority it merges onto

### DIFF
--- a/lib/sanbase/external_services/coinmarketcap/scraper.ex
+++ b/lib/sanbase/external_services/coinmarketcap/scraper.ex
@@ -9,8 +9,8 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.Scraper do
 
   plug(RateLimiting.Middleware, name: :http_coinmarketcap_rate_limiter)
   plug(ErrorCatcher.Middleware)
-  plug(Tesla.Middleware.FollowRedirects, max_redirects: 10)
   plug(Tesla.Middleware.BaseUrl, "https://coinmarketcap.com/currencies")
+  plug(Tesla.Middleware.FollowRedirects, max_redirects: 10)
   plug(Tesla.Middleware.Compression)
   plug(Tesla.Middleware.Logger)
 

--- a/lib/sanbase/external_services/etherscan/requests.ex
+++ b/lib/sanbase/external_services/etherscan/requests.ex
@@ -13,6 +13,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Requests do
   plug(RateLimiting.Middleware, name: :etherscan_rate_limiter)
   plug(ErrorCatcher.Middleware)
   plug(Tesla.Middleware.BaseUrl, "https://api.etherscan.io/api")
+  plug(Tesla.Middleware.FollowRedirects, max_redirects: 10)
   plug(Tesla.Middleware.Compression)
   plug(Tesla.Middleware.JSON)
 

--- a/lib/sanbase/external_services/etherscan/scraper.ex
+++ b/lib/sanbase/external_services/etherscan/scraper.ex
@@ -10,8 +10,8 @@ defmodule Sanbase.ExternalServices.Etherscan.Scraper do
 
   plug(RateLimiting.Middleware, name: :etherscan_rate_limiter)
   plug(ErrorCatcher.Middleware)
-  plug(Tesla.Middleware.FollowRedirects, max_redirects: 10)
   plug(Tesla.Middleware.BaseUrl, "https://etherscan.io")
+  plug(Tesla.Middleware.FollowRedirects, max_redirects: 10)
   plug(Tesla.Middleware.Logger)
 
   def fetch_address_page(address) do


### PR DESCRIPTION
#### Summary
The FollowRedirect middleware should be after the BaseUrl middleware, otherwise the env.url is set to `/` in the  FollowRediret middleware and we enter this part of code: https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/uri.ex#L512