### PR TITLE
Add ratelimit api

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -247,7 +247,7 @@ config :sanbase, Sanbase.Oauth2.Hydra,
 
 config :sanbase, SanbaseWeb.Graphql.PlugAttack,
   rate_limit_period: {:system, "RATE_LIMIT_PERIOD", "10000"},
-  rate_limit_max_requests: {:system, "RATE_LIMIT_MAX_REQUESTS", "20"}
+  rate_limit_max_requests: {:system, "RATE_LIMIT_MAX_REQUESTS", "40"}
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/config.exs
+++ b/config/config.exs
@@ -245,6 +245,10 @@ config :sanbase, Sanbase.Oauth2.Hydra,
   clients_that_require_san_tokens:
     {:system, "CLIENTS_THAT_REQUIRE_SAN_TOKENS", "{\"grafana\": 100}"}
 
+config :sanbase, SanbaseWeb.Graphql.PlugAttack,
+  rate_limit_period: {:system, "RATE_LIMIT_PERIOD", 10_000},
+  rate_limit_max_requests: {:system, "RATE_LIMIT_MAX_REQUESTS", 20}
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -246,8 +246,8 @@ config :sanbase, Sanbase.Oauth2.Hydra,
     {:system, "CLIENTS_THAT_REQUIRE_SAN_TOKENS", "{\"grafana\": 100}"}
 
 config :sanbase, SanbaseWeb.Graphql.PlugAttack,
-  rate_limit_period: {:system, "RATE_LIMIT_PERIOD", 10_000},
-  rate_limit_max_requests: {:system, "RATE_LIMIT_MAX_REQUESTS", 20}
+  rate_limit_period: {:system, "RATE_LIMIT_PERIOD", "10000"},
+  rate_limit_max_requests: {:system, "RATE_LIMIT_MAX_REQUESTS", "20"}
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/lib/sanbase/application.ex
+++ b/lib/sanbase/application.ex
@@ -100,6 +100,10 @@ defmodule Sanbase.Application do
           limit: 100,
           time_between_requests: 100
         ),
+        worker(PlugAttack.Storage.Ets, [
+          SanbaseWeb.Graphql.PlugAttack.Storage,
+          [clean_period: 60_000]
+        ]),
 
         # Price fetcher
         # TODO: Change after switching over to only this cmc

--- a/lib/sanbase/application.ex
+++ b/lib/sanbase/application.ex
@@ -100,7 +100,7 @@ defmodule Sanbase.Application do
           limit: 100,
           time_between_requests: 100
         ),
