### PR TITLE
Add marketcap percent

### DIFF
--- a/lib/sanbase/influxdb/measurement.ex
+++ b/lib/sanbase/influxdb/measurement.ex
@@ -69,7 +69,7 @@ defmodule Sanbase.Influxdb.Measurement do
   end
 
   @doc ~s"""
-    convert a list of slugs to comma separated measurements string
+    convert a list of slugs to measurement-slug map
   """
   def measurement_slug_map_from(slugs) do
     measurement_slug_map =

--- a/lib/sanbase/influxdb/measurement.ex
+++ b/lib/sanbase/influxdb/measurement.ex
@@ -69,13 +69,13 @@ defmodule Sanbase.Influxdb.Measurement do
   end
 
   @doc ~s"""
-    convert a list of slugs to comma separated measurements string 
+    convert a list of slugs to comma separated measurements string
   """
   def measurement_slug_map_from(slugs) do
     measurement_slug_map =
       Project.tickers_by_slug_list(slugs)
-      |> Enum.map(fn [ticker, slug] -> [ticker <> "_" <> slug, slug] end)
-      |> Enum.reduce(%{}, fn [measurement, slug], acc -> Map.put(acc, measurement, slug) end)
+      |> Enum.map(fn {ticker, slug} -> {ticker <> "_" <> slug, slug} end)
+      |> Map.new()
 
     if Enum.count(Map.keys(measurement_slug_map)) > 0 do
       {:ok, measurement_slug_map}

--- a/lib/sanbase/influxdb/measurement.ex
+++ b/lib/sanbase/influxdb/measurement.ex
@@ -71,14 +71,14 @@ defmodule Sanbase.Influxdb.Measurement do
   @doc ~s"""
     convert a list of slugs to comma separated measurements string 
   """
-  def measurement_str_from_slugs(slugs) do
-    measurements_list =
-      slugs
-      |> Enum.map(&Measurement.name_from_slug/1)
-      |> Enum.reject(&is_nil/1)
+  def measurement_slug_map_from(slugs) do
+    measurement_slug_map =
+      Project.tickers_by_slug_list(slugs)
+      |> Enum.map(fn [ticker, slug] -> [ticker <> "_" <> slug, slug] end)
+      |> Enum.reduce(%{}, fn [measurement, slug], acc -> Map.put(acc, measurement, slug) end)
 
-    if Enum.count(measurements_list) > 0 do
-      {:ok, measurements_list |> Enum.join(", ")}
+    if Enum.count(Map.keys(measurement_slug_map)) > 0 do
+      {:ok, measurement_slug_map}
     else
       nil
     end

--- a/lib/sanbase/model/project.ex
+++ b/lib/sanbase/model/project.ex
@@ -416,7 +416,7 @@ defmodule Sanbase.Model.Project do
     from(
       p in Sanbase.Model.Project,
       where: p.coinmarketcap_id in ^slugs_list and not is_nil(p.ticker),
-      select: [p.ticker, p.coinmarketcap_id]
+      select: {p.ticker, p.coinmarketcap_id}
     )
     |> Sanbase.Repo.all()
   end

--- a/lib/sanbase/model/project.ex
+++ b/lib/sanbase/model/project.ex
@@ -412,6 +412,15 @@ defmodule Sanbase.Model.Project do
     |> Sanbase.Repo.one()
   end
 
+  def tickers_by_slug_list(slugs_list) when is_list(slugs_list) do
+    from(
+      p in Sanbase.Model.Project,
+      where: p.coinmarketcap_id in ^slugs_list and not is_nil(p.ticker),
+      select: [p.ticker, p.coinmarketcap_id]
+    )
+    |> Sanbase.Repo.all()
+  end
+
   def eth_addresses(%Project{} = project) do
     project =
       project

--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -190,6 +190,9 @@ defmodule Sanbase.Prices.Store do
       AND time <= #{DateTime.to_unix(to, :nanoseconds)}/
   end
 
