### PR TITLE
Fix the github archive URL and follow redirects

### DIFF
--- a/lib/sanbase_workers/import_github_activity.ex
+++ b/lib/sanbase_workers/import_github_activity.ex
@@ -11,7 +11,7 @@ defmodule SanbaseWorkers.ImportGithubActivity do
   alias ExAws.S3
   alias Sanbase.Utils.Config
 
-  @github_archive "http://data.githubarchive.org/"
+  @github_archive "http://data.gharchive.org/"
 
   faktory_options(queue: "default", retry: -1, reserve_for: 900)
 
@@ -80,7 +80,8 @@ defmodule SanbaseWorkers.ImportGithubActivity do
         @github_archive <> archive <> ".json.gz",
         %{},
         stream_to: self(),
-        recv_timeout: 60_000
+        recv_timeout: 60_000,
+        follow_redirect: true
       )
 
     :ok = stream_loop(request_ref, output_file)

--- a/lib/sanbase_workers/import_github_activity.ex
+++ b/lib/sanbase_workers/import_github_activity.ex
@@ -81,7 +81,8 @@ defmodule SanbaseWorkers.ImportGithubActivity do
         %{},
         stream_to: self(),
         recv_timeout: 60_000,
-        follow_redirect: true
+        follow_redirect: true,
+        max_redirect: 10
       )
 
     :ok = stream_loop(request_ref, output_file)


### PR DESCRIPTION
#### Summary
<!-- (What does this pull request do in general terms?) -->
The URL of the GH archive have changed, which made our GH activity
tracking stop working.

Fixed the URL and also made the get request follow redirects to prevent
such problems in the future.
