### PR TITLE
Change the san_balance to be used everywhere with divided token decimals

### DIFF
--- a/lib/sanbase/internal_services/ethauth.ex
+++ b/lib/sanbase/internal_services/ethauth.ex
@@ -4,6 +4,8 @@ defmodule Sanbase.InternalServices.Ethauth do
   require Sanbase.Utils.Config
   alias Sanbase.Utils.Config
 
+  @san_token_decimals Decimal.new(:math.pow(10, 18))
+
   def verify_signature(signature, address, message_hash) do
     %Tesla.Env{status: 200, body: body} =
       get(client(), "recover", query: [sign: signature, hash: message_hash])
@@ -18,10 +20,11 @@ defmodule Sanbase.InternalServices.Ethauth do
 
     body
     |> Decimal.new()
+    |> Decimal.div(@san_token_decimals)
   end
 
   def san_token_decimals() do
-    Decimal.new(:math.pow(10, 18))
+    @san_token_decimals
   end
 
   defp client() do

--- a/lib/sanbase_web/graphql/middlewares/post_permissions.ex
+++ b/lib/sanbase_web/graphql/middlewares/post_permissions.ex
@@ -7,7 +7,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.PostPermissions do
     "id",
     "title",
     "shortDesc",
-    "totalSanVotes",
+    "votes",
     "user",
     "createdAt",
     "state",

--- a/lib/sanbase_web/graphql/resolvers/eth_account_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/eth_account_resolver.ex
@@ -3,6 +3,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.EthAccountResolver do
   alias Sanbase.InternalServices.Ethauth
 
   def san_balance(eth_account, _, _) do
-    {:ok, Decimal.div(EthAccount.san_balance(eth_account), Ethauth.san_token_decimals())}
+    {:ok, EthAccount.san_balance(eth_account)}
   end
 end

--- a/lib/sanbase_web/graphql/resolvers/voting_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/voting_resolver.ex
@@ -4,7 +4,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.VotingResolver do
   alias Sanbase.Auth.User
   alias Sanbase.Voting.{Poll, Post, Vote}
   alias Sanbase.Repo
-  alias Sanbase.InternalServices.Ethauth
   alias SanbaseWeb.Graphql.Resolvers.Helpers
 
   def current_poll(_root, _args, _context) do
@@ -24,7 +23,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.VotingResolver do
       |> Stream.map(&User.san_balance!/1)
       |> Enum.reduce(Decimal.new(0), &Decimal.add/2)
 
