### PR TITLE
Revert back to logging in non-json format

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -26,7 +26,7 @@ config :sasl, sasl_error_logger: false
 
 # Configures Elixir's Logger
 config :logger, :console,
-  format: {Sanbase.Utils.JsonLogger, :format},
+  format: "$time $metadata[$level] $message\n",
   metadata: [:request_id],
   handle_otp_reports: true,
   handle_sasl_reports: true

--- a/lib/sanbase/notifications/price_volume_diff.ex
+++ b/lib/sanbase/notifications/price_volume_diff.ex
@@ -21,8 +21,7 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
            seconds_ago(notifications_cooldown()),
            notification_type_name(currency)
          ) do
-      with %{from_datetime: from_datetime, to_datetime: to_datetime} <-
-             get_calculation_interval(),
+      with %{from_datetime: from_datetime, to_datetime: to_datetime} <- get_calculation_interval(),
            true <- check_volume(project, currency, from_datetime, to_datetime),
            {indicator, notification_log} <-
              get_indicator(project.ticker, currency, from_datetime, to_datetime),

--- a/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
@@ -179,7 +179,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
           average_activity = active_addresses |> round() |> trunc()
           {:ok, average_activity}
 
-        _ -> {:ok, 0}
+        _ ->
+          {:ok, 0}
       end
     else
       error ->

--- a/lib/sanbase_web/graphql/resolvers/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project_resolver.ex
@@ -15,7 +15,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
     Infrastructure
   }
 
-alias Sanbase.Voting.{Post, Tag}
+  alias Sanbase.Voting.{Post, Tag}
 
   alias Sanbase.{Prices, Github, ExternalServices.Etherscan}
 
@@ -500,8 +500,7 @@ alias Sanbase.Voting.{Post, Tag}
     yesterday = Timex.shift(Timex.now(), days: -1)
     the_other_day = Timex.shift(Timex.now(), days: -2)
 
-    with {:ok, [[_dt, today_vol]]} <-
-           Prices.Store.fetch_mean_volume(pair, yesterday, Timex.now()),
+    with {:ok, [[_dt, today_vol]]} <- Prices.Store.fetch_mean_volume(pair, yesterday, Timex.now()),
          {:ok, [[_dt, yesterday_vol]]} <-
            Prices.Store.fetch_mean_volume(pair, the_other_day, yesterday),
          true <- yesterday_vol > 0 do

--- a/lib/sanbase_web/graphql/schema/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/project_types.ex
@@ -35,7 +35,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     field(:token_decimals, :integer)
     field(:eth_addresses, list_of(:eth_address), resolve: dataloader(SanbaseRepo))
 
-    field(:related_posts, list_of(:post)) do
+    field :related_posts, list_of(:post) do
       resolve(&ProjectResolver.related_posts/3)
     end
 

--- a/lib/sanbase_web/graphql/schema/voting_types.ex
+++ b/lib/sanbase_web/graphql/schema/voting_types.ex
@@ -29,7 +29,7 @@ defmodule SanbaseWeb.Graphql.VotingTypes do
     field(:images, list_of(:image_data), resolve: dataloader(SanbaseRepo))
     field(:tags, list_of(:tag), resolve: dataloader(SanbaseRepo))
 
-    field(:related_projects, list_of(:project)) do
+    field :related_projects, list_of(:project) do
       resolve(&PostResolver.related_projects/3)
     end
 


### PR DESCRIPTION
#### Summary
Revert to the old logging format.
The PR includes some formatting fixes as I cannot sign my commits when the `mix format --check-formatted` fails.