### PR TITLE
feature/scss-responsive-mixin

### DIFF
--- a/app/src/App.scss
+++ b/app/src/App.scss
@@ -1,10 +1,14 @@
 @import 'variables.scss';
+@import 'mixins.scss';
 @import '~nprogress/nprogress';
 
 .App {
   height: 100%;
   display: flex;
   flex-direction: column;
+  @include responsive('desktop') {
+    background: red;
+  }
 }
 
 .App .page {

--- a/app/src/App.scss
+++ b/app/src/App.scss
@@ -1,14 +1,10 @@
 @import 'variables.scss';
-@import 'mixins.scss';
 @import '~nprogress/nprogress';
 
 .App {
   height: 100%;
   display: flex;
   flex-direction: column;
-  @include responsive('desktop') {
-    background: red;
-  }
 }
 
 .App .page {

--- a/app/src/mixins.scss
+++ b/app/src/mixins.scss
@@ -1,3 +1,42 @@
 @mixin border-box {
   box-sizing: border-box;
 }
+
+// Most common screen sizes
+// https://uiux.cc/blog/the-most-used-responsive-breakpoints-in-2017-of-mine/
+$desktopMinWidth: 1200px;
+$laptopMinWidth: 992px;
+$tabletMinWidth: 768px;
+$phoneMinWidth: 480px;
+
+@mixin responsive($device) {
+  @if $device == 'desktop' {
+    @media only screen and (min-width: $desktopMinWidth) {
+      @content;
+    }
+  }
+
+  @if $device == 'laptop' {
+    @media only screen and (min-width: $laptopMinWidth) and (max-width: ($desktopMinWidth - 1px)) {
+      @content;
+    }
+  }
+
+  @if $device == 'tablet' {
+    @media only screen and (min-width: $tabletMinWidth) and (max-width: ($laptopMinWidth - 1px)) {
+      @content;
+    }
+  }
+
+  @if $device == 'phone' {
+    @media only screen and (min-width: $phoneMinWidth) and (max-width: ($tabletMinWidth - 1px)) {
+      @content;
+    }
+  }
+
+  @if $device == 'phone-xs' {
+    @media only screen and (max-width: ($phoneMinWidth - 1px)) {
+      @content;
+    }
+  }
+}


### PR DESCRIPTION
#### Summary
This PR will give us an ability to quickly integrate and modify the responsive design. This can be achieved by setting up an appropriate media screen breakpoints and using SASS mixin function. 

## How to use it?
All we have to do is to include mixin inside styles block and specify a target device as an argument.
```scss
.App {
  height: 100%;
  @include responsive('desktop') {
    background: red;
  }
}
```
Inside `@include` mixin body, we have to provide styles which will be applied to this selector via media query.

## Benefits
- Reduced source code size;
- Explicit style targets (`desktop`, `tablet`, etc);
- Adjustable breakpoints and targets;
- After css optimization, multiple similar media queries will be grouped into a single one.

### SASS syntax comparison
In SASS syntax this procedure will look like this ->
```sass
.App
  height: 100%
  +responsive('desktop')
    background: red

```
[//]: # (#### Screenshots)
<!-- (if appropriate) -->

