### PR TITLE
Add topic_search_overview endpoint

### DIFF
--- a/lib/sanbase/internal_services/tech_indicators.ex
+++ b/lib/sanbase/internal_services/tech_indicators.ex
@@ -277,6 +277,39 @@ defmodule Sanbase.InternalServices.TechIndicators do
     end
   end
 
+  def topic_search_overview(
+        source,
+        search_text,
+        datetime_from,
+        datetime_to,
+        interval
+      ) do
+    topic_search_overview_request(
+      source,
+      search_text,
+      datetime_from,
+      datetime_to,
+      interval
+    )
+    |> case do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        {:ok, result} = Poison.decode(body)
+        topic_search_overview_result(result)
+
+      {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
+        error_result(
+          "Error status #{status} fetching results for search text \"#{search_text}\": #{body}"
+        )
+
+      {:error, %HTTPoison.Error{} = error} ->
+        error_result(
+          "Cannot fetch results for search text \"#{search_text}\": #{
+            HTTPoison.Error.message(error)
+          }"
+        )
+    end
+  end
+
   defp macd_request(
          ticker,
          currency,
@@ -635,6 +668,41 @@ defmodule Sanbase.InternalServices.TechIndicators do
         String.to_atom(key) => Map.get(result, key)
       }
     end)
+  end
+
+  defp topic_search_overview_request(
+         source,
+         search_text,
+         datetime_from,
+         datetime_to,
+         interval
+       ) do
+    from_unix = DateTime.to_unix(datetime_from)
+    to_unix = DateTime.to_unix(datetime_to)
+
+    url = "#{tech_indicators_url()}/indicator/topic_search_overview"
+
+    options = [
+      recv_timeout: @recv_timeout,
+      params: [
+        {"source", source},
+        {"search_text", search_text},
+        {"from_timestamp", from_unix},
+        {"to_timestamp", to_unix},
+        {"interval", interval}
+      ]
+    ]
+
+    http_client().get(url, [], options)
+  end
+
+  defp topic_search_overview_result(%{"messages" => messages, "chart_data" => chart_data}) do
+    messages = parse_topic_search_data(messages, "text")
+    chart_data = parse_topic_search_data(chart_data, "mentions_count")
+
+    result = %{messages: messages, chart_data: chart_data}
+
+    {:ok, result}
   end
 
   defp error_result(message) do

--- a/lib/sanbase/internal_services/tech_indicators.ex
+++ b/lib/sanbase/internal_services/tech_indicators.ex
@@ -245,46 +245,13 @@ defmodule Sanbase.InternalServices.TechIndicators do
   end
 
   def topic_search(
-        sources,
-        search_text,
-        datetime_from,
-        datetime_to,
-        interval
-      ) do
-    topic_search_request(
-      sources,
-      search_text,
-      datetime_from,
-      datetime_to,
-      interval
-    )
-    |> case do
-      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        {:ok, result} = Poison.decode(body)
-        topic_search_result(result)
-
-      {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
-        error_result(
-          "Error status #{status} fetching results for search text \"#{search_text}\": #{body}"
-        )
-
-      {:error, %HTTPoison.Error{} = error} ->
-        error_result(
-          "Cannot fetch results for search text \"#{search_text}\": #{
-            HTTPoison.Error.message(error)
-          }"
-        )
-    end
-  end
-
-  def topic_search_overview(
         source,
         search_text,
         datetime_from,
         datetime_to,
         interval
       ) do
