### PR TITLE
Add discord_channels_count to ES stats

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -69,7 +69,7 @@ config :arc,
 
 config :sanbase, Sanbase.Elasticsearch.Cluster, api: Sanbase.ElasticsearchMock
 
-config :sanbase, Sanbase.Elasticsearch, indices: "index1,index2,index3"
+config :sanbase, Sanbase.Elasticsearch, indices: "index1,index2,index3,index4"
 
 if File.exists?("config/test.secret.exs") do
   import_config "test.secret.exs"

--- a/lib/sanbase/elasticsearch/elasticsearch.ex
+++ b/lib/sanbase/elasticsearch/elasticsearch.ex
@@ -8,6 +8,7 @@ defmodule Sanbase.Elasticsearch do
           size_in_megabytes: non_neg_integer,
           telegram_channels_count: non_neg_integer,
           subreddits_count: non_neg_integer,
+          discord_channels_count: non_neg_integer,
           average_documents_per_day: non_neg_integer
         }
 
@@ -35,6 +36,7 @@ defmodule Sanbase.Elasticsearch do
       size_in_megabytes: size_in_megabytes,
       telegram_channels_count: telegram_channels_count(from, to),
       subreddits_count: subreddits_count(from, to),
+      discord_channels_count: discord_channels_count(from, to),
       average_documents_per_day: (documents_count / days_difference) |> Math.to_integer()
     }
   end
@@ -74,6 +76,18 @@ defmodule Sanbase.Elasticsearch do
       )
 
     %{"aggregations" => %{"subreddits" => %{"buckets" => buckets}}} = data
+    Enum.count(buckets)
+  end
+
+  defp discord_channels_count(from, to) do
+    {:ok, data} =
+      Elasticsearch.post(
+        Cluster,
+        "/discord/_search",
+        Sanbase.Elasticsearch.Query.discord_channels_count(from, to)
+      )
+
+    %{"aggregations" => %{"channel_names" => %{"buckets" => buckets}}} = data
     Enum.count(buckets)
   end
 end

--- a/lib/sanbase/elasticsearch/elasticsearch_api_mock.ex
+++ b/lib/sanbase/elasticsearch/elasticsearch_api_mock.ex
@@ -2,7 +2,7 @@ defmodule Sanbase.ElasticsearchMock do
   @behaviour Elasticsearch.API
 
   @impl true
-  def request(_config, :get, "/index1,index2,index3/_stats", _data, _opts) do
+  def request(_config, :get, "/index1,index2,index3,index4/_stats", _data, _opts) do
     {:ok,
      %HTTPoison.Response{
        status_code: 200,
@@ -11,7 +11,7 @@ defmodule Sanbase.ElasticsearchMock do
   end
 
   @impl true
-  def request(_config, :post, "/index1,index2,index3/_search", _data, _opts) do
+  def request(_config, :post, "/index1,index2,index3,index4/_search", _data, _opts) do
     {:ok,
      %HTTPoison.Response{
        status_code: 200,
@@ -38,6 +38,16 @@ defmodule Sanbase.ElasticsearchMock do
        body: %{
          "aggregations" => %{"subreddits" => %{"buckets" => [2, 4, 5, 6, 7, 8, 9, 0, 12, 2]}}
        }
+     }}
+  end
+
+  @impl true
+  def request(_config, :post, "/discord/_search", _data, _opts) do
+    # Buckets must be an Enumerable
+    {:ok,
+     %HTTPoison.Response{
+       status_code: 200,
+       body: %{"aggregations" => %{"channel_names" => %{"buckets" => [1, 2, 3, 4, 5, 6]}}}
      }}
   end
 end

--- a/lib/sanbase/elasticsearch/query.ex
+++ b/lib/sanbase/elasticsearch/query.ex
@@ -67,6 +67,40 @@ defmodule Sanbase.Elasticsearch.Query do
     """
   end
 
+  def discord_channels_count(from, to) do
+    from_unix = DateTime.to_unix(from, :millisecond)
+    to_unix = DateTime.to_unix(to, :millisecond)
+
+    ~s"""
+    {
+      "size": 0,
+      "aggs": {
+        "channel_names": {
+          "terms": {
+            "field": "channel_name.keyword",
+            "size": 999999
+          }
+        }
+      },
+      "query": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "timestamp": {
+                  "gte": #{from_unix},
+                  "lte": #{to_unix},
+                  "format": "epoch_millis"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+    """
+  end
+
   def documents_count_in_interval(from, to) do
     from_unix = DateTime.to_unix(from, :millisecond)
     to_unix = DateTime.to_unix(to, :millisecond)

--- a/lib/sanbase_web/graphql/schema/elasticsearch_types.ex
+++ b/lib/sanbase_web/graphql/schema/elasticsearch_types.ex
@@ -6,6 +6,7 @@ defmodule SanbaseWeb.Graphql.ElasticsearchTypes do
     field(:size_in_megabytes, non_null(:integer))
     field(:telegram_channels_count, non_null(:integer))
     field(:subreddits_count, non_null(:integer))
+    field(:discord_channels_count, non_null(:integer))
     field(:average_documents_per_day, non_null(:integer))
   end
 end

--- a/test/sanbase_web/graphql/elasticsearch/elasticsearch_stats_test.exs
+++ b/test/sanbase_web/graphql/elasticsearch/elasticsearch_stats_test.exs
@@ -15,6 +15,7 @@ defmodule SanbaseWeb.Graphql.ElasticsearchResolverTest do
                  "documentsCount" => 1_000_000,
                  "sizeInMegabytes" => 5,
                  "subredditsCount" => 10,
+                 "discordChannelsCount" => 6,
                  "telegramChannelsCount" => 5
                }
              }
@@ -31,6 +32,7 @@ defmodule SanbaseWeb.Graphql.ElasticsearchResolverTest do
           averageDocumentsPerDay
           telegramChannelsCount
           subredditsCount
+          discordChannelsCount
           sizeInMegabytes
       }
     }


### PR DESCRIPTION
#### Summary
<!-- (What does this pull request do in general terms?) -->
Adds stats for discord channels count to the elasticsearchStats GQL
endpoint.


[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
