### PR TITLE
Disable caching for insights

### DIFF
--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -213,7 +213,7 @@ defmodule SanbaseWeb.Graphql.Schema do
     field :all_insights, list_of(:post) do
       middleware(PostPermissions)
 
-      cache_resolve(&PostResolver.all_insights/3)
+      resolve(&PostResolver.all_insights/3)
     end
 
     @desc "Get all posts for given user"
@@ -222,7 +222,7 @@ defmodule SanbaseWeb.Graphql.Schema do
 
       middleware(PostPermissions)
 
-      cache_resolve(&PostResolver.all_insights_for_user/3)
+      resolve(&PostResolver.all_insights_for_user/3)
     end
 
     @desc "Get all posts a user has voted for"
@@ -231,7 +231,7 @@ defmodule SanbaseWeb.Graphql.Schema do
 
       middleware(PostPermissions)
 
-      cache_resolve(&PostResolver.all_insights_user_voted_for/3)
+      resolve(&PostResolver.all_insights_user_voted_for/3)
     end
 
     @desc "Get all tags"


### PR DESCRIPTION
#### Summary
<!-- (What does this pull request do in general terms?) -->
Currently we can't cache queries that return an array of insights.
For example `createPost/deletePost` and then fetching `allInsights` will not properly reflect the created/deleted insight. Also a user voting for a insight will not be reflected in `allInsightsUserVotedFor`.
We should think for a way to invalidate cache when create/delete or vote/unvote action happens.