-    topic_search_overview_request(
+    topic_search_request(
       source,
       search_text,
       datetime_from,
@@ -294,7 +261,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
     |> case do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, result} = Poison.decode(body)
-        topic_search_overview_result(result)
+        topic_search_result(result)
 
       {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
         error_result(
@@ -617,60 +584,6 @@ defmodule Sanbase.InternalServices.TechIndicators do
   end
 
   defp topic_search_request(
-         sources,
-         search_text,
-         datetime_from,
-         datetime_to,
-         interval
-       ) do
-    sources = Enum.join(sources, ", ")
-    from_unix = DateTime.to_unix(datetime_from)
-    to_unix = DateTime.to_unix(datetime_to)
-
-    url = "#{tech_indicators_url()}/indicator/topic_search"
-
-    options = [
-      recv_timeout: @recv_timeout,
-      params: [
-        {"sources", sources},
-        {"search_text", search_text},
-        {"from_timestamp", from_unix},
-        {"to_timestamp", to_unix},
-        {"interval", interval}
-      ]
-    ]
-
-    http_client().get(url, [], options)
-  end
-
-  defp topic_search_result(%{"messages" => messages, "charts_data" => charts_data}) do
-    messages = parse_topic_search_sources(messages, "text")
-    charts_data = parse_topic_search_sources(charts_data, "mentions_count")
-
-    result = %{messages: messages, charts_data: charts_data}
-
-    {:ok, result}
-  end
-
-  defp parse_topic_search_sources(source_data, key) do
-    source_data
-    |> Enum.map(fn {source, data} ->
-      {String.to_atom(source), parse_topic_search_data(data, key)}
-    end)
-    |> Map.new()
-  end
-
-  defp parse_topic_search_data(data, key) do
-    data
-    |> Enum.map(fn result ->
-      %{
-        :datetime => Map.get(result, "timestamp") |> DateTime.from_unix!(),
-        String.to_atom(key) => Map.get(result, key)
-      }
-    end)
-  end
-
-  defp topic_search_overview_request(
          source,
          search_text,
          datetime_from,
@@ -680,7 +593,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
     from_unix = DateTime.to_unix(datetime_from)
     to_unix = DateTime.to_unix(datetime_to)
 
-    url = "#{tech_indicators_url()}/indicator/topic_search_overview"
+    url = "#{tech_indicators_url()}/indicator/topic_search"
 
     options = [
       recv_timeout: @recv_timeout,
@@ -696,13 +609,23 @@ defmodule Sanbase.InternalServices.TechIndicators do
     http_client().get(url, [], options)
   end
 
-  defp topic_search_overview_result(%{"messages" => messages, "chart_data" => chart_data}) do
+  defp topic_search_result(%{"messages" => messages, "chart_data" => chart_data}) do
     messages = parse_topic_search_data(messages, "text")
     chart_data = parse_topic_search_data(chart_data, "mentions_count")
 
     result = %{messages: messages, chart_data: chart_data}
 
     {:ok, result}
+  end
+
+  defp parse_topic_search_data(data, key) do
+    data
+    |> Enum.map(fn result ->
+      %{
+        :datetime => Map.get(result, "timestamp") |> DateTime.from_unix!(),
+        String.to_atom(key) => Map.get(result, key)
+      }
+    end)
   end
 
   defp error_result(message) do

--- a/lib/sanbase_web/graphql/resolvers/tech_indicators_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/tech_indicators_resolver.ex
@@ -142,26 +142,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.TechIndicatorsResolver do
   def topic_search(
         _root,
         %{
-          sources: sources,
-          search_text: search_text,
-          from: from,
-          to: to,
-          interval: interval
-        },
-        _resolution
-      ) do
-    TechIndicators.topic_search(
-      sources,
-      search_text,
-      from,
-      to,
-      interval
-    )
-  end
-
-  def topic_search_overview(
-        _root,
-        %{
           source: source,
           search_text: search_text,
           from: from,
@@ -170,7 +150,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.TechIndicatorsResolver do
         },
         _resolution
       ) do
-    TechIndicators.topic_search_overview(
+    TechIndicators.topic_search(
       source,
       search_text,
       from,

--- a/lib/sanbase_web/graphql/resolvers/tech_indicators_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/tech_indicators_resolver.ex
@@ -159,6 +159,26 @@ defmodule SanbaseWeb.Graphql.Resolvers.TechIndicatorsResolver do
     )
   end
 
+  def topic_search_overview(
+        _root,
+        %{
+          source: source,
+          search_text: search_text,
+          from: from,
+          to: to,
+          interval: interval
+        },
+        _resolution
+      ) do
+    TechIndicators.topic_search_overview(
+      source,
+      search_text,
+      from,
+      to,
+      interval
+    )
+  end
+
   defp price_volume_diff_ma_window_type() do
     Config.module_get(Sanbase.Notifications.PriceVolumeDiff, :window_type)
   end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -487,6 +487,8 @@ defmodule SanbaseWeb.Graphql.Schema do
     end
 
     @desc ~s"""
+    This endpoint is deprecated and soon won't be available! Please use `topic_search_overview` instead.
+
     Returns lists with the mentions of the search phrase grouped by source. The results are in two formats - the messages themselves and the data for building graph representation of the result.
 
     Arguments description:
@@ -500,6 +502,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       * to - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
     """
     field :topic_search, :topic_search do
+      deprecate("Use topic_search_overview")
       arg(:sources, non_null(list_of(:topic_search_sources)))
       arg(:search_text, non_null(:string))
       arg(:from, non_null(:datetime))
@@ -510,6 +513,32 @@ defmodule SanbaseWeb.Graphql.Schema do
 
       complexity(&TechIndicatorsComplexity.topic_search/3)
       resolve(&TechIndicatorsResolver.topic_search/3)
+    end
+
+    @desc ~s"""
+    Returns lists with the mentions of the search phrase from the selected source. The results are in two formats - the messages themselves and the data for building graph representation of the result.
+
+    Arguments description:
+      * source - one of the following:
+        1. TELEGRAM
+        2. PROFESSIONAL_TRADERS_CHAT
+        3. REDDIT
+      * searchText - a string containing the key words for which the sources should be searched.
+      * interval - an integer followed by one of: `m`, `h`, `d`, `w`
+      * from - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
+      * to - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
+    """
+    field :topic_search_overview, :topic_search_overview do
+      arg(:source, non_null(:topic_search_sources))
+      arg(:search_text, non_null(:string))
+      arg(:from, non_null(:datetime))
+      arg(:to, :datetime, default_value: DateTime.utc_now())
+      arg(:interval, non_null(:string), default_value: "1d")
+
+      middleware(ApiTimeframeRestriction)
+
+      complexity(&TechIndicatorsComplexity.topic_search/3)
+      resolve(&TechIndicatorsResolver.topic_search_overview/3)
     end
 
     @desc "Fetch a list of all exchange wallets. This query requires basic authentication."

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -503,7 +503,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:source, non_null(:topic_search_sources))
       arg(:search_text, non_null(:string))
       arg(:from, non_null(:datetime))
-      arg(:to, :datetime, default_value: DateTime.utc_now())
+      arg(:to, :datetime)
       arg(:interval, non_null(:string), default_value: "1d")
 
       middleware(ApiTimeframeRestriction)

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -487,35 +487,6 @@ defmodule SanbaseWeb.Graphql.Schema do
     end
 
     @desc ~s"""
-    This endpoint is deprecated and soon won't be available! Please use `topic_search_overview` instead.
-
-    Returns lists with the mentions of the search phrase grouped by source. The results are in two formats - the messages themselves and the data for building graph representation of the result.
-
-    Arguments description:
-      * sources - an array of enum values that specify which sources should be searched. The sources are:
-        1. TELEGRAM
-        2. PROFESSIONAL_TRADERS_CHAT
-        3. REDDIT
-      * searchText - a string containing the key words for which the sources should be searched.
-      * interval - an integer followed by one of: `m`, `h`, `d`, `w`
-      * from - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
-      * to - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
-    """
-    field :topic_search, :topic_search do
-      deprecate("Use topic_search_overview")
-      arg(:sources, non_null(list_of(:topic_search_sources)))
-      arg(:search_text, non_null(:string))
-      arg(:from, non_null(:datetime))
-      arg(:to, :datetime, default_value: DateTime.utc_now())
-      arg(:interval, non_null(:string), default_value: "1d")
-
-      middleware(ApiTimeframeRestriction)
-
-      complexity(&TechIndicatorsComplexity.topic_search/3)
-      resolve(&TechIndicatorsResolver.topic_search/3)
-    end
-
-    @desc ~s"""
     Returns lists with the mentions of the search phrase from the selected source. The results are in two formats - the messages themselves and the data for building graph representation of the result.
 
     Arguments description:
@@ -528,7 +499,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       * from - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
       * to - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
     """
-    field :topic_search_overview, :topic_search_overview do
+    field :topic_search, :topic_search do
       arg(:source, non_null(:topic_search_sources))
       arg(:search_text, non_null(:string))
       arg(:from, non_null(:datetime))
@@ -538,7 +509,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       middleware(ApiTimeframeRestriction)
 
       complexity(&TechIndicatorsComplexity.topic_search/3)
-      resolve(&TechIndicatorsResolver.topic_search_overview/3)
+      resolve(&TechIndicatorsResolver.topic_search/3)
     end
 
     @desc "Fetch a list of all exchange wallets. This query requires basic authentication."

--- a/lib/sanbase_web/graphql/schema/tech_indicators_types.ex
+++ b/lib/sanbase_web/graphql/schema/tech_indicators_types.ex
@@ -66,33 +66,16 @@ defmodule SanbaseWeb.Graphql.TechIndicatorsTypes do
   end
 
   object :topic_search do
-    field(:messages, :messages)
-    field(:charts_data, :charts_data)
-  end
-
-  object :topic_search_overview do
-    field(:messages, list_of(:topic_search_messages))
-    field(:chart_data, list_of(:topic_search_chart_data))
+    field(:messages, list_of(:messages))
+    field(:chart_data, list_of(:chart_data))
   end
 
   object :messages do
-    field(:telegram, list_of(:topic_search_messages))
-    field(:professional_traders_chat, list_of(:topic_search_messages))
-    field(:reddit, list_of(:topic_search_messages))
-  end
-
-  object :charts_data do
-    field(:telegram, list_of(:topic_search_chart_data))
-    field(:professional_traders_chat, list_of(:topic_search_chart_data))
-    field(:reddit, list_of(:topic_search_chart_data))
-  end
-
-  object :topic_search_messages do
     field(:text, :string)
     field(:datetime, non_null(:datetime))
   end
 
-  object :topic_search_chart_data do
+  object :chart_data do
     field(:mentions_count, :integer)
     field(:datetime, non_null(:datetime))
   end

--- a/lib/sanbase_web/graphql/schema/tech_indicators_types.ex
+++ b/lib/sanbase_web/graphql/schema/tech_indicators_types.ex
@@ -70,6 +70,11 @@ defmodule SanbaseWeb.Graphql.TechIndicatorsTypes do
     field(:charts_data, :charts_data)
   end
 
+  object :topic_search_overview do
+    field(:messages, list_of(:topic_search_messages))
+    field(:chart_data, list_of(:topic_search_chart_data))
+  end
+
   object :messages do
     field(:telegram, list_of(:topic_search_messages))
     field(:professional_traders_chat, list_of(:topic_search_messages))

--- a/lib/sanbase_web/templates/api_examples/examples.html.eex
+++ b/lib/sanbase_web/templates/api_examples/examples.html.eex
@@ -204,25 +204,3 @@ curl \
     <%= "  #{ @api_url }" %>
 
 ```
-
-### Topic search overview
-
-<%= @topic_search_overview[:docs] %>
-
-
-<a href="<%= ~s|"#{@explorer_url}?variables=#{URI.encode(@topic_search_overview[:variables])}&query=#{URI.encode(@topic_search_overview[:query])}"| %>" target='_blank'>Run in explorer</a>
-
-```graphql
-<%= @topic_search_overview[:query] %>
-```
-
-Run in terminal
-
-```bash
-curl \
-  -X POST \
-  -H "Content-Type: application/json" \
-  --data '{ "query": <%= Poison.encode!(@topic_search_overview[:query]) %> }' \
-    <%= "  #{ @api_url }" %>
-
-```

--- a/lib/sanbase_web/templates/api_examples/examples.html.eex
+++ b/lib/sanbase_web/templates/api_examples/examples.html.eex
@@ -204,3 +204,25 @@ curl \
     <%= "  #{ @api_url }" %>
 
 ```
+
+### Topic search overview
+
+<%= @topic_search_overview[:docs] %>
+
+
+<a href="<%= ~s|"#{@explorer_url}?variables=#{URI.encode(@topic_search_overview[:variables])}&query=#{URI.encode(@topic_search_overview[:query])}"| %>" target='_blank'>Run in explorer</a>
+
+```graphql
+<%= @topic_search_overview[:query] %>
+```
+
+Run in terminal
+
+```bash
+curl \
+  -X POST \
+  -H "Content-Type: application/json" \
+  --data '{ "query": <%= Poison.encode!(@topic_search_overview[:query]) %> }' \
+    <%= "  #{ @api_url }" %>
+
+```

--- a/lib/sanbase_web/views/api_examples_view.ex
+++ b/lib/sanbase_web/views/api_examples_view.ex
@@ -50,6 +50,11 @@ defmodule SanbaseWeb.ApiExamplesView do
         query: topic_search(),
         variables: "{}",
         docs: docs(:topic_search)
+      },
+      topic_search_overview: %{
+        query: topic_search_overview(),
+        variables: "{}",
+        docs: docs(:topic_search_overview)
       }
     })
     |> as_html()
@@ -213,6 +218,29 @@ defmodule SanbaseWeb.ApiExamplesView do
             mentionsCount
             datetime
           }
+        }
+      }
+    }
+    """
+  end
+
+  defp topic_search_overview do
+    """
+    query {
+      topicSearchOverview(
+        source: TELEGRAM,
+        searchText: "btc moon",
+        from: "2018-08-01T12:00:00Z",
+        to: "2018-08-15T12:00:00Z",
+        interval: "6h"
+      ) {
+        messages {
+          datetime
+          text
+        }
+        chartData {
+          mentionsCount
+          datetime
         }
       }
     }

