### PR TITLE
Change Poison JSON library to Jason

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -8,6 +8,8 @@ use Mix.Config
 # General application configuration
 config :sanbase, ecto_repos: [Sanbase.Repo, Sanbase.TimescaleRepo]
 
+config :ecto, json_library: Jason
+
 config :sanbase, Sanbase, environment: "#{Mix.env()}"
 
 config :sanbase, Sanbase.ClickhouseRepo, adapter: Ecto.Adapters.Postgres

--- a/lib/sanbase/discourse/api.ex
+++ b/lib/sanbase/discourse/api.ex
@@ -17,7 +17,7 @@ defmodule Sanbase.Discourse.Api do
       {:ok, %HTTPoison.Response{body: body, status_code: code}}
       when code >= 200 and code < 300 ->
         Logger.info("Successfully created a topic '#{title}' in Discourse")
-        Poison.decode(body)
+        Jason.decode(body)
 
       {:ok, %HTTPoison.Response{status_code: status_code}} ->
         err_msg =

--- a/lib/sanbase/external_services/coinmarketcap/graph_data.ex
+++ b/lib/sanbase/external_services/coinmarketcap/graph_data.ex
@@ -131,7 +131,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData do
     end
   end
 
-  defp convert_to_price_points(%GraphData{
+  defp convert_to_price_points(%{
          market_cap_by_available_supply: market_cap_by_available_supply,
          price_usd: nil,
          volume_usd: volume_usd,

--- a/lib/sanbase/external_services/twitter_data/historical_data.ex
+++ b/lib/sanbase/external_services/twitter_data/historical_data.ex
@@ -109,7 +109,7 @@ defmodule Sanbase.ExternalServices.TwitterData.HistoricalData do
     case get("/?twitter_id=" <> twitter_id_str <> "&apikey=" <> apikey) do
       %Tesla.Env{status: 200, body: body} ->
         body
-        |> Poison.decode!()
+        |> Jason.decode!()
         |> Map.get("followersperdate")
 
       %Tesla.Env{status: 401} ->

--- a/lib/sanbase/internal_services/ethauth.ex
+++ b/lib/sanbase/internal_services/ethauth.ex
@@ -8,7 +8,7 @@ defmodule Sanbase.InternalServices.Ethauth do
   def verify_signature(signature, address, message_hash) do
     with %Tesla.Env{status: 200, body: body} <-
            get(client(), "recover", query: [sign: signature, hash: message_hash]),
-         {:ok, %{"recovered" => recovered}} <- Poison.decode!(body) do
+         {:ok, %{"recovered" => recovered}} <- Jason.decode!(body) do
       String.downcase(address) == String.downcase(recovered)
     else
       {:error, error} -> {:error, error}

--- a/lib/sanbase/internal_services/tech_indicators.ex
+++ b/lib/sanbase/internal_services/tech_indicators.ex
@@ -27,7 +27,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
     )
     |> case do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        {:ok, result} = Poison.decode(body)
+        {:ok, result} = Jason.decode(body)
 
         macd_result(result)
 
@@ -61,7 +61,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
     )
     |> case do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        {:ok, result} = Poison.decode(body)
+        {:ok, result} = Jason.decode(body)
 
         rsi_result(result)
 
@@ -99,7 +99,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
     )
     |> case do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        {:ok, result} = Poison.decode(body)
+        {:ok, result} = Jason.decode(body)
 
         price_volume_diff_ma_result(result)
 
@@ -133,7 +133,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
     )
     |> case do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        {:ok, result} = Poison.decode(body)
+        {:ok, result} = Jason.decode(body)
         twitter_mention_count_result(result)
 
       {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
@@ -164,7 +164,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
     )
     |> case do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        {:ok, result} = Poison.decode(body)
+        {:ok, result} = Jason.decode(body)
         emojis_sentiment_result(result)
 
       {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
@@ -185,7 +185,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
     )
     |> case do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        {:ok, result} = Poison.decode(body)
+        {:ok, result} = Jason.decode(body)
         erc20_exchange_funds_flow_result(result)
 
       {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
@@ -214,7 +214,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
     )
     |> case do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        {:ok, result} = Poison.decode(body)
