### PR TITLE
GQL emojis api - remove reduncant ticker parameter

### DIFF
--- a/lib/sanbase/internal_services/tech_indicators.ex
+++ b/lib/sanbase/internal_services/tech_indicators.ex
@@ -148,14 +148,12 @@ defmodule Sanbase.InternalServices.TechIndicators do
   end
 
   def emojis_sentiment(
-        ticker,
         from_datetime,
         to_datetime,
         aggregate_interval,
         result_size_tail \\ 0
       ) do
     emojis_sentiment_request(
-      ticker,
       from_datetime,
       to_datetime,
       aggregate_interval,
@@ -168,12 +166,12 @@ defmodule Sanbase.InternalServices.TechIndicators do
 
       {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
         error_result(
-          "Error status #{status} fetching emojis sentiment for ticker #{ticker}: #{body}"
+          "Error status #{status} fetching emojis sentiment: #{body}"
         )
 
       {:error, %HTTPoison.Error{} = error} ->
         error_result(
-          "Cannot fetch emojis sentiment data for ticker #{ticker}: #{
+          "Cannot fetch emojis sentiment data: #{
             HTTPoison.Error.message(error)
           }"
         )
@@ -355,7 +353,6 @@ defmodule Sanbase.InternalServices.TechIndicators do
   end
 
   defp emojis_sentiment_request(
-         ticker,
          from_datetime,
          to_datetime,
          aggregate_interval,
@@ -369,7 +366,6 @@ defmodule Sanbase.InternalServices.TechIndicators do
     options = [
       recv_timeout: @recv_timeout,
       params: [
-        {"ticker", ticker},
         {"from_timestamp", from_unix},
         {"to_timestamp", to_unix},
         {"aggregate_interval", aggregate_interval},

--- a/lib/sanbase_web/graphql/resolvers/tech_indicators_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/tech_indicators_resolver.ex
@@ -83,7 +83,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.TechIndicatorsResolver do
   def emojis_sentiment(
         _root,
         %{
-          ticker: ticker,
           from: from,
           to: to,
           interval: interval,
@@ -92,7 +91,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.TechIndicatorsResolver do
         _resolution
       ) do
     TechIndicators.emojis_sentiment(
-      ticker,
       from,
       to,
       interval,

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -321,7 +321,6 @@ defmodule SanbaseWeb.Graphql.Schema do
 
     @desc "Emojis sentiment for a ticker and time period"
     field :emojis_sentiment, list_of(:emojis_sentiment) do
-      arg(:ticker, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, :datetime, default_value: DateTime.utc_now())
       arg(:interval, :string, default_value: "1d")

--- a/test/sanbase/internal_services/tech_indicators_test.exs
+++ b/test/sanbase/internal_services/tech_indicators_test.exs
@@ -209,7 +209,6 @@ defmodule Sanbase.InternalServices.TechIndicatorsTest do
 
     result =
       TechIndicators.emojis_sentiment(
-        "XYZ",
         DateTime.from_unix!(1_516_406_400),
         DateTime.from_unix!(1_516_492_800),
         "1d"


### PR DESCRIPTION
There was an error in GQL emojis api - the ticker argument is not used