### PR TITLE
Correct displaying SAN balance in Settings Page

### DIFF
--- a/app/src/components/Balance.js
+++ b/app/src/components/Balance.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react'
 import { Message } from 'semantic-ui-react'
-import { formatCryptoCurrency, formatSAN } from './../utils/formatting'
+import { formatCryptoCurrency, formatBTC } from './../utils/formatting'
 
 export const Balance = ({user, onlyBalance = false}) => {
   return (
@@ -16,7 +16,7 @@ export const Balance = ({user, onlyBalance = false}) => {
             </a>
           </div>}
           <div className='account-balance'>
-            {formatCryptoCurrency('SAN', formatSAN(account.sanBalance))}
+            {formatCryptoCurrency('SAN', formatBTC(account.sanBalance))}
           </div>
         </Fragment>
       ))


### PR DESCRIPTION
Displaying 'SAN 2.7e-9' instead of 'SAN 27' on account settings page