### PR TITLE
Revert "Update Erlang/OTP to 21.0 and Elixir to 1.6.6"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY ./app /app
 RUN yarn build
 
 # Elixir and phoenix assets build image
-FROM elixir:1.6.6-alpine as code_builder
+FROM elixir:1.6.5-alpine as code_builder
 
 ENV MIX_ENV prod
 
@@ -46,7 +46,7 @@ RUN mix phx.digest
 RUN mix release
 
 # Release image
-FROM elixir:1.6.6-alpine
+FROM elixir:1.6.5-alpine
 
 RUN apk add --update bash
 

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,5 +1,5 @@
 # Elixir and phoenix assets build image
-FROM elixir:1.6.6-alpine
+FROM elixir:1.6.5-alpine
 
 RUN apk add --update git postgresql-client
 


### PR DESCRIPTION
Reverts santiment/sanbase2#523

The currently running version on staging is Elixir 1.6.5, so this change cannot start
Possibly this caused the following error:
```
init terminating in do_boot ({cannot get bootfile,no_dot_erlang.boot})

Crash dump is being written to: erl_crash.dump...done
```