### PR TITLE
Add GraphQL prometheus metrics

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -42,6 +42,7 @@ config :sanbase, SanbaseWeb.Endpoint,
 # configured to run both http and https servers on
 # different ports.
 
+config :logger, level: :debug
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"
 

--- a/lib/sanbase/web_supervisor.ex
+++ b/lib/sanbase/web_supervisor.ex
@@ -3,7 +3,8 @@ defmodule Sanbase.Application.WebSupervisor do
 
   def init() do
     # API metrics
-    SanbaseWeb.Graphql.Prometheus.Instrumenter.install(SanbaseWeb.Graphql.Schema)
+    SanbaseWeb.Graphql.Prometheus.HistogramInstrumenter.install(SanbaseWeb.Graphql.Schema)
+    SanbaseWeb.Graphql.Prometheus.CounterInstrumenter.install(SanbaseWeb.Graphql.Schema)
   end
 
   @doc ~s"""

--- a/lib/sanbase_web/graphql/prometheus/backends/counter_backend.ex
+++ b/lib/sanbase_web/graphql/prometheus/backends/counter_backend.ex
@@ -1,0 +1,37 @@
+if Code.ensure_loaded?(Prometheus) do
+  defmodule SanbaseWeb.Graphql.Prometheus.CounterBackend do
+    @behaviour AbsintheMetrics
+    use Prometheus
+
+    @query_metric_name :graphql_query_total_calls
+    @field_metric_name :graphql_query_field_total_calls
+
+    def field(object, field, args \\ [])
+
+    def field(:query, _field, _args) do
+      _ =
+        Counter.declare(
+          name: @query_metric_name,
+          help: "Total calls for a GraphQL API query",
+          labels: [:status, :query]
+        )
+    end
+
+    def field(_object, _field, _args) do
+      _ =
+        Counter.declare(
+          name: @field_metric_name,
+          help: "Total calls for a GraphQL API field",
+          labels: [:object, :field, :status]
+        )
+    end
+
+    def instrument(:query, query, {status, _}, _time) do
+      Counter.inc(name: @query_metric_name, labels: [status, query])
+    end
+
+    def instrument(object, field, {status, _}, _time) do
+      Counter.inc(name: @field_metric_name, labels: [object, field, status])
+    end
+  end
+end

--- a/lib/sanbase_web/graphql/prometheus/counter_instrumenter.ex
+++ b/lib/sanbase_web/graphql/prometheus/counter_instrumenter.ex
@@ -1,0 +1,4 @@
+defmodule SanbaseWeb.Graphql.Prometheus.CounterInstrumenter do
+  use AbsintheMetrics,
+    adapter: SanbaseWeb.Graphql.Prometheus.CounterBackend
+end

--- a/lib/sanbase_web/graphql/prometheus/histogram_instrumenter.ex
+++ b/lib/sanbase_web/graphql/prometheus/histogram_instrumenter.ex
@@ -1,0 +1,5 @@
+defmodule SanbaseWeb.Graphql.Prometheus.HistogramInstrumenter do
+  use AbsintheMetrics,
+    adapter: AbsintheMetrics.Backend.PrometheusHistogram,
+    arguments: [buckets: {:exponential, 250, 1.5, 7}]
+end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -72,7 +72,8 @@ defmodule SanbaseWeb.Graphql.Schema do
   end
 
   def middleware(middlewares, field, object) do
-    SanbaseWeb.Graphql.Prometheus.Instrumenter.instrument(middlewares, field, object)
+    SanbaseWeb.Graphql.Prometheus.HistogramInstrumenter.instrument(middlewares, field, object)
+    |> SanbaseWeb.Graphql.Prometheus.CounterInstrumenter.instrument(field, object)
   end
 
   query do


### PR DESCRIPTION
#### Summary
The default counter provided in the absinthe-metrics exports each metric with a different name instead of one name with different labels, which makes it much harder to display in Grafana in one dashboard. This backend exports metrics in the following format:
```
graphql_query_total_calls{status="ok",query="all_projects"} 2
graphql_fields_field_total_calls{object="project",field="description",status="ok"} 74
graphql_fields_field_total_calls{object="project",field="id",status="ok"} 74
```
Note that for a list of projects a current field is called one time per field. We need to test if this will cause performance issues.

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
