### PR TITLE
Update Erlang/OTP to 21 and Elixir to 1.6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY ./app /app
 RUN yarn build
 
 # Elixir and phoenix assets build image
-FROM elixir:1.6.5-alpine as code_builder
+FROM elixir:1.6.6-alpine as code_builder
 
 ENV MIX_ENV prod
 
@@ -46,7 +46,7 @@ RUN mix phx.digest
 RUN mix release
 
 # Release image
-FROM elixir:1.6.5-alpine
+FROM elixir:1.6.6-alpine
 
 RUN apk add --update bash
 

--- a/lib/sanbase/auth/eth_account.ex
+++ b/lib/sanbase/auth/eth_account.ex
@@ -3,7 +3,8 @@ defmodule Sanbase.Auth.EthAccount do
 
   alias Sanbase.Auth.{User, EthAccount}
 
-  @ethauth Mockery.of("Sanbase.InternalServices.Ethauth")
+  require Mockery.Macro
+  defp ethauth, do: Mockery.Macro.mockable(Sanbase.InternalServices.Ethauth)
 
   schema "eth_accounts" do
     field(:address, :string)
@@ -13,6 +14,6 @@ defmodule Sanbase.Auth.EthAccount do
   end
 
   def san_balance(%EthAccount{address: address}) do
-    @ethauth.san_balance(address)
+    ethauth().san_balance(address)
   end
 end

--- a/lib/sanbase/auth/user.ex
+++ b/lib/sanbase/auth/user.ex
@@ -1,7 +1,8 @@
 defmodule Sanbase.Auth.User do
   use Ecto.Schema
-  import Ecto.Changeset
   use Timex.Ecto.Timestamps
+
+  import Ecto.Changeset
 
   alias Sanbase.Auth.{User, EthAccount}
   alias Sanbase.Voting.Vote
@@ -21,7 +22,8 @@ defmodule Sanbase.Auth.User do
   # 5 minutes
   @san_balance_cache_seconds 60 * 5
 
-  @mandrill_api Mockery.of("Sanbase.MandrillApi")
+  require Mockery.Macro
+  defp mandrill_api, do: Mockery.Macro.mockable(Sanbase.MandrillApi)
 
   schema "users" do
     field(:email, :string)
@@ -151,7 +153,7 @@ defmodule Sanbase.Auth.User do
   end
 
   def send_login_email(user) do
-    @mandrill_api.send(@login_email_template, user.email, %{
+    mandrill_api().send(@login_email_template, user.email, %{
       LOGIN_LINK: SanbaseWeb.Endpoint.login_url(user.email_token, user.email)
     })
   end

--- a/lib/sanbase/external_services/etherscan/worker.ex
+++ b/lib/sanbase/external_services/etherscan/worker.ex
@@ -22,8 +22,12 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
   @default_update_interval_ms 1000 * 60 * 5
   @confirmations 10
   @num_18_zeroes 1_000_000_000_000_000_000
-  @tx Mockery.of("Sanbase.ExternalServices.Etherscan.Requests.Tx")
-  @internal_tx Mockery.of("Sanbase.ExternalServices.Etherscan.Requests.InternalTx")
+
+  require Mockery.Macro
+  defp tx(), do: Mockery.Macro.mockable(Sanbase.ExternalServices.Etherscan.Requests.Tx)
+
+  defp internal_tx(),
+    do: Mockery.Macro.mockable(Sanbase.ExternalServices.Etherscan.Requests.InternalTx)
 
   def start_link(_state) do
     GenServer.start_link(__MODULE__, :ok)
@@ -152,7 +156,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
   defp fetch_internal_transactions(address, measurement_name, endblock) do
     last_block_with_data = Store.last_block_number!(address <> "_in") || 0
 
-    case @internal_tx.get(address, last_block_with_data, endblock) do
+    case internal_tx().get(address, last_block_with_data, endblock) do
       {:ok, list} ->
         list
 
@@ -170,7 +174,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Worker do
   defp fetch_transactions(address, measurement_name, endblock) do
     last_block_with_data = Store.last_block_number!(address) || 0
 
-    case @tx.get(address, last_block_with_data, endblock) do
+    case tx().get(address, last_block_with_data, endblock) do
       {:ok, list} ->
         list
 

--- a/lib/sanbase/github/scheduler.ex
+++ b/lib/sanbase/github/scheduler.ex
@@ -6,8 +6,8 @@ defmodule Sanbase.Github.Scheduler do
 
   require Logger
 
-  # A dependency injection, so that we can test this module in isolation
-  @worker Mockery.of("SanbaseWorkers.ImportGithubActivity")
+  require Mockery.Macro
+  defp worker(), do: Mockery.Macro.mockable(SanbaseWorkers.ImportGithubActivity)
 
   def schedule_scrape do
     available_projects = Github.available_projects()
@@ -52,7 +52,7 @@ defmodule Sanbase.Github.Scheduler do
         if need_to_scrape do
           archive_name = archive_name_for(current_datetime)
 
-          @worker.perform_async([archive_name])
+          worker().perform_async([archive_name])
         end
 
         current_datetime

--- a/lib/sanbase/internal_services/tech_indicators.ex
+++ b/lib/sanbase/internal_services/tech_indicators.ex
@@ -3,7 +3,9 @@ defmodule Sanbase.InternalServices.TechIndicators do
   require Sanbase.Utils.Config
   alias Sanbase.Utils.Config
 
-  @http_client Mockery.of("HTTPoison")
+  require Mockery.Macro
+  defp http_client, do: Mockery.Macro.mockable(HTTPoison)
+
   @recv_timeout 15_000
 
   def macd(
@@ -197,7 +199,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
       ]
     ]
 
-    @http_client.get(url, [], options)
+    http_client().get(url, [], options)
   end
 
   defp macd_result(result) do
@@ -237,7 +239,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
       ]
     ]
 
