### PR TITLE
Add dataloader caching

### DIFF
--- a/lib/sanbase/application.ex
+++ b/lib/sanbase/application.ex
@@ -1,7 +1,6 @@
 defmodule Sanbase.Application do
   use Application
   import Supervisor.Spec
-  import Cachex.Spec
 
   # See https://hexdocs.pm/elixir/Application.html
   # for more information on OTP Applications

--- a/lib/sanbase_web/graphql/helpers/cache.ex
+++ b/lib/sanbase_web/graphql/helpers/cache.ex
@@ -56,10 +56,22 @@ defmodule SanbaseWeb.Graphql.Helpers.Cache do
     # Caching is only possible for query resolvers for now. Field resolvers are
     # not supported, because they are scoped on their root object, we can't get
     # a good, general cache key for arbitrary root objects
-    fn %{}, args, resolution ->
-      ConCache.get_or_store(@cache_name, cache_key(name, args), fn ->
-        resolver_fn.(%{}, args, resolution)
-      end)
+    fn
+      %Sanbase.Model.Project{id: id} = project, args, resolution ->
+        {:ok, value} =
+          ConCache.get_or_store(@cache_name, cache_key({name, id}, args), fn ->
+            {:ok, resolver_fn.(project, args, resolution)}
+          end)
+
+        value
+
+      %{}, args, resolution ->
+        {:ok, value} =
+          ConCache.get_or_store(@cache_name, cache_key(name, args), fn ->
+            {:ok, resolver_fn.(%{}, args, resolution)}
+          end)
+
+        value
     end
   end
 

--- a/lib/sanbase_web/graphql/helpers/cache.ex
+++ b/lib/sanbase_web/graphql/helpers/cache.ex
@@ -6,6 +6,17 @@ defmodule SanbaseWeb.Graphql.Helpers.Cache do
 
   alias __MODULE__, as: CacheMod
 
