### PR TITLE
Modal img element max-width styles

### DIFF
--- a/app/src/pages/Insights/InsightImageModal.css
+++ b/app/src/pages/Insights/InsightImageModal.css
@@ -6,3 +6,7 @@
 .InsightImageModal i {
   left: 100%;
 }
+
+.InsightImageModal__pic {
+  max-width: 100%;
+}

--- a/app/src/pages/Insights/InsightImageModal.js
+++ b/app/src/pages/Insights/InsightImageModal.js
@@ -13,7 +13,7 @@ const InsightImageModal = ({ pic, onInsightImageModalClose }) => {
         onUnmount={onInsightImageModalClose}
       >
         <Modal.Content>
-          <img src={pic} alt='Modal pic' />
+          <img src={pic} alt='Modal pic' className='InsightImageModal__pic' />
         </Modal.Content>
       </Modal>
     )


### PR DESCRIPTION
#### Summary
Enlarged image will no longer overlap close [X] button. It's `max-width` is set to `100%`.

#### Related PRs
#546 Feature: insight image modal 
