### PR TITLE
Fix editing san balance and exchange addresses

### DIFF
--- a/lib/sanbase_web/admin/auth/user.ex
+++ b/lib/sanbase_web/admin/auth/user.ex
@@ -29,11 +29,9 @@ defmodule Sanbase.ExAdmin.Auth.User do
     end
 
     form user do
-      if params[:id] do
-        inputs do
-          input(user, :test_san_balance)
-          input(user, :email)
-        end
+      inputs do
+        input(user, :test_san_balance)
+        input(user, :email)
       end
     end
   end

--- a/lib/sanbase_web/admin/model/exchange_eth_address.ex
+++ b/lib/sanbase_web/admin/model/exchange_eth_address.ex
@@ -6,33 +6,24 @@ defmodule Sanbase.ExAdmin.Model.ExchangeEthAddress do
 
   register_resource ExchangeEthAddress do
     form exchange_eth_address do
-      if params[:id] do
-        inputs do
-          input(exchange_eth_address, :address)
-          input(exchange_eth_address, :name)
-          input(exchange_eth_address, :source)
-          input(exchange_eth_address, :comments)
+      inputs do
+        content do
+          """
+          <div>
+          Paste CSV in the following format:
+          <ul>
+            <li>Format: <b>address*</b>,<b>name*</b>,<b>source</b>,<b>comments</b></li>
+            <li>Required: address, name</li>
+            <li>Column titles should be ommited</li>
+            <li>Example:
+              <pre>0x123f35fae36d75b1e72770e244f6595b68501234,Kyber,,\n0x1234465f45eac01389dbb3045206c1d07c123456,Another one,,</pre>
+            </li>
+          </ul>
+          </div>
+          """
         end
-      else
-        inputs do
-          content do
-            """
-            <div>
-            Paste CSV in the following format:
-            <ul>
-              <li>Format: <b>address*</b>,<b>name*</b>,<b>source</b>,<b>comments</b></li>
-              <li>Required: address, name</li>
-              <li>Column titles should be ommited</li>
-              <li>Example:
-                <pre>0x123f35fae36d75b1e72770e244f6595b68501234,Kyber,,\n0x1234465f45eac01389dbb3045206c1d07c123456,Another one,,</pre>
-              </li>
-            </ul>
-            </div>
-            """
-          end
 
-          input(exchange_eth_address, :csv, type: :text, label: "paste CSV")
-        end
+        input(exchange_eth_address, :csv, type: :text, label: "paste CSV")
       end
     end
 


### PR DESCRIPTION
elixir 1.7 breaks usage of `if params[:id]` to differentiate create and edit form in ex_admin.
It shows empty form.