### PR TITLE
Increase timescale timeout

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,6 +22,7 @@ config :sanbase, Sanbase.Repo,
 
 config :sanbase, Sanbase.TimescaleRepo,
   adapter: Ecto.Adapters.Postgres,
+  timeout: 30_000,
   pool_size: {:system, "TIMESCALE_POOL_SIZE", "30"},
   # because of pgbouncer
   prepare: :unnamed


### PR DESCRIPTION
Increase Timescale Repo postgres adapter timeout to 30 seconds. We have queries for bigger intervals that sometimes take more than 15 secs