-    @http_client.get(url, [], options)
+    http_client().get(url, [], options)
   end
 
   defp rsi_result(result) do
@@ -281,7 +283,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
       ]
     ]
 
-    @http_client.get(url, [], options)
+    http_client().get(url, [], options)
   end
 
   defp price_volume_diff_ma_result(result) do
@@ -327,7 +329,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
       ]
     ]
 
-    @http_client.get(url, [], options)
+    http_client().get(url, [], options)
   end
 
   defp twitter_mention_count_result(result) do
@@ -367,7 +369,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
       ]
     ]
 
-    @http_client.get(url, [], options)
+    http_client().get(url, [], options)
   end
 
   defp emojis_sentiment_result(result) do

--- a/lib/sanbase/notifications/check_prices.ex
+++ b/lib/sanbase/notifications/check_prices.ex
@@ -11,13 +11,11 @@ defmodule Sanbase.Notifications.CheckPrices do
 
   require Sanbase.Utils.Config
 
-  @http_service Mockery.of("Tesla")
+  require Mockery.Macro
+  defp http_client(), do: Mockery.Macro.mockable(Tesla)
 
-  # 60 minutes
   @cooldown_period_in_sec 60 * 60
-  # 60 minutes
   @check_interval_in_sec 60 * 60
-  # percent
   @price_change_threshold 5
 
   def exec(project, counter_currency) do
@@ -56,7 +54,7 @@ defmodule Sanbase.Notifications.CheckPrices do
 
   def send_slack_notification(price_difference, project, counter_currency) do
     %{status: 200} =
-      @http_service.post(
+      http_client().post(
         webhook_url(),
         notification_payload(price_difference, project, counter_currency),
         headers: %{"Content-Type" => "application/json"}

--- a/lib/sanbase/notifications/price_volume_diff.ex
+++ b/lib/sanbase/notifications/price_volume_diff.ex
@@ -8,7 +8,8 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
 
   require Sanbase.Utils.Config
 
-  @http_service Mockery.of("HTTPoison")
+  require Mockery.Macro
+  defp http_client(), do: Mockery.Macro.mockable(HTTPoison)
 
   @notification_type_name "price_volume_diff"
 
@@ -120,7 +121,7 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
          {notification_data, debug_info}
        ) do
     {:ok, %HTTPoison.Response{status_code: 204}} =
-      @http_service.post(
+      http_client().post(
         webhook_url(),
         notification_payload(project, currency, indicator, debug_info),
         [

--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule Sanbase.Mixfile do
       {:hammer, "~> 2.0.0"},
       {:ex_admin, github: "smpallen99/ex_admin", branch: "phx-1.3"},
       {:basic_auth, "~> 2.2"},
-      {:mockery, "~> 2.0"},
+      {:mockery, "~> 2.2"},
       {:distillery, "~> 1.5", runtime: false},
       {:timex, "~> 3.0"},
       {:timex_ecto, "~> 3.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -51,7 +51,7 @@
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [], [], "hexpm"},
   "mix_test_watch": {:hex, :mix_test_watch, "0.5.0", "2c322d119a4795c3431380fca2bca5afa4dc07324bd3c0b9f6b2efbdd99f5ed3", [], [{:fs, "~> 0.9.1", [hex: :fs, repo: "hexpm", optional: false]}], "hexpm"},
   "mochiweb": {:hex, :mochiweb, "2.15.0", "e1daac474df07651e5d17cc1e642c4069c7850dc4508d3db7263a0651330aacc", [], [], "hexpm"},
-  "mockery": {:hex, :mockery, "2.0.2", "c4b5815445600a4a261e377c5171d1e94c0c352430dfc7db3c26b6a5e48043a6", [], [], "hexpm"},
+  "mockery": {:hex, :mockery, "2.2.0", "67304d5e1d247e698b171913689369bd23c94e437b4a8f32777c6f74b98cb36f", [:mix], [], "hexpm"},
   "oauther": {:hex, :oauther, "1.1.0", "c9a56e200507ce64e069f5273143db0cddd7904cd5d1fe46920388a48f22441b", [], [], "hexpm"},
   "observer_cli": {:hex, :observer_cli, "1.3.0", "ce699d31662c34da8783ff17ab980c6350ba50bd82475569dbe0ff929553d9ca", [:rebar3], [{:recon, "2.3.4", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm"},
   "parallel_stream": {:hex, :parallel_stream, "1.0.6", "b967be2b23f0f6787fab7ed681b4c45a215a81481fb62b01a5b750fa8f30f76c", [], [], "hexpm"},


### PR DESCRIPTION
Erlang/OTP 21 ships by default without tuple calls. `Mockery.of` uses
tuple calls, so update the version of `Mockery` and start using the new
`Mockery.Macro.mockable`. It cannot be used via module attribute.

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
