### PR TITLE
Fix projects stats query

### DIFF
--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -194,21 +194,21 @@ defmodule Sanbase.Prices.Store do
     do: {:error, error}
 
   defp combine_results_multiple_measurements(
-         %{results: [%{series: series}]} = results,
+         %{results: [%{series: series}]},
          measurement_slug_map
        ) do
     slugs = series |> Enum.map(fn s -> measurement_slug_map[s.name] end)
     values = series |> Enum.map(& &1.values)
-    combined_volume = values |> Enum.reduce(0, fn [[_, vol, _]], acc -> acc + vol end)
+    volume_values = values |> Enum.map(fn [[_, vol, _]] -> vol end)
     combined_mcap = values |> Enum.reduce(0, fn [[_, _, mcap]], acc -> acc + mcap end)
     marketcap_values = values |> Enum.map(fn [[_, _, mcap]] -> mcap end)
 
     marketcap_percent =
       marketcap_values |> Enum.map(fn mcap -> Float.round(mcap / combined_mcap, 5) end)
 
-    slug_marketcap_percent = Enum.zip([slugs, marketcap_values, marketcap_percent])
+    result = Enum.zip([slugs, volume_values, marketcap_values, marketcap_percent])
 
-    {:ok, combined_volume, slug_marketcap_percent}
+    {:ok, result}
   end
 
   defp combine_results_multiple_measurements(_, _), do: {:error, nil}

--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -206,9 +206,9 @@ defmodule Sanbase.Prices.Store do
     marketcap_percent =
       marketcap_values |> Enum.map(fn mcap -> Float.round(mcap / combined_mcap, 5) end)
 
-    slug_marketcap_percent_map = Enum.zip(slugs, marketcap_percent) |> Enum.into(%{})
+    slug_marketcap_percent = Enum.zip([slugs, marketcap_values, marketcap_percent])
 
-    {:ok, combined_volume, combined_mcap, slug_marketcap_percent_map}
+    {:ok, combined_volume, slug_marketcap_percent}
   end
 
   defp combine_results_multiple_measurements(_, _), do: {:error, nil}

--- a/lib/sanbase_web/graphql/resolvers/price_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/price_resolver.ex
@@ -89,23 +89,20 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
     end
   end
 
-  def projects_group_stats(_root, %{slugs: slugs} = args, _context) do
+  def projects_list_stats(_root, %{slugs: slugs} = args, _context) do
     with {:ok, measurement_slug_map} <- Measurement.measurement_slug_map_from(slugs),
-         {:ok, combined_volume, slug_marketcap_percent} <-
+         {:ok, values} <-
            Sanbase.Prices.Store.fetch_combined_vol_mcap(
              measurement_slug_map,
              args.from,
              args.to
            ) do
       {:ok,
-       %{
-         volume: combined_volume,
-         marketcap:
-           slug_marketcap_percent
-           |> Enum.map(fn
-             {slug, mcap, percent} -> %{slug: slug, marketcap: mcap, percent: percent}
-           end)
-       }}
+       values
+       |> Enum.map(fn
+         {slug, volume, mcap, percent} ->
+           %{slug: slug, volume: volume, marketcap: mcap, marketcap_percent: percent}
+       end)}
     else
       _ ->
         {:error, "Can't fetch combined volume and marketcap for slugs"}

--- a/lib/sanbase_web/graphql/resolvers/price_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/price_resolver.ex
@@ -91,7 +91,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
 
   def projects_group_stats(_root, %{slugs: slugs} = args, _context) do
     with {:ok, measurement_slug_map} <- Measurement.measurement_slug_map_from(slugs),
