### PR TITLE
Enhance/user email login tabs sync

### DIFF
--- a/app/src/utils/localStorage.js
+++ b/app/src/utils/localStorage.js
@@ -61,8 +61,6 @@ export const savePrevAuthProvider = (authProviderType = 'email') => {
 }
 
 window.addEventListener('storage', evt => {
-  console.log(evt)
-
   if (
     evt.key === 'user' &&
     evt.oldValue.includes('"token":null') &&

--- a/app/src/utils/localStorage.js
+++ b/app/src/utils/localStorage.js
@@ -59,3 +59,15 @@ export const savePrevAuthProvider = (authProviderType = 'email') => {
     // Ignore write errors.
   }
 }
+
+window.addEventListener('storage', evt => {
+  console.log(evt)
+
+  if (
+    evt.key === 'user' &&
+    evt.oldValue.includes('"token":null') &&
+    evt.newValue.includes('"token":"')
+  ) {
+    window.location.reload()
+  }
+})


### PR DESCRIPTION
#### Summary
The unselected tabs are reloaded after `token` changes from `null` to a `string` (e.g. `"token":"1daadf..."`) in localStorage
