### PR TITLE
Filter transactions between project own addresses

### DIFF
--- a/lib/sanbase/etherbi/transactions/store.ex
+++ b/lib/sanbase/etherbi/transactions/store.ex
@@ -71,10 +71,6 @@ defmodule Sanbase.Etherbi.Transactions.Store do
     GROUP BY time(#{interval}) fill(0)/
   end
 
-  defp parse_transactions_time_series(%{results: [%{error: error}]}) do
-    {:error, error}
-  end
-
   defp parse_in_out_diff_time_series(%{
          results: [
            %{

--- a/lib/sanbase/external_services/etherscan/store.ex
+++ b/lib/sanbase/external_services/etherscan/store.ex
@@ -107,7 +107,8 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
   def eth_spent_by_projects(measurements_list, from, to) do
     total_eth_spent =
       measurements_list
-      |> Stream.map(&trx_sum_in_interval(&1, from, to, "out"))
+      |> Enum.map(&Task.async(fn -> trx_sum_in_interval(&1, from, to, "out") end))
+      |> Stream.map(&Task.await/1)
       |> Stream.reject(fn {:ok, sum} -> sum == nil end)
       |> Enum.reduce(0, fn
         {:ok, sum}, acc ->

--- a/lib/sanbase/external_services/etherscan/store.ex
+++ b/lib/sanbase/external_services/etherscan/store.ex
@@ -7,6 +7,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
 
   alias Sanbase.Influxdb.Measurement
   alias Sanbase.ExternalServices.Etherscan.Store
+  alias Sanbase.Model.Project
 
   @last_block_measurement "sanbase-internal-last-blocks-measurement"
 
@@ -286,8 +287,8 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
   defp sum_over_time_from_to_query(measurement, from, to, resolution, transaction_type) do
     ~s/SELECT time, SUM(trx_value)
     FROM "#{measurement}"
-    WHERE transaction_type = '#{transaction_type}'
-    AND trx_hash != ''
+    WHERE trx_hash != ''
+    AND #{construct_internal_eth_addresses_filter(measurement, transaction_type)}
     AND time >= #{DateTime.to_unix(from, :nanoseconds)}
     AND time <= #{DateTime.to_unix(to, :nanoseconds)}
     GROUP BY TIME(#{resolution}) fill(0)/
@@ -297,6 +298,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
     ~s/SELECT trx_hash, TOP(trx_value, #{limit}) as trx_value, transaction_type, from_addr, to_addr
     FROM "#{measurement}"
     WHERE trx_hash != ''
+    AND #{construct_internal_eth_addresses_filter(measurement, "all")}
     AND time >= #{DateTime.to_unix(from, :nanoseconds)}
     AND time <= #{DateTime.to_unix(to, :nanoseconds)}/
   end
@@ -304,8 +306,8 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
   defp select_top_transactions(measurement, from, to, transaction_type, limit) do
     ~s/SELECT trx_hash, TOP(trx_value, #{limit}) as trx_value, transaction_type, from_addr, to_addr
     FROM "#{measurement}"
-    WHERE transaction_type='#{transaction_type}'
-    AND trx_hash != ''
+    WHERE trx_hash != ''
+    AND #{construct_internal_eth_addresses_filter(measurement, transaction_type)}
     AND time >= #{DateTime.to_unix(from, :nanoseconds)}
     AND time <= #{DateTime.to_unix(to, :nanoseconds)}/
   end
@@ -388,4 +390,39 @@ defmodule Sanbase.ExternalServices.Etherscan.Store do
   end
 
   defp parse_transactions_time_series(_), do: {:ok, []}
+
+  defp construct_internal_eth_addresses_filter(ticker, transaction_type) do
+    ticker
+    |> Project.project_eth_addresses_by_ticker()
+    |> Map.get(:eth_addresses)
+    |> Enum.map(fn eth_address -> eth_address.address end)
+    |> filter_eth_addresses(transaction_type)
+  end
+
+  defp filter_eth_addresses([], _transaction_type), do: ""
+
+  defp filter_eth_addresses(addresses, transaction_type) when transaction_type in ["in", "IN"] do
+    "transaction_type = '#{transaction_type}' AND " <>
+      filter_eth_addresses_by_field(addresses, "from_addr")
+  end
+
+  defp filter_eth_addresses(addresses, transaction_type)
+       when transaction_type in ["out", "OUT"] do
+    "transaction_type = '#{transaction_type}' AND " <>
+      filter_eth_addresses_by_field(addresses, "to_addr")
+  end
+
+  defp filter_eth_addresses(addresses, transaction_type)
+       when transaction_type in ["all", "ALL"] do
+    ~s/(#{filter_eth_addresses(addresses, "in")})/ <>
+      " OR " <> ~s/(#{filter_eth_addresses(addresses, "out")})/
+  end
+
+  def filter_eth_addresses_by_field(addresses, field) do
+    addresses
+    |> Enum.map(&filter_address(&1, field))
+    |> Enum.join(" AND ")
+  end
+
+  defp filter_address(address, field), do: "#{field} != '#{address}'"
 end

--- a/lib/sanbase/model/project.ex
+++ b/lib/sanbase/model/project.ex
@@ -304,14 +304,20 @@ defmodule Sanbase.Model.Project do
     Repo.all(query)
   end
 
-  def project_eth_addresses_by_ticker(ticker) do
+  def eth_addresses_by_tickers(tickers) do
     query =
       from(
         p in Project,
-        where: p.ticker == ^ticker and not is_nil(p.coinmarketcap_id),
+        where: p.ticker in ^tickers and not is_nil(p.coinmarketcap_id),
         preload: [:eth_addresses]
       )
 
-    Repo.one(query)
+    Repo.all(query)
+    |> Stream.map(fn %Project{ticker: ticker, eth_addresses: eth_addresses} ->
+      eth_addresses = eth_addresses |> Enum.map(&Map.get(&1, :address))
+
+      {ticker, eth_addresses}
+    end)
+    |> Enum.into(%{})
   end
 end

--- a/lib/sanbase/model/project.ex
+++ b/lib/sanbase/model/project.ex
@@ -303,4 +303,15 @@ defmodule Sanbase.Model.Project do
 
     Repo.all(query)
   end
+
+  def project_eth_addresses_by_ticker(ticker) do
+    query =
+      from(
+        p in Project,
+        where: p.ticker == ^ticker and not is_nil(p.coinmarketcap_id),
+        preload: [:eth_addresses]
+      )
+
+    Repo.one(query)
+  end
 end

--- a/lib/sanbase/notifications/price_volume_diff.ex
+++ b/lib/sanbase/notifications/price_volume_diff.ex
@@ -21,8 +21,7 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
            seconds_ago(notifications_cooldown()),
            notification_type_name(currency)
          ) do
-      with %{from_datetime: from_datetime, to_datetime: to_datetime} <-
-             get_calculation_interval(),
+      with %{from_datetime: from_datetime, to_datetime: to_datetime} <- get_calculation_interval(),
            true <- check_volume(project, currency, from_datetime, to_datetime),
            {indicator, notification_log} <-
              get_indicator(project.ticker, currency, from_datetime, to_datetime),

--- a/lib/sanbase_web/graphql/resolvers/price_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/price_resolver.ex
@@ -13,8 +13,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
     loader
     |> Dataloader.load(PriceStore, "TOTAL_MARKET_USD", args)
     |> on_load(fn loader ->
-      with {:ok, usd_prices} <-
-             Dataloader.get(loader, PriceStore, "TOTAL_MARKET_USD", args) do
+      with {:ok, usd_prices} <- Dataloader.get(loader, PriceStore, "TOTAL_MARKET_USD", args) do
         result =
           usd_prices
           |> Enum.map(fn [dt, _, volume, marketcap] ->

--- a/lib/sanbase_web/graphql/resolvers/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project_resolver.ex
@@ -170,7 +170,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
            Etherscan.Store.trx_sum_over_time_in_interval(ticker, from, to, interval, "out") do
       result =
         eth_spent_over_time
-        |> Enum.map(fn {datetime, eth_spent} ->
+        |> Enum.map(fn [datetime, eth_spent] ->
           %{datetime: datetime, eth_spent: eth_spent}
         end)
 
@@ -217,7 +217,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
            ) do
       result =
         total_eth_spent_over_time
-        |> Enum.map(fn {datetime, eth_spent} ->
+        |> Enum.map(fn [datetime, eth_spent] ->
           %{
             datetime: datetime,
             eth_spent: eth_spent
@@ -253,7 +253,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
            Etherscan.Store.top_transactions(ticker, from, to, trx_type, limit) do
       result =
         eth_transactions
-        |> Enum.map(fn {datetime, trx_hash, trx_value, trx_type, from_addr, to_addr} ->
+        |> Enum.map(fn [datetime, trx_hash, trx_value, trx_type, from_addr, to_addr] ->
           %{
             datetime: datetime,
             trx_hash: trx_hash,


### PR DESCRIPTION
#### Summary
<!-- (What does this pull request do in general terms?) -->
We should filter transactions between project eth own addresses from aggregation queries

TODO:
- [x]  probably should be added also here: 
https://github.com/santiment/sanbase2/blob/master/lib/sanbase/external_services/etherscan/store.ex#L258 and here
https://github.com/santiment/sanbase2/blob/master/lib/sanbase/external_services/etherscan/store.ex#L258 The problem is that the select is from multiple measurements and it is hard to build a proper `where` clause.
- [x] probably should be added here: https://github.com/santiment/sanbase2/blob/master/lib/sanbase/external_services/etherscan/store.ex#L277 but it returned some errors while testing with staging data.
- [x] test whether queries make things slower
- [x] fix tests

Ivan: Making the influxdb queries async + the in-memory caching solves the problem with the slower queries. Maybe for this data we can even increase the cache from 5 to 10 minutes and it won't matter that much. The query before caching takes around 6 seconds through kubectl proxy

Ivan2: This PR contains some cleaning of the Store module and changing the project resolver to match them. This is part of the process of unifying all store modules

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
![image 3](https://user-images.githubusercontent.com/122794/37922576-9304a82e-3135-11e8-892d-14bfd0c3d6d6.png)
![image 2](https://user-images.githubusercontent.com/122794/37922577-9327b4b8-3135-11e8-8942-6d8462ec0b5f.png)
