### PR TITLE
Use everywhere Sanbase Case templates. Make async: false explicit in all tests

### DIFF
--- a/test/sanbase/external_services/coinmarketcap/graph_data_test.exs
+++ b/test/sanbase/external_services/coinmarketcap/graph_data_test.exs
@@ -1,5 +1,5 @@
 defmodule Sanbase.ExternalServices.Coinmarketcap.GraphDataTest do
-  use ExUnit.Case
+  use Sanbase.DataCase, async: false
 
   alias Sanbase.ExternalServices.Coinmarketcap.{GraphData, PricePoint}
 

--- a/test/sanbase/external_services/coinmarketcap/price_point_test.exs
+++ b/test/sanbase/external_services/coinmarketcap/price_point_test.exs
@@ -1,5 +1,5 @@
 defmodule Sanbase.ExternalServices.Coinmarketcap.PricePointTest do
-  use ExUnit.Case
+  use Sanbase.DataCase, async: false
 
   alias Sanbase.ExternalServices.Coinmarketcap.PricePoint
   alias Sanbase.Influxdb.Measurement

--- a/test/sanbase/external_services/coinmarketcap/scraper_test.exs
+++ b/test/sanbase/external_services/coinmarketcap/scraper_test.exs
@@ -1,5 +1,5 @@
 defmodule Sanbase.ExternalServices.Coinmarketcap.ScraperTest do
-  use ExUnit.Case
+  use Sanbase.DataCase, async: false
 
   alias Sanbase.ExternalServices.Coinmarketcap.Scraper
   alias Sanbase.ExternalServices.ProjectInfo

--- a/test/sanbase/external_services/etherscan/fetch_transactions_test.exs
+++ b/test/sanbase/external_services/etherscan/fetch_transactions_test.exs
@@ -1,5 +1,5 @@
 defmodule Sanbase.ExternalServices.Etherscan.FetchTransactions do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
 
   import Mockery
 

--- a/test/sanbase/external_services/etherscan/scraper_test.exs
+++ b/test/sanbase/external_services/etherscan/scraper_test.exs
@@ -1,5 +1,5 @@
 defmodule Sanbase.ExternalServices.Etherscan.ScraperTest do
-  use ExUnit.Case
+  use Sanbase.DataCase, async: false
 
   alias Sanbase.ExternalServices.Etherscan.Scraper
   alias Sanbase.ExternalServices.ProjectInfo

--- a/test/sanbase/internal_services/tech_indicators_test.exs
+++ b/test/sanbase/internal_services/tech_indicators_test.exs
@@ -1,6 +1,5 @@
 defmodule Sanbase.InternalServices.TechIndicatorsTest do
-  use SanbaseWeb.ConnCase
-  use Phoenix.ConnTest
+  use SanbaseWeb.ConnCase, async: false
 
   import Mockery
 

--- a/test/sanbase/notifications/check_prices/compute_movements_test.exs
+++ b/test/sanbase/notifications/check_prices/compute_movements_test.exs
@@ -1,5 +1,5 @@
 defmodule Sanbase.Notifications.CheckPrices.ComputeMovementsTest do
-  use Sanbase.DataCase, async: true
+  use Sanbase.DataCase, async: false
 
   alias Sanbase.Notifications.CheckPrices.ComputeMovements
   alias Sanbase.Notifications.Notification

--- a/test/sanbase_web/graphql/account_test.exs
+++ b/test/sanbase_web/graphql/account_test.exs
@@ -1,5 +1,5 @@
 defmodule SanbaseWeb.Graphql.AccountTest do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
 
   alias Sanbase.Model.Project
   alias Sanbase.Auth.User

--- a/test/sanbase_web/graphql/context_plug_test.exs
+++ b/test/sanbase_web/graphql/context_plug_test.exs
@@ -1,5 +1,5 @@
 defmodule SanbaseWeb.Graphql.ContextPlugTest do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
 
   import ExUnit.CaptureLog
   import SanbaseWeb.Graphql.TestHelpers

--- a/test/sanbase_web/graphql/etherbi_burn_rate_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_burn_rate_api_test.exs
@@ -1,6 +1,5 @@
 defmodule Sanbase.Etherbi.BurnRateApiTest do
-  use SanbaseWeb.ConnCase
-  use Phoenix.ConnTest
+  use SanbaseWeb.ConnCase, async: false
 
   alias Sanbase.Influxdb.Measurement
   alias Sanbase.Etherbi.BurnRate.Store

--- a/test/sanbase_web/graphql/etherbi_daily_active_addresses_test.exs
+++ b/test/sanbase_web/graphql/etherbi_daily_active_addresses_test.exs
@@ -1,6 +1,5 @@
 defmodule Sanbase.Etherbi.DailyActiveAddressesApiTest do
