### PR TITLE
Fetch the contract info by slug instead of ticker to avoid duplicates

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
@@ -10,6 +10,32 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
   require Logger
 
   @doc ~S"""
+    Return the token burn rate for the given ticker and time period.
+    Uses the influxdb cached values instead of issuing a GET request to etherbi
+  """
+  @deprecated "Use burn_rate by slug"
+  def burn_rate(_root, %{ticker: ticker, from: from, to: to, interval: interval}, _resolution) do
+    with {:ok, contract_address, token_decimals} <- ticker_to_contract_info(ticker),
+         {:ok, burn_rates} <- BurnRate.Store.burn_rate(contract_address, from, to, interval) do
+      result =
+        burn_rates
+        |> Enum.map(fn {datetime, burn_rate} ->
+          %{
+            datetime: datetime,
+            burn_rate: burn_rate / :math.pow(10, token_decimals)
+          }
+        end)
+
+      {:ok, result}
+    else
+      error ->
+        error_msg = "Can't fetch burn rate for #{ticker}"
+        Logger.warn(error_msg <> "Reason: #{inspect(error)}")
+        {:error, error_msg}
+    end
+  end
+
+  @doc ~S"""
     Return the token burn rate for the given slug and time period.
     Uses the influxdb cached values instead of issuing a GET request to etherbi
   """
@@ -29,6 +55,37 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
     else
       error ->
         error_msg = "Can't fetch burn rate for #{slug}"
+        Logger.warn(error_msg <> "Reason: #{inspect(error)}")
+        {:error, error_msg}
+    end
+  end
+
+  @doc ~S"""
+    Return the transaction volume for the given ticker and time period.
+    Uses the influxdb cached values instead of issuing a GET request to etherbi
+  """
+  @deprecated "Use transaction_volume by slug"
+  def transaction_volume(
+        _root,
+        %{ticker: ticker, from: from, to: to, interval: interval},
+        _resolution
+      ) do
+    with {:ok, contract_address, token_decimals} <- ticker_to_contract_info(ticker),
+         {:ok, trx_volumes} <-
+           TransactionVolume.Store.transaction_volume(contract_address, from, to, interval) do
+      result =
+        trx_volumes
+        |> Enum.map(fn {datetime, trx_volume} ->
+          %{
+            datetime: datetime,
+            transaction_volume: trx_volume / :math.pow(10, token_decimals)
+          }
+        end)
+
+      {:ok, result}
+    else
+      error ->
+        error_msg = "Can't fetch transaction for #{ticker}"
         Logger.warn(error_msg <> "Reason: #{inspect(error)}")
         {:error, error_msg}
     end
@@ -59,6 +116,36 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
     else
       error ->
         error_msg = "Can't fetch transaction for #{slug}"
+        Logger.warn(error_msg <> "Reason: #{inspect(error)}")
+        {:error, error_msg}
+    end
+  end
+
+  @doc ~S"""
+    Return the number of daily active addresses for a given ticker
+  """
+  @deprecated "Use DAA by slug"
+  def daily_active_addresses(
+        _root,
+        %{ticker: ticker, from: from, to: to, interval: interval},
+        _resolution
+      ) do
+    with {:ok, contract_address, _token_decimals} <- ticker_to_contract_info(ticker),
+         {:ok, daily_active_addresses} <-
+           DailyActiveAddresses.Store.daily_active_addresses(contract_address, from, to, interval) do
+      result =
+        daily_active_addresses
+        |> Enum.map(fn [datetime, active_addresses] ->
+          %{
+            datetime: datetime,
+            active_addresses: active_addresses |> round() |> trunc()
+          }
+        end)
+
+      {:ok, result}
+    else
+      error ->
+        error_msg = "Can't fetch daily active addresses for #{ticker}"
         Logger.warn(error_msg <> "Reason: #{inspect(error)}")
         {:error, error_msg}
     end
@@ -129,6 +216,48 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
     else
       error ->
         error_msg = "Can't fetch the exchange fund flow for #{slug}."
