### PR TITLE
Format the Logger logs as json

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -26,7 +26,7 @@ config :sasl, sasl_error_logger: false
 
 # Configures Elixir's Logger
 config :logger, :console,
-  format: "$time $metadata[$level] $message\n",
+  format: {Sanbase.Utils.JsonLogger, :format},
   metadata: [:request_id],
   handle_otp_reports: true,
   handle_sasl_reports: true

--- a/lib/sanbase/utils/json_logger.ex
+++ b/lib/sanbase/utils/json_logger.ex
@@ -1,0 +1,18 @@
+defmodule Sanbase.Utils.JsonLogger do
+  def format(level, message, {date, {h, min, s, ms}} = timestamp, metadata) do
+    [
+      %{
+        timestamp: NaiveDateTime.from_erl!({date, {h, min, s}}, {ms * 1000, 3}),
+        level: level,
+        message: "#{message}"
+      }
+      |> Poison.encode_to_iodata!()
+      | "\n"
+    ]
+  rescue
+    error ->
+      "Could not format log message as json: #{inspect({level, timestamp, message, metadata})}. Reason: #{
+        inspect(error)
+      }.\n"
+  end
+end


### PR DESCRIPTION
Note: The `config/dev.exs` still overrides the console logger as it was before so it's more human readable during development
![](https://i.imgur.com/uGJirB7.png)