### PR TITLE
Handle error tuples in Store.import/1 and log them as warnings

### DIFF
--- a/lib/sanbase/influxdb/store.ex
+++ b/lib/sanbase/influxdb/store.ex
@@ -30,6 +30,14 @@ defmodule Sanbase.Influxdb.Store do
         :ok
       end
 
+      def import({:error, reason} = err_tuple) do
+        Logger.warn(
+          "Store.import/1 from #{__MODULE__} called with an error tuple: #{inspect(err_tuple)}"
+        )
+
+        err_tuple
+      end
+
       def import(measurements) do
         measurements
         |> Stream.map(&Measurement.convert_measurement_for_import/1)


### PR DESCRIPTION
When there's no check from the module calling `Store.import/1` it often happens that we try to `map` and error tuple `{:error, reason}` which results in sentry errors