### PR TITLE
Rework cmc price fetching

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -129,6 +129,7 @@ config :sanbase, Sanbase.ExternalServices.Coinmarketcap,
   update_interval: 5 * 1000 * 60,
   sync_enabled: {:system, "COINMARKETCAP_PRICES_ENABLED", false}
 
+# TODO: Change after switching over to only this cmc
 config :sanbase, Sanbase.ExternalServices.Coinmarketcap2,
   # 5 minutes
   update_interval: 5 * 1000 * 60,
@@ -139,6 +140,7 @@ config :sanbase, Sanbase.ExternalServices.Coinmarketcap.TickerFetcher,
   sync_enabled: {:system, "COINMARKETCAP_TICKERS_ENABLED", false},
   top_projects_to_follow: {:system, "TOP_PROJECTS_TO_FOLLOW", "25"}
 
+# TODO: Change after switching over to only this cmc
 config :sanbase, Sanbase.ExternalServices.Coinmarketcap.TickerFetcher2,
   update_interval: 5 * 1000 * 60,
   sync_enabled: {:system, "COINMARKETCAP_TICKER_FETCHER_ENABLED", false},

--- a/config/config.exs
+++ b/config/config.exs
@@ -129,9 +129,19 @@ config :sanbase, Sanbase.ExternalServices.Coinmarketcap,
   update_interval: 5 * 1000 * 60,
   sync_enabled: {:system, "COINMARKETCAP_PRICES_ENABLED", false}
 
+config :sanbase, Sanbase.ExternalServices.Coinmarketcap2,
+  # 5 minutes
+  update_interval: 5 * 1000 * 60,
+  sync_enabled: {:system, "COINMARKETCAP_SCRAPER_ENABLED", false}
+
 config :sanbase, Sanbase.ExternalServices.Coinmarketcap.TickerFetcher,
   update_interval: 5 * 1000 * 60,
   sync_enabled: {:system, "COINMARKETCAP_TICKERS_ENABLED", false},
+  top_projects_to_follow: {:system, "TOP_PROJECTS_TO_FOLLOW", "25"}
+
+config :sanbase, Sanbase.ExternalServices.Coinmarketcap.TickerFetcher2,
+  update_interval: 5 * 1000 * 60,
+  sync_enabled: {:system, "COINMARKETCAP_TICKER_FETCHER_ENABLED", false},
   top_projects_to_follow: {:system, "TOP_PROJECTS_TO_FOLLOW", "25"}
 
 config :sanbase, Sanbase.ExternalServices.Etherscan.Worker,

--- a/lib/sanbase/application.ex
+++ b/lib/sanbase/application.ex
@@ -65,8 +65,8 @@ defmodule Sanbase.Application do
         Sanbase.ExternalServices.RateLimiting.Server.child_spec(
           :graph_coinmarketcap_rate_limiter,
           scale: 60_000,
-          limit: 20,
-          time_between_requests: 2000
+          limit: 30,
+          time_between_requests: 1000
         ),
 
         # Coinmarketcap api rate limiter
@@ -81,8 +81,8 @@ defmodule Sanbase.Application do
         Sanbase.ExternalServices.RateLimiting.Server.child_spec(
           :http_coinmarketcap_rate_limiter,
           scale: 60_000,
-          limit: 20,
-          time_between_requests: 2000
+          limit: 30,
+          time_between_requests: 1000
         ),
 
         # Twitter API rate limiter

--- a/lib/sanbase/application.ex
+++ b/lib/sanbase/application.ex
@@ -102,10 +102,12 @@ defmodule Sanbase.Application do
         ),
 
         # Price fetcher
+        # TODO: Change after switching over to only this cmc
         Sanbase.ExternalServices.Coinmarketcap.child_spec(%{}),
         Sanbase.ExternalServices.Coinmarketcap2.child_spec(%{}),
 
         # Current marketcap fetcher
+        # TODO: Change after switching over to only this cmc
         Sanbase.ExternalServices.Coinmarketcap.TickerFetcher.child_spec(%{}),
         Sanbase.ExternalServices.Coinmarketcap.TickerFetcher2.child_spec(%{}),
 

--- a/lib/sanbase/application.ex
+++ b/lib/sanbase/application.ex
@@ -103,9 +103,11 @@ defmodule Sanbase.Application do
 
         # Price fetcher
         Sanbase.ExternalServices.Coinmarketcap.child_spec(%{}),
+        Sanbase.ExternalServices.Coinmarketcap2.child_spec(%{}),
 
         # Current marketcap fetcher
         Sanbase.ExternalServices.Coinmarketcap.TickerFetcher.child_spec(%{}),
+        Sanbase.ExternalServices.Coinmarketcap.TickerFetcher2.child_spec(%{}),
 
         # Etherscan wallet tracking worker
         Sanbase.ExternalServices.Etherscan.Worker.child_spec(%{}),