+  @doc ~s"""
+    Macro that's used instead of Absinthe's `resolve`. The value of the resolver is
+    1. get from a cache if it exists there
+    2. calculated and stored in the cache if it does not exist
+
+    The value of `captured_mfa_ast` when executed MUST be a concrete value but not
+    a new middleware.
+
+    The function MUST be a captured named function because its name is extracted
+    and used in the cache key.
+  """
   defmacro cache_resolve(captured_mfa_ast) do
     quote do
       middleware(
@@ -15,6 +26,38 @@ defmodule SanbaseWeb.Graphql.Helpers.Cache do
     end
   end
 
+  @doc ~s"""
+    Macro that's used instead of Absinthe's `resolve`. The value of the resolver is
+    1. Get from a cache if it exists there
+    2. Calculated and stored in the cache if it does not exist
+
+    The value of `captured_mfa_ast` when executed MUST be a concrete value but not
+    a new middleware.
+
+    The function's name is not used but instead `fun_name` is used in the cache key
+  """
+  defmacro cache_resolve(captured_mfa_ast, fun_name) do
+    quote do
+      middleware(
+        Absinthe.Resolution,
+        CacheMod.from(unquote(captured_mfa_ast), unquote(fun_name))
+      )
+    end
+  end
+
+  @doc ~s"""
+    Macro that's used instead of Absinthe's `resolve`. The value of the resolver is
+    1. Get from a cache if it exists there
+    2. Calculated at a later point in time (when the middleware is executed)
+    and stored in the cache if it does not exist
+
+    The value of `captured_mfa_ast` MUST be a dataloader middleware tuple with three elements
+    `{:middleware, Absinthe.Middleware.Dataloder, callback}` where `callback` is a
+    function with arity 1 that accepts `loader` as a single parameter.
+
+    The function MUST be a captured named function because its name is extracted
+    and used in the cache key.
+  """
   defmacro cache_resolve_dataloader(captured_mfa_ast) do
     quote do
       middleware(
@@ -24,33 +67,37 @@ defmodule SanbaseWeb.Graphql.Helpers.Cache do
     end
   end
 
-  def from(captured_mfa) when is_function(captured_mfa) do
-    fun_name = captured_mfa |> captured_mfa_name()
+  @doc ~s"""
+    Exposed as
+    sometimes it can be useful to use it outside the macros.
 
-    captured_mfa
-    |> resolver(fun_name)
-  end
+    Gets a function, name and arguments and returns a new function that:
+    1. On execution checks if the value is present in the cache and returns it
+    2. If it's not in the cache it gets executed and the value is stored in the cache.
 
-  def dataloader_from(captured_mfa) when is_function(captured_mfa) do
-    fun_name = captured_mfa |> captured_mfa_name()
-
-    captured_mfa
-    |> dataloader_resolver(fun_name)
-  end
-
-  def from(fun, fun_name) when is_function(fun) do
-    fun
-    |> resolver(fun_name)
-  end
-
+    NOTE: `cached_func` is a function with arity 0. That means if you want to use it
+    in your code and you want some arguments you should use it like this:
+      > Cache.func(
+      >   fn ->
+      >     fetch_last_price_record(pair)
+      >   end,
+      >   :fetch_price_last_record, %{pair: pair}
+      > ).()
+  """
   def func(cached_func, name, args \\ %{}) do
     fn ->
-      ConCache.get_or_store(@cache_name, cache_key(name, args), fn ->
-        cached_func.()
-      end)
+      {:ok, value} =
+        ConCache.get_or_store(@cache_name, cache_key(name, args), fn ->
+          {:ok, cached_func.()}
+        end)
+
+      value
     end
   end
 
+  @doc ~s"""
+    Clears the whole cache. Slow.
+  """
   def clear_all() do
     @cache_name
     |> ConCache.ets()
@@ -58,9 +105,31 @@ defmodule SanbaseWeb.Graphql.Helpers.Cache do
     |> Enum.each(fn {key, _} -> ConCache.delete(@cache_name, key) end)
   end
 
+  @doc ~s"""
+    The size of the cache in megabytes
+  """
   def size(:megabytes) do
     bytes_size = :ets.info(ConCache.ets(@cache_name), :memory) * :erlang.system_info(:wordsize)
     (bytes_size / (1024 * 1024)) |> Float.round(2)
+  end
+
+  # Public so it can be used by the resolve macros. You should not use it.
+  def from(captured_mfa) when is_function(captured_mfa) do
+    fun_name = captured_mfa |> captured_mfa_name()
+
+    resolver(captured_mfa, fun_name)
+  end
+
+  # Public so it can be used by the resolve macros. You should not use it.
+  def from(fun, fun_name) when is_function(fun) do
+    resolver(fun, fun_name)
+  end
+
+  # Public so it can be used by the resolve macros. You should not use it.
+  def dataloader_from(captured_mfa) when is_function(captured_mfa) do
+    fun_name = captured_mfa |> captured_mfa_name()
+
+    dataloader_resolver(captured_mfa, fun_name)
   end
 
   # Private functions
@@ -86,6 +155,22 @@ defmodule SanbaseWeb.Graphql.Helpers.Cache do
     end
   end
 
+  # The actual work for the dataloader cache resolver is done here.
+  #
+  # The most important part is how the cache is actually populated. The resolver
+  # returns a `{:middleware, Absinthe.Middleware.Dataloader, callback}` tuple.
+  # This is NOT the final result so it cannot be used. Instead, `callback` is replaced
+  # by a function that does the caching.
+  # That works because `callback` is always a function with one argument `loader`, which
+  # when executed (after `Dataloader.run` is called from the middleware) returns the
+  # actual result.
+  #
+  # The modified callback internally calls the original callback, passing it the argument,
+  # stores the value in the cache and returns the value. From the outside it works the same
+  # as the original callback
+  #
+  # Because Elixir's lambdas are correctly implemented, we can fetch what's needed
+  # from the context to use it for `cache_key`
   defp dataloader_resolver(resolver_fn, name) do
     # Works only for top-level resolvers and fields with root object Project
     fn
@@ -98,14 +183,15 @@ defmodule SanbaseWeb.Graphql.Helpers.Cache do
 
             caching_callback = fn loader ->
               value = callback.(loader)
-              ConCache.put(@cache_name, cache_key, value)
+              ConCache.put(@cache_name, cache_key, {:ok, value})
 
               value
             end
 
             {:middleware, midl, {loader, caching_callback}}
 
-          value ->
+          # Wrap in a tuple to distinguish value = nil from not having a record
+          {:ok, value} ->
             value
         end
 
@@ -118,29 +204,33 @@ defmodule SanbaseWeb.Graphql.Helpers.Cache do
 
             caching_callback = fn loader_arg ->
               value = callback.(loader_arg)
-              ConCache.put(@cache_name, cache_key, value)
+              ConCache.put(@cache_name, cache_key, {:ok, value})
 
               value
             end
 
             {:middleware, midl, {loader, caching_callback}}
 
-          value ->
+          # Wrap in a tuple to distinguish value = nil from not having a record
+          {:ok, value} ->
             value
         end
     end
   end
 
+  # Calculate the cache key from a given name and arguments.
   defp cache_key(name, args) do
     args_hash =
       args
-      |> convert_values
+      |> convert_values()
       |> Poison.encode!()
-      |> sha256
+      |> sha256()
 
     {name, args_hash}
   end
 
+  # Convert the values for using in the cache. A special treatement is done for
+  # `%DateTime{}` so all datetimes in a @ttl sized window are treated the same
   defp convert_values(args) do
     args
     |> Enum.map(fn

--- a/lib/sanbase_web/graphql/resolvers/project/project_balance_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_balance_resolver.ex
@@ -1,0 +1,126 @@
+defmodule SanbaseWeb.Graphql.Resolvers.ProjectBalanceResolver do
+  require Logger
+
+  import Ecto.Query
+  import Absinthe.Resolution.Helpers
+
+  alias Sanbase.Model.{
+    Project,
+    LatestCoinmarketcapData,
+    MarketSegment,
+    Infrastructure,
+    ProjectTransparencyStatus,
+    ProjectEthAddress,
+    Ico,
+    Infrastructure
+  }
+
+  alias Sanbase.Voting.{Post, Tag}
+
+  alias Sanbase.{Prices, Github, ExternalServices.Etherscan}
+
+  alias SanbaseWeb.Graphql.SanbaseRepo
+  alias SanbaseWeb.Graphql.PriceStore
+  alias SanbaseWeb.Graphql.Helpers.Cache
+
+  alias Sanbase.Repo
+
+  def eth_balance(%Project{} = project, _args, %{context: %{loader: loader}}) do
+    loader
+    |> eth_balance_loader(project)
+    |> on_load(&eth_balance_from_loader(&1, project))
+  end
+
+  def eth_balance_loader(loader, project) do
+    loader
+    |> Dataloader.load(SanbaseRepo, :eth_addresses, project)
+  end
+
+  def eth_balance_from_loader(loader, project) do
+    balance =
+      loader
+      |> Dataloader.get(SanbaseRepo, :eth_addresses, project)
+      |> Stream.reject(&is_nil/1)
+      |> Stream.map(& &1.latest_eth_wallet_data)
+      |> Stream.reject(&is_nil/1)
+      |> Stream.map(& &1.balance)
+      |> Enum.reduce(Decimal.new(0), &Decimal.add/2)
+
+    {:ok, balance}
+  end
+
+  def btc_balance(%Project{} = project, _args, %{context: %{loader: loader}}) do
+    loader
+    |> btc_balance_loader(project)
+    |> on_load(&btc_balance_from_loader(&1, project))
+  end
+
+  def btc_balance_loader(loader, project) do
+    loader
+    |> Dataloader.load(SanbaseRepo, :btc_addresses, project)
+  end
+
+  def btc_balance_from_loader(loader, project) do
+    balance =
+      loader
+      |> Dataloader.get(SanbaseRepo, :btc_addresses, project)
+      |> Stream.reject(&is_nil/1)
+      |> Stream.map(& &1.latest_btc_wallet_data)
+      |> Stream.reject(&is_nil/1)
+      |> Stream.map(& &1.balance)
+      |> Enum.reduce(Decimal.new(0), &Decimal.add/2)
+
+    {:ok, balance}
+  end
+
+  def usd_balance(%Project{} = project, _args, %{context: %{loader: loader}}) do
+    IO.puts("RESOLVING USD BALANCE")
+
+    loader
+    |> usd_balance_loader(project)
+    |> on_load(&usd_balance_from_loader(&1, project))
+  end
+
+  def usd_balance_loader(loader, project) do
+    loader
+    |> eth_balance_loader(project)
+    |> btc_balance_loader(project)
+    |> Dataloader.load(PriceStore, "ETH_USD", :last)
+    |> Dataloader.load(PriceStore, "BTC_USD", :last)
+  end
+
+  def usd_balance_from_loader(loader, project) do
+    with {:ok, eth_balance} <- eth_balance_from_loader(loader, project),
+         {:ok, btc_balance} <- btc_balance_from_loader(loader, project),
+         eth_price when not is_nil(eth_price) <-
+           Dataloader.get(loader, PriceStore, "ETH_USD", :last),
+         btc_price when not is_nil(btc_price) <-
+           Dataloader.get(loader, PriceStore, "BTC_USD", :last) do
+      {:ok,
+       Decimal.add(
+         Decimal.mult(eth_balance, eth_price),
+         Decimal.mult(btc_balance, btc_price)
+       )}
+    else
+      error ->
+        Logger.warn("Cannot calculate USD balance. Reason: #{inspect(error)}")
+        {:ok, nil}
+    end
+  end
+
+  def eth_address_balance(%ProjectEthAddress{} = eth_address, _args, %{
+        context: %{loader: loader}
+      }) do
+    loader
+    |> Dataloader.load(SanbaseRepo, :latest_eth_wallet_data, eth_address)
+    |> on_load(fn loader ->
+      with latest_eth_wallet_data when not is_nil(latest_eth_wallet_data) <-
+             Dataloader.get(loader, SanbaseRepo, :latest_eth_wallet_data, eth_address),
+           balance <- latest_eth_wallet_data.balance do
+        {:ok, balance}
+      else
+        _ -> {:ok, nil}
+      end
+    end)
+  end
+end

--- a/lib/sanbase_web/graphql/resolvers/project/project_balance_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_balance_resolver.ex
@@ -1,29 +1,15 @@
 defmodule SanbaseWeb.Graphql.Resolvers.ProjectBalanceResolver do
   require Logger
 
-  import Ecto.Query
   import Absinthe.Resolution.Helpers
 
   alias Sanbase.Model.{
     Project,
-    LatestCoinmarketcapData,
-    MarketSegment,
-    Infrastructure,
-    ProjectTransparencyStatus,
-    ProjectEthAddress,
-    Ico,
-    Infrastructure
+    ProjectEthAddress
   }
-
-  alias Sanbase.Voting.{Post, Tag}
-
-  alias Sanbase.{Prices, Github, ExternalServices.Etherscan}
 
   alias SanbaseWeb.Graphql.SanbaseRepo
   alias SanbaseWeb.Graphql.PriceStore
-  alias SanbaseWeb.Graphql.Helpers.Cache
-
-  alias Sanbase.Repo
 
   def eth_balance(%Project{} = project, _args, %{context: %{loader: loader}}) do
     loader
@@ -74,8 +60,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectBalanceResolver do
   end
 
   def usd_balance(%Project{} = project, _args, %{context: %{loader: loader}}) do
-    IO.puts("RESOLVING USD BALANCE")
-
     loader
     |> usd_balance_loader(project)
     |> on_load(&usd_balance_from_loader(&1, project))

--- a/lib/sanbase_web/graphql/resolvers/project/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_resolver.ex
@@ -10,7 +10,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
     MarketSegment,
     Infrastructure,
     ProjectTransparencyStatus,
-    ProjectEthAddress,
     Ico,
     Infrastructure
   }
@@ -23,8 +22,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
     ExternalServices.Etherscan
   }
 
-  alias SanbaseWeb.Graphql.SanbaseRepo
-  alias SanbaseWeb.Graphql.PriceStore
   alias SanbaseWeb.Graphql.Helpers.Cache
 
   alias SanbaseWeb.Graphql.Resolvers.ProjectBalanceResolver

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -27,9 +27,6 @@ defmodule SanbaseWeb.Graphql.Schema do
     PostPermissions
   }
 
