### PR TITLE
Reduce the boilerplate of using the GQL cache and add caching to more queries

### DIFF
--- a/lib/sanbase_web/graphql/helpers/cache.ex
+++ b/lib/sanbase_web/graphql/helpers/cache.ex
@@ -1,9 +1,18 @@
 defmodule SanbaseWeb.Graphql.Helpers.Cache do
   @ttl :timer.minutes(5)
+  def from(captured_mfa) when is_function(captured_mfa) do
+    fun_name =
+      captured_mfa
+      |> :erlang.fun_info()
+      |> Keyword.get(:name)
+
+    captured_mfa
+    |> resolver(fun_name)
+  end
 
   def resolver(resolver_fn, name) do
     # Caching is only possible for query resolvers for now. Field resolvers are
-    # not cupported, because they are scoped on their root object, we can't get
+    # not supported, because they are scoped on their root object, we can't get
     # a good, general cache key for arbitrary root objects
     fn %{}, args, resolution ->
       {_, value} =

--- a/lib/sanbase_web/graphql/price_store.ex
+++ b/lib/sanbase_web/graphql/price_store.ex
@@ -1,5 +1,6 @@
 defmodule SanbaseWeb.Graphql.PriceStore do
   alias Sanbase.Prices
+  alias SanbaseWeb.Graphql.Helpers.Cache
 
   def data() do
     Dataloader.KV.new(&query/2)
@@ -16,15 +17,24 @@ defmodule SanbaseWeb.Graphql.PriceStore do
 
   # Helper functions
 
+  # TODO: not covered in tests
   defp fetch_price(pair, :last) do
+    Cache.func(fn -> fetch_last_price_record(pair) end, :fetch_price_last_record, %{pair: pair}).()
+  end
+
+  defp fetch_price(pair, %{from: from, to: to, interval: interval} = args) do
+    Cache.func(
+      fn -> Prices.Store.fetch_prices_with_resolution(pair, from, to, interval) end,
+      :fetch_prices_with_resolution,
+      Map.merge(%{pair: pair}, args)
+    ).()
+  end
+
+  defp fetch_last_price_record(pair) do
     with {:ok, {_dt, price, _mcap, _volume}} <- Prices.Store.last_record(pair) do
       Decimal.new(price)
     else
       _error -> nil
     end
-  end
-
-  defp fetch_price(pair, %{from: from, to: to, interval: interval}) do
-    Prices.Store.fetch_prices_with_resolution(pair, from, to, interval)
   end
 end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -15,7 +15,6 @@ defmodule SanbaseWeb.Graphql.Schema do
   }
 
   alias SanbaseWeb.Graphql.Helpers.Cache
-
   alias SanbaseWeb.Graphql.Complexity.PriceComplexity
   alias SanbaseWeb.Graphql.Complexity.TechIndicatorsComplexity
 
@@ -68,8 +67,7 @@ defmodule SanbaseWeb.Graphql.Schema do
 
       middleware(ProjectPermissions)
 
-      (&ProjectResolver.all_projects/3)
-      |> Cache.resolver(:all_projects)
+      Cache.from(&ProjectResolver.all_projects/3)
       |> resolve()
     end
 
@@ -77,8 +75,7 @@ defmodule SanbaseWeb.Graphql.Schema do
     field :all_erc20_projects, list_of(:project) do
       middleware(ProjectPermissions)
 
-      (&ProjectResolver.all_erc20_projects/3)
-      |> Cache.resolver(:all_erc20_projects)
+      Cache.from(&ProjectResolver.all_erc20_projects/3)
       |> resolve()
     end
 
@@ -86,8 +83,7 @@ defmodule SanbaseWeb.Graphql.Schema do
     field :all_currency_projects, list_of(:project) do
       middleware(ProjectPermissions)
 
-      (&ProjectResolver.all_currency_projects/3)
-      |> Cache.resolver(:all_currency_projects)
+      Cache.from(&ProjectResolver.all_currency_projects/3)
       |> resolve()
     end
 
@@ -154,8 +150,7 @@ defmodule SanbaseWeb.Graphql.Schema do
     field :twitter_data, :twitter_data do
       arg(:ticker, non_null(:string))
 
-      (&TwitterResolver.twitter_data/3)
-      |> Cache.resolver(:twitter_data)
+      Cache.from(&TwitterResolver.twitter_data/3)
       |> resolve()
     end
 
@@ -166,8 +161,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:to, :datetime, default_value: DateTime.utc_now())
       arg(:interval, :string, default_value: "6h")
 
-      (&TwitterResolver.history_twitter_data/3)
-      |> Cache.resolver(:history_twitter_data)
+      Cache.from(&TwitterResolver.history_twitter_data/3)
       |> resolve()
     end
 
@@ -280,9 +274,8 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
 
-      (&ProjectResolver.eth_spent_by_erc20_projects/3)
-      |> Cache.resolver(:eth_spent_by_erc20_projects)
-      |> resolve
+      Cache.from(&ProjectResolver.eth_spent_by_erc20_projects/3)
+      |> resolve()
     end
 
     @desc "Returns the ETH spent by all projects in a given time period for a given interval"
@@ -291,8 +284,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:to, non_null(:datetime))
       arg(:interval, :string, default_value: "1d")
 
-      (&ProjectResolver.eth_spent_over_time_by_erc20_projects/3)
-      |> Cache.resolver(:eth_spent_over_time_by_erc20_projects)
+      Cache.from(&ProjectResolver.eth_spent_over_time_by_erc20_projects/3)
       |> resolve
     end
   end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -109,13 +109,17 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:only_project_transparency, :boolean, default_value: false)
 
       middleware(ProjectPermissions)