--- a/lib/sanbase/external_services/coinmarketcap2.ex
+++ b/lib/sanbase/external_services/coinmarketcap2.ex
@@ -1,0 +1,196 @@
+defmodule Sanbase.ExternalServices.Coinmarketcap2 do
+  @moduledoc """
+  # Syncronize data from coinmarketcap.com
+
+  A GenServer, which updates the data from coinmarketcap on a regular basis.
+  On regular intervals it will fetch the data from coinmarketcap and insert it
+  into a local DB
+  """
+  use GenServer, restart: :permanent, shutdown: 5_000
+
+  import Ecto.Query
+
+  require Sanbase.Utils.Config
+  require Logger
+
+  alias Sanbase.Model.{Project, Ico}
+  alias Sanbase.Repo
+  alias Sanbase.Prices.Store
+  alias Sanbase.ExternalServices.ProjectInfo
+  alias Sanbase.ExternalServices.Coinmarketcap.GraphData
+  alias Sanbase.Notifications.CheckPrices
+  alias Sanbase.Notifications.PriceVolumeDiff
+  alias Sanbase.Utils.Config
+
+  # 5 minutes
+  @default_update_interval 1000 * 60 * 5
+
+  def start_link(_state) do
+    GenServer.start_link(__MODULE__, :ok)
+  end
+
+  def init(:ok) do
+    if Config.get(:sync_enabled, false) do
+      Store.create_db()
+
+      Process.send(self(), :fetch_missing_info)
+      Process.send(self(), :fetch_total_market)
+      Process.send(self(), :fetch_prices)
+
+      update_interval = Config.get(:update_interval, @default_update_interval)
+
+      {:ok,
+       %{
+         missing_info_update_interval: update_interval * 10,
+         total_market_update_interval: update_interval,
+         prices_update_interval: update_interval
+       }}
+    else
+      :ignore
+    end
+  end
+
+  def handle_info(:fetch_missing_info, %{missing_info_update_interval: update_interval} = state) do
+    Task.Supervisor.async_stream_nolink(
+      Sanbase.TaskSupervisor,
+      projects(),
+      &fetch_project_info/1,
+      ordered: false,
+      max_concurrency: 5,
+      timeout: 180_000
+    )
+    |> Stream.run()
+
+    Process.send_after(self(), :fetch_missing_info, update_interval)
+    {:noreply, state}
+  end
+
+  def handle_info(:fetch_total_market, %{total_market_update_interval: update_interval} = state) do
+    # Start the task under the supervisor in a way that does not need await
+    Task.Supervisor.start_child(
+      Sanbase.TaskSupervisor,
+      &fetch_and_process_marketcap_total_data/0
+    )
+
+    Process.send_after(self(), :fetch_total_market, update_interval)
+    {:noreply, state}
+  end
+
+  def handle_info(:fetch_prices, %{prices_update_interval: update_interval} = state) do
+    # Run the tasks in a stream concurrently so `max_concurrency` can be used.
+    # Otherwise risking to start too many tasks to a service that's rate limited
+    Task.Supervisor.async_stream_nolink(
+      Sanbase.TaskSupervisor,
+      projects(),
+      &fetch_and_process_price_data/1,
+      ordered: false,
+      max_concurrency: 5,
+      timeout: 180_000
+    )
+    |> Stream.run()
+
+    Process.send_after(self(), :fetch_prices, update_interval)
+    {:noreply, state}
+  end
+
+  def handle_info(msg, state) do
+    Logger.warn("Unknown message received: #{msg}")
+    {:noreply, state}
+  end
+
+  # Private functions
+
+  defp projects() do
+    Project
+    |> where([p], not is_nil(p.coinmarketcap_id))
+    |> Repo.all()
+  end
+
+  defp project_info_missing?(
+         %Project{
+           website_link: website_link,
+           email: email,
+           reddit_link: reddit_link,
+           twitter_link: twitter_link,
+           btt_link: btt_link,
+           blog_link: blog_link,
+           github_link: github_link,
+           telegram_link: telegram_link,
+           slack_link: slack_link,
+           facebook_link: facebook_link,
+           whitepaper_link: whitepaper_link,
+           ticker: ticker,
+           name: name,
+           token_decimals: token_decimals,
+           main_contract_address: main_contract_address
+         } = project
+       ) do
+    !website_link or !email or !reddit_link or !twitter_link or !btt_link or !blog_link or
+      !github_link or !telegram_link or !slack_link or !facebook_link or !whitepaper_link or
+      !ticker or !name or !main_contract_address or !token_decimals
+  end
+
+  defp fetch_project_info(project) do
+    if project_info_missing?(project) do
+      ProjectInfo.from_project(project)
+      |> ProjectInfo.fetch_coinmarketcap_info()
+      |> case do
+        {:ok, project_info_with_coinmarketcap_info} ->
+          project_info_with_coinmarketcap_info
+          |> ProjectInfo.fetch_etherscan_token_summary()
+          |> ProjectInfo.fetch_contract_info()
+          |> ProjectInfo.update_project(project)
+
+        _ ->
+          nil
+      end
+    end
+  end
+
+  defp missing_ico_info?(%Ico{
+         contract_abi: contract_abi,
+         contract_block_number: contract_block_number
+       }) do
+    !contract_abi or !contract_block_number
+  end
+
+  defp fetch_and_process_price_data(%Project{} = project) do
+    last_price_datetime = last_price_datetime(project)
+    GraphData.fetch_and_store_prices(project, last_price_datetime)
+
+    # TODO: Activate later when old coinmarketcap is disabled
+    # process_notifications(project)
+  end
+
+  defp process_notifications(%Project{} = project) do
+    CheckPrices.exec(project, "usd")
+    CheckPrices.exec(project, "btc")
+
+    PriceVolumeDiff.exec(project, "usd")
+  end
+
+  defp last_price_datetime(%Project{ticker: ticker, coinmarketcap_id: coinmarketcap_id}) do
+    case Store.last_history_datetime_cmc!(ticker <> _ <> coinmarketcap_id) do
+      nil ->
+        GraphData.fetch_first_price_datetime(coinmarketcap_id)
+
+      datetime ->
+        datetime
+    end
+  end
+
+  defp fetch_and_process_marketcap_total_data() do
+    last_marketcap_total_datetime = last_marketcap_total_datetime()
+    GraphData.fetch_and_store_marketcap_total(last_marketcap_total_datetime)
+  end
+
+  defp last_marketcap_total_datetime() do
+    case Store.last_history_datetime_cmc!("TOTAL_MARKET") do
+      nil ->
+        GraphData.fetch_first_marketcap_total_datetime()
+
+      datetime ->
+        datetime
+    end
+  end
+end

--- a/lib/sanbase/external_services/coinmarketcap2/graph_data.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/graph_data.ex
@@ -95,14 +95,16 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
 
       measurement_points |> Store.import()
 