-  alias SanbaseWeb.Graphql.SanbaseRepo
-  alias SanbaseWeb.Graphql.PriceStore
-
   import_types(Absinthe.Plug.Types)
   import_types(Absinthe.Type.Custom)
   import_types(SanbaseWeb.Graphql.CustomTypes)
@@ -45,6 +42,9 @@ defmodule SanbaseWeb.Graphql.Schema do
   import_types(SanbaseWeb.Graphql.FileTypes)
 
   def dataloader() do
+    alias SanbaseWeb.Graphql.SanbaseRepo
+    alias SanbaseWeb.Graphql.PriceStore
+
     Dataloader.new()
     |> Dataloader.add_source(SanbaseRepo, SanbaseRepo.data())
     |> Dataloader.add_source(PriceStore, PriceStore.data())
@@ -55,7 +55,9 @@ defmodule SanbaseWeb.Graphql.Schema do
   end
 
   def plugins do
-    [Absinthe.Middleware.Dataloader] ++ Absinthe.Plugin.defaults()
+    [
+      Absinthe.Middleware.Dataloader | Absinthe.Plugin.defaults()
+    ]
   end
 
   query do

--- a/lib/sanbase_web/graphql/schema/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/project_types.ex
@@ -3,11 +3,16 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
   use Absinthe.Ecto, repo: Sanbase.Repo
 
   import Absinthe.Resolution.Helpers
