### PR TITLE
Use token_name instead of coinmarketcap_id

### DIFF
--- a/lib/sanbase/external_services/project_info.ex
+++ b/lib/sanbase/external_services/project_info.ex
@@ -72,13 +72,13 @@ defmodule Sanbase.ExternalServices.ProjectInfo do
     |> fetch_abi()
   end
 
-  def fetch_etherscan_token_summary(%ProjectInfo{coinmarketcap_id: nil} = project_info),
+  def fetch_etherscan_token_summary(%ProjectInfo{etherscan_token_name: nil} = project_info),
     do: project_info
 
   def fetch_etherscan_token_summary(
-        %ProjectInfo{coinmarketcap_id: coinmarketcap_id} = project_info
+        %ProjectInfo{etherscan_token_name: etherscan_token_name} = project_info
       ) do
-    Etherscan.Scraper.fetch_token_page(coinmarketcap_id)
+    Etherscan.Scraper.fetch_token_page(etherscan_token_name)
     |> Etherscan.Scraper.parse_token_page!(project_info)
   end
 


### PR DESCRIPTION
#### Summary
<!-- (What does this pull request do in general terms?) -->
Reverts the changes in fetch_etherscan_token_summary method to use
token_name instead of coinmarketcap_id. Looks like not all currencies
have pages with coinmarketcap_id.

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
