### PR TITLE
Fix: filtering insights by user id

### DIFF
--- a/app/src/components/Post.js
+++ b/app/src/components/Post.js
@@ -48,7 +48,7 @@ const Author = ({id, username}) => (
   <div className='event-post-author'>
     {id &&
       <Fragment>
-        by&nbsp; <a href={`/insights/users/${id}`}>{username}</a>
+        by&nbsp; <Link to={`/insights/users/${id}`}>{username}</Link>
       </Fragment>}
   </div>
 )

--- a/app/src/pages/InsightsPage.js
+++ b/app/src/pages/InsightsPage.js
@@ -270,20 +270,16 @@ const mapDataToProps = props => {
   }, {})
 
   const applyFilter = posts => {
-    if (filter === 'users') {
-      return reduceAllKeys(posts)(
-        compose(
-          filteredByPublished,
-          filteredByUserID,
-          filteredByTagPosts
-        )
-      )
-    } else if (filter === 'my') {
-      return reduceAllKeys(posts)(filteredBySelfUser)
-    } else if (filter === 'tags') {
-      return reduceAllKeys(posts)(filteredByTagPosts)
+    switch (filter) {
+      case 'users':
+        return reduceAllKeys(posts)(filteredByUserID)
+      case 'my':
+        return reduceAllKeys(posts)(filteredBySelfUser)
+      case 'tags':
+        return reduceAllKeys(posts)(filteredByTagPosts)
+      default:
+        return reduceAllKeys(posts)(filteredByPublished)
     }
-    return reduceAllKeys(posts)(filteredByPublished)
   }
 
   const applySort = posts => {


### PR DESCRIPTION
#### Summary
- Insights can be filtered by the user id;
- Post's author name is now a react-router `Link`.