+  import SanbaseWeb.Graphql.Helpers.Cache, only: [cache_resolve: 1]
 
-  alias SanbaseWeb.Graphql.Resolvers.ProjectResolver
-  alias SanbaseWeb.Graphql.Resolvers.IcoResolver
-  alias SanbaseWeb.Graphql.Resolvers.TwitterResolver
-  alias SanbaseWeb.Graphql.Resolvers.EtherbiResolver
+  alias SanbaseWeb.Graphql.Resolvers.{
+    ProjectResolver,
+    ProjectBalanceResolver,
+    IcoResolver,
+    TwitterResolver,
+    EtherbiResolver
+  }
+
   alias SanbaseWeb.Graphql.SanbaseRepo
 
   # Includes all available fields
@@ -57,23 +62,23 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     field(:project_transparency_description, :string)
 
     field :eth_balance, :decimal do
-      resolve(&ProjectResolver.eth_balance/3)
+      resolve(&ProjectBalanceResolver.eth_balance/3)
     end
 
     field :btc_balance, :decimal do
-      resolve(&ProjectResolver.btc_balance/3)
+      resolve(&ProjectBalanceResolver.btc_balance/3)
     end
 
     field :usd_balance, :decimal do
-      resolve(&ProjectResolver.usd_balance/3)
+      resolve(&ProjectBalanceResolver.usd_balance/3)
     end
 
     field :funds_raised_icos, list_of(:currency_amount) do
