### PR TITLE
Apidocs change burn rate header

### DIFF
--- a/lib/sanbase_web/templates/api_examples/examples.html.eex
+++ b/lib/sanbase_web/templates/api_examples/examples.html.eex
@@ -50,7 +50,7 @@ curl \
 
 ```
 
-### Burn rate
+### Token aging (burn rate) 
 
 <%= @burn_rate[:docs] %>
 


### PR DESCRIPTION

#### Summary
<!-- (What does this pull request do in general terms?) -->

Change only the header in the API docs.

There is card in the backlog to rename throughout the sanbase: https://favro.com/organization/bdbb4f24afc48b29c74f4fa4/cffeb6e3eaf254588cb68a9a?card=San-1860
