### PR TITLE
Fix updateUserList

### DIFF
--- a/lib/sanbase/user_lists/user_list.ex
+++ b/lib/sanbase/user_lists/user_list.ex
@@ -87,22 +87,18 @@ defmodule Sanbase.UserLists.UserList do
   end
 
   defp update_list_items_params(params, id) do
-    list_items = Map.get(params, :list_items, [])
-
-    list_items =
-      list_items
-      |> Enum.reject(&is_nil/1)
-      |> Enum.map(fn item ->
-        %{project_id: item.project_id, user_list_id: id}
-      end)
+    list_items = Map.get(params, :list_items)
 
     case list_items do
-      [] ->
-        Map.delete(params, :list_items)
+      nil ->
+        params
 
       list_items ->
-        Map.delete(params, :list_items)
-        put_in(params[:list_items], list_items)
+        list_items =
+          list_items
+          |> Enum.map(fn item -> %{project_id: item.project_id, user_list_id: id} end)
+
+        Map.replace!(params, :list_items, list_items)
     end
   end
 end


### PR DESCRIPTION
#### Summary
<!-- (What does this pull request do in general terms?) -->
Fixes an issue when trying to remove the `list_items`. Now it's possible
to clear the `list_items` and to do an update without passing `list_items`
array.

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
