### PR TITLE
Market segments queries return proper JSON object

### DIFF
--- a/app/src/__tests__/__snapshots__/cashflow.spec.js.snap
+++ b/app/src/__tests__/__snapshots__/cashflow.spec.js.snap
@@ -2,7 +2,8 @@
 
 exports[`Cashflow container it should render correctly 1`] = `
 <ProjectsTable
-  allMarketSegments={
+  categories={Object {}}
+  marketSegments={
     Object {
       "advertising": "Advertising",
       "blockchain_network": "Blockchain Network",
@@ -19,7 +20,6 @@ exports[`Cashflow container it should render correctly 1`] = `
       "unknown": null,
     }
   }
-  categories={Object {}}
   match={
     Object {
       "path": "/products",
@@ -33,4 +33,4 @@ exports[`Cashflow container it should render correctly 1`] = `
     }
   }
 />
-`
+`;

--- a/app/src/__tests__/cashflow.spec.js
+++ b/app/src/__tests__/cashflow.spec.js
@@ -39,7 +39,7 @@ const projects = [
   }
 ]
 
-const allMarketSegments = {
+const marketSegments = {
   advertising: 'Advertising',
   blockchain_network: 'Blockchain Network',
   data: 'Data',
@@ -66,7 +66,7 @@ describe('Cashflow container', () => {
           pageSize: 32,
           page: 1
         }}
-        allMarketSegments={allMarketSegments}
+        marketSegments={marketSegments}
         categories={categories}
         match={{ path: '/products' }}
       />

--- a/app/src/components/ProjectsNavigation.js
+++ b/app/src/components/ProjectsNavigation.js
@@ -7,7 +7,6 @@ import { simpleSortStrings } from '../utils/sortMethods'
 const HiddenElements = () => ''
 
 const ProjectsNavigation = ({
-  path,
   categories,
   handleSetCategory,
   marketSegments,
@@ -53,42 +52,44 @@ const ProjectsNavigation = ({
           More data about Ethereum
         </Link>
       </div>
-      <Popup
-        trigger={
-          <span className='categories-button'>
-            <Button>Categories</Button>
-          </span>
-        }
-        on='click'
-        position='bottom center'
-      >
-        <div className='categories-links'>
-          {marketSegments.length > 0
-            ? [...marketSegments]
-              .filter(marketSegment => marketSegment.count > 0)
-              .sort((previous, next) =>
-                simpleSortStrings(previous.name, next.name)
-              )
-              .map(({ name, count }) => (
-                <Checkbox
-                  key={name}
-                  id={name}
-                  label={`${name} (${count})`}
-                  onChange={handleSetCategory}
-                  checked={categories[name]}
-                />
-              ))
-            : 'Categories not founded'}
-          {marketSegments.length > 0 && (
-            <Button
-              className='clear-all-categories'
-              content='Clear All'
-              onClick={handleSetCategory}
-              name='clearAllCategories'
-            />
-          )}
-        </div>
-      </Popup>
+      <HiddenElements>
+        <Popup
+          trigger={
+            <span className='categories-button'>
+              <Button>Categories</Button>
+            </span>
+          }
+          on='click'
+          position='bottom center'
+        >
+          <div className='categories-links'>
+            {marketSegments.length > 0
+              ? [...marketSegments]
+                .filter(marketSegment => marketSegment.count > 0)
+                .sort((previous, next) =>
+                  simpleSortStrings(previous.name, next.name)
+                )
+                .map(({ name, count }) => (
+                  <Checkbox
+                    key={name}
+                    id={name}
+                    label={`${name} (${count})`}
+                    onChange={handleSetCategory}
+                    checked={categories[name]}
+                  />
+                ))
+              : 'Categories not founded'}
+            {marketSegments.length > 0 && (
+              <Button
+                className='clear-all-categories'
+                content='Clear All'
+                onClick={handleSetCategory}
+                name='clearAllCategories'
+              />
+            )}
+          </div>
+        </Popup>
+      </HiddenElements>
     </div>
   )
 }

--- a/app/src/components/ProjectsNavigation.js
+++ b/app/src/components/ProjectsNavigation.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { NavLink as Link } from 'react-router-dom'
 import { Button, Checkbox, Popup } from 'semantic-ui-react'
 import './ProjectsNavigation.css'
+import { simpleSortStrings } from '../utils/sortMethods'
 
 const HiddenElements = () => ''
 
@@ -9,7 +10,7 @@ const ProjectsNavigation = ({
   path,
   categories,
   handleSetCategory,
-  allMarketSegments,
+  marketSegments,
   user
 }) => {
   return (
@@ -19,6 +20,8 @@ const ProjectsNavigation = ({
           activeClassName='projects-navigation-list__page-link--active'
           className='projects-navigation-list__page-link'
           to={'/projects'}
+          onClick={handleSetCategory}
+          name='clearAllCategories'
         >
           ERC20 Projects
         </Link>
@@ -26,6 +29,8 @@ const ProjectsNavigation = ({
           activeClassName='projects-navigation-list__page-link--active'
           className='projects-navigation-list__page-link'
           to={'/currencies'}
+          onClick={handleSetCategory}
+          name='clearAllCategories'
         >
           Currencies
         </Link>
@@ -34,6 +39,8 @@ const ProjectsNavigation = ({
             activeClassName='projects-navigation-list__page-link--active'
             className='projects-navigation-list__page-link'
             to={'/favorites'}
+            onClick={handleSetCategory}
+            name='clearAllCategories'
           >
             Favorites
           </Link>
@@ -46,41 +53,42 @@ const ProjectsNavigation = ({
           More data about Ethereum
         </Link>
       </div>
-      <HiddenElements>
-        <Popup
-          trigger={
-            <span className='categories-button'>
-              <Button>Categories</Button>
-            </span>
-          }
-          on='click'
-          position='bottom center'
-        >
-          <div className='categories-links'>
-            {Object.entries(allMarketSegments).length > 0
-              ? Object.entries(allMarketSegments)
-                .sort()
-                .map(([key, value]) => (
-                  <Checkbox
-                    key={key}
-                    id={key}
-                    label={value || 'Unknown'}
-                    onChange={handleSetCategory}
-                    checked={categories[key]}
-                  />
-                ))
-              : 'Categories not founded'}
-            {Object.entries(allMarketSegments).length > 0 && (
-              <Button
-                className='clear-all-categories'
-                content='Clear All'
-                onClick={handleSetCategory}
-                name='clearAllCategories'
-              />
-            )}
-          </div>
-        </Popup>
-      </HiddenElements>
+      <Popup
+        trigger={
+          <span className='categories-button'>
+            <Button>Categories</Button>
+          </span>
+        }
+        on='click'
+        position='bottom center'
+      >
+        <div className='categories-links'>
+          {marketSegments.length > 0
+            ? [...marketSegments]
+              .filter(marketSegment => marketSegment.count > 0)
+              .sort((previous, next) =>
+                simpleSortStrings(previous.name, next.name)
+              )
+              .map(({ name, count }) => (
+                <Checkbox
+                  key={name}
+                  id={name}
+                  label={`${name} (${count})`}
+                  onChange={handleSetCategory}
+                  checked={categories[name]}
+                />
+              ))
+            : 'Categories not founded'}
+          {marketSegments.length > 0 && (
+            <Button
+              className='clear-all-categories'
+              content='Clear All'
+              onClick={handleSetCategory}
+              name='clearAllCategories'
+            />
+          )}
+        </div>
+      </Popup>
     </div>
   )
 }

--- a/app/src/pages/Cashflow.js
+++ b/app/src/pages/Cashflow.js
@@ -12,7 +12,7 @@ export const Cashflow = ({
   search,
   tableInfo,
   categories,
-  allMarketSegments,
+  marketSegments,
   preload,
   user
 }) => (
@@ -25,7 +25,7 @@ export const Cashflow = ({
     search={search}
     tableInfo={tableInfo}
     categories={categories}
-    allMarketSegments={allMarketSegments}
+    marketSegments={marketSegments}
     preload={preload}
     user={user}
   />

--- a/app/src/pages/Currencies.js
+++ b/app/src/pages/Currencies.js
@@ -12,7 +12,7 @@ export const Currencies = ({
   search,
   tableInfo,
   categories,
-  allMarketSegments,
+  marketSegments,
   preload,
   user
 }) => (
@@ -25,7 +25,7 @@ export const Currencies = ({
     search={search}
     tableInfo={tableInfo}
     categories={categories}
-    allMarketSegments={allMarketSegments}
+    marketSegments={marketSegments}
     preload={preload}
     user={user}
   />

--- a/app/src/pages/Favorites.js
+++ b/app/src/pages/Favorites.js
@@ -15,7 +15,7 @@ export const Favorites = ({
   search,
   tableInfo,
   categories,
-  allMarketSegments,
+  marketSegments,
   preload,
   user
 }) => (
@@ -28,7 +28,7 @@ export const Favorites = ({
     search={search}
     tableInfo={tableInfo}
     categories={categories}
-    allMarketSegments={allMarketSegments}
+    marketSegments={marketSegments}
     preload={preload}
     user={user}
   />

--- a/app/src/pages/Projects/ProjectsTable.js
+++ b/app/src/pages/Projects/ProjectsTable.js
@@ -83,16 +83,12 @@ const ProjectsTable = ({
   search,
   tableInfo,
   categories,
-  allMarketSegments,
+  marketSegments,
   preload,
   user
 }) => {
   const { loading } = Projects
-  const projects = filterProjectsByMarketSegment(
-    Projects.projects,
-    categories,
-    allMarketSegments
-  )
+  const projects = filterProjectsByMarketSegment(Projects.projects, categories)
   const currentTableSection = match.path.split('/')[1] // currencies or projects ...
   const refetchThrottled = data => {
     throttle(data => data.refetch(), 1000)
@@ -363,7 +359,7 @@ const ProjectsTable = ({
               path={match.path}
               categories={categories}
               handleSetCategory={handleSetCategory}
-              allMarketSegments={allMarketSegments}
+              marketSegments={marketSegments}
               user={user}
             />
           </div>

--- a/app/src/pages/Projects/allProjectsGQL.js
+++ b/app/src/pages/Projects/allProjectsGQL.js
@@ -129,7 +129,28 @@ export const allShortProjectsGQL = gql`
 
 export const allMarketSegmentsGQL = gql`
   {
-    allMarketSegments
+    allMarketSegments {
+      name
+      count
+    }
+  }
+`
+
+export const erc20MarketSegmentsGQL = gql`
+  {
+    erc20MarketSegments {
+      name
+      count
+    }
+  }
+`
+
+export const currenciesMarketSegmentsGQL = gql`
+  {
+    currenciesMarketSegments {
+      name
+      count
+    }
   }
 `
 

--- a/app/src/pages/Projects/withProjectsData.js
+++ b/app/src/pages/Projects/withProjectsData.js
@@ -6,7 +6,9 @@ import {
   allProjectsGQL,
   allErc20ProjectsGQL,
   currenciesGQL,
-  allMarketSegmentsGQL
+  allMarketSegmentsGQL,
+  currenciesMarketSegmentsGQL,
+  erc20MarketSegmentsGQL
 } from './allProjectsGQL'
 
 const mapStateToProps = state => {
@@ -39,7 +41,7 @@ const mapDispatchToProps = dispatch => {
   }
 }
 
-const mapDataToProps = type => ({ Projects }) => {
+const mapProjectsToProps = type => ({ Projects }) => {
   const loading = Projects.loading
   const isError = !!Projects.error
   const errorMessage = Projects.error ? Projects.error.message : ''
@@ -58,27 +60,40 @@ const mapDataToProps = type => ({ Projects }) => {
   }
 }
 
+const mapMarketSegmentsToProps = type => ({ marketSegments }) => {
+  marketSegments = marketSegments[pickProjectsType(type).marketSegments] || []
+  return { marketSegments }
+}
+
 const pickProjectsType = type => {
   switch (type) {
     case 'all':
       return {
         projects: 'allProjects',
-        gql: allProjectsGQL
+        projectsGQL: allProjectsGQL,
+        marketSegments: 'allMarketSegments',
+        marketSegmentsGQL: allMarketSegmentsGQL
       }
     case 'currency':
       return {
         projects: 'allCurrencyProjects',
-        gql: currenciesGQL
+        projectsGQL: currenciesGQL,
+        marketSegments: 'currenciesMarketSegments',
+        marketSegmentsGQL: currenciesMarketSegmentsGQL
       }
     case 'erc20':
       return {
         projects: 'allErc20Projects',
-        gql: allErc20ProjectsGQL
+        projectsGQL: allErc20ProjectsGQL,
+        marketSegments: 'erc20MarketSegments',
+        marketSegmentsGQL: erc20MarketSegmentsGQL
       }
     default:
       return {
         projects: 'allProjects',
-        gql: allProjectsGQL
+        projectsGQL: allProjectsGQL,
+        marketSegments: 'allMarketSegments',
+        marketSegmentsGQL: allMarketSegmentsGQL
       }
   }
 }
@@ -87,9 +102,9 @@ const enhance = (type = 'all') =>
   compose(
     connect(mapStateToProps, mapDispatchToProps),
     withRouter,
-    graphql(pickProjectsType(type).gql, {
+    graphql(pickProjectsType(type).projectsGQL, {
       name: 'Projects',
-      props: mapDataToProps(type),
+      props: mapProjectsToProps(type),
       options: () => {
         return {
           errorPolicy: 'all',
@@ -97,13 +112,9 @@ const enhance = (type = 'all') =>
         }
       }
     }),
-    graphql(allMarketSegmentsGQL, {
-      name: 'allMarketSegments',
-      props: ({ allMarketSegments: { allMarketSegments } }) => ({
-        allMarketSegments: allMarketSegments
-          ? JSON.parse(allMarketSegments)
-          : {}
-      })
+    graphql(pickProjectsType(type).marketSegmentsGQL, {
+      name: 'marketSegments',
+      props: mapMarketSegmentsToProps(type)
     }),
     pure
   )

--- a/app/src/pages/Projects/withProjectsData.js
+++ b/app/src/pages/Projects/withProjectsData.js
@@ -41,28 +41,32 @@ const mapDispatchToProps = dispatch => {
   }
 }
 
-const mapProjectsToProps = type => ({ Projects }) => {
-  const loading = Projects.loading
-  const isError = !!Projects.error
-  const errorMessage = Projects.error ? Projects.error.message : ''
-  const projects = Projects[pickProjectsType(type).projects] || []
-
-  const isEmpty = projects && projects.length === 0
+const mapDataToProps = type => {
   return {
-    Projects: {
-      loading,
-      isEmpty,
-      isError,
-      projects,
-      errorMessage,
-      refetch: Projects.refetch
+    projects: ({ Projects }) => {
+      const loading = Projects.loading
+      const isError = !!Projects.error
+      const errorMessage = Projects.error ? Projects.error.message : ''
+      const projects = Projects[pickProjectsType(type).projects] || []
+
+      const isEmpty = projects && projects.length === 0
+      return {
+        Projects: {
+          loading,
+          isEmpty,
+          isError,
+          projects,
+          errorMessage,
+          refetch: Projects.refetch
+        }
+      }
+    },
+    marketSegments: ({ marketSegments }) => {
+      marketSegments =
+        marketSegments[pickProjectsType(type).marketSegments] || []
+      return { marketSegments }
     }
   }
-}
-
-const mapMarketSegmentsToProps = type => ({ marketSegments }) => {
-  marketSegments = marketSegments[pickProjectsType(type).marketSegments] || []
-  return { marketSegments }
 }
 
 const pickProjectsType = type => {
@@ -104,7 +108,7 @@ const enhance = (type = 'all') =>
     withRouter,
     graphql(pickProjectsType(type).projectsGQL, {
       name: 'Projects',
-      props: mapProjectsToProps(type),
+      props: mapDataToProps(type).projects,
       options: () => {
         return {
           errorPolicy: 'all',
@@ -114,7 +118,7 @@ const enhance = (type = 'all') =>
     }),
     graphql(pickProjectsType(type).marketSegmentsGQL, {
       name: 'marketSegments',
-      props: mapMarketSegmentsToProps(type)
+      props: mapDataToProps(type).marketSegments
     }),
     pure
   )

--- a/app/src/utils/sortMethods.js
+++ b/app/src/utils/sortMethods.js
@@ -1,8 +1,17 @@
 export const simpleSort = (a, b) => {
-  if (a === b) {
-    return 0
-  }
+  if (a === b) return 0
+
   return b > a ? 1 : -1
+}
+
+export const simpleSortStrings = (a, b) => {
+  a = a.toUpperCase()
+  b = b.toUpperCase()
+
+  if (a < b) return -1
+  if (a > b) return 1
+
+  return 0
 }
 
 // Why we have so long sort method
@@ -15,20 +24,12 @@ export const sortDate = (a, b, isDesc = true) => {
     return simpleSort(_a, _b)
   }
   if (isDesc) {
-    if (!a && b) {
-      return -1
-    }
-    if (a && !b) {
-      return 1
-    }
+    if (!a && b) return -1
+    if (a && !b) return 1
   }
   if (!isDesc) {
-    if (!a && b) {
-      return 1
-    }
-    if (a && !b) {
-      return -1
-    }
+    if (!a && b) return 1
+    if (a && !b) return -1
   }
 }
 

--- a/app/src/utils/sortMethods.spec.js
+++ b/app/src/utils/sortMethods.spec.js
@@ -1,11 +1,24 @@
 /* eslint-env jest */
-import { simpleSort, sortDate, sortBalances } from './sortMethods'
+import {
+  simpleSort,
+  simpleSortStrings,
+  sortDate,
+  sortBalances
+} from './sortMethods'
 
 describe('Sort date method', () => {
-  it('simple', () => {
+  it('simpleSort', () => {
     expect(simpleSort(5, 234)).toEqual(1)
     expect(simpleSort(234235, 234)).toEqual(-1)
     expect(simpleSort(234, 234)).toEqual(0)
+  })
+})
+
+describe('Sort strings method', () => {
+  it('simpleSortStrings', () => {
+    expect(simpleSortStrings('bbc', 'abc')).toEqual(1)
+    expect(simpleSortStrings('abc', 'bbc')).toEqual(-1)
+    expect(simpleSortStrings('abc', 'abc')).toEqual(0)
   })
 })
 

--- a/app/src/utils/utils.js
+++ b/app/src/utils/utils.js
@@ -39,21 +39,13 @@ const sanitizeMediumDraftHtml = html =>
     }
   })
 
-const filterProjectsByMarketSegment = (
-  projects,
-  categories,
-  allMarketSegments
-) => {
+const filterProjectsByMarketSegment = (projects, categories) => {
   if (projects === undefined || Object.keys(categories).length === 0) {
     return projects
   }
 
   return projects.filter(project =>
-    Object.keys(categories).includes(
-      Object.keys(allMarketSegments).find(
-        key => allMarketSegments[key] === project.marketSegment
-      )
-    )
+    Object.keys(categories).includes(project.marketSegment)
   )
 }
 

--- a/app/src/utils/utils.spec.js
+++ b/app/src/utils/utils.spec.js
@@ -80,32 +80,17 @@ describe('sanitizeMediumDraftHtml', () => {
 
 describe('filterProjectsByMarketSegment', () => {
   it('should return expected values', () => {
-    const allMarketSegments = {
-      advertising: 'Advertising',
-      blockchain_network: 'Blockchain Network',
-      data: 'Data',
-      digital_identity: 'Digital Identity',
-      financial: 'Financial',
-      gambling: 'Gambling',
-      gaming: 'Gaming',
-      legal: 'Legal',
-      media: 'Media',
-      prediction_market: 'Prediction Market',
-      protocol: 'Protocol',
-      transportation: 'Transportation',
-      unknown: null
-    }
     const dataProvider = [
       // projects is undefined, there is a category
       {
         projects: undefined,
-        categories: { financial: true },
+        categories: { Financial: true },
         expectation: undefined
       },
       // projects is an empty array, there is a category
       {
         projects: [],
-        categories: { financial: true },
+        categories: { Financial: true },
         expectation: []
       },
       // projects is an empty array, categories is an empty object
@@ -123,7 +108,7 @@ describe('filterProjectsByMarketSegment', () => {
       // projects is not empty, there is a category
       {
         projects: [{ marketSegment: 'Financial' }, { marketSegment: 'media' }],
-        categories: { financial: true },
+        categories: { Financial: true },
         expectation: [{ marketSegment: 'Financial' }]
       },
       // projects is not empty, there are multiple categories
@@ -134,8 +119,8 @@ describe('filterProjectsByMarketSegment', () => {
           { marketSegment: 'Advertising' }
         ],
         categories: {
-          financial: true,
-          blockchain_network: true
+          Financial: true,
+          'Blockchain Network': true
         },
         expectation: [
           { marketSegment: 'Financial' },
@@ -145,11 +130,7 @@ describe('filterProjectsByMarketSegment', () => {
     ]
     dataProvider.map(data =>
       expect(
-        filterProjectsByMarketSegment(
-          data.projects,
-          data.categories,
-          allMarketSegments
-        )
+        filterProjectsByMarketSegment(data.projects, data.categories)
       ).toEqual(data.expectation)
     )
   })

--- a/lib/sanbase_web/graphql/resolvers/market_segment_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/market_segment_resolver.ex
@@ -8,57 +8,48 @@ defmodule SanbaseWeb.Graphql.Resolvers.MarketSegmentResolver do
   alias Sanbase.Repo
 
   def all_market_segments(_parent, _args, _resolution) do
-    market_segments =
-      Repo.all(MarketSegment)
-      |> Repo.preload(:projects)
-      |> Enum.map(fn %{name: name, projects: projects} ->
-        %{
-          name: name,
-          count: Enum.count(projects)
-        }
-      end)
+    filter = fn _ -> true end
+    market_segments = market_segments(filter)
 
     {:ok, market_segments}
   end
 
   def erc20_market_segments(_parent, _args, _resolution) do
-    market_segments =
-      Repo.all(MarketSegment)
-      |> Repo.preload(projects: :infrastructure)
-      |> Enum.filter(fn %{projects: projects} ->
-        Enum.any?(projects, fn project ->
-          not is_nil(project.coinmarketcap_id) and not is_nil(project.main_contract_address) and
-            not is_nil(project.infrastructure) and project.infrastructure.code === "ETH"
-        end)
+    filter = fn %{projects: projects} ->
+      Enum.any?(projects, fn project ->
+        not is_nil(project.coinmarketcap_id) and not is_nil(project.main_contract_address) and
+          not is_nil(project.infrastructure) and project.infrastructure.code === "ETH"
       end)
-      |> Enum.map(fn %{name: name, projects: projects} ->
-        %{
-          name: name,
-          count: Enum.count(projects)
-        }
-      end)
+    end
+
+    market_segments = market_segments(filter)
 
     {:ok, market_segments}
   end
 
   def currencies_market_segments(_parent, _args, _resolution) do
-    market_segments =
-      Repo.all(MarketSegment)
-      |> Repo.preload(projects: :infrastructure)
-      |> Enum.filter(fn %{projects: projects} ->
-        Enum.any?(projects, fn project ->
-          not is_nil(project.coinmarketcap_id) and
-            (is_nil(project.main_contract_address) or
-               (not is_nil(project.infrastructure) and project.infrastructure.code !== "ETH"))
-        end)
+    filter = fn %{projects: projects} ->
+      Enum.any?(projects, fn project ->
+        not is_nil(project.coinmarketcap_id) and
+          (is_nil(project.main_contract_address) or
+             (not is_nil(project.infrastructure) and project.infrastructure.code !== "ETH"))
       end)
-      |> Enum.map(fn %{name: name, projects: projects} ->
-        %{
-          name: name,
-          count: Enum.count(projects)
-        }
-      end)
+    end
+
+    market_segments = market_segments(filter)
 
     {:ok, market_segments}
+  end
+
+  defp market_segments(filter) do
+    Repo.all(MarketSegment)
+    |> Repo.preload(projects: :infrastructure)
+    |> Enum.filter(filter)
+    |> Enum.map(fn %{name: name, projects: projects} ->
+      %{
+        name: name,
+        count: Enum.count(projects)
+      }
+    end)
   end
 end

--- a/lib/sanbase_web/graphql/resolvers/market_segment_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/market_segment_resolver.ex
@@ -10,19 +10,55 @@ defmodule SanbaseWeb.Graphql.Resolvers.MarketSegmentResolver do
   def all_market_segments(_parent, _args, _resolution) do
     market_segments =
       Repo.all(MarketSegment)
-      |> Map.new(fn market_segment ->
-        {to_snake_case(market_segment.name), market_segment.name}
+      |> Repo.preload(:projects)
+      |> Enum.map(fn %{name: name, projects: projects} ->
+        %{
+          name: name,
+          count: Enum.count(projects)
+        }
       end)
-      |> Map.merge(%{unknown: nil})
-      |> Poison.encode!()
 
     {:ok, market_segments}
   end
 
-  defp to_snake_case(string) do
-    string
-    |> String.downcase()
-    |> String.replace(~r/'|`|"/, "")
-    |> String.replace(~r/[^A-za-z0-9]/, "_")
+  def erc20_market_segments(_parent, _args, _resolution) do
+    market_segments =
+      Repo.all(MarketSegment)
+      |> Repo.preload(projects: :infrastructure)
+      |> Enum.filter(fn %{projects: projects} ->
+        Enum.any?(projects, fn project ->
+          not is_nil(project.coinmarketcap_id) and not is_nil(project.main_contract_address) and
+            not is_nil(project.infrastructure) and project.infrastructure.code === "ETH"
+        end)
+      end)
+      |> Enum.map(fn %{name: name, projects: projects} ->
+        %{
+          name: name,
+          count: Enum.count(projects)
+        }
+      end)
+
+    {:ok, market_segments}
+  end
+
+  def currencies_market_segments(_parent, _args, _resolution) do
+    market_segments =
+      Repo.all(MarketSegment)
+      |> Repo.preload(projects: :infrastructure)
+      |> Enum.filter(fn %{projects: projects} ->
+        Enum.any?(projects, fn project ->
+          not is_nil(project.coinmarketcap_id) and
+            (is_nil(project.main_contract_address) or
+               (not is_nil(project.infrastructure) and project.infrastructure.code !== "ETH"))
+        end)
+      end)
+      |> Enum.map(fn %{name: name, projects: projects} ->
+        %{
+          name: name,
+          count: Enum.count(projects)
+        }
+      end)
+
+    {:ok, market_segments}
   end
 end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -47,6 +47,7 @@ defmodule SanbaseWeb.Graphql.Schema do
   import_types(SanbaseWeb.Graphql.TransactionTypes)
   import_types(SanbaseWeb.Graphql.FileTypes)
   import_types(SanbaseWeb.Graphql.UserListTypes)
+  import_types(SanbaseWeb.Graphql.MarketSegmentTypes)
 
   def dataloader() do
     alias SanbaseWeb.Graphql.SanbaseRepo
@@ -74,9 +75,21 @@ defmodule SanbaseWeb.Graphql.Schema do
     end
 
     @desc "Fetch all market segments."
-    field :all_market_segments, :string do
+    field :all_market_segments, list_of(:market_segment) do
       middleware(ProjectPermissions)
       cache_resolve(&MarketSegmentResolver.all_market_segments/3)
+    end
+
+    @desc "Fetch ERC20 projects' market segments."
+    field :erc20_market_segments, list_of(:market_segment) do
+      middleware(ProjectPermissions)
+      cache_resolve(&MarketSegmentResolver.erc20_market_segments/3)
+    end
+
+    @desc "Fetch currency projects' market segments."
+    field :currencies_market_segments, list_of(:market_segment) do
+      middleware(ProjectPermissions)
+      cache_resolve(&MarketSegmentResolver.currencies_market_segments/3)
     end
 
     @desc "Fetch all projects that have price data."

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -76,19 +76,16 @@ defmodule SanbaseWeb.Graphql.Schema do
 
     @desc "Fetch all market segments."
     field :all_market_segments, list_of(:market_segment) do
-      middleware(ProjectPermissions)
       cache_resolve(&MarketSegmentResolver.all_market_segments/3)
     end
 
     @desc "Fetch ERC20 projects' market segments."
     field :erc20_market_segments, list_of(:market_segment) do
-      middleware(ProjectPermissions)
       cache_resolve(&MarketSegmentResolver.erc20_market_segments/3)
     end
 
     @desc "Fetch currency projects' market segments."
     field :currencies_market_segments, list_of(:market_segment) do
-      middleware(ProjectPermissions)
       cache_resolve(&MarketSegmentResolver.currencies_market_segments/3)
     end
 

--- a/lib/sanbase_web/graphql/schema/market_segment_types.ex
+++ b/lib/sanbase_web/graphql/schema/market_segment_types.ex
@@ -1,0 +1,8 @@
+defmodule SanbaseWeb.Graphql.MarketSegmentTypes do
+  use Absinthe.Schema.Notation
+
+  object :market_segment do
+    field(:name, :string)
+    field(:count, :integer)
+  end
+end

--- a/test/sanbase_web/graphql/market_segment_resolver_test.exs
+++ b/test/sanbase_web/graphql/market_segment_resolver_test.exs
@@ -1,0 +1,155 @@
+defmodule SanbaseWeb.Graphql.MarketSegmentResolverTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import SanbaseWeb.Graphql.TestHelpers
+
+  alias Sanbase.Repo
+  alias Sanbase.Model.{Project, MarketSegment, Infrastructure}
+  alias Sanbase.Auth.User
+
+  setup do
+    user =
+      %User{salt: User.generate_salt(), privacy_policy_accepted: true}
+      |> Repo.insert!()
+
+    contract_address = "0x123123123"
+
+    eth_infrastructure =
+      %Infrastructure{code: "ETH"}
+      |> Repo.insert!()
+
+    btc_infrastructure =
+      %Infrastructure{code: "BTC"}
+      |> Repo.insert!()
+
+    # All necesarry fields
+    %MarketSegment{
+      name: "Foo",
+      projects: [
+        %Project{
+          name: "Foo Project",
+          coinmarketcap_id: "fooproject",
+          main_contract_address: contract_address,
+          infrastructure_id: eth_infrastructure.id
+        }
+      ]
+    }
+    |> Repo.insert!()
+
+    # Missing coinmarketcap_id - won't appear in erc20 and currency market segments
+    %MarketSegment{
+      name: "Bar",
+      projects: [
+        %Project{
+          name: "Bar Project",
+          main_contract_address: contract_address,
+          infrastructure_id: eth_infrastructure.id
+        }
+      ]
+    }
+    |> Repo.insert!()
+
+    # Missing main_contract_address - won't appear in erc20 market segments
+    %MarketSegment{
+      name: "Baz",
+      projects: [
+        %Project{
+          name: "Baz Project",
+          coinmarketcap_id: "bazproject",
+          infrastructure_id: eth_infrastructure.id
+        }
+      ]
+    }
+    |> Repo.insert!()
+
+    # Infrastructure is not "ETH" - won't appear in erc20 market segments
+    %MarketSegment{
+      name: "Qux",
+      projects: [
+        %Project{
+          name: "Qux Project",
+          coinmarketcap_id: "quxproject",
+          main_contract_address: contract_address,
+          infrastructure_id: btc_infrastructure.id
+        }
+      ]
+    }
+    |> Repo.insert!()
+
+    conn = setup_jwt_auth(build_conn(), user)
+
+    %{conn: conn, user: user}
+  end
+
+  test "all_market_segments/3", %{conn: conn} do
+    market_segments =
+      market_segments_query(conn, "allMarketSegments")
+      |> json_response(200)
+      |> extract_all_market_segments()
+
+    assert Enum.count(market_segments) === 4
+
+    assert market_segments === [
+             %{"count" => 1, "name" => "Foo"},
+             %{"count" => 1, "name" => "Bar"},
+             %{"count" => 1, "name" => "Baz"},
+             %{"count" => 1, "name" => "Qux"}
+           ]
+  end
+
+  test "erc20_market_segments/3", %{conn: conn} do
+    market_segments =
+      market_segments_query(conn, "erc20MarketSegments")
+      |> json_response(200)
+      |> extract_erc20_market_segments()
+
+    assert Enum.count(market_segments) === 1
+
+    assert market_segments === [
+             %{"count" => 1, "name" => "Foo"}
+           ]
+  end
+
+  test "currencies_market_segments/3", %{conn: conn} do
+    market_segments =
+      market_segments_query(conn, "currenciesMarketSegments")
+      |> json_response(200)
+      |> extract_currencies_market_segments()
+
+    assert Enum.count(market_segments) === 2
+
+    assert market_segments === [
+             %{"count" => 1, "name" => "Baz"},
+             %{"count" => 1, "name" => "Qux"}
+           ]
+  end
+
+  defp market_segments_query(conn, query_name) do
+    query = """
+    {
+      #{query_name} {
+        name,
+        count
+      }
+    }
+    """
+
+    conn |> post("/graphql", query_skeleton(query, query_name))
+  end
+
+  defp extract_all_market_segments(%{"data" => %{"allMarketSegments" => all_market_segments}}) do
+    all_market_segments
+  end
+
+  defp extract_erc20_market_segments(%{
+         "data" => %{"erc20MarketSegments" => erc20_market_segments}
+       }) do
+    erc20_market_segments
+  end
+
+  defp extract_currencies_market_segments(%{
+         "data" => %{"currenciesMarketSegments" => currencies_market_segments}
+       }) do
+    currencies_market_segments
+  end
+end


### PR DESCRIPTION
#### Summary
<!-- (What does this pull request do in general terms?) -->
Market segments queries return a JSON object with name and count instead
of the string representation of the object.

The front end changes the list of categories based on the type of
projects that are selected and when the user changes the type of the
project the categories filter is cleared.

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

#### Screenshots
<!-- (if appropriate) -->
![image](https://user-images.githubusercontent.com/5284935/43322975-f42b444e-91b8-11e8-95ec-c1650b18c7b4.png)