+  defp combine_results_multiple_measurements(%{results: [%{error: error}]}, _),
+    do: {:error, error}
+
   defp combine_results_multiple_measurements(
          %{results: [%{series: series}]} = results,
          measurement_slug_map
@@ -207,4 +210,6 @@ defmodule Sanbase.Prices.Store do
 
     {:ok, combined_volume, combined_mcap, slug_marketcap_percent_map}
   end
+
+  defp combine_results_multiple_measurements(_, _), do: {:error, nil}
 end

--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -143,7 +143,7 @@ defmodule Sanbase.Prices.Store do
   end
 
   defp fetch_ohlc_query(measurement, from, to, interval) do
-    ~s/SELECT 
+    ~s/SELECT
      time,
      first(price_usd) as open,
      max(price_usd) as high,
@@ -204,7 +204,7 @@ defmodule Sanbase.Prices.Store do
     marketcap_values = values |> Enum.map(fn [[_, _, mcap]] -> mcap end)
 
     marketcap_percent =
-      marketcap_values |> Enum.map(fn mcap -> Float.round(mcap / combined_mcap, 2) end)
+      marketcap_values |> Enum.map(fn mcap -> Float.round(mcap / combined_mcap, 5) end)
 
     slug_marketcap_percent_map = Enum.zip(slugs, marketcap_percent) |> Enum.into(%{})
 

--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -116,10 +116,12 @@ defmodule Sanbase.Prices.Store do
     |> parse_time_series()
   end
 
-  def fetch_combined_vol_mcap(measurements_str, from, to) do
+  def fetch_combined_vol_mcap(measurement_slug_map, from, to) do
+    measurements_str = measurement_slug_map |> Map.keys() |> Enum.join(", ")
+
     fetch_combined_vol_mcap_query(measurements_str, from, to)
     |> Store.query()
-    |> combine_results_multiple_measurements()
+    |> combine_results_multiple_measurements(measurement_slug_map)
   end
 
   def all_with_data_after_datetime(datetime) do
@@ -182,13 +184,17 @@ defmodule Sanbase.Prices.Store do
 
   defp fetch_combined_vol_mcap_query(measurements_str, from, to) do
     ~s/
-      SELECT SUM(volume_usd) as volume_sum, SUM(marketcap_usd) as marketcap_sum
+      SELECT LAST(volume_usd), LAST(marketcap_usd)
       FROM #{measurements_str}
       WHERE time >= #{DateTime.to_unix(from, :nanoseconds)}
       AND time <= #{DateTime.to_unix(to, :nanoseconds)}/
   end
 
-  defp combine_results_multiple_measurements(%{results: [%{series: series}]}) do
+  defp combine_results_multiple_measurements(
+         %{results: [%{series: series}]} = results,
+         measurement_slug_map
+       ) do
+    slugs = series |> Enum.map(fn s -> measurement_slug_map[s.name] end)
     values = series |> Enum.map(& &1.values)
     combined_volume = values |> Enum.reduce(0, fn [[_, vol, _]], acc -> acc + vol end)
     combined_mcap = values |> Enum.reduce(0, fn [[_, _, mcap]], acc -> acc + mcap end)
@@ -197,6 +203,8 @@ defmodule Sanbase.Prices.Store do
     marketcap_percent =
       marketcap_values |> Enum.map(fn mcap -> Float.round(mcap / combined_mcap, 2) end)
 
-    {:ok, combined_volume, combined_mcap, marketcap_percent}
+    slug_marketcap_percent_map = Enum.zip(slugs, marketcap_percent) |> Enum.into(%{})
+
+    {:ok, combined_volume, combined_mcap, slug_marketcap_percent_map}
   end
 end

--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -192,6 +192,11 @@ defmodule Sanbase.Prices.Store do
     values = series |> Enum.map(& &1.values)
     combined_volume = values |> Enum.reduce(0, fn [[_, vol, _]], acc -> acc + vol end)
     combined_mcap = values |> Enum.reduce(0, fn [[_, _, mcap]], acc -> acc + mcap end)
-    {:ok, combined_volume, combined_mcap}
+    marketcap_values = values |> Enum.map(fn [[_, _, mcap]] -> mcap end)
+
+    marketcap_percent =
+      marketcap_values |> Enum.map(fn mcap -> Float.round(mcap / combined_mcap, 2) end)
+
+    {:ok, combined_volume, combined_mcap, marketcap_percent}
   end
 end

--- a/lib/sanbase_web/graphql/resolvers/price_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/price_resolver.ex
@@ -106,7 +106,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
        }}
     else
       _ ->
-        {:error, "Can't fetch combined volume and marketcap for slugs: #{slugs}"}
+        {:error, "Can't fetch combined volume and marketcap for slugs"}
     end
   end
 