-  use SanbaseWeb.ConnCase
-  use Phoenix.ConnTest
+  use SanbaseWeb.ConnCase, async: false
 
   alias Sanbase.Influxdb.Measurement
   alias Sanbase.Etherbi.DailyActiveAddresses.Store

--- a/test/sanbase_web/graphql/etherbi_exchange_wallets_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_exchange_wallets_api_test.exs
@@ -1,6 +1,5 @@
 defmodule Sanbase.Etherbi.ExchangeWalletsApiTest do
-  use SanbaseWeb.ConnCase
-  use Phoenix.ConnTest
+  use SanbaseWeb.ConnCase, async: false
 
   alias Sanbase.Model.ExchangeEthAddress
   alias Sanbase.Repo

--- a/test/sanbase_web/graphql/etherbi_transactions_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_transactions_api_test.exs
@@ -1,6 +1,5 @@
 defmodule Sanbase.Etherbi.TransactionsApiTest do
-  use SanbaseWeb.ConnCase
-  use Phoenix.ConnTest
+  use SanbaseWeb.ConnCase, async: false
 
   alias Sanbase.Influxdb.Measurement
   alias Sanbase.Etherbi.Transactions.Store

--- a/test/sanbase_web/graphql/etherbi_trx_volume_api_test.exs
+++ b/test/sanbase_web/graphql/etherbi_trx_volume_api_test.exs
@@ -1,6 +1,5 @@
 defmodule Sanbase.Etherbi.TransactionVolumeApiTest do
-  use SanbaseWeb.ConnCase
-  use Phoenix.ConnTest
+  use SanbaseWeb.ConnCase, async: false
 
   alias Sanbase.Influxdb.Measurement
   alias Sanbase.Etherbi.TransactionVolume.Store

--- a/test/sanbase_web/graphql/github_api_test.exs
+++ b/test/sanbase_web/graphql/github_api_test.exs
@@ -1,5 +1,5 @@
 defmodule Sanbase.Github.GithubApiTest do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
 
   alias Sanbase.Influxdb.Measurement
   alias Sanbase.Github

--- a/test/sanbase_web/graphql/middlewares/multiple_auth_test.exs
+++ b/test/sanbase_web/graphql/middlewares/multiple_auth_test.exs
@@ -1,5 +1,5 @@
 defmodule SanbaseWeb.Graphql.Middlewares.MultipleAuthTest do
-  use ExUnit.Case
+  use Sanbase.DataCase, async: false
 
   alias SanbaseWeb.Graphql.Middlewares.MultipleAuth
 

--- a/test/sanbase_web/graphql/plug_attack_test.exs
+++ b/test/sanbase_web/graphql/plug_attack_test.exs
@@ -1,5 +1,6 @@
 defmodule PlugAttackTest do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
+
   require Sanbase.Utils.Config
   alias Sanbase.Utils.Config
 

--- a/test/sanbase_web/graphql/prices_api_test.exs
+++ b/test/sanbase_web/graphql/prices_api_test.exs
@@ -1,5 +1,5 @@
 defmodule SanbaseWeb.Graphql.PricesApiTest do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
 
   alias Sanbase.Prices.Store
   alias Sanbase.Influxdb.Measurement

--- a/test/sanbase_web/graphql/privacy_policy_access_test.exs
+++ b/test/sanbase_web/graphql/privacy_policy_access_test.exs
@@ -1,5 +1,5 @@
 defmodule SanbaseWeb.Graphql.PrivacyPolicyAccessTest do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
 
   alias Sanbase.Auth.User
   alias Sanbase.Repo

--- a/test/sanbase_web/graphql/project_api_eth_contract_test.exs
+++ b/test/sanbase_web/graphql/project_api_eth_contract_test.exs
@@ -1,5 +1,5 @@
 defmodule Sanbase.Graphql.ProjectApiEthContractTest do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
 
   require Sanbase.Utils.Config
 

--- a/test/sanbase_web/graphql/project_api_eth_spent_over_time_test.exs
+++ b/test/sanbase_web/graphql/project_api_eth_spent_over_time_test.exs
@@ -1,5 +1,5 @@
 defmodule SanbaseWeb.Graphql.ProjectApiEthSpentOverTimeTest do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
 
   alias Sanbase.Influxdb.Measurement
   alias Sanbase.ExternalServices.Etherscan.Store

