### PR TITLE
Increase the Sanbase.Repo pool_size to 10

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,7 +10,7 @@ config :sanbase, ecto_repos: [Sanbase.Repo]
 
 config :sanbase, Sanbase.Repo,
   adapter: Ecto.Adapters.Postgres,
-  pool_size: 5,
+  pool_size: 10,
   prepare: :unnamed
 
 # Configures the endpoint


### PR DESCRIPTION
#### Summary
It happens that checkout out a connection times out. Also I do not remember why we reduced the pool_size from the default value of 10 to 5
```
(ErlangError) Erlang error: {:timeout, {:gen_server, :call, [#PID<0.2891.0>, {:checkout, #Reference<0.3898258736.2462056450.45908>, true, 15000}, 5000]}}
```
Sentry: https://sentry.production.internal.santiment.net/sentry/sanbase-backend/issues/521/
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