+        Logger.warn(error_msg <> "Reason: #{inspect(error)}")
+        {:error, error_msg}
+    end
+  end
+
+  @doc ~S"""
+    Return the transactions that happend in or out of an exchange wallet for a given ticker
+    and time period.
+    Uses the influxdb cached values instead of issuing a GET request to etherbi
+  """
+  @deprecated "Use exchange funds flow by slug"
+  def exchange_funds_flow(
+        _root,
+        %{
+          ticker: ticker,
+          from: from,
+          to: to,
+          interval: interval
+        },
+        _resolution
+      ) do
+    with {:ok, contract_address, _token_decimals} <- ticker_to_contract_info(ticker),
+         {:ok, funds_flow_list} <-
+           Transactions.Store.transactions_in_out_difference(
+             contract_address,
+             from,
+             to,
+             interval
+           ) do
+      result =
+        funds_flow_list
+        |> Enum.map(fn {datetime, funds_flow} ->
+          %{
+            datetime: datetime,
+            funds_flow: funds_flow
+          }
+        end)
+
+      {:ok, result}
+    else
+      error ->
+        error_msg = "Can't fetch the exchange fund flow for #{ticker}."
         Logger.warn(error_msg <> "Reason: #{inspect(error)}")
         {:error, error_msg}
     end
@@ -211,6 +340,23 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
   defp get_project_by_slug(slug) do
     Project
     |> where([p], p.coinmarketcap_id == ^slug)
+    |> Repo.one()
+  end
+
+  @deprecated "use slug_to_contract_info"
+  defp ticker_to_contract_info(ticker) do
+    with project when not is_nil(project) <- get_project_by_ticker(ticker),
+         {:ok, contract_address, token_decimals} <- project_to_contract_info(project) do
+      {:ok, contract_address, token_decimals}
+    else
+      _ -> {:error, "Can't find contract address for #{ticker}"}
+    end
+  end
+
+  @deprecated "use get_project_by_slug"
+  defp get_project_by_ticker(ticker) do
+    Project
+    |> where([p], not is_nil(p.coinmarketcap_id) and p.ticker == ^ticker)
     |> Repo.one()
   end
 end

--- a/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
@@ -10,11 +10,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
   require Logger
 
   @doc ~S"""
-    Return the token burn rate for the given ticker and time period.
+    Return the token burn rate for the given slug and time period.
     Uses the influxdb cached values instead of issuing a GET request to etherbi
   """
-  def burn_rate(_root, %{ticker: ticker, from: from, to: to, interval: interval}, _resolution) do
-    with {:ok, contract_address, token_decimals} <- ticker_to_contract_info(ticker),
+  def burn_rate(_root, %{slug: slug, from: from, to: to, interval: interval}, _resolution) do
+    with {:ok, contract_address, token_decimals} <- slug_to_contract_info(slug),
          {:ok, burn_rates} <- BurnRate.Store.burn_rate(contract_address, from, to, interval) do
       result =
         burn_rates
@@ -28,22 +28,22 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
       {:ok, result}
     else
       error ->
-        error_msg = "Can't fetch burn rate for #{ticker}"
+        error_msg = "Can't fetch burn rate for #{slug}"
         Logger.warn(error_msg <> "Reason: #{inspect(error)}")
         {:error, error_msg}
     end
   end
 
   @doc ~S"""
-    Return the transaction volume for the given ticker and time period.
+    Return the transaction volume for the given slug and time period.
     Uses the influxdb cached values instead of issuing a GET request to etherbi
   """
   def transaction_volume(
         _root,
-        %{ticker: ticker, from: from, to: to, interval: interval},
+        %{slug: slug, from: from, to: to, interval: interval},
         _resolution
       ) do
-    with {:ok, contract_address, token_decimals} <- ticker_to_contract_info(ticker),
+    with {:ok, contract_address, token_decimals} <- slug_to_contract_info(slug),
          {:ok, trx_volumes} <-
            TransactionVolume.Store.transaction_volume(contract_address, from, to, interval) do
       result =
@@ -58,21 +58,21 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
       {:ok, result}
     else
       error ->
-        error_msg = "Can't fetch transaction for #{ticker}"
+        error_msg = "Can't fetch transaction for #{slug}"
         Logger.warn(error_msg <> "Reason: #{inspect(error)}")
         {:error, error_msg}
     end
   end
 
   @doc ~S"""
-    Return the number of daily active addresses for a given ticker
+    Return the number of daily active addresses for a given slug
   """
   def daily_active_addresses(
         _root,
-        %{ticker: ticker, from: from, to: to, interval: interval},
+        %{slug: slug, from: from, to: to, interval: interval},
         _resolution
       ) do