--- a/test/sanbase_web/graphql/project_api_etherscan_links_test.exs
+++ b/test/sanbase_web/graphql/project_api_etherscan_links_test.exs
@@ -1,5 +1,5 @@
 defmodule SanbaseWeb.Graphql.ProjecApiEtherscanLinksTest do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
 
   alias Sanbase.ExternalServices.Etherscan.Store
   alias Sanbase.Model.{Project, Ico, LatestCoinmarketcapData}

--- a/test/sanbase_web/graphql/project_api_forbidden_fields_test.exs
+++ b/test/sanbase_web/graphql/project_api_forbidden_fields_test.exs
@@ -1,5 +1,5 @@
 defmodule SanbaseWeb.Graphql.ProjectApiForbiddenFieldsTest do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
 
   import SanbaseWeb.Graphql.TestHelpers
 

--- a/test/sanbase_web/graphql/project_api_funds_raised_test.exs
+++ b/test/sanbase_web/graphql/project_api_funds_raised_test.exs
@@ -1,5 +1,5 @@
 defmodule SanbaseWeb.Graphql.ProjectApiFundsRaisedTest do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
 
   import Sanbase.Utils.Config, only: [parse_config_value: 1]
 

--- a/test/sanbase_web/graphql/project_api_get_queries_test.exs
+++ b/test/sanbase_web/graphql/project_api_get_queries_test.exs
@@ -1,5 +1,5 @@
 defmodule Sanbase.Graphql.ProjectApiGetQueriesTest do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
 
   require Sanbase.Utils.Config
 

--- a/test/sanbase_web/graphql/project_api_roi_test.exs
+++ b/test/sanbase_web/graphql/project_api_roi_test.exs
@@ -1,5 +1,5 @@
 defmodule SanbaseWeb.Graphql.ProjectApiRoiTest do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
 
   require Sanbase.Utils.Config
 

--- a/test/sanbase_web/graphql/project_api_spent_eth_test.exs
+++ b/test/sanbase_web/graphql/project_api_spent_eth_test.exs
@@ -1,5 +1,5 @@
 defmodule SanbaseWeb.Graphql.ProjecApiEthSpentTest do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
 
   alias Sanbase.Influxdb.Measurement
   alias Sanbase.ExternalServices.Etherscan.Store

--- a/test/sanbase_web/graphql/project_api_test.exs
+++ b/test/sanbase_web/graphql/project_api_test.exs
@@ -1,5 +1,5 @@
 defmodule Sanbase.Graphql.ProjectApiTest do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
 
   require Sanbase.Utils.Config
 

--- a/test/sanbase_web/graphql/project_api_wallet_transactions_test.exs
+++ b/test/sanbase_web/graphql/project_api_wallet_transactions_test.exs
@@ -1,5 +1,5 @@
 defmodule SanbaseWeb.Graphql.ProjectApiWalletTransactionsTest do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
 
   alias Sanbase.Influxdb.Measurement
   alias Sanbase.ExternalServices.Etherscan.Store

--- a/test/sanbase_web/graphql/twitter_api_test.exs
+++ b/test/sanbase_web/graphql/twitter_api_test.exs
@@ -1,5 +1,5 @@
 defmodule Sanbase.Github.TwitterApiTest do
-  use SanbaseWeb.ConnCase
+  use SanbaseWeb.ConnCase, async: false
 
   alias Sanbase.Influxdb.Measurement
   alias Sanbase.ExternalServices.TwitterData.Store

--- a/test/sanbase_web/views/error_view_test.exs
+++ b/test/sanbase_web/views/error_view_test.exs
@@ -1,5 +1,5 @@
 defmodule SanbaseWeb.ErrorViewTest do
-  use SanbaseWeb.ConnCase, async: true
+  use SanbaseWeb.ConnCase, async: false
 
   # Bring render/3 and render_to_string/3 for testing custom views
   import Phoenix.View

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
 ExUnit.start()
 
-Ecto.Adapters.SQL.Sandbox.mode(Sanbase.Repo, {:shared, self()})
+Ecto.Adapters.SQL.Sandbox.mode(Sanbase.Repo, :manual)


### PR DESCRIPTION
#### Summary
Not sure if this fixes the DB Connection checkout issues 100% but according to the tests on my machine there are alot less problems now.

We currently do not have issues with the performance of the tests. In order to be 
able to make a test suite `async: true` a research of the code should be made.
Making them all async has the benefit of making use of :shared mode of
the Ecto SQL Sandbox. If not in :shared mode the test will fail if the test process
spawns a new process (this can be hidden behind a call) which executes
an Ecto function. The :shared mode cannot run tests concurrently (async: true).

Using `use ExUnit.Case`  does put the SQL Sandbox into :shared mode. Note that there is no default mode, so it's to :manual in the test_helpers to cover wider variety of tests. :manual allows running of tests async

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
