### PR TITLE
Do not use the Absinthe Async middleware in tests

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -15,7 +15,9 @@ config :tesla, adapter: :mock
 # Configure your database
 config :sanbase, Sanbase.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,
-  database: "sanbase_test"
+  database: "sanbase_test",
+  # closest to real case as there are 3 pods with 10 connections each
+  pool_size: 30
 
 config :sanbase, Sanbase.Auth.Hmac, secret_key: "Non_empty_key_used_in_tests_only"
 

--- a/lib/sanbase_web/graphql/helpers/async.ex
+++ b/lib/sanbase_web/graphql/helpers/async.ex
@@ -1,0 +1,18 @@
+defmodule SanbaseWeb.Graphql.Helpers.Async do
+  require Absinthe.Resolution.Helpers
+
+  @doc ~s"""
+  Macro to be used instead of `Absinthe.Resolution.Helpers.async`.
+  This macro falls back to the Absinthe's async in `:dev` and `:prod` but in
+  `:test` env just executes the function as if no `async` has been used
+  """
+  defmacro async(func) do
+    quote bind_quoted: [func: func] do
+      if Mix.env() == :test do
+        func.()
+      else
+        Absinthe.Resolution.Helpers.async(func)
+      end
+    end
+  end
+end

--- a/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
@@ -4,7 +4,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
   alias Sanbase.Model.{Project, ExchangeEthAddress}
   alias SanbaseWeb.Graphql.Helpers.{Cache, Utils}
 
-  import Absinthe.Resolution.Helpers
+  import SanbaseWeb.Graphql.Helpers.Async
   import Ecto.Query
 
   require Logger

--- a/lib/sanbase_web/graphql/resolvers/project/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_resolver.ex
@@ -2,7 +2,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
   require Logger
 
   import Ecto.Query
-  import Absinthe.Resolution.Helpers
+  import Absinthe.Resolution.Helpers, except: [async: 1]
+  import SanbaseWeb.Graphql.Helpers.Async
 
   alias Sanbase.Model.{
     Project,

--- a/lib/sanbase_web/graphql/resolvers/twitter_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/twitter_resolver.ex
@@ -5,7 +5,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.TwitterResolver do
   alias SanbaseWeb.Graphql.Helpers.{Cache, Utils}
 
   import Ecto.Query
-  import Absinthe.Resolution.Helpers
+  import SanbaseWeb.Graphql.Helpers.Async
 
   def twitter_data(_root, %{ticker: ticker}, _resolution) do
     async(Cache.func(fn -> calculate_twitter_data(ticker) end, {:twitter_data, ticker}))


### PR DESCRIPTION
#### Summary
The issue with tests happens when Absinthe `async` is used. This is strange because these tests run with `async: false` so the pool mode is `:shared` and this should not happen

To understand the issue behind this problem the DB connection ownership should be understood. To start with this you can read [here](https://medium.com/@qertoip/making-sense-of-ecto-2-sql-sandbox-and-connection-ownership-modes-b45c5337c6b7) and [here](https://hexdocs.pm/ecto/Ecto.Adapters.SQL.Sandbox.html)

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