-    with {:ok, contract_address, _token_decimals} <- ticker_to_contract_info(ticker),
+    with {:ok, contract_address, _token_decimals} <- slug_to_contract_info(slug),
          {:ok, daily_active_addresses} <-
            DailyActiveAddresses.Store.daily_active_addresses(contract_address, from, to, interval) do
       result =
@@ -87,28 +87,28 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
       {:ok, result}
     else
       error ->
-        error_msg = "Can't fetch daily active addresses for #{ticker}"
+        error_msg = "Can't fetch daily active addresses for #{slug}"
         Logger.warn(error_msg <> "Reason: #{inspect(error)}")
         {:error, error_msg}
     end
   end
 
   @doc ~S"""
-    Return the transactions that happend in or out of an exchange wallet for a given ticker
+    Return the transactions that happend in or out of an exchange wallet for a given slug
     and time period.
     Uses the influxdb cached values instead of issuing a GET request to etherbi
   """
   def exchange_funds_flow(
         _root,
         %{
-          ticker: ticker,
+          slug: slug,
           from: from,
           to: to,
           interval: interval
         },
         _resolution
       ) do
-    with {:ok, contract_address, _token_decimals} <- ticker_to_contract_info(ticker),
+    with {:ok, contract_address, _token_decimals} <- slug_to_contract_info(slug),
          {:ok, funds_flow_list} <-
            Transactions.Store.transactions_in_out_difference(
              contract_address,
@@ -128,7 +128,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
       {:ok, result}
     else
       error ->
-        error_msg = "Can't fetch the exchange fund flow for #{ticker}."
+        error_msg = "Can't fetch the exchange fund flow for #{slug}."
         Logger.warn(error_msg <> "Reason: #{inspect(error)}")
         {:error, error_msg}
     end
@@ -139,7 +139,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
   end
 
   @doc ~S"""
-    Return the average number of daily active addresses for a given ticker and period of time
+    Return the average number of daily active addresses for a given slug and period of time
   """
   def average_daily_active_addresses(
         %Project{id: id} = project,
@@ -199,18 +199,18 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
     {:error, "Can't find contract address of #{project.coinmarketcap_id}"}
   end
 
-  defp ticker_to_contract_info(ticker) do
-    with project when not is_nil(project) <- get_project_by_ticker(ticker),
+  defp slug_to_contract_info(slug) do
+    with project when not is_nil(project) <- get_project_by_slug(slug),
          {:ok, contract_address, token_decimals} <- project_to_contract_info(project) do
       {:ok, contract_address, token_decimals}
     else
-      _ -> {:error, "Can't find ticker contract address"}
+      _ -> {:error, "Can't find contract address for #{slug}"}
     end
   end
 
-  defp get_project_by_ticker(ticker) do
+  defp get_project_by_slug(slug) do
     Project
-    |> where([p], p.ticker == ^ticker and not is_nil(p.coinmarketcap_id))
+    |> where([p], p.coinmarketcap_id == ^slug)
     |> Repo.one()
   end
 end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -169,7 +169,9 @@ defmodule SanbaseWeb.Graphql.Schema do
 
     @desc "Burn rate for a ticker and given time period"
     field :burn_rate, list_of(:burn_rate_data) do
-      arg(:slug, non_null(:string))
+      arg(:ticker, :string, deprecate: "Use slug instead of ticker")
+      # TODO: Make non_null after removing :ticker
+      arg(:slug, :string)
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:interval, :string, default_value: "1h")
@@ -179,7 +181,9 @@ defmodule SanbaseWeb.Graphql.Schema do
 
     @desc "Transaction volume for a ticker and given time period"
     field :transaction_volume, list_of(:transaction_volume) do
-      arg(:slug, non_null(:string))
+      arg(:ticker, :string, deprecate: "Use slug instead of ticker")
+      # TODO: Make non_null after removing :ticker
+      arg(:slug, :string)
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:interval, :string, default_value: "1h")
@@ -189,7 +193,9 @@ defmodule SanbaseWeb.Graphql.Schema do
 
     @desc "Daily active addresses for a ticker and given time period"
     field :daily_active_addresses, list_of(:active_addresses) do
-      arg(:slug, non_null(:string))
+      arg(:ticker, :string, deprecate: "Use slug instead of ticker")
+      # TODO: Make non_null after removing :ticker
+      arg(:slug, :string)
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:interval, :string, default_value: "1d")
@@ -252,7 +258,9 @@ defmodule SanbaseWeb.Graphql.Schema do
 
     @desc "Shows the flow of funds in an exchange wallet"
     field :exchange_funds_flow, list_of(:funds_flow) do