-      update_last_cmc_history_datetime(Measurement.name_from(project), measurement_points)
+      update_last_cmc_history_datetime(project, measurement_points)
     end)
     |> Stream.run()
   end
 
   def update_last_cmc_history_datetime(_project, []), do: :ok
 
-  def update_last_cmc_history_datetime(measurement_name, points) do
+  def update_last_cmc_history_datetime(%Project{} = project, points) do
+    measurement_name = Measurement.name_from(project)
+
     last_price_datetime_updated =
       points
       |> Enum.max_by(&Measurement.get_timestamp/1)

--- a/lib/sanbase/external_services/coinmarketcap2/graph_data.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/graph_data.ex
@@ -69,7 +69,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
   # Helper functions
 
   defp process_marketcap_total_stream(marketcap_total_stream) do
-    measurement_name = "TOTAL_MARKET-total_market"
+    measurement_name = "TOTAL_MARKET_total-market"
 
     marketcap_total_stream
     # Store each data point and the information when it was last updated

--- a/lib/sanbase/external_services/coinmarketcap2/graph_data.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/graph_data.ex
@@ -5,6 +5,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
 
   use Tesla
 
+  # TODO: Change after switching over to only this cmc
   alias __MODULE__, as: GraphData
   alias Sanbase.ExternalServices.Coinmarketcap.PricePoint2, as: PricePoint
   alias Sanbase.Influxdb.Measurement

--- a/lib/sanbase/external_services/coinmarketcap2/graph_data.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/graph_data.ex
@@ -1,0 +1,228 @@
+defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
+  defstruct [:market_cap_by_available_supply, :price_usd, :volume_usd, :price_btc]
+
+  require Logger
+
+  use Tesla
+
+  alias __MODULE__, as: GraphData
+  alias Sanbase.ExternalServices.Coinmarketcap.PricePoint2, as: PricePoint
+  alias Sanbase.Influxdb.Measurement
+  alias Sanbase.Model.Project
+  alias Sanbase.ExternalServices.RateLimiting
+  alias Sanbase.ExternalServices.ErrorCatcher
+  alias Sanbase.Prices.Store
+
+  plug(RateLimiting.Middleware, name: :graph_coinmarketcap_rate_limiter)
+  plug(ErrorCatcher.Middleware)
+  plug(Tesla.Middleware.BaseUrl, "https://graphs2.coinmarketcap.com")
+  plug(Tesla.Middleware.Compression)
+  plug(Tesla.Middleware.Logger)
+
+  # Number of seconds in a day
+  @seconds_in_day 24 * 60 * 60
+
+  def fetch_first_price_datetime(coinmarketcap_id) do
+    fetch_all_time_prices(coinmarketcap_id)
+    |> Enum.take(1)
+    |> hd
+    |> Map.get(:datetime)
+  end
+
+  def fetch_and_store_prices(%Project{coinmarketcap_id: coinmarketcap_id} = project, to_datetime) do
+    fetch_price_stream(coinmarketcap_id, to_datetime, DateTime.utc_now())
+    |> process_price_stream(project)
+
+    :ok
+  end
+
+  def fetch_price_stream(coinmarketcap_id, from_datetime, to_datetime) do
+    day_ranges(from_datetime, to_datetime)
+    |> Stream.map(&extract_price_points_for_interval(coinmarketcap_id, &1))
+  end
+
+  def fetch_first_marketcap_total_datetime() do
+    fetch_all_time_marketcap()
+    |> Enum.take(1)
+    |> hd
+    |> Map.get(:datetime)
+  end
+
+  def fetch_and_store_marketcap_total(to_datetime) do
+    fetch_marketcap_total_stream(to_datetime, DateTime.utc_now())
+    |> process_marketcap_total_stream()
+
+    :ok
+  end
+
+  def fetch_marketcap_total_stream(from_datetime, to_datetime) do
+    day_ranges(from_datetime, to_datetime)
+    |> Stream.map(&extract_price_points_for_interval(&1))
+  end
+
+  # Helper functions
+
+  defp process_marketcap_total_stream(marketcap_total_stream) do
+    marketcap_total_stream
+    |> Stream.each(fn marketcap_totals ->
+      measurement_points =
+        marketcap_totals
+        |> Enum.flat_map(&PricePoint2.price_points_to_measurements(&1))
+
+      measurement_points |> Store.import()
+
+      update_last_cmc_history_datetime("TOTAL_MARKET", measurement_points)
+    end)
+    |> Stream.run()
+  end
+
+  defp process_price_stream(price_stream, %Project{} = project) do
+    price_stream
+    |> Stream.each(fn prices ->
+      measurement_points =
+        prices
+        |> Enum.flat_map(&PricePoint.price_points_to_measurements(&1, project))
+
+      measurement_points |> Store.import()
+
+      update_last_cmc_history_datetime(project.coinmarketcap_id, measurement_points)
+    end)
+    |> Stream.run()
+  end
+
+  def update_last_cmc_history_datetime(_project, []), do: :ok
+
+  def update_last_cmc_history_datetime(coinmarketcap_id, points) do
+    last_price_datetime_updated =
+      points
+      |> Enum.max_by(&Measurement.get_timestamp/1)
+      |> Measurement.get_datetime()
+
+    Store.update_last_history_datetime_cmc(coinmarketcap_id, last_price_datetime_updated)
+  end
+
+  defp json_to_price_points(json) do
+    json
+    |> Poison.decode!(as: %GraphData{})
+    |> convert_to_price_points()
+  end
+
+  defp fetch_all_time_prices(coinmarketcap_id) do
+    graph_data_currencies_all_time_url(coinmarketcap_id)
+    |> get()
+    |> case do
+      %{status: 200, body: body} ->
+        body |> json_to_price_points()
+    end
+  end
+
+  defp fetch_all_time_marketcap() do
+    graph_data_marketcap_total_all_time_url()
+    |> get()
+    |> case do
+      %{status: 200, body: body} ->
+        body |> json_to_price_points()
+    end
+  end
+
+  defp convert_to_price_points(%GraphData{
+         market_cap_by_available_supply: market_cap_by_available_supply,
+         price_usd: nil,
+         volume_usd: volume_usd,
+         price_btc: nil
+       }) do
+    List.zip([market_cap_by_available_supply, volume_usd])
+    |> Enum.map(fn {[dt, marketcap], [dt, volume_usd]} ->
+      %PricePoint{
+        marketcap: marketcap,
+        volume_usd: volume_usd,
+        datetime: DateTime.from_unix!(dt, :millisecond)
+      }
+    end)
+  end
+
+  defp convert_to_price_points(%GraphData{
+         market_cap_by_available_supply: market_cap_by_available_supply,
+         price_usd: price_usd,
+         volume_usd: volume_usd,
+         price_btc: price_btc
+       }) do
+    List.zip([market_cap_by_available_supply, price_usd, volume_usd, price_btc])
+    |> Enum.map(fn {[dt, marketcap], [dt, price_usd], [dt, volume_usd], [dt, price_btc]} ->
+      %PricePoint{
+        marketcap: marketcap,
+        price_usd: price_usd,
+        volume_usd: volume_usd,
+        price_btc: price_btc,
+        datetime: DateTime.from_unix!(dt, :millisecond)
+      }
+    end)
+  end
+
+  defp extract_price_points_for_interval({start_interval_sec, end_interval_sec}) do
+    graph_data_marketcap_total_interval_url(start_interval_sec * 1000, end_interval_sec * 1000)
+    |> get()
+    |> case do
+      %{status: 200, body: body} ->
+        body |> json_to_price_points()
+
+      _ ->
+        Logger.error("Failed to fetch graph data for total marketcap for the selected interval")
+        []
+    end
+  end
+
+  defp extract_price_points_for_interval(coinmarketcap_id, {start_interval_sec, end_interval_sec}) do
+    graph_data_currencies_interval_url(
+      coinmarketcap_id,
+      start_interval_sec * 1000,
+      end_interval_sec * 1000
+    )
+    |> get()
+    |> case do
+      %{status: 200, body: body} ->
+        body |> json_to_price_points()
+
+      _ ->
+        Logger.error(
+          "Failed to fetch graph data for #{coinmarketcap_id} for the selected interval"
+        )
+
+        []
+    end
+  end
+
+  defp day_ranges(from_datetime, to_datetime)
+       when not is_number(from_datetime) and not is_number(to_datetime) do
+    day_ranges(DateTime.to_unix(from_datetime), DateTime.to_unix(to_datetime))
+  end
+
+  defp day_ranges(from_datetime, to_datetime) do
+    Stream.unfold(from_datetime, fn start_interval ->
+      if start_interval <= to_datetime do
+        {
+          {start_interval, start_interval + @seconds_in_day},
+          start_interval + @seconds_in_day
+        }
+      else
+        nil
+      end
+    end)
+  end
+
+  defp graph_data_currencies_all_time_url(coinmarketcap_id) do
+    "/currencies/#{coinmarketcap_id}/"
+  end
+
+  defp graph_data_currencies_interval_url(coinmarketcap_id, from_timestamp, to_timestamp) do
+    "/currencies/#{coinmarketcap_id}/#{from_timestamp}/#{to_timestamp}/"
+  end
+
+  defp graph_data_marketcap_total_all_time_url() do
+    "/global/marketcap-total/"
+  end
+
+  defp graph_data_marketcap_total_interval_url(from_timestamp, to_timestamp) do
+    "/global/marketcap-total/#{from_timestamp}/#{to_timestamp}/"
+  end
+end

