### PR TITLE
Fix bug in saving last CMC price due to having an old column present in the database

### DIFF
--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -162,7 +162,7 @@ defmodule Sanbase.Prices.Store do
            %{
              series: [
                %{
-                 values: [[_iso8601_datetime, iso8601_last_updated, _]]
+                 values: [[_iso8601_datetime, iso8601_last_updated | _]]
                }
              ]
            }


### PR DESCRIPTION
#### Summary
In the database there is an old `tickers` column that is not present in any tests and local environments. This caused the problem to be impossible to reproduce when testing before discovering this.
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