-      resolve(&ProjectResolver.funds_raised_icos/3)
+      cache_resolve(&ProjectResolver.funds_raised_icos/3)
     end
 
     field :roi_usd, :decimal do
-      resolve(&ProjectResolver.roi_usd/3)
+      cache_resolve(&ProjectResolver.roi_usd/3)
     end
 
     field(:coinmarketcap_id, :string)
@@ -136,19 +141,19 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     end
 
     field :funds_raised_usd_ico_end_price, :decimal do
-      resolve(&ProjectResolver.funds_raised_usd_ico_end_price/3)
+      cache_resolve(&ProjectResolver.funds_raised_usd_ico_end_price/3)
     end
 
     field :funds_raised_eth_ico_end_price, :decimal do
-      resolve(&ProjectResolver.funds_raised_eth_ico_end_price/3)
+      cache_resolve(&ProjectResolver.funds_raised_eth_ico_end_price/3)
     end
 
     field :funds_raised_btc_ico_end_price, :decimal do
-      resolve(&ProjectResolver.funds_raised_btc_ico_end_price/3)
+      cache_resolve(&ProjectResolver.funds_raised_btc_ico_end_price/3)
     end
 
     field :initial_ico, :ico do
-      resolve(&ProjectResolver.initial_ico/3)
+      cache_resolve(&ProjectResolver.initial_ico/3)
     end
 
     field(:icos, list_of(:ico), resolve: assoc(:icos))