+        {:ok, result} = Jason.decode(body)
         social_volume_result(result)
 
       {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
@@ -231,7 +231,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
     social_volume_projects_request()
     |> case do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        {:ok, result} = Poison.decode(body)
+        {:ok, result} = Jason.decode(body)
         social_volume_projects_result(result)
 
       {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
@@ -260,7 +260,7 @@ defmodule Sanbase.InternalServices.TechIndicators do
     )
     |> case do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        {:ok, result} = Poison.decode(body)
+        {:ok, result} = Jason.decode(body)
         topic_search_result(result)
 
       {:ok, %HTTPoison.Response{status_code: status, body: body}} ->

--- a/lib/sanbase/mandrill_api.ex
+++ b/lib/sanbase/mandrill_api.ex
@@ -7,14 +7,14 @@ defmodule Sanbase.MandrillApi do
   def send(template, recepient, variables) do
     request_body =
       build_request(template, recepient, variables)
-      |> Poison.encode!()
+      |> Jason.encode!()
 
     case HTTPoison.post(@send_email_url, request_body) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        {:ok, Poison.decode!(body)}
+        {:ok, Jason.decode!(body)}
 
       {:ok, %HTTPoison.Response{body: body}} ->
-        {:error, Poison.decode!(body)}
+        {:error, Jason.decode!(body)}
 
       {:error, error} ->
         {:error, error}

--- a/lib/sanbase/notifications/insight.ex
+++ b/lib/sanbase/notifications/insight.ex
@@ -28,7 +28,7 @@ defmodule Sanbase.Notifications.Insight do
     New insight published: #{title} [#{link}]
     """
 
-    Poison.encode!(%{content: content, username: insights_discord_publish_user()})
+    Jason.encode!(%{content: content, username: insights_discord_publish_user()})
   end
 
   defp publish(payload) do

--- a/lib/sanbase/notifications/price_volume_diff.ex
+++ b/lib/sanbase/notifications/price_volume_diff.ex
@@ -154,7 +154,7 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
       |> Timex.shift(days: 1)
       |> Timex.format("{YYYY}-{0M}-{0D} {h24}:{m}:{s}")
 
-    Poison.encode!(%{
+    Jason.encode!(%{
       content:
         "#{name}: #{ticker}/#{String.upcase(currency)} #{notification_emoji(price_change)} Price #{
           notification_emoji(volume_change)

--- a/lib/sanbase/oauth2/hydra.ex
+++ b/lib/sanbase/oauth2/hydra.ex
@@ -73,7 +73,7 @@ defmodule Sanbase.Oauth2.Hydra do
       "subject" => "user:#{id}:#{username}"
     }
 
-    HTTPoison.patch(consent_url() <> "/#{consent}/accept", Poison.encode!(data), [
+    HTTPoison.patch(consent_url() <> "/#{consent}/accept", Jason.encode!(data), [
       {"Authorization", "Bearer #{access_token}"},
       {"Content-type", "application/json"},
       {"Accept", "application/json"}
@@ -85,7 +85,7 @@ defmodule Sanbase.Oauth2.Hydra do
       "reason" => "#{email || username} doesn't have enough SAN tokens"
     }
 
-    HTTPoison.patch(consent_url() <> "/#{consent}/reject", Poison.encode!(data), [
+    HTTPoison.patch(consent_url() <> "/#{consent}/reject", Jason.encode!(data), [
       {"Authorization", "Bearer #{access_token}"},
       {"Content-type", "application/json"},
       {"Accept", "application/json"}
@@ -93,7 +93,7 @@ defmodule Sanbase.Oauth2.Hydra do
   end
 
   defp extract_field_from_json(json, field) do
-    with {:ok, body} <- Poison.decode(json),
+    with {:ok, body} <- Jason.decode(json),
          {:ok, result} <- Map.fetch(body, field) do
       {:ok, result}
     end
@@ -113,6 +113,6 @@ defmodule Sanbase.Oauth2.Hydra do
 
   defp json_config_value(key) do
     Config.get(key)
-    |> Poison.decode!()
+    |> Jason.decode!()
   end
 end

--- a/lib/sanbase/utils/json_logger.ex
+++ b/lib/sanbase/utils/json_logger.ex
@@ -6,7 +6,7 @@ defmodule Sanbase.Utils.JsonLogger do
         level: level,
         message: "#{message}"
       }
-      |> Poison.encode_to_iodata!()
+      |> Jason.encode_to_iodata!()
       | "\n"
     ]
   rescue

--- a/lib/sanbase_web/endpoint.ex
+++ b/lib/sanbase_web/endpoint.ex
@@ -23,7 +23,7 @@ defmodule SanbaseWeb.Endpoint do
     Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json, Absinthe.Plug.Parser],
     pass: ["*/*"],
-    json_decoder: Poison
+    json_decoder: Jason
   )
 
   plug(Plug.MethodOverride)

--- a/lib/sanbase_web/graphql/helpers/cache.ex
+++ b/lib/sanbase_web/graphql/helpers/cache.ex
@@ -268,7 +268,7 @@ defmodule SanbaseWeb.Graphql.Helpers.Cache do
     args_hash =
       args
       |> convert_values()
-      |> Poison.encode!()
+      |> Jason.encode!()
       |> sha256()
 
     {name, args_hash}

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -32,6 +32,7 @@ defmodule SanbaseWeb.Router do
     forward(
       "/graphql",
       Absinthe.Plug,
+      json_codec: Jason,
       schema: SanbaseWeb.Graphql.Schema,
       analyze_complexity: true,
       max_complexity: 5000,
@@ -41,6 +42,7 @@ defmodule SanbaseWeb.Router do
     forward(
       "/graphiql",
       Absinthe.Plug.GraphiQL,
+      json_codec: Jason,
       schema: SanbaseWeb.Graphql.Schema,
       analyze_complexity: true,
       max_complexity: 5000,

--- a/lib/sanbase_web/templates/api_examples/examples.html.eex
+++ b/lib/sanbase_web/templates/api_examples/examples.html.eex
@@ -45,7 +45,7 @@ Run in terminal
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  --data '{ "query": <%= Poison.encode!(@daa[:query]) %> }' \
+  --data '{ "query": <%= Jason.encode!(@daa[:query]) %> }' \
     <%= "  #{ @api_url }" %>
 
 ```
@@ -66,7 +66,7 @@ Run in terminal
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  --data '{ "query": <%= Poison.encode!(@burn_rate[:query]) %> }' \
+  --data '{ "query": <%= Jason.encode!(@burn_rate[:query]) %> }' \
     <%= "  #{ @api_url }" %>
 
 ```
@@ -88,7 +88,7 @@ Run in terminal
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  --data '{ "query": <%= Poison.encode!(@tv[:query]) %> }' \
+  --data '{ "query": <%= Jason.encode!(@tv[:query]) %> }' \
     <%= "  #{ @api_url }" %>
 
 ```
@@ -110,7 +110,7 @@ Run in terminal
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  --data '{ "query": <%= Poison.encode!(@exchange_funds_flow[:query]) %> }' \
+  --data '{ "query": <%= Jason.encode!(@exchange_funds_flow[:query]) %> }' \
     <%= "  #{ @api_url }" %>
 
 ```
@@ -134,7 +134,7 @@ Run in terminal
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  --data '{ "query": <%= Poison.encode!(@ga[:query]) %> }' \
+  --data '{ "query": <%= Jason.encode!(@ga[:query]) %> }' \
     <%= "  #{ @api_url }" %>
 
 ```
@@ -156,7 +156,7 @@ Run in terminal
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  --data '{ "query": <%= Poison.encode!(@erc20_exchange_funds_flow[:query]) %> }' \
+  --data '{ "query": <%= Jason.encode!(@erc20_exchange_funds_flow[:query]) %> }' \
     <%= "  #{ @api_url }" %>
 
 ```
@@ -178,7 +178,7 @@ Run in terminal
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  --data '{ "query": <%= Poison.encode!(@social_volume[:query]) %> }' \
+  --data '{ "query": <%= Jason.encode!(@social_volume[:query]) %> }' \
     <%= "  #{ @api_url }" %>
 
 ```
@@ -200,7 +200,7 @@ Run in terminal
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  --data '{ "query": <%= Poison.encode!(@social_volume_projects[:query]) %> }' \
+  --data '{ "query": <%= Jason.encode!(@social_volume_projects[:query]) %> }' \
     <%= "  #{ @api_url }" %>
 
 ```
@@ -222,7 +222,7 @@ Run in terminal
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  --data '{ "query": <%= Poison.encode!(@topic_search[:query]) %> }' \
+  --data '{ "query": <%= Jason.encode!(@topic_search[:query]) %> }' \
     <%= "  #{ @api_url }" %>
 
 ```

--- a/lib/sanbase_workers/import_github_activity.ex
+++ b/lib/sanbase_workers/import_github_activity.ex
@@ -136,7 +136,7 @@ defmodule SanbaseWorkers.ImportGithubActivity do
 
   defp reduce_to_counts(stream, orgs) do
     stream
-    |> Stream.map(&Poison.decode!/1)
+    |> Stream.map(&Jason.decode!/1)
     |> Stream.map(&get_repository_name/1)
     |> Stream.reject(&is_nil/1)
     |> Enum.reduce(%{}, fn repo, counts ->

--- a/mix.exs
+++ b/mix.exs
@@ -94,7 +94,8 @@ defmodule Sanbase.Mixfile do
       {:earmark, "~> 1.2"},
       {:ecto_enum, "~> 1.1"},
       {:ex_machina, "~> 2.2", only: :test},
-      {:clickhouse_ecto, git: "https://github.com/santiment/clickhouse_ecto"}
+      {:clickhouse_ecto, git: "https://github.com/santiment/clickhouse_ecto"},
+      {:jason, "~> 1.1"}
     ]
   end
 


### PR DESCRIPTION
#### Summary
Why? Because https://github.com/phoenixframework/phoenix/issues/2693#issuecomment-388881650

`Poison` is left as a decoder in a few places, because `Jason` does not support decoding into structs (the `:as` option)
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
