### PR TITLE
Add slug all projects query

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/project/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_resolver.ex
@@ -109,6 +109,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
     {:ok, project}
   end
 
+  def slug(%Project{coinmarketcap_id: nil}, _, _), do: {:ok, nil}
+  def slug(%Project{coinmarketcap_id: coinmarketcap_id}, _, _), do: {:ok, coinmarketcap_id}
+
   def project_by_slug(_parent, %{slug: slug}, _resolution) do
     Project
     |> Repo.get_by(coinmarketcap_id: slug)

--- a/lib/sanbase_web/graphql/resolvers/project/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_resolver.ex
@@ -109,7 +109,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
     {:ok, project}
   end
 
-  def slug(%Project{coinmarketcap_id: nil}, _, _), do: {:ok, nil}
   def slug(%Project{coinmarketcap_id: coinmarketcap_id}, _, _), do: {:ok, coinmarketcap_id}
 
   def project_by_slug(_parent, %{slug: slug}, _resolution) do

--- a/lib/sanbase_web/graphql/schema/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/project_types.ex
@@ -23,6 +23,11 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     field(:id, non_null(:id))
     field(:name, non_null(:string))
     field(:ticker, :string)
+
+    field(:slug, :string) do
+      resolve(&ProjectResolver.slug/3)
+    end
+
     field(:logo_url, :string)
     field(:website_link, :string)
     field(:email, :string)

--- a/test/sanbase_web/graphql/project_api_get_queries_test.exs
+++ b/test/sanbase_web/graphql/project_api_get_queries_test.exs
@@ -79,7 +79,8 @@ defmodule Sanbase.Graphql.ProjectApiGetQueriesTest do
     query = """
     {
       allProjects{
-        name
+        name,
+        slug
       }
     }
     """
@@ -90,9 +91,9 @@ defmodule Sanbase.Graphql.ProjectApiGetQueriesTest do
 
     projects = json_response(result, 200)["data"]["allProjects"]
 
-    assert %{"name" => "Project1"} in projects
-    assert %{"name" => "Project2"} in projects
-    assert %{"name" => "Project3"} in projects
+    assert %{"name" => "Project1", "slug" => "proj1"} in projects
+    assert %{"name" => "Project2", "slug" => "proj2"} in projects
+    assert %{"name" => "Project3", "slug" => "proj3"} in projects
   end
 
   test "fetch all erc20 projects", context do


### PR DESCRIPTION
#### Summary
card: https://favro.com/organization/bdbb4f24afc48b29c74f4fa4/9ff267872fcd8b7925f1d7c7?card=San-1914
We have API queries by slug but we don't return it in the `allProjects`.
Adds slug to `allProjects` query so we can describe to  API users what is slug (instead of `coinmarketcap_id`)