--- a/lib/sanbase/external_services/coinmarketcap2/graph_data.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/graph_data.ex
@@ -95,16 +95,14 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
 
       measurement_points |> Store.import()
 
-      update_last_cmc_history_datetime(project, measurement_points)
+      update_last_cmc_history_datetime(Measurement.name_from(project), measurement_points)
     end)
     |> Stream.run()
   end
 
   def update_last_cmc_history_datetime(_project, []), do: :ok
 
-  def update_last_cmc_history_datetime(%Project{} = project, points) do
-    measurement_name = Measurement.name_from(project)
-
+  def update_last_cmc_history_datetime(measurement_name, points) do
     last_price_datetime_updated =
       points
       |> Enum.max_by(&Measurement.get_timestamp/1)

--- a/lib/sanbase/external_services/coinmarketcap2/price_point.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/price_point.ex
@@ -1,0 +1,75 @@
+defmodule Sanbase.ExternalServices.Coinmarketcap.PricePoint2 do
+  alias __MODULE__, as: PricePoint
+  alias Sanbase.Influxdb.Measurement
+  alias Sanbase.Model.Project
+
+  defstruct [
+    :ticker,
+    :slug,
+    :datetime,
+    :marketcap,
+    :price_usd,
+    :volume_usd,
+    :price_btc,
+    :volume_btc
+  ]
+
+  def convert_to_measurement(%PricePoint{datetime: datetime} = point, suffix, name) do
+    %Measurement{
+      timestamp: DateTime.to_unix(datetime, :nanosecond),
+      fields: price_point_to_fields(point, suffix),
+      tags: [],
+      name: name <> "_#{suffix}"
+    }
+  end
+
+  def price_points_to_measurements(%PricePoint{} = price_point) do
+    [convert_to_measurement(price_point, "USD", "TOTAL_MARKET")]
+  end
+
+  def price_points_to_measurements(price_points) do
+    price_points
+    |> Enum.flat_map(fn price_point ->
+      [convert_to_measurement(price_point, "USD", "TOTAL_MARKET")]
+    end)
+  end
+
+  def price_points_to_measurements(%PricePoint{} = price_point, %Project{ticker: ticker}) do
+    [
+      convert_to_measurement(price_point, "USD", ticker),
+      convert_to_measurement(price_point, "BTC", ticker)
+    ]
+  end
+
+  def price_points_to_measurements(price_points, %Project{ticker: ticker}) do
+    price_points
+    |> Enum.flat_map(fn price_point ->
+      [
+        convert_to_measurement(price_point, "USD", ticker),
+        convert_to_measurement(price_point, "BTC", ticker)
+      ]
+    end)
+  end
+
+  defp price_point_to_fields(
+         %PricePoint{marketcap: marketcap, volume_usd: volume_usd, price_btc: price_btc},
+         "BTC"
+       ) do
+    %{
+      price: price_btc,
+      volume: volume_usd,
+      marketcap: marketcap
+    }
+  end
+
+  defp price_point_to_fields(
+         %PricePoint{marketcap: marketcap, volume_usd: volume_usd, price_usd: price_usd},
+         "USD"
+       ) do
+    %{
+      price: price_usd,
+      volume: volume_usd,
+      marketcap: marketcap
+    }
+  end
+end

