### PR TITLE
Feature: Insights filtering by chosen tag

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -94,13 +94,13 @@ export const App = ({
       duration='1.0s'
       timingFunction='ease-out'
       as='div'>
-          OFFLINE
+        OFFLINE
     </FadeInDown>}
     {isFullscreenMobile
-        ? undefined
-        : (isDesktop
-          ? <Menu />
-          : <MobileMenu />)}
+      ? undefined
+      : (isDesktop
+        ? <Menu />
+        : <MobileMenu />)}
     <ErrorBoundary>
       <Switch>
         <Route exact path='/projects' render={props => {
@@ -166,8 +166,8 @@ export const App = ({
             <LoginPage
               isDesktop={isDesktop}
               {...props} />
-            )}
-          />
+          )}
+        />
         <Redirect from='/' to='/projects' />
       </Switch>
     </ErrorBoundary>
@@ -176,7 +176,7 @@ export const App = ({
     <GDPRModal />
     {isDesktop && <Footer />}
   </div>
-  )
+)
 
 const mapStateToProps = state => {
   return {

--- a/app/src/App.js
+++ b/app/src/App.js
@@ -94,13 +94,13 @@ export const App = ({
       duration='1.0s'
       timingFunction='ease-out'
       as='div'>
-        OFFLINE
+          OFFLINE
     </FadeInDown>}
     {isFullscreenMobile
-      ? undefined
-      : (isDesktop
-        ? <Menu />
-        : <MobileMenu />)}
+        ? undefined
+        : (isDesktop
+          ? <Menu />
+          : <MobileMenu />)}
     <ErrorBoundary>
       <Switch>
         <Route exact path='/projects' render={props => {
@@ -148,6 +148,7 @@ export const App = ({
         <Route exact path='/insights/popular' component={LoadableInsights} />
         <Route exact path='/insights/my' component={LoadableInsights} />
         <Route exact path='/insights/users/:userId' component={LoadableInsights} />
+        <Route exact path='/insights/tags/:tagName' component={LoadableInsights} />
         <Route exact path='/insights/:insightId' component={LoadableInsight} />
         <Route exact path='/projects/:slug' render={props => (
           <LoadableDetailedPage isDesktop={isDesktop} {...props} />)} />
@@ -165,8 +166,8 @@ export const App = ({
             <LoginPage
               isDesktop={isDesktop}
               {...props} />
-          )}
-        />
+            )}
+          />
         <Redirect from='/' to='/projects' />
       </Switch>
     </ErrorBoundary>
@@ -175,7 +176,7 @@ export const App = ({
     <GDPRModal />
     {isDesktop && <Footer />}
   </div>
-)
+  )
 
 const mapStateToProps = state => {
   return {

--- a/app/src/components/Post.js
+++ b/app/src/components/Post.js
@@ -142,4 +142,6 @@ const Post = ({
   )
 }
 
+export const UnwrappedPost = Post // for tests
+
 export default withRouter(Post)

--- a/app/src/components/Post.js
+++ b/app/src/components/Post.js
@@ -93,7 +93,7 @@ const Post = ({
             {tags.length > 0
               ? <div className='post-tags'>
                 {tags.map((tag, index) => (
-                  <Link key={index} className='post-tag' to={`/insights/tags/${tag.name}`} href={`/insights/tags/${tag.name}`}>{tag.label || tag.name}</Link>
+                  <Link key={index} className='post-tag' to={`/insights/tags/${tag.name}`}>{tag.label || tag.name}</Link>
                 ))}
               </div>
               : <Author {...user} />}

--- a/app/src/components/Post.js
+++ b/app/src/components/Post.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react'
 import moment from 'moment'
-import { withRouter } from 'react-router-dom'
+import { withRouter, Link } from 'react-router-dom'
 import { Label, Button } from 'semantic-ui-react'
 import { createSkeletonElement } from '@trainline/react-skeletor'
 import LikeBtn from './../pages/InsightsNew/LikeBtn'
@@ -93,7 +93,7 @@ const Post = ({
             {tags.length > 0
               ? <div className='post-tags'>
                 {tags.map((tag, index) => (
-                  <div key={index} className='post-tag'>{tag.label || tag.name}</div>
+                  <Link key={index} className='post-tag' to={`/insights/tags/${tag.name}`} href={`/insights/tags/${tag.name}`}>{tag.label || tag.name}</Link>
                 ))}
               </div>
               : <Author {...user} />}

--- a/app/src/components/Post.spec.js
+++ b/app/src/components/Post.spec.js
@@ -67,16 +67,6 @@ describe('Post component', () => {
         />)
         expect(wrapper.find('.post-tag').prop('to')).toBe('/insights/tags/EOS')
       })
-      it('should have equal "to" and "href" prop', () => {
-        const wrapper = shallow(<Post
-          user={user}
-          {...postWithTag}
-        />)
-        const tag = wrapper.find('.post-tag')
-        const to = tag.prop('to')
-        const href = tag.prop('href')
-        expect(href).toBe(to)
-      })
       it('every tag should have correct link("to" prop)', () => {
         const wrapper = shallow(<Post
           user={user}

--- a/app/src/components/Post.spec.js
+++ b/app/src/components/Post.spec.js
@@ -1,0 +1,93 @@
+/* eslint-env jest */
+import React from 'react'
+import { shallow } from 'enzyme'
+import { UnwrappedPost as Post } from './Post'
+
+const user = {
+  username: '0xjsadhf92fhk2fjhe',
+  email: null
+}
+
+const post = {
+  id: 0,
+  title: '',
+  votes: {},
+  tags: [],
+  createdAt: 0
+}
+
+const threeTags = [
+  {
+    name: 'EOS'
+  },
+  {
+    name: 'BTC'
+  },
+  {
+    name: 'Doge'
+  }
+]
+
+const postWithTag = {
+  ...post,
+  tags: [
+    threeTags[0]
+  ]
+}
+
+describe('Post component', () => {
+  describe('Tags render', () => {
+    it('should render no tags', () => {
+      const wrapper = shallow(<Post
+        user={user}
+        {...post}
+      />)
+      expect(wrapper.find('.post-tag').length).toBe(0)
+    })
+    it('should render 1 tag', () => {
+      const wrapper = shallow(<Post
+        user={user}
+        {...postWithTag}
+      />)
+      expect(wrapper.find('.post-tag').length).toBe(1)
+    })
+    it('should render 3 tags', () => {
+      const wrapper = shallow(<Post
+        user={user}
+        {...postWithTag}
+        tags={threeTags}
+      />)
+      expect(wrapper.find('.post-tag').length).toBe(3)
+    })
+    describe('Links', () => {
+      it('should render corresponding link', () => {
+        const wrapper = shallow(<Post
+          user={user}
+          {...postWithTag}
+        />)
+        expect(wrapper.find('.post-tag').prop('to')).toBe('/insights/tags/EOS')
+      })
+      it('should have equal "to" and "href" prop', () => {
+        const wrapper = shallow(<Post
+          user={user}
+          {...postWithTag}
+        />)
+        const tag = wrapper.find('.post-tag')
+        const to = tag.prop('to')
+        const href = tag.prop('href')
+        expect(href).toBe(to)
+      })
+      it('every tag should have correct link("to" prop)', () => {
+        const wrapper = shallow(<Post
+          user={user}
+          {...postWithTag}
+          tags={threeTags}
+        />)
+        const tags = wrapper.find('.post-tag')
+        tags.forEach((tag, index) => {
+          expect(tag.prop('to')).toBe(`/insights/tags/${threeTags[index].name}`)
+        })
+      })
+    })
+  })
+})

--- a/app/src/components/ProjectChart/ProjectChartFooter.js
+++ b/app/src/components/ProjectChart/ProjectChartFooter.js
@@ -205,7 +205,7 @@ const ProjectChartFooter = ({
             <p>
               You can learn something new.
             </p>
-            <Link to='/insights'>{Insights.items.length}&nbsp;
+            <Link to={`/insights/tags/${props.project.ticker}`}>{Insights.items.length}&nbsp;
               Insight{Insights.items.length > 1 && 's'} about {props.project.ticker}</Link>
           </Message>
         }

--- a/app/src/pages/InsightsPage.js
+++ b/app/src/pages/InsightsPage.js
@@ -160,15 +160,15 @@ const InsightsPage = ({
                   votePost={debounce(postId => {
                     user.token
                       ? votePost(voteMutationHelper({postId, action: 'vote'}))
-                      .then(data => Posts.refetch())
-                      .catch(e => Raven.captureException(e))
+                        .then(data => Posts.refetch())
+                        .catch(e => Raven.captureException(e))
                       : loginModalRequest()
                   }, 100)}
                   unvotePost={debounce(postId => {
                     user.token
                       ? unvotePost(voteMutationHelper({postId, action: 'unvote'}))
-                      .then(data => Posts.refetch())
-                      .catch(e => Raven.captureException(e))
+                        .then(data => Posts.refetch())
+                        .catch(e => Raven.captureException(e))
                       : loginModalRequest()
                   }, 100)}
                 />
@@ -249,6 +249,9 @@ const mapDataToProps = props => {
   const hasUserInsights = filteredBySelfUser(normalizedPosts).length > 0
   const filteredByUserID = posts => posts.filter(post => post.user.id === ownProps.match.params.userId)
 
+  const searchedTag = ownProps.match.params.tagName && ownProps.match.params.tagName.toLowerCase() // This optimize calculations inside filter func
+  const filteredByTagPosts = posts => posts.filter(post => post.tags.some(({ name }) => name.toLowerCase() === searchedTag))
+
   const postsByDay = normalizedPosts.reduce((acc, post) => {
     const day = moment(post.createdAt).endOf('day').unix()
     if (!acc[`${day}`]) {
@@ -271,11 +274,14 @@ const mapDataToProps = props => {
       return reduceAllKeys(posts)(
         compose(
           filteredByPublished,
-          filteredByUserID
+          filteredByUserID,
+          filteredByTagPosts
         )
       )
     } else if (filter === 'my') {
       return reduceAllKeys(posts)(filteredBySelfUser)
+    } else if (filter === 'tags') {
+      return reduceAllKeys(posts)(filteredByTagPosts)
     }
     return reduceAllKeys(posts)(filteredByPublished)
   }

--- a/app/src/pages/InsightsPage.js
+++ b/app/src/pages/InsightsPage.js
@@ -160,15 +160,15 @@ const InsightsPage = ({
                   votePost={debounce(postId => {
                     user.token
                       ? votePost(voteMutationHelper({postId, action: 'vote'}))
-                        .then(data => Posts.refetch())
-                        .catch(e => Raven.captureException(e))
+                      .then(data => Posts.refetch())
+                      .catch(e => Raven.captureException(e))
                       : loginModalRequest()
                   }, 100)}
                   unvotePost={debounce(postId => {
                     user.token
                       ? unvotePost(voteMutationHelper({postId, action: 'unvote'}))
-                        .then(data => Posts.refetch())
-                        .catch(e => Raven.captureException(e))
+                      .then(data => Posts.refetch())
+                      .catch(e => Raven.captureException(e))
                       : loginModalRequest()
                   }, 100)}
                 />


### PR DESCRIPTION
#### Summary
Tags on the "Insights" page are now clickable. Posts can be filtered by tag.
On the chosen project page (e.g. `/projects/eos`) "Community Insights" link leads to the insights page with posts containing `EOS` tag.
_P.S: Have written a few test cases for Post component_