-      arg(:slug, non_null(:string))
+      arg(:ticker, :string, deprecate: "Use slug instead of ticker")
+      # TODO: Make non_null after removing :ticker
+      arg(:slug, :string)
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:interval, :string, default_value: "1d")

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -169,7 +169,7 @@ defmodule SanbaseWeb.Graphql.Schema do
 
     @desc "Burn rate for a ticker and given time period"
     field :burn_rate, list_of(:burn_rate_data) do
-      arg(:ticker, non_null(:string))
+      arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:interval, :string, default_value: "1h")
@@ -179,7 +179,7 @@ defmodule SanbaseWeb.Graphql.Schema do
 
     @desc "Transaction volume for a ticker and given time period"
     field :transaction_volume, list_of(:transaction_volume) do
-      arg(:ticker, non_null(:string))
+      arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:interval, :string, default_value: "1h")
@@ -189,7 +189,7 @@ defmodule SanbaseWeb.Graphql.Schema do
 
     @desc "Daily active addresses for a ticker and given time period"
     field :daily_active_addresses, list_of(:active_addresses) do
-      arg(:ticker, non_null(:string))
+      arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:interval, :string, default_value: "1d")
@@ -252,7 +252,7 @@ defmodule SanbaseWeb.Graphql.Schema do
 
     @desc "Shows the flow of funds in an exchange wallet"
     field :exchange_funds_flow, list_of(:funds_flow) do
-      arg(:ticker, non_null(:string))
+      arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:interval, :string, default_value: "1d")

--- a/test/sanbase_web/graphql/etherbi_burn_rate_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_burn_rate_api_test.exs
@@ -13,6 +13,7 @@ defmodule Sanbase.Etherbi.BurnRateApiTest do
     Store.create_db()
 
     ticker = "SAN"
+    slug = "santiment"
     contract_address = "0x1234"
     Store.drop_measurement(contract_address)
 
@@ -20,7 +21,7 @@ defmodule Sanbase.Etherbi.BurnRateApiTest do
       %Project{
         name: "Santiment",
         ticker: ticker,
-        coinmarketcap_id: "santiment",
+        coinmarketcap_id: slug,
         main_contract_address: contract_address
       }
       |> Repo.insert!()