--- a/lib/sanbase/external_services/coinmarketcap2/price_point.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/price_point.ex
@@ -23,11 +23,11 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.PricePoint2 do
     }
   end
 
-  def price_points_to_measurements(price_points, "TOTAL_MARKET") do
+  def price_points_to_measurements(price_points, "TOTAL_MARKET_total-market" = total_market) do
     price_points
     |> List.wrap()
     |> Enum.map(fn price_point ->
-      convert_to_measurement(price_point, "TOTAL_MARKET_total-market")
+      convert_to_measurement(price_point, total_market)
     end)
   end
 

--- a/lib/sanbase/external_services/coinmarketcap2/price_point.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/price_point.ex
@@ -1,4 +1,5 @@
 defmodule Sanbase.ExternalServices.Coinmarketcap.PricePoint2 do
+  # TODO: Change after switching over to only this cmc
   alias __MODULE__, as: PricePoint
   alias Sanbase.Influxdb.Measurement
   alias Sanbase.Model.Project

--- a/lib/sanbase/external_services/coinmarketcap2/scraper.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/scraper.ex
@@ -29,7 +29,12 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.Scraper2 do
         {:error, error}
 
       %Tesla.Error{message: error_msg} ->
-        Logger.warn(error_msg)
+        Logger.error(
+          "Error fetching project page for #{coinmarketcap_id}. Error message: #{
+            inspect(error_msg)
+          }"
+        )
+
         {:error, error_msg}
     end
   end
@@ -45,6 +50,8 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.Scraper2 do
         etherscan_token_name: etherscan_token_name(html)
     }
   end
+
+  # Private functions
 
   defp name(html) do
     Floki.attribute(html, ".logo-32x32", "alt")

