### PR TITLE
Update poolboy max overflow for TimescaleRepo

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -17,6 +17,7 @@ config :sanbase, Sanbase.ClickhouseRepo, adapter: Ecto.Adapters.Postgres
 config :sanbase, Sanbase.Repo,
   adapter: Ecto.Adapters.Postgres,
   pool_size: {:system, "SANBASE_POOL_SIZE", "20"},
+  max_overflow: 5,
   # because of pgbouncer
   prepare: :unnamed
 
@@ -24,6 +25,7 @@ config :sanbase, Sanbase.TimescaleRepo,
   adapter: Ecto.Adapters.Postgres,
   timeout: 30_000,
   pool_size: {:system, "TIMESCALE_POOL_SIZE", "30"},
+  max_overflow: 5,
   # because of pgbouncer
   prepare: :unnamed
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -27,7 +27,8 @@ config :sanbase, Sanbase.ClickhouseRepo,
   password: "",
   pool_timeout: 60_000,
   timeout: 60_000,
-  pool_size: {:system, "CLICKHOUSE_POOL_SIZE", "30"}
+  pool_size: {:system, "CLICKHOUSE_POOL_SIZE", "30"},
+  max_overflow: 5
 
 # Do not print debug messages in production
 config :logger, level: :info


### PR DESCRIPTION
Update poolboy max_overflow to 5, so apps can run without predefined pool of connections