@@ -197,7 +202,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     field(:address, non_null(:string))
 
     field :balance, :decimal do
-      resolve(&ProjectResolver.eth_address_balance/3)
+      resolve(&ProjectBalanceResolver.eth_address_balance/3)
     end
   end
 

--- a/lib/sanbase_web/graphql/schema/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/project_types.ex
@@ -3,7 +3,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
   use Absinthe.Ecto, repo: Sanbase.Repo
 
   import Absinthe.Resolution.Helpers
-  import SanbaseWeb.Graphql.Helpers.Cache, only: [cache_resolve: 1]
+  import SanbaseWeb.Graphql.Helpers.Cache, only: [cache_resolve: 1, cache_resolve_dataloader: 1]
 
   alias SanbaseWeb.Graphql.Resolvers.{
     ProjectResolver,
@@ -62,15 +62,15 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     field(:project_transparency_description, :string)
 
     field :eth_balance, :decimal do
-      resolve(&ProjectBalanceResolver.eth_balance/3)
+      cache_resolve_dataloader(&ProjectBalanceResolver.eth_balance/3)
     end
 
     field :btc_balance, :decimal do
-      resolve(&ProjectBalanceResolver.btc_balance/3)
+      cache_resolve_dataloader(&ProjectBalanceResolver.btc_balance/3)
     end
 
     field :usd_balance, :decimal do
-      resolve(&ProjectBalanceResolver.usd_balance/3)
+      cache_resolve_dataloader(&ProjectBalanceResolver.usd_balance/3)
     end
 
     field :funds_raised_icos, list_of(:currency_amount) do
@@ -159,7 +159,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     field(:icos, list_of(:ico), resolve: assoc(:icos))
 
     field :signals, list_of(:signal) do
-      resolve(&ProjectResolver.signals/3)
+      cache_resolve_dataloader(&ProjectResolver.signals/3)
     end
 
     field :price_to_book_ratio, :decimal do

--- a/lib/sanbase_web/graphql/schema/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/project_types.ex
@@ -163,7 +163,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     end
 
     field :price_to_book_ratio, :decimal do
-      resolve(&ProjectResolver.price_to_book_ratio/3)
+      cache_resolve_dataloader(&ProjectResolver.price_to_book_ratio/3)
     end
 
     field :eth_spent, :float do


### PR DESCRIPTION
#### Summary

Also separated the project resolver into two resolvers. Ultimately there should be more resolvers, separated logically 

From the screenshot we can see that the second request's value is returned from the cache

![](https://i.imgur.com/0Xr2Ig1.png)
