### PR TITLE
Price volume diff notification change datetime

### DIFF
--- a/lib/sanbase/internal_services/tech_indicators.ex
+++ b/lib/sanbase/internal_services/tech_indicators.ex
@@ -4,7 +4,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
   alias Sanbase.Utils.Config
 
   @http_client Mockery.of("HTTPoison")
-  @recv_timeout 45_000
+  @recv_timeout 15_000
 
   def macd(
         ticker,

--- a/lib/sanbase/notifications/price_volume_diff.ex
+++ b/lib/sanbase/notifications/price_volume_diff.ex
@@ -27,7 +27,7 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
         get_indicator(project.ticker, currency, from_datetime, to_datetime)
 
       if check_notification(indicator) do
-        send_notification(project, currency, to_datetime, indicator, notification_log)
+        send_notification(project, currency, indicator, notification_log)
       end
     end
   end
@@ -49,12 +49,14 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
         {:ok,
          [
            %{
+             datetime: datetime,
              price_volume_diff: price_volume_diff,
              price_change: price_change,
              volume_change: volume_change
            }
          ]} ->
           %{
+            datetime: datetime,
             price_volume_diff: nil_to_zero(price_volume_diff),
             price_change: nil_to_zero(price_change),
             volume_change: nil_to_zero(volume_change)
@@ -62,6 +64,7 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
 
         _ ->
           %{
+            datetime: to_datetime,
             price_volume_diff: 0,
             price_change: 0,
             volume_change: 0
@@ -100,14 +103,13 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
   defp send_notification(
          project,
          currency,
-         notification_date,
          indicator,
          {notification_data, debug_info}
        ) do
     {:ok, %HTTPoison.Response{status_code: 204}} =
       @http_service.post(
         webhook_url(),
-        notification_payload(project, currency, notification_date, indicator, debug_info),
+        notification_payload(project, currency, indicator, debug_info),
         [
           {"Content-Type", "application/json"}
         ]
@@ -119,18 +121,20 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
   defp notification_payload(
          %Project{name: name, ticker: ticker, coinmarketcap_id: coinmarketcap_id},
          currency,
-         notification_date,
-         %{price_change: price_change, volume_change: volume_change},
+         %{datetime: datetime, price_change: price_change, volume_change: volume_change},
          debug_info
        ) do
+    # Timex.shift(days: 1) is because the returned datetime is the beginning of the day
     {:ok, notification_date_string} =
-      Timex.format(notification_date, "{YYYY}-{0M}-{0D} {h24}:{m}:{s}")
+      datetime
+      |> Timex.shift(days: 1)
+      |> Timex.format("{YYYY}-{0M}-{0D} {h24}:{m}:{s}")
 
     Poison.encode!(%{
       content:
-        "[#{notification_date_string} UTC] #{name}: #{ticker}/#{String.upcase(currency)} #{
-          notification_emoji(price_change)
-        } Price #{notification_emoji(volume_change)} Volume opposite trends. https://coinmarketcap.com/currencies/#{
+        "#{name}: #{ticker}/#{String.upcase(currency)} #{notification_emoji(price_change)} Price #{
+          notification_emoji(volume_change)
+        } Volume opposite trends (as of #{notification_date_string} UTC). https://coinmarketcap.com/currencies/#{
           coinmarketcap_id
         } #{debug_info}",
       username: "Price-Volume Difference"


### PR DESCRIPTION
Change the datetime reported in the price-volume diff notification - now it reports the timestamp for the last datapoint used in the calculation (not the timestamp of the notification itself)