@@ -89,7 +90,7 @@ defmodule Sanbase.Etherbi.BurnRateApiTest do
     ])
 
     [
-      ticker: ticker,
+      slug: slug,
       datetime1: datetime1,
       datetime2: datetime2,
       datetime3: datetime3,
@@ -105,7 +106,7 @@ defmodule Sanbase.Etherbi.BurnRateApiTest do
     query = """
     {
       burnRate(
-        ticker: "#{context.ticker}",
+        slug: "#{context.slug}",
         from: "#{context.datetime1}",
         to: "#{context.datetime8}",
         interval: "5m") {
@@ -166,7 +167,7 @@ defmodule Sanbase.Etherbi.BurnRateApiTest do
     query = """
     {
       burnRate(
-        ticker: "#{context.ticker}",
+        slug: "#{context.slug}",
         from: "#{context.datetime1}",
         to: "#{context.datetime8}",
         interval: "30m") {

--- a/test/sanbase_web/graphql/etherbi_daily_active_addresses_test.exs
+++ b/test/sanbase_web/graphql/etherbi_daily_active_addresses_test.exs
@@ -13,6 +13,7 @@ defmodule Sanbase.Etherbi.DailyActiveAddressesApiTest do
     Store.create_db()
 
     ticker = "SAN"
+    slug = "santiment"
     contract_address = "0x1234"
     Store.drop_measurement(contract_address)
 
@@ -20,7 +21,7 @@ defmodule Sanbase.Etherbi.DailyActiveAddressesApiTest do
       %Project{
         name: "Santiment",
         ticker: ticker,
-        coinmarketcap_id: "santiment",
+        coinmarketcap_id: slug,
         main_contract_address: contract_address
       }
       |> Repo.insert!()
@@ -89,7 +90,7 @@ defmodule Sanbase.Etherbi.DailyActiveAddressesApiTest do
     ])
 
     [
-      ticker: ticker,
+      slug: slug,
       datetime1: datetime1,
       datetime2: datetime2,
       datetime3: datetime3,
@@ -105,7 +106,7 @@ defmodule Sanbase.Etherbi.DailyActiveAddressesApiTest do
     query = """
     {
       dailyActiveAddresses(
-        ticker: "#{context.ticker}",
+        slug: "#{context.slug}",
         from: "#{context.datetime1}",
         to: "#{context.datetime8}") {
           datetime
@@ -166,7 +167,7 @@ defmodule Sanbase.Etherbi.DailyActiveAddressesApiTest do
     query = """
     {
       dailyActiveAddresses(
-        ticker: "#{context.ticker}",
+        slug: "#{context.slug}",
         from: "#{context.datetime1}",
         to: "#{context.datetime8}",
         interval: "2d") {
@@ -215,7 +216,7 @@ defmodule Sanbase.Etherbi.DailyActiveAddressesApiTest do
     query = """
     {
       dailyActiveAddresses(
-        ticker: "#{context.ticker}",
+        slug: "#{context.slug}",
         from: "#{from_no_data}",
         to: "#{to_no_data}",
         interval: "2d") {

--- a/test/sanbase_web/graphql/etherbi_transactions_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_transactions_api_test.exs
@@ -13,6 +13,7 @@ defmodule Sanbase.Etherbi.TransactionsApiTest do
     Store.create_db()
 
     ticker = "SAN"
+    slug = "santiment"
     exchange_address = "0x4321"
     contract_address = "0x1234"
     Store.drop_measurement(contract_address)
@@ -21,7 +22,7 @@ defmodule Sanbase.Etherbi.TransactionsApiTest do
       %Project{
         name: "Santiment",
         ticker: ticker,
-        coinmarketcap_id: "santiment",
+        coinmarketcap_id: slug,
         main_contract_address: contract_address
       }
       |> Repo.insert!()
@@ -106,7 +107,7 @@ defmodule Sanbase.Etherbi.TransactionsApiTest do
 
     [
       exchange_address: exchange_address,
-      ticker: ticker,
+      slug: slug,
       datetime1: datetime1,
       datetime2: datetime2,
       datetime3: datetime3,
@@ -122,7 +123,7 @@ defmodule Sanbase.Etherbi.TransactionsApiTest do
     query = """
     {
       exchangeFundsFlow(
-        ticker: "#{context.ticker}",
+        slug: "#{context.slug}",
         from: "#{context.datetime1}",
         to: "#{context.datetime8}") {
           datetime

--- a/test/sanbase_web/graphql/etherbi_trx_volume_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_trx_volume_api_test.exs
@@ -13,6 +13,7 @@ defmodule Sanbase.Etherbi.TransactionVolumeApiTest do
     Store.create_db()
 
     ticker = "SAN"
+    slug = "santiment"
     contract_address = "0x1234"
     Store.drop_measurement(contract_address)
 
@@ -20,7 +21,7 @@ defmodule Sanbase.Etherbi.TransactionVolumeApiTest do
       %Project{
         name: "Santiment",
         ticker: ticker,
-        coinmarketcap_id: "santiment",
+        coinmarketcap_id: slug,
         main_contract_address: contract_address
       }
       |> Repo.insert!()
@@ -89,7 +90,7 @@ defmodule Sanbase.Etherbi.TransactionVolumeApiTest do
     ])
 
     [
-      ticker: ticker,
+      slug: slug,
       datetime1: datetime1,
       datetime2: datetime2,
       datetime3: datetime3,
@@ -105,7 +106,7 @@ defmodule Sanbase.Etherbi.TransactionVolumeApiTest do
     query = """
     {
       transactionVolume(
-        ticker: "#{context.ticker}",
+        slug: "#{context.slug}",
         from: "#{context.datetime1}",
         to: "#{context.datetime8}",
         interval: "5m") {
@@ -166,7 +167,7 @@ defmodule Sanbase.Etherbi.TransactionVolumeApiTest do
     query = """
     {
       transactionVolume(
-        ticker: "#{context.ticker}",
+        slug: "#{context.slug}",
         from: "#{context.datetime1}",
         to: "#{context.datetime8}",
         interval: "15m") {


### PR DESCRIPTION
#### Summary
We now have duplicate tickers that both have coinmarketcap id - that causes troubles.

#### Screenshots
Support both `ticker` and `slug` arguments for smoother transition.
![](https://imgur.com/5p6u8mC.png)
![](https://imgur.com/zAOVRid.png)