### PR TITLE
Increase the lock timeout ConCache can wait from 5s to 30s

### DIFF
--- a/lib/sanbase/application.ex
+++ b/lib/sanbase/application.ex
@@ -29,7 +29,8 @@ defmodule Sanbase.Application do
          [
            name: :graphql_cache,
            ttl_check_interval: :timer.minutes(1),
-           global_ttl: :timer.minutes(5)
+           global_ttl: :timer.minutes(5),
+           acquire_lock_timeout: 30_000
          ]},
 
         # Time series Prices DB connection


### PR DESCRIPTION
#### Summary
After the `cache_resolve_async` was introduced it crashes with timeouts now. The reason for this is that we start `async` for long running tasks - the default timeout is 30s.
Meanwhile, the ConCache lock aquire timeout is equal to the GenServer call timeout - 5s. Increase the ConCache timeout to 30s, so they both match.
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