-    {:ok, Decimal.div(total_san_votes, Ethauth.san_token_decimals())}
+    {:ok, total_san_votes}
   end
 
   def voted_at(%Post{} = post, _args, %{

--- a/lib/sanbase_web/graphql/resolvers/voting_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/voting_resolver.ex
@@ -14,16 +14,28 @@ defmodule SanbaseWeb.Graphql.Resolvers.VotingResolver do
     {:ok, poll}
   end
 
-  def total_san_votes(%Post{} = post, _args, _context) do
-    total_san_votes =
+  @doc ~s"""
+    Returns a tuple `{total_votes, total_san_votes}` where:
+    - `total_votes` represents the number of votes where each vote's weight is 1
+    - `total_san_votes` represents the number of votes where each vote's weight is
+    equal to the san balance of the voter
+  """
+  def votes(%Post{} = post, _args, _context) do
+    {total_votes, total_san_votes} =
       post
       |> Repo.preload(votes: [user: :eth_accounts])
       |> Map.get(:votes)
       |> Stream.map(&Map.get(&1, :user))
       |> Stream.map(&User.san_balance!/1)
-      |> Enum.reduce(Decimal.new(0), &Decimal.add/2)
+      |> Enum.reduce({0, 0}, fn san_balance, {votes, san_token_votes} ->
+        {votes + 1, san_token_votes + Decimal.to_float(san_balance)}
+      end)
 
-    {:ok, total_san_votes}
+    {:ok,
+     %{
+       total_votes: total_votes,
+       total_san_votes: total_san_votes |> round() |> trunc()
+     }}
   end
 
   def voted_at(%Post{} = post, _args, %{

--- a/lib/sanbase_web/graphql/schema/voting_types.ex
+++ b/lib/sanbase_web/graphql/schema/voting_types.ex
@@ -6,6 +6,11 @@ defmodule SanbaseWeb.Graphql.VotingTypes do
   alias SanbaseWeb.Graphql.Resolvers.{VotingResolver, PostResolver}
   alias SanbaseWeb.Graphql.SanbaseRepo
 
+  object :vote do
+    field(:total_votes, non_null(:integer))
+    field(:total_san_votes, non_null(:integer))
+  end
+
   object :tag do
     field(:name, non_null(:string))
   end
@@ -44,8 +49,8 @@ defmodule SanbaseWeb.Graphql.VotingTypes do
       resolve(&VotingResolver.voted_at/3)
     end
 
-    field :total_san_votes, :integer do
-      resolve(&VotingResolver.total_san_votes/3)
+    field :votes, :vote do
+      resolve(&VotingResolver.votes/3)
     end
   end
 end

--- a/test/sanbase_web/graphql/post_test.exs
+++ b/test/sanbase_web/graphql/post_test.exs
@@ -90,7 +90,9 @@ defmodule SanbaseWeb.Graphql.PostTest do
           id,
           username
         },
-        totalSanVotes
+        votes{
+          totalSanVotes
+        }
       }
     }
     """
@@ -445,7 +447,9 @@ defmodule SanbaseWeb.Graphql.PostTest do
         user {
           id
         },
-        totalSanVotes,
+        votes{
+          totalSanVotes,
+        }
         state,
         createdAt
       }
@@ -462,8 +466,7 @@ defmodule SanbaseWeb.Graphql.PostTest do
     assert sanbasePost["title"] == "Awesome post"
     assert sanbasePost["state"] == nil
     assert sanbasePost["user"]["id"] == user.id |> Integer.to_string()
-    {total_san_votes, _after_decimal_point} = sanbasePost["totalSanVotes"] |> Integer.parse()
-    assert total_san_votes == 0
+    assert sanbasePost["votes"]["totalSanVotes"] == 0
 
     createdAt = Timex.parse!(sanbasePost["createdAt"], "{ISO:Extended}")
 

--- a/test/sanbase_web/graphql/voting_test.exs
+++ b/test/sanbase_web/graphql/voting_test.exs
@@ -70,7 +70,9 @@ defmodule SanbaseWeb.Graphql.VotingTest do
         endAt,
         posts {
           id,
-          totalSanVotes
+          votes{
+            totalSanVotes
+          }
         }
       }
     }
@@ -85,12 +87,10 @@ defmodule SanbaseWeb.Graphql.VotingTest do
     assert Timex.parse!(currentPoll["startAt"], "{ISO:Extended}") ==
              Timex.beginning_of_week(Timex.now())
 
-    assert currentPoll["posts"] == [
-             %{
-               "id" => Integer.to_string(approved_post.id),
-               "totalSanVotes" => Decimal.to_string(user.san_balance)
-             }
-           ]
+    assert %{
+             "id" => Integer.to_string(approved_post.id),
+             "votes" => %{"totalSanVotes" => Decimal.to_integer(user.san_balance)}
+           } in currentPoll["posts"]
   end
 
   test "getting the current poll with the dates when the current user voted", %{
@@ -152,7 +152,9 @@ defmodule SanbaseWeb.Graphql.VotingTest do
     mutation {
       vote(postId: #{sanbase_post.id}) {
         id,
-        totalSanVotes
+        votes{
+          totalSanVotes
+        }
       }
     }
     """
@@ -165,7 +167,7 @@ defmodule SanbaseWeb.Graphql.VotingTest do
 
     assert sanbasePost["id"] == Integer.to_string(sanbase_post.id)
 
-    assert sanbasePost["totalSanVotes"] == Decimal.to_string(user.san_balance)
+    assert sanbasePost["votes"]["totalSanVotes"] == Decimal.to_integer(user.san_balance)
   end
 
   test "unvoting for a post", %{conn: conn, user: user} do
@@ -188,7 +190,9 @@ defmodule SanbaseWeb.Graphql.VotingTest do
     mutation {
       unvote(postId: #{sanbase_post.id}) {
         id,
-        totalSanVotes
+        votes{
+          totalSanVotes
+        }
       }
     }
     """
@@ -200,6 +204,6 @@ defmodule SanbaseWeb.Graphql.VotingTest do
     sanbasePost = json_response(result, 200)["data"]["unvote"]
 
     assert sanbasePost["id"] == Integer.to_string(sanbase_post.id)
-    assert Decimal.cmp(sanbasePost["totalSanVotes"] |> Decimal.new(), Decimal.new(0)) == :eq
+    assert sanbasePost["votes"]["totalSanVotes"] == 0
   end
 end

--- a/test/sanbase_web/graphql/voting_test.exs
+++ b/test/sanbase_web/graphql/voting_test.exs
@@ -4,7 +4,6 @@ defmodule SanbaseWeb.Graphql.VotingTest do
   alias Sanbase.Voting.{Poll, Post, Vote}
   alias Sanbase.Auth.User
   alias Sanbase.Repo
-  alias Sanbase.InternalServices.Ethauth
 
   import SanbaseWeb.Graphql.TestHelpers
 
@@ -12,8 +11,7 @@ defmodule SanbaseWeb.Graphql.VotingTest do
     user =
       %User{
         salt: User.generate_salt(),
-        san_balance:
-          Decimal.mult(Decimal.new("10.000000000000000000"), Ethauth.san_token_decimals()),
+        san_balance: Decimal.new("10.000000000000000000"),
         san_balance_updated_at: Timex.now()
       }
       |> Repo.insert!()
@@ -90,8 +88,7 @@ defmodule SanbaseWeb.Graphql.VotingTest do
     assert currentPoll["posts"] == [
              %{
                "id" => Integer.to_string(approved_post.id),
-               "totalSanVotes" =>
-                 Decimal.to_string(Decimal.div(user.san_balance, Ethauth.san_token_decimals()))
+               "totalSanVotes" => Decimal.to_string(user.san_balance)
              }
            ]
   end
@@ -168,8 +165,7 @@ defmodule SanbaseWeb.Graphql.VotingTest do
 
     assert sanbasePost["id"] == Integer.to_string(sanbase_post.id)
 
-    assert sanbasePost["totalSanVotes"] ==
-             Decimal.to_string(Decimal.div(user.san_balance, Ethauth.san_token_decimals()))
+    assert sanbasePost["totalSanVotes"] == Decimal.to_string(user.san_balance)
   end
 
   test "unvoting for a post", %{conn: conn, user: user} do
@@ -204,6 +200,6 @@ defmodule SanbaseWeb.Graphql.VotingTest do
     sanbasePost = json_response(result, 200)["data"]["unvote"]
 
     assert sanbasePost["id"] == Integer.to_string(sanbase_post.id)
-    assert sanbasePost["totalSanVotes"] == "0.000000000000000000"
+    assert Decimal.cmp(sanbasePost["totalSanVotes"] |> Decimal.new(), Decimal.new(0)) == :eq
   end
 end


### PR DESCRIPTION
Note: Waiting for @Partysun to implement the frontend changes needed to work with `vote` object instead of plain `sanTokensVotes`