--- a/lib/sanbase_web/graphql/resolvers/price_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/price_resolver.ex
@@ -91,7 +91,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
 
   def projects_group_stats(_root, %{slugs: slugs} = args, _context) do
     with {:ok, measurement_str} <- Measurement.measurement_str_from_slugs(slugs),
-         {:ok, combined_volume, combined_mcap} <-
+         {:ok, combined_volume, combined_mcap, marketcap_percent} <-
            Sanbase.Prices.Store.fetch_combined_vol_mcap(
              measurement_str,
              args.from,
@@ -100,7 +100,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
       {:ok,
        %{
          volume: combined_volume,
-         marketcap: combined_mcap
+         marketcap: combined_mcap,
+         marketcap_percent: marketcap_percent
        }}
     else
       _ ->

--- a/lib/sanbase_web/graphql/resolvers/price_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/price_resolver.ex
@@ -90,10 +90,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
   end
 
   def projects_group_stats(_root, %{slugs: slugs} = args, _context) do
-    with {:ok, measurement_str} <- Measurement.measurement_str_from_slugs(slugs),
-         {:ok, combined_volume, combined_mcap, marketcap_percent} <-
+    with {:ok, measurement_slug_map} <- Measurement.measurement_slug_map_from(slugs),
+         {:ok, combined_volume, combined_mcap, slug_marketcap_percent_map} <-
            Sanbase.Prices.Store.fetch_combined_vol_mcap(
-             measurement_str,
+             measurement_slug_map,
              args.from,
              args.to
            ) do
@@ -101,7 +101,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
        %{
          volume: combined_volume,
          marketcap: combined_mcap,
-         marketcap_percent: marketcap_percent
+         marketcap_percent:
+           slug_marketcap_percent_map |> Enum.map(fn {k, v} -> %{slug: k, percent: v} end)
        }}
     else
       _ ->

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -178,7 +178,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
 
-      cache_resolve(&PriceResolver.projects_group_stats/3)
+      resolve(&PriceResolver.projects_group_stats/3)
     end
 
     @desc "Returns a list of available github repositories."

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -178,7 +178,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
 
-      resolve(&PriceResolver.projects_group_stats/3)
+      cache_resolve(&PriceResolver.projects_group_stats/3)
     end
 
     @desc "Returns a list of available github repositories."

--- a/lib/sanbase_web/graphql/schema/price_types.ex
+++ b/lib/sanbase_web/graphql/schema/price_types.ex
@@ -21,6 +21,11 @@ defmodule SanbaseWeb.Graphql.PriceTypes do
   object :group_stats do
     field(:volume, :float)
     field(:marketcap, :float)
-    field(:marketcap_percent, list_of(:float))
+    field(:marketcap_percent, list_of(:slug_mcap))
+  end
+
+  object :slug_mcap do
+    field(:slug, :string)
+    field(:percent, :float)
   end
 end

--- a/lib/sanbase_web/graphql/schema/price_types.ex
+++ b/lib/sanbase_web/graphql/schema/price_types.ex
@@ -21,5 +21,6 @@ defmodule SanbaseWeb.Graphql.PriceTypes do
   object :group_stats do
     field(:volume, :float)
     field(:marketcap, :float)
+    field(:marketcap_percent, list_of(:float))
   end
 end


### PR DESCRIPTION
#### Summary
<!-- (What does this pull request do in general terms?) -->
```graphql
{
  projectsGroupStats(
    slugs:["bitcoin", "ethereum", "eos", "santiment"],
    from:"2018-10-20 00:00:00Z",
    to:"2018-10-20 23:59:59Z"
  ) {
    volume,
    marketcap,
    marketcapPercent {
      slug,
      percent
    }
  }
}

```

```graphql
{
  "data": {
    "projectsGroupStats": [
      {
        "marketcap": 138470814824,
        "marketcapPercent": [
          {
            "percent": 0.81228,
            "slug": "bitcoin"
          },
          {
            "percent": 0.03516,
            "slug": "eos"
          },
          {
            "percent": 0.15236,
            "slug": "ethereum"
          },
          {
            "percent": 0.00021,
            "slug": "santiment"
          }
        ],
        "volume": 4984290677
      }
    ]
  }
}
```