### PR TITLE
Fill githubactivity gaps with zeros

### DIFF
--- a/lib/sanbase/github/store.ex
+++ b/lib/sanbase/github/store.ex
@@ -57,7 +57,7 @@ defmodule Sanbase.Github.Store do
     FROM "#{ticker}"
     WHERE time >= #{DateTime.to_unix(from, :nanoseconds)}
     AND time <= #{DateTime.to_unix(to, :nanoseconds)}
-    GROUP BY time(#{resolution}) fill(none)/
+    GROUP BY time(#{resolution}) fill(0)/
   end
 
   defp parse_activity_series!(result) do


### PR DESCRIPTION
don't skip these with 0:

```
{
  "data": {
    "query_3": [
      {
        "activity": 14,
        "datetime": "2018-04-20T00:00:00Z"
      },
      {
        "activity": 11,
        "datetime": "2018-04-21T00:00:00Z"
      },
      {
        "activity": 0,
        "datetime": "2018-04-22T00:00:00Z"
      },
      {
        "activity": 33,
        "datetime": "2018-04-23T00:00:00Z"
      },
      {
        "activity": 35,
        "datetime": "2018-04-24T00:00:00Z"
      },
      {
        "activity": 5,
        "datetime": "2018-04-25T00:00:00Z"
      }
    ]
  }
}
```