### PR TITLE
Switch the release elixir image to non-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,9 @@ RUN mix phx.digest
 RUN mix release
 
 # Release image
-FROM elixir:1.7.4-alpine
+FROM elixir:1.7.4
 
-RUN apk add --update bash
+RUN apt-get install -y --only-upgrade bash
 
 WORKDIR /app
 


### PR DESCRIPTION
#### Summary
The deployment fails with `Unusable Erlang runtime system! This is likely due to being compiled for another system than the host is running`
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->