-        supervisor(PlugAttack.Storage.Ets, [
+        worker(PlugAttack.Storage.Ets, [
           SanbaseWeb.Graphql.PlugAttack.Storage,
           [clean_period: 60_000]
         ]),

--- a/lib/sanbase/application.ex
+++ b/lib/sanbase/application.ex
@@ -100,7 +100,7 @@ defmodule Sanbase.Application do
           limit: 100,
           time_between_requests: 100
         ),
-        worker(PlugAttack.Storage.Ets, [
+        supervisor(PlugAttack.Storage.Ets, [
           SanbaseWeb.Graphql.PlugAttack.Storage,
           [clean_period: 60_000]
         ]),

--- a/lib/sanbase_web/graphql/plug_attack.ex
+++ b/lib/sanbase_web/graphql/plug_attack.ex
@@ -1,0 +1,52 @@
+defmodule SanbaseWeb.Graphql.PlugAttack do
+  use PlugAttack
+  import Plug.Conn
+  require Sanbase.Utils.Config
+  alias Sanbase.Utils.Config
+
+  rule "allow local", conn do
+    allow(conn.remote_ip == {127, 0, 0, 1})
+  end
+
+  rule "throttle per ip", conn do
+    throttle(
+      conn.remote_ip,
+      period: Config.get(:rate_limit_period),
+      limit: Config.get(:rate_limit_max_requests),
+      storage: {PlugAttack.Storage.Ets, SanbaseWeb.Graphql.PlugAttack.Storage}
+    )
+  end
+
+  def allow_action(conn, {:throttle, data}, opts) do
+    conn
+    |> add_throttling_headers(data)
+    |> allow_action(true, opts)
+  end
+
+  def allow_action(conn, _data, _opts) do
+    conn
+  end
+
+  def block_action(conn, {:throttle, data}, opts) do
+    conn
+    |> add_throttling_headers(data)
+    |> block_action(false, opts)
+  end
+
+  def block_action(conn, _data, _opts) do
+    conn
+    |> send_resp(:forbidden, "Forbidden\n")
+    |> halt
+  end
+
+  defp add_throttling_headers(conn, data) do
+    # The expires_at value is a unix time in milliseconds, we want to return one
+    # in seconds
+    reset = div(data[:expires_at], 1_000)
+
+    conn
+    |> put_resp_header("x-ratelimit-limit", to_string(data[:limit]))
+    |> put_resp_header("x-ratelimit-remaining", to_string(data[:remaining]))
+    |> put_resp_header("x-ratelimit-reset", to_string(reset))
+  end
+end

--- a/lib/sanbase_web/graphql/plug_attack.ex
+++ b/lib/sanbase_web/graphql/plug_attack.ex
@@ -11,8 +11,8 @@ defmodule SanbaseWeb.Graphql.PlugAttack do
   rule "throttle per ip", conn do
     throttle(
       conn.remote_ip,
-      period: Config.get(:rate_limit_period),
-      limit: Config.get(:rate_limit_max_requests),
+      period: Config.get(:rate_limit_period) |> String.to_integer(),
+      limit: Config.get(:rate_limit_max_requests) |> String.to_integer(),
       storage: {PlugAttack.Storage.Ets, SanbaseWeb.Graphql.PlugAttack.Storage}
     )
   end

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -15,6 +15,7 @@ defmodule SanbaseWeb.Router do
 
   pipeline :api do
     plug(:accepts, ["json"])
+    plug(SanbaseWeb.Graphql.PlugAttack)
     plug(SanbaseWeb.Graphql.ContextPlug)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -87,7 +87,8 @@ defmodule Sanbase.Mixfile do
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:con_cache, "~> 0.13"},
       {:excoveralls, "~> 0.8", optional: true, only: [:dev, :test]},
-      {:observer_cli, "~> 1.3"}
+      {:observer_cli, "~> 1.3"},
+      {:plug_attack, "~> 0.3.1"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -61,6 +61,7 @@
   "phoenix_live_reload": {:hex, :phoenix_live_reload, "1.1.3", "1d178429fc8950b12457d09c6afec247bfe1fcb6f36209e18fbb0221bdfe4d41", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}, {:phoenix, "~> 1.0 or ~> 1.2 or ~> 1.3", [hex: :phoenix, repo: "hexpm", optional: false]}], "hexpm"},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [], [], "hexpm"},
   "plug": {:hex, :plug, "1.4.5", "7b13869283fff6b8b21b84b8735326cc012c5eef8607095dc6ee24bd0a273d8e", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "plug_attack": {:hex, :plug_attack, "0.3.1", "2bffce1cd36267e4c4d2a25ef5e807ff724e0755a37ad5e95da391edabeff692", [], [{:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [], [], "hexpm"},
   "postgrex": {:hex, :postgrex, "0.13.3", "c277cfb2a9c5034d445a722494c13359e361d344ef6f25d604c2353185682bfc", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/sanbase_web/graphql/plug_attack_test.exs
+++ b/test/sanbase_web/graphql/plug_attack_test.exs
@@ -1,5 +1,6 @@
 defmodule PlugAttackTest do
   use SanbaseWeb.ConnCase
+  require Sanbase.Utils.Config
   alias Sanbase.Utils.Config
 
   setup do

--- a/test/sanbase_web/graphql/plug_attack_test.exs
+++ b/test/sanbase_web/graphql/plug_attack_test.exs
@@ -10,14 +10,22 @@ defmodule PlugAttackTest do
   test "get graphql updates the remaining ratelimit headers", %{conn: conn} do
     conn = %{conn | remote_ip: {192, 168, 0, 1}}
     response = conn |> get("/graphql")
-    ratelimit_remaining = response |> get_resp_header("x-ratelimit-remaining") |> List.first()
+
+    ratelimit_remaining =
+      response
+      |> get_resp_header("x-ratelimit-remaining")
+      |> List.first()
+
     assert ratelimit_remaining == Integer.to_string(get_max_requests() - 1)
   end
 
   test "after max requests the api returns 403 Forbidden", %{conn: conn} do
     conn = %{conn | remote_ip: {192, 168, 0, 1}}
+
     for _n <- 1..get_max_requests(), do: conn |> get("/graphql")
+
     response = conn |> get("/graphql")
+
     assert response.status == 403
   end
 
@@ -25,5 +33,6 @@ defmodule PlugAttackTest do
     Application.fetch_env!(:sanbase, SanbaseWeb.Graphql.PlugAttack)
     |> Keyword.get(:rate_limit_max_requests)
     |> Config.parse_config_value()
+    |> String.to_integer()
   end
 end

--- a/test/sanbase_web/graphql/plug_attack_test.exs
+++ b/test/sanbase_web/graphql/plug_attack_test.exs
@@ -30,9 +30,7 @@ defmodule PlugAttackTest do
   end
 
   defp get_max_requests() do
-    Application.fetch_env!(:sanbase, SanbaseWeb.Graphql.PlugAttack)
-    |> Keyword.get(:rate_limit_max_requests)
-    |> Config.parse_config_value()
+    Config.module_get(SanbaseWeb.Graphql.PlugAttack, :rate_limit_max_requests)
     |> String.to_integer()
   end
 end

--- a/test/sanbase_web/graphql/plug_attack_test.exs
+++ b/test/sanbase_web/graphql/plug_attack_test.exs
@@ -1,0 +1,29 @@
+defmodule PlugAttackTest do
+  use SanbaseWeb.ConnCase
+  alias Sanbase.Utils.Config
+
+  setup do
+    :ets.delete_all_objects(:"Elixir.SanbaseWeb.Graphql.PlugAttack.Storage")
+    :ok
+  end
+
+  test "get graphql updates the remaining ratelimit headers", %{conn: conn} do
+    conn = %{conn | remote_ip: {192, 168, 0, 1}}
+    response = conn |> get("/graphql")
+    ratelimit_remaining = response |> get_resp_header("x-ratelimit-remaining") |> List.first()
+    assert ratelimit_remaining == Integer.to_string(get_max_requests() - 1)
+  end
+
+  test "after max requests the api returns 403 Forbidden", %{conn: conn} do
+    conn = %{conn | remote_ip: {192, 168, 0, 1}}
+    for _n <- 1..get_max_requests(), do: conn |> get("/graphql")
+    response = conn |> get("/graphql")
+    assert response.status == 403
+  end
+
+  defp get_max_requests() do
+    Application.fetch_env!(:sanbase, SanbaseWeb.Graphql.PlugAttack)
+    |> Keyword.get(:rate_limit_max_requests)
+    |> Config.parse_config_value()
+  end
+end


### PR DESCRIPTION
#### Summary
Add ratelimit to graphql API.

Current default limit is set to 20 requests / 10 secs because our frontend sometimes makes a couple of queries at the same time.

card: https://favro.com/organization/bdbb4f24afc48b29c74f4fa4/9ff267872fcd8b7925f1d7c7?card=San-1758