-      resolve(&ProjectResolver.project_by_slug/3)
+
+      Cache.from(&ProjectResolver.project_by_slug/3)
+      |> resolve()
     end
 
     @desc "Fetch all projects that have ETH contract info"
     field :all_projects_with_eth_contract_info, list_of(:project) do
       middleware(BasicAuth)
-      resolve(&ProjectResolver.all_projects_with_eth_contract_info/3)
+
+      Cache.from(&ProjectResolver.all_projects_with_eth_contract_info/3)
+      |> resolve()
     end
 
     @desc "Historical information for the price"
@@ -126,12 +130,15 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:interval, :string, default_value: "1h")
 
       complexity(&PriceComplexity.history_price/3)
-      resolve(&PriceResolver.history_price/3)
+
+      Cache.from(&PriceResolver.history_price/3)
+      |> resolve()
     end
 
     @desc "Returns a list of available github repositories"
     field :github_availables_repos, list_of(:string) do
-      resolve(&GithubResolver.available_repos/3)
+      Cache.from(&GithubResolver.available_repos/3)
+      |> resolve()
     end
 
     @desc "Returns a list of github activities"
@@ -143,7 +150,8 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:moving_average_interval, :integer, default_value: 10)
       arg(:transform, :string, default_value: "None")
 
-      resolve(&GithubResolver.activity/3)
+      Cache.from(&GithubResolver.activity/3)
+      |> resolve()
     end
 
     @desc "Current data for a twitter account"
@@ -172,7 +180,8 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:to, non_null(:datetime))
       arg(:interval, :string, default_value: "1h")
 
-      resolve(&EtherbiResolver.burn_rate/3)
+      Cache.from(&EtherbiResolver.burn_rate/3)
+      |> resolve()
     end
 
     @desc "Transaction volume for a ticker and given time period"
@@ -182,19 +191,22 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:to, non_null(:datetime))
       arg(:interval, :string, default_value: "1h")
 
-      resolve(&EtherbiResolver.transaction_volume/3)
+      Cache.from(&EtherbiResolver.transaction_volume/3)
+      |> resolve()
     end
 
     @desc "Returns the currently running poll"
     field :current_poll, :poll do
-      resolve(&VotingResolver.current_poll/3)
+      Cache.from(&VotingResolver.current_poll/3)
+      |> resolve()
     end
 
     @desc "Get the post with the specified id"
     field :post, :post do
       arg(:id, non_null(:integer))
 
-      resolve(&VotingResolver.post/3)
+      Cache.from(&VotingResolver.post/3)
+      |> resolve()
     end
 
     @desc "Shows the flow of funds in an exchange wallet"
@@ -204,7 +216,8 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:to, non_null(:datetime))
       arg(:interval, :string, default_value: "1d")
 
-      resolve(&EtherbiResolver.exchange_funds_flow/3)
+      Cache.from(&EtherbiResolver.exchange_funds_flow/3)
+      |> resolve()
     end
 
     @desc "MACD for a ticker and given currency and time period"
@@ -218,7 +231,9 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:result_size_tail, :integer, default_value: 0)
 
       complexity(&TechIndicatorsComplexity.macd/3)
-      resolve(&TechIndicatorsResolver.macd/3)
+
+      Cache.from(&TechIndicatorsResolver.macd/3)
+      |> resolve()
     end
 
     @desc "RSI for a ticker and given currency and time period"
@@ -233,7 +248,9 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:result_size_tail, :integer, default_value: 0)
 
       complexity(&TechIndicatorsComplexity.rsi/3)
-      resolve(&TechIndicatorsResolver.rsi/3)
+
+      Cache.from(&TechIndicatorsResolver.rsi/3)
+      |> resolve()
     end
 
     @desc "Price-volume diff for a ticker and given currency and time period"
@@ -247,7 +264,9 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:result_size_tail, :integer, default_value: 0)
 
       complexity(&TechIndicatorsComplexity.price_volume_diff/3)
-      resolve(&TechIndicatorsResolver.price_volume_diff/3)
+
+      Cache.from(&TechIndicatorsResolver.price_volume_diff/3)
+      |> resolve()
     end
 
     @desc "Twitter mention count for a ticker and time period"
@@ -259,14 +278,17 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:result_size_tail, :integer, default_value: 0)
 
       complexity(&TechIndicatorsComplexity.twitter_mention_count/3)
-      resolve(&TechIndicatorsResolver.twitter_mention_count/3)
+
+      Cache.from(&TechIndicatorsResolver.twitter_mention_count/3)
+      |> resolve()
     end
 
     @desc "Returns a list of all exchange wallets. Internal API."
     field :exchange_wallets, list_of(:wallet) do
       middleware(BasicAuth)
 
-      resolve(&EtherbiResolver.exchange_wallets/3)
+      Cache.from(&EtherbiResolver.exchange_wallets/3)
+      |> resolve()
     end
 
     @desc "Returns the ETH spent by all projects in a given time period"

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -27,6 +27,8 @@ defmodule SanbaseWeb.ConnCase do
   end
 
   setup tags do
+    SanbaseWeb.Graphql.Helpers.Cache.clear_all()
+
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Sanbase.Repo)
 
     unless tags[:async] do


### PR DESCRIPTION
#### Summary
This PR aims to reduce the boilerplate when using our GQL cache. The ideal goal is to have something like `cache_resolve(captured_mfa)` instead of `resolve(captured_mfa)` (may not be achieved in this PR, but that's one step closer)

1. Due to the way Dataloader works with middlewares we put the caching inside the dataloader functions.

2. Now we cache the PDP page

3. Caching every gql query except `current_user` (Note: never cache current_user)

4. Add cache clear before every test. Otherwise tests like 'test exchangeWallets returns []' executed could hit the cache after exchangeWallets returns non-empty test.