### PR TITLE
Add combined vol mcap

### DIFF
--- a/lib/sanbase/influxdb/measurement.ex
+++ b/lib/sanbase/influxdb/measurement.ex
@@ -68,6 +68,9 @@ defmodule Sanbase.Influxdb.Measurement do
     end
   end
 
+  @doc ~s"""
+    convert a list of slugs to comma separated measurements string 
+  """
   def measurement_str_from_slugs(slugs) do
     measurements_list =
       slugs

--- a/lib/sanbase/influxdb/measurement.ex
+++ b/lib/sanbase/influxdb/measurement.ex
@@ -68,6 +68,19 @@ defmodule Sanbase.Influxdb.Measurement do
     end
   end
 
+  def measurement_str_from_slugs(slugs) do
+    measurements_list =
+      slugs
+      |> Enum.map(&Measurement.name_from_slug/1)
+      |> Enum.reject(&is_nil/1)
+
+    if Enum.count(measurements_list) > 0 do
+      {:ok, measurements_list |> Enum.join(", ")}
+    else
+      nil
+    end
+  end
+
   # Private functions
 
   defp format_timestamp(%DateTime{} = datetime) do

--- a/lib/sanbase_web/graphql/complexity/complexity.ex
+++ b/lib/sanbase_web/graphql/complexity/complexity.ex
@@ -14,9 +14,12 @@ defmodule SanbaseWeb.Graphql.Complexity do
   If the logged in user has no SAN tokens or they cannot be fetched, fallback
   to the default complexity calculation
   """
-  def from_to_interval(%{} = args, child_complexity, %Absinthe.Complexity{context: %{auth: %{current_user: user}}}) do
+  def from_to_interval(%{} = args, child_complexity, %Absinthe.Complexity{
+        context: %{auth: %{current_user: user}}
+      }) do
     with {:ok, san_balance} when not is_nil(san_balance) <- Sanbase.Auth.User.san_balance(user) do
       san_balance = Decimal.to_float(san_balance)
+
       if san_balance >= 1000 do
         0
       else

--- a/lib/sanbase_web/graphql/resolvers/price_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/price_resolver.ex
@@ -89,6 +89,25 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
     end
   end
 
+  def combined_volume_mcap(_root, %{slugs: slugs} = args, _context) do
+    with {:ok, measurement_str} <- Measurement.measurement_str_from_slugs(slugs),
+         {:ok, combined_volume, combined_mcap} <-
+           Sanbase.Prices.Store.fetch_combined_vol_mcap(
+             measurement_str,
+             args.from,
+             args.to
+           ) do
+      {:ok,
+       %{
+         volume: combined_volume,
+         marketcap: combined_mcap
+       }}
+    else
+      _ ->
+        {:error, "Can't fetch combined volume and marketcap for slugs: #{slugs}"}
+    end
+  end
+
   # Private functions
 
   defp total_market_history_price_on_load(loader, args) do

--- a/lib/sanbase_web/graphql/resolvers/price_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/price_resolver.ex
@@ -89,7 +89,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
     end
   end
 
-  def combined_volume_mcap(_root, %{slugs: slugs} = args, _context) do
+  def projects_group_stats(_root, %{slugs: slugs} = args, _context) do
     with {:ok, measurement_str} <- Measurement.measurement_str_from_slugs(slugs),
          {:ok, combined_volume, combined_mcap} <-
            Sanbase.Prices.Store.fetch_combined_vol_mcap(

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -170,6 +170,9 @@ defmodule SanbaseWeb.Graphql.Schema do
       cache_resolve(&PriceResolver.ohlc/3)
     end
 
+    @desc ~s"""
+    Fetch combined stats for a given list of project's slugs
+    """
     field :projects_group_stats, list_of(:group_stats) do
       arg(:slugs, non_null(list_of(:string)))
       arg(:from, non_null(:datetime))

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -170,12 +170,12 @@ defmodule SanbaseWeb.Graphql.Schema do
       cache_resolve(&PriceResolver.ohlc/3)
     end
 
-    field :combined_volume_mcap, list_of(:volume_mcap) do
+    field :projects_group_stats, list_of(:group_stats) do
       arg(:slugs, non_null(list_of(:string)))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
 
-      cache_resolve(&PriceResolver.combined_volume_mcap/3)
+      cache_resolve(&PriceResolver.projects_group_stats/3)
     end
 
     @desc "Returns a list of available github repositories."

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -170,6 +170,14 @@ defmodule SanbaseWeb.Graphql.Schema do
       cache_resolve(&PriceResolver.ohlc/3)
     end
 
+    field :combined_volume_mcap, list_of(:volume_mcap) do
+      arg(:slugs, non_null(list_of(:string)))
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+
+      resolve(&PriceResolver.combined_volume_mcap/3)
+    end
+
     @desc "Returns a list of available github repositories."
     field :github_availables_repos, list_of(:string) do
       cache_resolve(&GithubResolver.available_repos/3)

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -175,7 +175,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
 
-      resolve(&PriceResolver.combined_volume_mcap/3)
+      cache_resolve(&PriceResolver.combined_volume_mcap/3)
     end
 
     @desc "Returns a list of available github repositories."

--- a/lib/sanbase_web/graphql/schema/price_types.ex
+++ b/lib/sanbase_web/graphql/schema/price_types.ex
@@ -18,7 +18,7 @@ defmodule SanbaseWeb.Graphql.PriceTypes do
     field(:close_price_usd, :float)
   end
 
-  object :volume_mcap do
+  object :group_stats do
     field(:volume, :float)
     field(:marketcap, :float)
   end

--- a/lib/sanbase_web/graphql/schema/price_types.ex
+++ b/lib/sanbase_web/graphql/schema/price_types.ex
@@ -17,4 +17,9 @@ defmodule SanbaseWeb.Graphql.PriceTypes do
     field(:low_price_usd, :float)
     field(:close_price_usd, :float)
   end
+
+  object :volume_mcap do
+    field(:volume, :float)
+    field(:marketcap, :float)
+  end
 end


### PR DESCRIPTION
#### Summary
API endpoint : combined volume and mcap for a list of slugs
card: https://favro.com/organization/bdbb4f24afc48b29c74f4fa4/9ff267872fcd8b7925f1d7c7?card=San-2456

```graphql
{
  projectsGroupStats(
    slugs:["bitcoin", "ethereum", "santiment"],
    from:"2018-08-01 16:00:00Z",
    to:"2018-08-02 16:00:00Z"
  ) {
    volume,
    marketcap
  }
}
```

```graphql
{
  "data": {
    "projectsGroupStats": [
      {
        "marketcap": 98705005393020,
        "volume": 3598670966330
      }
    ]
  }
}
```