-         {:ok, combined_volume, combined_mcap, slug_marketcap_percent_map} <-
+         {:ok, combined_volume, slug_marketcap_percent} <-
            Sanbase.Prices.Store.fetch_combined_vol_mcap(
              measurement_slug_map,
              args.from,
@@ -100,9 +100,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
       {:ok,
        %{
          volume: combined_volume,
-         marketcap: combined_mcap,
-         marketcap_percent:
-           slug_marketcap_percent_map |> Enum.map(fn {k, v} -> %{slug: k, percent: v} end)
+         marketcap:
+           slug_marketcap_percent
+           |> Enum.map(fn
+             {slug, mcap, percent} -> %{slug: slug, marketcap: mcap, percent: percent}
+           end)
        }}
     else
       _ ->

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -173,12 +173,12 @@ defmodule SanbaseWeb.Graphql.Schema do
     @desc ~s"""
     Fetch combined stats for a given list of project's slugs
     """
-    field :projects_group_stats, list_of(:group_stats) do
+    field :projects_list_stats, list_of(:project_stats) do
       arg(:slugs, non_null(list_of(:string)))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
 
-      cache_resolve(&PriceResolver.projects_group_stats/3)
+      cache_resolve(&PriceResolver.projects_list_stats/3)
     end
 
     @desc "Returns a list of available github repositories."

--- a/lib/sanbase_web/graphql/schema/price_types.ex
+++ b/lib/sanbase_web/graphql/schema/price_types.ex
@@ -18,14 +18,10 @@ defmodule SanbaseWeb.Graphql.PriceTypes do
     field(:close_price_usd, :float)
   end
 
-  object :group_stats do
-    field(:volume, :float)
-    field(:marketcap, list_of(:slug_mcap))
-  end
-
-  object :slug_mcap do
+  object :project_stats do
     field(:slug, :string)
+    field(:volume, :float)
     field(:marketcap, :float)
-    field(:percent, :float)
+    field(:marketcap_percent, :float)
   end
 end

--- a/lib/sanbase_web/graphql/schema/price_types.ex
+++ b/lib/sanbase_web/graphql/schema/price_types.ex
@@ -20,12 +20,12 @@ defmodule SanbaseWeb.Graphql.PriceTypes do
 
   object :group_stats do
     field(:volume, :float)
-    field(:marketcap, :float)
-    field(:marketcap_percent, list_of(:slug_mcap))
+    field(:marketcap, list_of(:slug_mcap))
   end
 
   object :slug_mcap do
     field(:slug, :string)
+    field(:marketcap, :float)
     field(:percent, :float)
   end
 end

--- a/test/sanbase_web/graphql/prices_api_test.exs
+++ b/test/sanbase_web/graphql/prices_api_test.exs
@@ -333,30 +333,27 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
   test "project group stats with existing slugs returns correct stats", context do
     slugs = [context.slug1, context.slug2]
     query = project_group_stats_query(slugs, context.datetime1, context.datetime3)
-    result = execute_query(context.conn, query, "projectsGroupStats")
+    result = execute_query(context.conn, query, "projectsListStats")
 
     assert [
              %{
-               "volume" => 305,
-               "marketcap" => [
-                 %{
-                   "marketcap" => 800,
-                   "percent" => Float.round(800 / 1300, 5),
-                   "slug" => context.slug1
-                 },
-                 %{
-                   "marketcap" => 500,
-                   "percent" => Float.round(500 / 1300, 5),
-                   "slug" => context.slug2
-                 }
-               ]
+               "volume" => 300,
+               "marketcap" => 800,
+               "marketcapPercent" => Float.round(800 / 1300, 5),
+               "slug" => context.slug1
+             },
+             %{
+               "volume" => 5,
+               "marketcap" => 500,
+               "marketcapPercent" => Float.round(500 / 1300, 5),
+               "slug" => context.slug2
              }
            ] == result
   end
 
   test "project group stats with non existing slugs return no data", context do
     query = project_group_stats_query(["non-existing"], context.datetime1, context.datetime3)
-    result = execute_query(context.conn, query, "projectsGroupStats")
+    result = execute_query(context.conn, query, "projectsListStats")
     assert result == nil
   end
 
@@ -368,14 +365,14 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
         context.datetime3
       )
 
-    result = execute_query(context.conn, query, "projectsGroupStats")
+    result = execute_query(context.conn, query, "projectsListStats")
 
     assert [
              %{
                "volume" => 300,
-               "marketcap" => [
-                 %{"marketcap" => 800, "percent" => 1.0000, "slug" => context.slug1}
-               ]
+               "marketcap" => 800,
+               "marketcapPercent" => 1.0000,
+               "slug" => context.slug1
              }
            ] == result
   end
@@ -393,17 +390,15 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
 
     """
     {
-      projectsGroupStats(
+      projectsListStats(
         slugs: [#{slugs_str}],
         from: "#{from}",
         to: "#{to}"
       ) {
         volume,
-        marketcap {
-          marketcap,
-          slug,
-          percent
-        }
+        marketcap,
+        slug,
+        marketcapPercent
       }
     }
     """

--- a/test/sanbase_web/graphql/prices_api_test.exs
+++ b/test/sanbase_web/graphql/prices_api_test.exs
@@ -337,11 +337,18 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
 
     assert [
              %{
-               "marketcap" => 1300,
                "volume" => 305,
-               "marketcapPercent" => [
-                 %{"percent" => Float.round(800 / 1300, 5), "slug" => context.slug1},
-                 %{"percent" => Float.round(500 / 1300, 5), "slug" => context.slug2}
+               "marketcap" => [
+                 %{
+                   "marketcap" => 800,
+                   "percent" => Float.round(800 / 1300, 5),
+                   "slug" => context.slug1
+                 },
+                 %{
+                   "marketcap" => 500,
+                   "percent" => Float.round(500 / 1300, 5),
+                   "slug" => context.slug2
+                 }
                ]
              }
            ] == result
@@ -365,10 +372,9 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
 
     assert [
              %{
-               "marketcap" => 800,
                "volume" => 300,
-               "marketcapPercent" => [
-                 %{"percent" => 1.0000, "slug" => context.slug1}
+               "marketcap" => [
+                 %{"marketcap" => 800, "percent" => 1.0000, "slug" => context.slug1}
                ]
              }
            ] == result
@@ -393,8 +399,8 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
         to: "#{to}"
       ) {
         volume,
-        marketcap,
-        marketcapPercent {
+        marketcap {
+          marketcap,
           slug,
           percent
         }


### PR DESCRIPTION
#### Summary
```graphql
{
  projectsListStats(
    slugs:["bitcoin", "ethereum", "eos", "santiment"],
    from:"2018-10-20 00:00:00Z",
    to:"2018-10-20 23:59:59Z"
  ) {
    slug,
    volume,
    marketcap,
    marketcapPercent
  }
}
```

```graphql
{
  "data": {
    "projectsListStats": [
      {
        "marketcap": 112476559221,
        "marketcapPercent": 0.81228,
        "slug": "bitcoin",
        "volume": 3379130000
      },
      {
        "marketcap": 4868702207,
        "marketcapPercent": 0.03516,
        "slug": "eos",
        "volume": 366171000
      },
      {
        "marketcap": 21097037288,
        "marketcapPercent": 0.15236,
        "slug": "ethereum",
        "volume": 1238780000
      },
      {
        "marketcap": 28516108,
        "marketcapPercent": 0.00021,
        "slug": "santiment",
        "volume": 209677
      }
    ]
  }
}
```