### PR TITLE
Raise the limit for fetch_data

### DIFF
--- a/lib/sanbase/external_services/coinmarketcap/ticker.ex
+++ b/lib/sanbase/external_services/coinmarketcap/ticker.ex
@@ -30,7 +30,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.Ticker do
   alias Sanbase.ExternalServices.Coinmarketcap.Ticker
 
   def fetch_data() do
-    "/?limit=1000"
+    "/?limit=10000"
     |> get()
     |> case do
       %{status: 200, body: body} ->
@@ -41,6 +41,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.Ticker do
   def parse_json(json) do
     json
     |> Poison.decode!(as: [%Ticker{}])
+    |> Stream.filter(fn(ticker) -> ticker.last_updated end)
     |> Enum.map(&make_timestamp_integer/1)
   end
 


### PR DESCRIPTION
#### Summary
<!-- (What does this pull request do in general terms?) -->
Raises the limit for fetch_data so that projects can be scraped for
latest_coinmarketcap_data. Otherwise this will cause issues in the
front end.

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