--- a/lib/sanbase/external_services/coinmarketcap2/scraper.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/scraper.ex
@@ -1,0 +1,90 @@
+defmodule Sanbase.ExternalServices.Coinmarketcap.Scraper do
+  use Tesla
+
+  require Logger
+
+  alias Sanbase.ExternalServices.RateLimiting
+  alias Sanbase.ExternalServices.ProjectInfo
+  alias Sanbase.ExternalServices.ErrorCatcher
+
+  plug(RateLimiting.Middleware, name: :http_coinmarketcap_rate_limiter)
+  plug(ErrorCatcher.Middleware)
+  plug(Tesla.Middleware.BaseUrl, "https://coinmarketcap.com/currencies")
+  plug(Tesla.Middleware.FollowRedirects, max_redirects: 10)
+  plug(Tesla.Middleware.Compression)
+  plug(Tesla.Middleware.Logger)
+
+  def fetch_project_page(coinmarketcap_id) do
+    case get("/#{coinmarketcap_id}/") do
+      %Tesla.Env{status: 200, body: body} ->
+        {:ok, body}
+
+      %Tesla.Env{status: status, body: _body} ->
+        error = "Failed fetching project page for #{coinmarketcap_id}. Status: #{status}"
+        Logger.warn(error)
+        {:error, error}
+
+      %Tesla.Error{message: error_msg} ->
+        Logger.warn(error_msg)
+        {:error, error_msg}
+    end
+  end
+
+  def parse_project_page(html, project_info) do
+    %ProjectInfo{
+      project_info
+      | name: name(html),
+        ticker: ticker(html),
+        main_contract_address: main_contract_address(html),
+        website_link: website_link(html),
+        github_link: github_link(html),
+        etherscan_token_name: etherscan_token_name(html)
+    }
+  end
+
+  defp name(html) do
+    Floki.attribute(html, ".logo-32x32", "alt")
+    |> List.first()
+  end
+
+  defp ticker(html) do
+    Floki.find(html, "h1 small.bold")
+    |> hd
+    |> Floki.text()
+    |> String.replace(~r/[\(\)]/, "")
+  end
+
+  defp website_link(html) do
+    Floki.attribute(html, ".bottom-margin-2x a:fl-contains('Website')", "href")
+    |> List.first()
+  end
+
+  defp github_link(html) do
+    Floki.attribute(html, "a:fl-contains('Source Code')", "href")
+    |> List.first()
+  end
+
+  defp etherscan_token_name(html) do
+    Floki.attribute(html, "a:fl-contains('Explorer')", "href")
+    |> Enum.map(fn link ->
+      Regex.run(~r{https://etherscan.io/token/(.+)}, link)
+    end)
+    |> Enum.find(& &1)
+    |> case do
+      nil -> nil
+      list -> List.last(list)
+    end
+  end
+
+  defp main_contract_address(html) do
+    Floki.attribute(html, "a:fl-contains('Explorer')", "href")
+    |> Enum.map(fn link ->
+      Regex.run(~r{https://ethplorer.io/address/(.+)}, link)
+    end)
+    |> Enum.find(& &1)
+    |> case do
+      nil -> nil
+      list -> List.last(list)
+    end
+  end
+end

--- a/lib/sanbase/external_services/coinmarketcap2/scraper.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/scraper.ex
@@ -1,4 +1,8 @@
-defmodule Sanbase.ExternalServices.Coinmarketcap.Scraper do
+defmodule Sanbase.ExternalServices.Coinmarketcap.Scraper2 do
+  @moduledoc ~s"""
+
+  """
+
   use Tesla
 
   require Logger

--- a/lib/sanbase/external_services/coinmarketcap2/scraper.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/scraper.ex
@@ -37,11 +37,11 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.Scraper2 do
   def parse_project_page(html, project_info) do
     %ProjectInfo{
       project_info
-      | name: name(html),
-        ticker: ticker(html),
-        main_contract_address: main_contract_address(html),
-        website_link: website_link(html),
-        github_link: github_link(html),
+      | name: project_info.name || name(html),
+        ticker: project_info.ticker || ticker(html),
+        main_contract_address: project_info.main_contract_address || main_contract_address(html),
+        website_link: project_info.website_link || website_link(html),
+        github_link: project_info.github_link || github_link(html),
         etherscan_token_name: etherscan_token_name(html)
     }
   end

--- a/lib/sanbase/external_services/coinmarketcap2/ticker.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/ticker.ex
@@ -13,7 +13,6 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.Ticker2 do
   defstruct [
     :id,
     :name,
-    :coinmarketcap_id,
     :symbol,
     :price_usd,
     :price_btc,
@@ -53,13 +52,12 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.Ticker2 do
   def parse_json(json) do
     json
     |> Poison.decode!(as: [%Ticker{}])
-    |> Stream.filter(fn ticker -> ticker.last_updated end)
+    |> Stream.filter(fn %Ticker{last_updated: last_updated} -> last_updated end)
     |> Enum.map(&make_timestamp_integer/1)
   end
 
   def convert_for_importing(
         %Ticker{
-          symbol: ticker,
           last_updated: last_updated,
           price_btc: price_btc,
           price_usd: price_usd,

--- a/lib/sanbase/external_services/coinmarketcap2/ticker.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/ticker.ex
@@ -1,0 +1,93 @@
+defmodule Sanbase.ExternalServices.Coinmarketcap.Ticker2 do
+  # A module which fetches the ticker data from coinmarketcap
+  defstruct [
+    :id,
+    :name,
+    :coinmarketcap_id,
+    :symbol,
+    :price_usd,
+    :price_btc,
+    :rank,
+    :"24h_volume_usd",
+    :market_cap_usd,
+    :last_updated,
+    :available_supply,
+    :total_supply,
+    :percent_change_1h,
+    :percent_change_24h,
+    :percent_change_7d
+  ]
+
+  use Tesla
+
+  alias Sanbase.ExternalServices.RateLimiting
+  alias Sanbase.ExternalServices.Coinmarketcap.PricePoint
+
+  plug(RateLimiting.Middleware, name: :api_coinmarketcap_rate_limiter)
+  plug(Tesla.Middleware.BaseUrl, "https://api.coinmarketcap.com/v1/ticker")
+  plug(Tesla.Middleware.Compression)
+  plug(Tesla.Middleware.Logger)
+
+  alias __MODULE__, as: Ticker
+
+  def fetch_data() do
+    "/?limit=10000"
+    |> get()
+    |> case do
+      %{status: 200, body: body} ->
+        parse_json(body)
+    end
+  end
+
+  def parse_json(json) do
+    json
+    |> Poison.decode!(as: [%Ticker{}])
+    |> Stream.filter(fn ticker -> ticker.last_updated end)
+    |> Enum.map(&make_timestamp_integer/1)
+  end
+
+  def convert_for_importing(%Ticker{
+        symbol: ticker,
+        last_updated: last_updated,
+        price_btc: price_btc,
+        price_usd: price_usd,
+        "24h_volume_usd": volume_usd,
+        market_cap_usd: marketcap_usd
+      }) do
+    price_point = %PricePoint{
+      marketcap: marketcap_usd |> to_integer(),
+      volume_usd: volume_usd |> to_integer(),
+      price_btc: price_btc |> to_float(),
+      price_usd: price_usd |> to_float(),
+      datetime: DateTime.from_unix!(last_updated)
+    }
+
+    [
+      PricePoint.convert_to_measurement(price_point, "USD", ticker),
+      PricePoint.convert_to_measurement(price_point, "BTC", ticker)
+    ]
+  end
+
+  # Helper functions
+
+  defp make_timestamp_integer(ticker) do
+    {ts, ""} = Integer.parse(ticker.last_updated)
+    %{ticker | last_updated: ts}
+  end
+
+  defp to_float(nil), do: nil
+  defp to_float(fl) when is_float(fl), do: fl
+
+  defp to_float(str) when is_binary(str) do
+    {num, _} = str |> Float.parse()
+    num
+  end
+
+  defp to_integer(nil), do: nil
+  defp to_integer(int) when is_integer(int), do: int
+
+  defp to_integer(str) when is_binary(str) do
+    {num, _} = str |> Integer.parse()
+    num
+  end
+end

--- a/lib/sanbase/external_services/coinmarketcap2/ticker.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/ticker.ex
@@ -30,6 +30,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.Ticker2 do
   use Tesla
 
   alias Sanbase.ExternalServices.RateLimiting
+  # TODO: Change after switching over to only this cmc
   alias Sanbase.ExternalServices.Coinmarketcap.PricePoint2, as: PricePoint
   alias Sanbase.Influxdb.Measurement
 

--- a/lib/sanbase/external_services/coinmarketcap2/ticker_fetcher.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/ticker_fetcher.ex
@@ -13,6 +13,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcher2 do
   alias Sanbase.Model.LatestCoinmarketcapData
   alias Sanbase.Model.Project
   alias Sanbase.Repo
+  # TODO: Change
   alias Sanbase.ExternalServices.Coinmarketcap.Ticker2, as: Ticker
   alias Sanbase.Utils.Config
   alias Sanbase.Prices.Store
@@ -72,8 +73,8 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcher2 do
     end
   end
 
-  defp store_latest_coinmarketcap_data(ticker) do
-    ticker.id
+  defp store_latest_coinmarketcap_data(%Ticker{id: coinmarketcap_id} = ticker) do
+    coinmarketcap_id
     |> get_or_create_latest_coinmarketcap_data()
     |> LatestCoinmarketcapData.changeset(%{
       market_cap_usd: ticker.market_cap_usd,

--- a/lib/sanbase/external_services/coinmarketcap2/ticker_fetcher.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/ticker_fetcher.ex
@@ -1,0 +1,112 @@
+defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcher2 do
+  # # Syncronize ticker data from coinmarketcap.com
+  #
+  # A GenServer, which updates the data from coinmarketcap on a regular basis.
+  # On regular intervals it will fetch the data from coinmarketcap and insert it
+  # into a local DB
+  use GenServer, restart: :permanent, shutdown: 5_000
+
+  require Sanbase.Utils.Config
+
+  alias Sanbase.Model.LatestCoinmarketcapData
+  alias Sanbase.Model.Project
+  alias Sanbase.Repo
+  alias Sanbase.ExternalServices.Coinmarketcap.Ticker2, as: Ticker
+  alias Sanbase.Utils.Config
+  alias Sanbase.Prices.Store
+
+  # 5 minutes
+  @default_update_interval 1000 * 60 * 5
+
+  def start_link(_state) do
+    GenServer.start_link(__MODULE__, :ok)
+  end
+
+  def init(:ok) do
+    if Config.get(:sync_enabled, false) do
+      Store.create_db()
+
+      GenServer.cast(self(), :sync)
+
+      update_interval = Config.get(:update_interval, @default_update_interval)
+      {:ok, %{update_interval: update_interval}}
+    else
+      :ignore
+    end
+  end
+
+  def handle_cast(:sync, %{update_interval: update_interval} = state) do
+    # Fetch current  marketcap
+    tickers = Ticker.fetch_data()
+
+    tickers
+    |> Enum.each(&store_latest_coinmarketcap_data/1)
+
+    tickers
+    |> Enum.flat_map(&Ticker.convert_for_importing/1)
+    |> Store.import()
+
+    tickers
+    |> Enum.take(top_projects_to_follow())
+    |> Enum.each(&insert_or_create_project/1)
+
+    Process.send_after(self(), {:"$gen_cast", :sync}, update_interval)
+
+    {:noreply, state}
+  end
+
+  # Helper functions
+
+  defp get_or_create_latest_coinmarketcap_data(coinmarketcap_id) do
+    case Repo.get_by(LatestCoinmarketcapData, coinmarketcap_id: coinmarketcap_id) do
+      nil ->
+        %LatestCoinmarketcapData{coinmarketcap_id: coinmarketcap_id}
+
+      entry ->
+        entry
+    end
+  end
+
+  defp store_latest_coinmarketcap_data(ticker) do
+    ticker.id
+    |> get_or_create_latest_coinmarketcap_data()
+    |> LatestCoinmarketcapData.changeset(%{
+      market_cap_usd: ticker.market_cap_usd,
+      name: ticker.name,
+      price_usd: ticker.price_usd,
+      price_btc: ticker.price_btc,
+      rank: ticker.rank,
+      volume_usd: ticker."24h_volume_usd",
+      available_supply: ticker.available_supply,
+      total_supply: ticker.total_supply,
+      symbol: ticker.symbol,
+      percent_change_1h: ticker.percent_change_1h,
+      percent_change_24h: ticker.percent_change_24h,
+      percent_change_7d: ticker.percent_change_7d,
+      update_time: DateTime.from_unix!(ticker.last_updated)
+    })
+    |> Repo.insert_or_update!()
+  end
+
+  defp insert_or_create_project(%Ticker{id: coinmarketcap_id, name: name, symbol: ticker}) do
+    find_or_init_project(%Project{name: name, coinmarketcap_id: coinmarketcap_id, ticker: ticker})
+    |> Repo.insert_or_update!()
+  end
+
+  defp find_or_init_project(%Project{coinmarketcap_id: coinmarketcap_id} = project) do
+    case Repo.get_by(Project, coinmarketcap_id: coinmarketcap_id) do
+      nil ->
+        Project.changeset(project)
+
+      existing_project ->
+        Project.changeset(existing_project, %{
+          coinmarketcap_id: coinmarketcap_id,
+          ticker: project.ticker
+        })
+    end
+  end
+
+  defp top_projects_to_follow() do
+    Config.get(:top_projects_to_follow, "25") |> String.to_integer()
+  end
+end

--- a/lib/sanbase/external_services/coinmarketcap2/ticker_fetcher.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/ticker_fetcher.ex
@@ -13,7 +13,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcher2 do
   alias Sanbase.Model.LatestCoinmarketcapData
   alias Sanbase.Model.Project
   alias Sanbase.Repo
-  # TODO: Change
+  # TODO: Change after switching over to only this cmc
   alias Sanbase.ExternalServices.Coinmarketcap.Ticker2, as: Ticker
   alias Sanbase.Utils.Config
   alias Sanbase.Prices.Store

--- a/lib/sanbase/external_services/coinmarketcap2/ticker_fetcher.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/ticker_fetcher.ex
@@ -40,7 +40,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcher2 do
 
   def handle_cast(:sync, %{update_interval: update_interval} = state) do
     # Fetch current coinmarketcap data for many tickers
-    tickers = Ticker.fetch_data()
+    {:ok, tickers} = Ticker.fetch_data()
 
     # Create a project if it's a new one in the top projects and we don't have it
     tickers

--- a/lib/sanbase/influxdb/measurement.ex
+++ b/lib/sanbase/influxdb/measurement.ex
@@ -5,7 +5,13 @@ defmodule Sanbase.Influxdb.Measurement do
   defstruct [:timestamp, :fields, :tags, :name]
 
   alias __MODULE__
+  alias Sanbase.ExternalServices.Coinmarketcap.Ticker2, as: Ticker
 
+  @doc ~s"""
+    Converts the measurement to a format that the Influxdb and the Instream library
+    understand.
+    The timestamp should be either a DateTime struct or timestamp in nanoseconds.
+  """
   def convert_measurement_for_import(nil), do: nil
 
   def convert_measurement_for_import(%Measurement{
@@ -13,22 +19,49 @@ defmodule Sanbase.Influxdb.Measurement do
         fields: fields,
         tags: tags,
         name: name
-      }) do
+      })
+      when %{} != fields do
     %{
       points: [
         %{
           measurement: name,
           fields: fields,
           tags: tags || [],
-          timestamp: timestamp
+          timestamp: timestamp |> format_timestamp()
         }
       ]
     }
   end
 
+  def get_timestamp(%Measurement{timestamp: %DateTime{} = datetime}) do
+    DateTime.to_unix(datetime, :nanoseconds)
+  end
+
   def get_timestamp(%Measurement{timestamp: ts}), do: ts
+
+  def get_datetime(%Measurement{timestamp: %DateTime{} = datetime}) do
+    datetime
+  end
 
   def get_datetime(%Measurement{timestamp: ts}) do
     DateTime.from_unix!(ts, :nanoseconds)
   end
+
+  def name_from(%Sanbase.Model.Project{ticker: ticker, coinmarketcap_id: coinmarketcap_id})
+      when nil != ticker and nil != coinmarketcap_id do
+    ticker <> "_" <> coinmarketcap_id
+  end
+
+  def name_from(%Ticker{symbol: ticker, id: coinmarketcap_id})
+      when nil != ticker and nil != coinmarketcap_id do
+    ticker <> "_" <> coinmarketcap_id
+  end
+
+  # Private functions
+
+  defp format_timestamp(%DateTime{} = datetime) do
+    DateTime.to_unix(datetime, :nanoseconds)
+  end
+
+  defp format_timestamp(ts) when is_integer(ts), do: ts
 end

--- a/lib/sanbase/influxdb/store.ex
+++ b/lib/sanbase/influxdb/store.ex
@@ -152,6 +152,7 @@ defmodule Sanbase.Influxdb.Store do
 
       @doc ~s"""
         Transforms the `datetime` parammeter to the internally used datetime format
+        which is timestamp in nanoseconds
       """
       def influx_time(datetime, from_type \\ nil)
 
@@ -161,6 +162,10 @@ defmodule Sanbase.Influxdb.Store do
 
       def influx_time(datetime, :seconds) when is_integer(datetime) do
         datetime * 1_000_000_000
+      end
+
+      def influx_time(datetime, :milliseconds) when is_integer(datetime) do
+        datetime * 1_000_000
       end
 
       def parse_time_series(%{results: [%{error: error}]}) do

--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -59,26 +59,26 @@ defmodule Sanbase.Prices.Store do
     |> parse_price_series
   end
 
-  def update_last_history_datetime_cmc(ticker, last_updated_datetime) do
+  def update_last_history_datetime_cmc(ticker_cmc_id, last_updated_datetime) do
     %Measurement{
       timestamp: 0,
       fields: %{last_updated: last_updated_datetime |> DateTime.to_unix(:nanoseconds)},
-      tags: [ticker: ticker],
+      tags: [ticker_cmc_id: ticker_cmc_id],
       name: @last_history_price_cmc_measurement
     }
     |> Store.import()
   end
 
-  def last_history_datetime_cmc!(ticker) do
-    case last_history_datetime_cmc(ticker) do
+  def last_history_datetime_cmc!(ticker_cmc_id) do
+    case last_history_datetime_cmc(ticker_cmc_id) do
       {:ok, datetime} -> datetime
       {:error, error} -> raise(error)
     end
   end
 
-  def last_history_datetime_cmc(ticker) do
+  def last_history_datetime_cmc(ticker_cmc_id) do
     ~s/SELECT * FROM "#{@last_history_price_cmc_measurement}"
-    WHERE ticker = '#{ticker}'/
+    WHERE ticker_cmc_id = '#{ticker_cmc_id}'/
     |> Store.query()
     |> parse_last_history_datetime_cmc()
   end

--- a/priv/repo/migrations/20180112084549_ico_move_funds_raised_totals_to_details.exs
+++ b/priv/repo/migrations/20180112084549_ico_move_funds_raised_totals_to_details.exs
@@ -17,10 +17,14 @@ defmodule Sanbase.Repo.Migrations.IcoMoveFundsRaisedTotalsToDetails do
     from(
       i in Ico,
       preload: [ico_currencies: [:currency]],
-      where: fragment("NOT EXISTS(select 1
+      where:
+        fragment(
+          "NOT EXISTS(select 1
                   from ico_currencies ic
                   where ic.ico_id = ?
-                        and ic.amount is not null)", i.id)
+                        and ic.amount is not null)",
+          i.id
+        )
     )
     |> Repo.stream(max_rows: 10000)
     |> Stream.each(fn ico ->


### PR DESCRIPTION
#### Summary

Currently there is a serious issue with fetching prices. The prices measurement consists solely of the ticker, which is not unique. We also scrape the whole CMC list of prices, so these duplicates happen often. Example is the KNC ticker.

This PR reworks the fetching so it now uses a single measurement `SAN_santiment` (ticker_cmc_id) instead of two measurements `SAN_USD` and `SAN_BTC`. The structure of the code is mostly the same as the old, hence the big number of LOC added.

As a first step this new scrapers should be enabled so they can catch up with the historical data. On a second step in a different PR the places where these prices are used (GQL, dataloaders, etc.) should be changed to use the new measurements.

Also at some point **before** switching off the old scrapers Grafana dashboards should be reworked, too. Only after that we can delete the old code and rename all modules ending with **2** to the original name.

#### Screenshots
![](https://i.imgur.com/XeMt6Zo.png)