### PR TITLE
Add creating of DB in the apiresolver test.

### DIFF
--- a/test/sanbase_web/graphql/apikey_resolver_test.exs
+++ b/test/sanbase_web/graphql/apikey_resolver_test.exs
@@ -355,6 +355,8 @@ defmodule SanbaseWeb.Graphql.ApikeyResolverTest do
     alias Sanbase.Repo
     alias Sanbase.Model.Project
 
+    Store.create_db()
+
     contract_address = "0x123123123"
 
     Store.import([


### PR DESCRIPTION
#### Summary
If the apiresolver test suite runs before the burn rate test there will be no database created and will fail.
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
