### PR TITLE
Fix to correctly use coinmarketcap_id in the cmc query

### DIFF
--- a/lib/sanbase/external_services/coinmarketcap.ex
+++ b/lib/sanbase/external_services/coinmarketcap.ex
@@ -140,10 +140,10 @@ defmodule Sanbase.ExternalServices.Coinmarketcap do
     PriceVolumeDiff.exec(project, "usd")
   end
 
-  defp last_price_datetime(%Project{ticker: ticker}) do
-    case Store.last_history_datetime_cmc!(ticker) do
+  defp last_price_datetime(%Project{coinmarketcap_id: coinmarketcap_id}) do
+    case Store.last_history_datetime_cmc!(coinmarketcap_id) do
       nil ->
-        GraphData.fetch_first_price_datetime(ticker)
+        GraphData.fetch_first_price_datetime(coinmarketcap_id)
 
       datetime ->
         datetime

--- a/lib/sanbase/external_services/coinmarketcap/graph_data.ex
+++ b/lib/sanbase/external_services/coinmarketcap/graph_data.ex
@@ -43,7 +43,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData do
 
   # Helper functions
 
-  defp process_price_stream(price_stream, %Project{ticker: ticker} = project) do
+  defp process_price_stream(price_stream, %Project{coinmarketcap_id: coinmarketcap_id} = project) do
     price_stream
     |> Stream.each(fn prices ->
       measurement_points =
@@ -57,7 +57,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData do
         |> Enum.max_by(&Measurement.get_timestamp/1)
         |> Measurement.get_datetime()
 
-      Store.update_last_history_datetime_cmc(ticker, last_price_datetime_updated)
+      Store.update_last_history_datetime_cmc(coinmarketcap_id, last_price_datetime_updated)
     end)
     |> Stream.run()
   end

--- a/lib/sanbase/external_services/coinmarketcap/graph_data.ex
+++ b/lib/sanbase/external_services/coinmarketcap/graph_data.ex
@@ -43,7 +43,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData do
 
   # Helper functions
 
-  defp process_price_stream(price_stream, %Project{coinmarketcap_id: coinmarketcap_id} = project) do
+  defp process_price_stream(price_stream, %Project{} = project) do
     price_stream
     |> Stream.each(fn prices ->
       measurement_points =
@@ -52,14 +52,20 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData do
 
       measurement_points |> Store.import()
 
-      last_price_datetime_updated =
-        measurement_points
-        |> Enum.max_by(&Measurement.get_timestamp/1)
-        |> Measurement.get_datetime()
-
-      Store.update_last_history_datetime_cmc(coinmarketcap_id, last_price_datetime_updated)
+      update_last_cmc_history_datetime(project, measurement_points)
     end)
     |> Stream.run()
+  end
+
+  def update_last_cmc_history_datetime(_project, []), do: :ok
+
+  def update_last_cmc_history_datetime(%Project{coinmarketcap_id: coinmarketcap_id}, points) do
+    last_price_datetime_updated =
+      points
+      |> Enum.max_by(&Measurement.get_timestamp/1)
+      |> Measurement.get_datetime()
+
+    Store.update_last_history_datetime_cmc(coinmarketcap_id, last_price_datetime_updated)
   end
 
   defp price_points_to_measurements(%PricePoint{} = price_point, %Project{ticker: ticker}) do

--- a/lib/sanbase/notifications/price_volume_diff.ex
+++ b/lib/sanbase/notifications/price_volume_diff.ex
@@ -95,7 +95,9 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
 
   defp get_calculation_interval() do
     to_datetime = DateTime.utc_now()
-    from_datetime = Timex.shift(to_datetime, days: -approximation_window() - comparison_window() - 2)
+
+    from_datetime =
+      Timex.shift(to_datetime, days: -approximation_window() - comparison_window() - 2)
 
     %{from_datetime: from_datetime, to_datetime: to_datetime}
   end


### PR DESCRIPTION
#### Summary
pass coinmarketcap_id instead of ticker where needed.
fix errors caused by executing Enum.max_by on empty list