### PR TITLE
Markets page enhancement

### DIFF
--- a/app/src/components/HelpPopup/HelpPopup.js
+++ b/app/src/components/HelpPopup/HelpPopup.js
@@ -3,7 +3,7 @@ import { Popup } from 'semantic-ui-react'
 import HelpPopupIcon from './HelpPopupIcon'
 
 const style = {
-  maxWidth: 380,
+  maxWidth: 417,
   padding: '2rem 1.8rem'
 }
 

--- a/app/src/components/HelpPopup/HelpPopupIcon.css
+++ b/app/src/components/HelpPopup/HelpPopupIcon.css
@@ -1,19 +1,15 @@
 .HelpPopupIcon {
-  font-size: 17px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: 1rem;
+  margin-bottom: -4px;
+  height: 22px;
+  width: 22px;
+  font-size: 15px;
   font-weight: bold;
   border: 1px solid black;
   border-radius: 50%;
-  height: 29px;
-  width: 29px;
   user-select: none;
   cursor: pointer;
-  display: inline-block;
-  margin-left: 1rem;
-  text-align: center;
-}
-
-.HelpPopupIcon .HelpPopupIcon__symbol {
-  vertical-align: middle;
-  margin: 0;
-  padding: 0;
 }

--- a/app/src/components/HelpPopup/HelpPopupProjectsContent.css
+++ b/app/src/components/HelpPopup/HelpPopupProjectsContent.css
@@ -15,6 +15,11 @@
   margin-bottom: 1rem;
 }
 