--- a/lib/sanbase_web/views/api_examples_view.ex
+++ b/lib/sanbase_web/views/api_examples_view.ex
@@ -50,11 +50,6 @@ defmodule SanbaseWeb.ApiExamplesView do
         query: topic_search(),
         variables: "{}",
         docs: docs(:topic_search)
-      },
-      topic_search_overview: %{
-        query: topic_search_overview(),
-        variables: "{}",
-        docs: docs(:topic_search_overview)
       }
     })
     |> as_html()
@@ -185,49 +180,6 @@ defmodule SanbaseWeb.ApiExamplesView do
     """
     query {
       topicSearch(
-        sources: [TELEGRAM, PROFESSIONAL_TRADERS_CHAT, REDDIT],
-        searchText: "btc moon",
-        from: "2018-08-01T12:00:00Z",
-        to: "2018-08-15T12:00:00Z",
-        interval: "6h"
-      ) {
-        messages {
-          telegram {
-            datetime
-            text
-          }
-          professionalTradersChat {
-            datetime
-            text
-          }
-          reddit {
-            datetime
-            text
-          }
-        }
-        chartsData {
-          telegram {
-            mentionsCount
-            datetime
-          }
-          professionalTradersChat {
-            mentionsCount
-            datetime
-          }
-          reddit {
-            mentionsCount
-            datetime
-          }
-        }
-      }
-    }
-    """
-  end
-
-  defp topic_search_overview do
-    """
-    query {
-      topicSearchOverview(
         source: TELEGRAM,
         searchText: "btc moon",
         from: "2018-08-01T12:00:00Z",

--- a/test/sanbase/internal_services/tech_indicators_test.exs
+++ b/test/sanbase/internal_services/tech_indicators_test.exs
@@ -618,4 +618,96 @@ defmodule Sanbase.InternalServices.TechIndicatorsTest do
                "Cannot fetch results for search text \"btc moon\": :econnrefused\n"
     end
   end
+
+  describe "topic_search_overview/5" do
+    test "response: success" do
+      from = 1_533_114_000
+      to = 1_534_323_600
+
+      mock(
+        HTTPoison,
+        :get,
+        {:ok,
+         %HTTPoison.Response{
+           body:
+             "{\"messages\": [{\"text\": \"BTC moon\", \"timestamp\": 1533307652}, {\"text\": \"0.1c of usd won't make btc moon, you realize that?\", \"timestamp\": 1533694150}], \"chart_data\": [{\"mentions_count\": 1, \"timestamp\": 1533146400}, {\"mentions_count\": 0, \"timestamp\": 1533168000}]}",
+           status_code: 200
+         }}
+      )
+
+      result =
+        TechIndicators.topic_search_overview(
+          :telegram,
+          "btc moon",
+          DateTime.from_unix!(from),
+          DateTime.from_unix!(to),
+          "6h"
+        )
+
+      assert result ==
+               {:ok,
+                %{
+                  chart_data: [
+                    %{datetime: DateTime.from_unix!(1_533_146_400), mentions_count: 1},
+                    %{datetime: DateTime.from_unix!(1_533_168_000), mentions_count: 0}
+                  ],
+                  messages: [
+                    %{datetime: DateTime.from_unix!(1_533_307_652), text: "BTC moon"},
+                    %{
+                      datetime: DateTime.from_unix!(1_533_694_150),
+                      text: "0.1c of usd won't make btc moon, you realize that?"
+                    }
+                  ]
+                }}
+    end
+
+    test "response: 404" do
+      mock(
+        HTTPoison,
+        :get,
+        {:ok,
+         %HTTPoison.Response{
+           body: "Some message",
+           status_code: 404
+         }}
+      )
+
+      result = fn ->
+        TechIndicators.topic_search_overview(
+          :telegram,
+          "btc moon",
+          DateTime.from_unix!(1_533_114_000),
+          DateTime.from_unix!(1_534_323_600),
+          "6h"
+        )
+      end
+
+      assert capture_log(result) =~
+               "Error status 404 fetching results for search text \"btc moon\": Some message\n"
+    end
+
+    test "response: error" do
+      mock(
+        HTTPoison,
+        :get,
+        {:error,
+         %HTTPoison.Error{
+           reason: :econnrefused
+         }}
+      )
+
+      result = fn ->
+        TechIndicators.topic_search_overview(
+          :telegram,
+          "btc moon",
+          DateTime.from_unix!(1_533_114_000),
+          DateTime.from_unix!(1_534_323_600),
+          "6h"
+        )
+      end
+
+      assert capture_log(result) =~
+               "Cannot fetch results for search text \"btc moon\": :econnrefused\n"
+    end
+  end
 end

--- a/test/sanbase/internal_services/tech_indicators_test.exs
+++ b/test/sanbase/internal_services/tech_indicators_test.exs
@@ -523,120 +523,13 @@ defmodule Sanbase.InternalServices.TechIndicatorsTest do
         {:ok,
          %HTTPoison.Response{
            body:
-             "{\"messages\": {\"telegram\": [{\"text\": \"BTC moon\", \"timestamp\": 1533307652}, {\"text\": \"0.1c of usd won't make btc moon, you realize that?\", \"timestamp\": 1533694150}], \"professional_traders_chat\": [{\"text\": \"ow ... yea ... after btc moon and u become rich u mean ::D:\", \"timestamp\": 1533373739}, {\"text\": \"Next btc moon\", \"timestamp\": 1533741643}]}, \"charts_data\": {\"telegram\": [{\"mentions_count\": 1, \"timestamp\": 1533146400}, {\"mentions_count\": 0, \"timestamp\": 1533168000}], \"professional_traders_chat\": [{\"mentions_count\": 1, \"timestamp\": 1533362400}, {\"mentions_count\": 1, \"timestamp\": 1533384000}]}}",
-           status_code: 200
-         }}
-      )
-
-      result =
-        TechIndicators.topic_search(
-          [:telegram, :professional_traders_chat],
-          "btc moon",
-          DateTime.from_unix!(from),
-          DateTime.from_unix!(to),
-          "6h"
-        )
-
-      assert result ==
-               {:ok,
-                %{
-                  charts_data: %{
-                    telegram: [
-                      %{datetime: DateTime.from_unix!(1_533_146_400), mentions_count: 1},
-                      %{datetime: DateTime.from_unix!(1_533_168_000), mentions_count: 0}
-                    ],
-                    professional_traders_chat: [
-                      %{datetime: DateTime.from_unix!(1_533_362_400), mentions_count: 1},
-                      %{datetime: DateTime.from_unix!(1_533_384_000), mentions_count: 1}
-                    ]
-                  },
-                  messages: %{
-                    telegram: [
-                      %{datetime: DateTime.from_unix!(1_533_307_652), text: "BTC moon"},
-                      %{
-                        datetime: DateTime.from_unix!(1_533_694_150),
-                        text: "0.1c of usd won't make btc moon, you realize that?"
-                      }
-                    ],
-                    professional_traders_chat: [
-                      %{
-                        datetime: DateTime.from_unix!(1_533_373_739),
-                        text: "ow ... yea ... after btc moon and u become rich u mean ::D:"
-                      },
-                      %{datetime: DateTime.from_unix!(1_533_741_643), text: "Next btc moon"}
-                    ]
-                  }
-                }}
-    end
-
-    test "response: 404" do
-      mock(
-        HTTPoison,
-        :get,
-        {:ok,
-         %HTTPoison.Response{
-           body: "Some message",
-           status_code: 404
-         }}
-      )
-
-      result = fn ->
-        TechIndicators.topic_search(
-          [:telegram, :professional_traders_chat],
-          "btc moon",
-          DateTime.from_unix!(1_533_114_000),
-          DateTime.from_unix!(1_534_323_600),
-          "6h"
-        )
-      end
-
-      assert capture_log(result) =~
-               "Error status 404 fetching results for search text \"btc moon\": Some message\n"
-    end
-
-    test "response: error" do
-      mock(
-        HTTPoison,
-        :get,
-        {:error,
-         %HTTPoison.Error{
-           reason: :econnrefused
-         }}
-      )
-
-      result = fn ->
-        TechIndicators.topic_search(
-          [:telegram, :professional_traders_chat],
-          "btc moon",
-          DateTime.from_unix!(1_533_114_000),
-          DateTime.from_unix!(1_534_323_600),
-          "6h"
-        )
-      end
-
-      assert capture_log(result) =~
-               "Cannot fetch results for search text \"btc moon\": :econnrefused\n"
-    end
-  end
-
-  describe "topic_search_overview/5" do
-    test "response: success" do
-      from = 1_533_114_000
-      to = 1_534_323_600
-
-      mock(
-        HTTPoison,
-        :get,
-        {:ok,
-         %HTTPoison.Response{
-           body:
              "{\"messages\": [{\"text\": \"BTC moon\", \"timestamp\": 1533307652}, {\"text\": \"0.1c of usd won't make btc moon, you realize that?\", \"timestamp\": 1533694150}], \"chart_data\": [{\"mentions_count\": 1, \"timestamp\": 1533146400}, {\"mentions_count\": 0, \"timestamp\": 1533168000}]}",
            status_code: 200
          }}
       )
 
       result =
-        TechIndicators.topic_search_overview(
+        TechIndicators.topic_search(
           :telegram,
           "btc moon",
           DateTime.from_unix!(from),
@@ -673,7 +566,7 @@ defmodule Sanbase.InternalServices.TechIndicatorsTest do
       )
 
       result = fn ->
-        TechIndicators.topic_search_overview(
+        TechIndicators.topic_search(
           :telegram,
           "btc moon",
           DateTime.from_unix!(1_533_114_000),
@@ -697,7 +590,7 @@ defmodule Sanbase.InternalServices.TechIndicatorsTest do
       )
 
       result = fn ->
-        TechIndicators.topic_search_overview(
+        TechIndicators.topic_search(
           :telegram,
           "btc moon",
           DateTime.from_unix!(1_533_114_000),


### PR DESCRIPTION
#### Summary
<!-- (What does this pull request do in general terms?) -->
Changes `topic_search` implementation to be `topic_search_overview`
because it is not used at the moment and there is no need to deprecate
the method and introduce a new one.

#### Related PRs
<!-- (List of related PR in correct order) -->
Depends on: https://github.com/santiment/tech_indicators/pull/88

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

#### Screenshots
<!-- (if appropriate) -->
![image](https://user-images.githubusercontent.com/5284935/45035110-da903400-b061-11e8-96c5-709d52ed282f.png)

![image](https://user-images.githubusercontent.com/5284935/45035116-e4b23280-b061-11e8-872a-97474157cd43.png)

![image](https://user-images.githubusercontent.com/5284935/45035135-f09df480-b061-11e8-889d-c9e0f9ee7b6f.png)