+.HelpPopupProjectsContent__item h4,
+.HelpPopupProjectsContent__item p {
+  line-height: 1.3;
+}
+
 .HelpPopupProjectsContent__item_inline h4,
 .HelpPopupProjectsContent__item_inline p {
   display: inline;

--- a/app/src/components/HelpPopup/HelpPopupProjectsContent.js
+++ b/app/src/components/HelpPopup/HelpPopupProjectsContent.js
@@ -5,44 +5,39 @@ import './HelpPopupProjectsContent.css'
 const HelpPopupProjectsContent = () => {
   return (
     <div className='HelpPopupProjectsContent'>
-      <h3 className='HelpPopupProjectsContent__title'>
-        This overview can be used to:
-      </h3>
+      <p>The "Markets" section includes lists of tokens you can use to:</p>
       <ol className='HelpPopupProjectsContent__list'>
         <li className='HelpPopupProjectsContent__item'>
-          <h4>1. Spot potentially undervalued projects.</h4>
+          <h4>1. Spot increase or decrease in token usage.</h4>
           <p>
-            These projects generally have more in "crypto cash" balance than their market capitalization. Look for a value more than 1 in the CAP/BALANCE column.
+            Look at the DAILY ACTIVE ADDRESSES column to see how many unique addresses participated in transactions for that token for the last 30 days. Sudden increases in activity can sometimes preceed sharp price movements.
+          </p>
+        </li>
+        <li className='HelpPopupProjectsContent__item'>
+          <h4>2. See if, and how much, a project is "dumping" its collected ETH funds.</h4>
+          <p>
+            Look for this figure in the ETH SPENT column. Activity here could effect the price of ETH and, by extention, related tokens.
+          </p>
+        </li>
+        <li className='HelpPopupProjectsContent__item'>
+          <h4>3. See how active a project's team is in building their product.</h4>
+          <p>
+            Look for this metric in the DEV ACTIVITY column, which shows a summary of Github activity.
           </p>
         </li>
         <li className='HelpPopupProjectsContent__item HelpPopupProjectsContent__item_inline'>
-          <h4>2. See if, and how much, </h4>
+          <h4>4. Compare tokens.</h4>
           <p>
-            a project is "dumping" its collected ETH funds. Look for this in the TRANSACTIONS column.
+            Click the column headers to sort by the various metrics.
           </p>
         </li>
         <li className='HelpPopupProjectsContent__item HelpPopupProjectsContent__item_inline'>
-          <h4>3. See how active a project's team is </h4>
+          <h4>5. Get details, including price charts, for each token.</h4>
           <p>
-            in building their product. Look for this in the DEV ACTIVITY column which shows a summary of Github activity.
+            Click the token name to drill down to a detail page.
           </p>
         </li>
       </ol>
-      <h4 className='HelpPopupProjectsContent__subtitle'>
-        Are you following a project but don't see it here?
-      </h4>
-      <p>
-        That means their wallet information isn't available. Why not talk to their project leadership and ask them to disclose it? Financial transparence is important and should be available to everyone in the cryptospace.
-      </p>
-      <p>
-        <a
-          href='https://docs.google.com/forms/d/e/1FAIpQLSeFuCxjJjId98u1Bp3qpXCq2A9YAQ02OEdhOgiM9Hr-rMDxhQ/viewform'
-          className='HelpPopupProjectsContent__link'
-        >
-          Once you have the data - submit it here.{' '}
-        </a>
-        Your project will then be in the overview!
-      </p>
     </div>
   )
 }

--- a/app/src/components/ProjectsNavigation.js
+++ b/app/src/components/ProjectsNavigation.js
@@ -5,8 +5,6 @@ import {
   Checkbox,
   Popup
 } from 'semantic-ui-react'
-import HelpPopup from './HelpPopup/HelpPopup'
-import HelpPopupProjectsContent from './HelpPopup/HelpPopupProjectsContent'
 import './ProjectsNavigation.css'
 
 const HiddenElements = () => ''
@@ -76,9 +74,6 @@ const ProjectsNavigation = ({
           </div>
         </Popup>
       </HiddenElements>
-      <HelpPopup>
-        <HelpPopupProjectsContent />
-      </HelpPopup>
     </div>
   )
 }

--- a/app/src/pages/Projects/ProjectsTable.css
+++ b/app/src/pages/Projects/ProjectsTable.css
@@ -227,3 +227,28 @@
 .projects-table-tips {
   text-align: 'center';
 }
+
+.page-head-projects {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.page-head.page-head-projects {
+  margin: 0;
+}
+
+@media (min-width: 1025px) {
+  .page-head.page-head-projects {
+    margin-top: 16px;
+  }
+}
+
+.page-head-projects__left {
+  display: flex;
+  align-items: center;
+}
+
+.projects-search-row {
+  justify-content: initial;
+}

--- a/app/src/pages/Projects/ProjectsTable.js
+++ b/app/src/pages/Projects/ProjectsTable.js
@@ -14,6 +14,8 @@ import ProjectIcon from '../../components/ProjectIcon'
 import Panel from '../../components/Panel'
 import PercentChanges from '../../components/PercentChanges'
 import ProjectsNavigation from '../../components/ProjectsNavigation'
+import HelpPopup from '../../components/HelpPopup/HelpPopup'
+import HelpPopupProjectsContent from '../../components/HelpPopup/HelpPopupProjectsContent'
 import './ProjectsTable.css'
 
 export const CustomThComponent = ({ toggleSort, className, children, ...rest }) => (
@@ -265,15 +267,25 @@ const ProjectsTable = ({
         <link rel='canonical' href={`${getOrigin()}/projects`} />
       </Helmet>
       <FadeIn duration='0.3s' timingFunction='ease-in' as='div'>
-        <ProjectsNavigation
-          path={match.path}
-          categories={categories}
-          handleSetCategory={handleSetCategory}
-          allMarketSegments={allMarketSegments}
-          user={user}
-        />
+        <div className='page-head page-head-projects'>
+          <div className='page-head-projects__left'>
+            <h1>Markets</h1>
+            <HelpPopup>
+              <HelpPopupProjectsContent />
+            </HelpPopup>
+          </div>
+          <div>
+            <ProjectsNavigation
+              path={match.path}
+              categories={categories}
+              handleSetCategory={handleSetCategory}
+              allMarketSegments={allMarketSegments}
+              user={user}
+              />
+          </div>
+        </div>
         <Panel>
-          <div className='row'>
+          <div className='row projects-search-row'>
             <div className='datatables-info'>
               {false && <label>
                 Showing {


### PR DESCRIPTION
#### Summary
The `/projects` page now has a title. 
The tabs are moved to the right, the search bar to the left.
Updated `HelpPopup` content and styles.

#### Related PRs
#522 by DmitriVanGuard - _HelpPopup component and story. HelpPopupIcon and ProjectsContent help overview_

#### Screenshots
![image](https://user-images.githubusercontent.com/25135650/42157446-69d547e8-7df6-11e8-83b0-a82e5b575e20.png)