### PR TITLE
enhance/totalmarket-widget

### DIFF
--- a/app/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
+++ b/app/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import cx from 'classnames'
 import { ResponsiveContainer, AreaChart, Area, XAxis } from 'recharts'
+import PercentChanges from '../PercentChanges'
 import Widget from '../Widget/Widget'
 import {
   getTop3Area,
@@ -56,6 +57,7 @@ class TotalMarketcapWidget extends Component {
     let {
       totalmarketCapPrice = '.',
       volumeAmplitudePrice = '.',
+      volume24PercentChange,
       marketcapDataset = []
     } = generateWidgetData(
       TOTAL_LIST_MARKET && isListView ? TOTAL_LIST_MARKET : TOTAL_MARKET
@@ -95,7 +97,14 @@ class TotalMarketcapWidget extends Component {
             <h4 className={valueClassNames}>{totalmarketCapPrice}</h4>
           </div>
           <div className='TotalMarketcapWidget__right'>
-            <h3 className='TotalMarketcapWidget__label'>Vol 24 hr</h3>
+            <h3 className='TotalMarketcapWidget__label'>
+              Vol 24 hr (
+              <PercentChanges
+                changes={volume24PercentChange}
+                className='TotalMarketcapWidget__change'
+              />
+              )
+            </h3>
             <h4 className={valueClassNames}>{volumeAmplitudePrice}</h4>
           </div>
         </div>

--- a/app/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
+++ b/app/src/components/TotalMarketcapWidget/TotalMarketcapWidget.js
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { Component } from 'react'
+import cx from 'classnames'
 import { ResponsiveContainer, AreaChart, Area, XAxis } from 'recharts'
 import Widget from '../Widget/Widget'
 import { formatNumber } from '../../utils/formatting'
@@ -102,58 +103,126 @@ const getTop3Area = restProjects => {
   })
 }
 
-const TotalMarketcapWidget = ({
-  historyPrices: { TOTAL_MARKET, ...restProjects },
-  loading
-}) => {
-  let {
-    totalmarketCapPrice = '.',
-    volumeAmplitudePrice = '.',
-    marketcapDataset = []
-  } = generateWidgetData(TOTAL_MARKET)
+const WidgetMarketView = {
+  DETAILED: 'Detailed',
+  GLOBAL: 'Global'
+}
 
-  let restAreas = null
+const MarketView = ({ currentView, handleViewSelect }) => (
+  <>
+    View:{' '}
+    {Object.values(WidgetMarketView).map(view => (
+      <button
+        key={view}
+        className={cx({
+          'TotalMarketcapWidget__view-btn': true,
+          active: currentView === view
+        })}
+        onClick={() => handleViewSelect(view)}
+      >
+        {view}
+      </button>
+    ))}
+  </>
+)
 
-  if (!loading && Object.keys(restProjects).length > 0) {
-    marketcapDataset = combineDataset(marketcapDataset, restProjects)
-    restAreas = getTop3Area(restProjects)
+class TotalMarketcapWidget extends Component {
+  state = {
+    view: WidgetMarketView.DETAILED
   }
 
-  const valueClassNames = `TotalMarketcapWidget__value ${
-    totalmarketCapPrice === '.' ? 'TotalMarketcapWidget__value_loading' : ''
-  }`
+  handleViewSelect = view => {
+    this.setState({
+      view
+    })
+  }
 
-  return (
-    <Widget className='TotalMarketcapWidget'>
-      <div className='TotalMarketcapWidget__info'>
-        <div className='TotalMarketcapWidget__left'>
-          <h3 className='TotalMarketcapWidget__label'>Total marketcap</h3>
-          <h4 className={valueClassNames}>{totalmarketCapPrice}</h4>
+  render () {
+    const {
+      historyPrices: { TOTAL_MARKET, TOTAL_LIST_MARKET, ...restProjects },
+      loading,
+      listName
+    } = this.props
+
+    const { view } = this.state
+
+    let {
+      totalmarketCapPrice = '.',
+      volumeAmplitudePrice = '.',
+      marketcapDataset = []
+    } = generateWidgetData(
+      TOTAL_LIST_MARKET && view === WidgetMarketView.DETAILED
+        ? TOTAL_LIST_MARKET
+        : TOTAL_MARKET
+    )
+
+    let restAreas = null
+
+    if (!loading && Object.keys(restProjects).length > 0) {
+      const target =
+        view === WidgetMarketView.DETAILED
+          ? restProjects
+          : { [listName]: TOTAL_LIST_MARKET }
+      marketcapDataset = combineDataset(marketcapDataset, target)
+      restAreas = getTop3Area(target)
+    }
+
+    const valueClassNames = `TotalMarketcapWidget__value ${
+      totalmarketCapPrice === '.' ? 'TotalMarketcapWidget__value_loading' : ''
+    }`
+
+    return (
+      <Widget
+        className='TotalMarketcapWidget'
+        title={
+          TOTAL_LIST_MARKET ? (
+            <MarketView
+              currentView={view}
+              handleViewSelect={this.handleViewSelect}
+            />
+          ) : null
+        }
+      >
+        <div className='TotalMarketcapWidget__info'>
+          <div className='TotalMarketcapWidget__left'>
+            <h3 className='TotalMarketcapWidget__label'>{`${
+              TOTAL_LIST_MARKET && view === WidgetMarketView.DETAILED
+                ? 'List'
+                : 'Total'
+            } marketcap`}</h3>
+            <h4 className={valueClassNames}>{totalmarketCapPrice}</h4>
+          </div>
+          <div className='TotalMarketcapWidget__right'>
+            <h3 className='TotalMarketcapWidget__label'>Vol 24 hr</h3>
+            <h4 className={valueClassNames}>{volumeAmplitudePrice}</h4>
+          </div>
         </div>
-        <div className='TotalMarketcapWidget__right'>
-          <h3 className='TotalMarketcapWidget__label'>Vol 24 hr</h3>
-          <h4 className={valueClassNames}>{volumeAmplitudePrice}</h4>
-        </div>
-      </div>
-      <ResponsiveContainer width='100%' className='TotalMarketcapWidget__chart'>
-        <AreaChart
-          data={marketcapDataset}
-          margin={{ top: 0, right: 0, left: 0, bottom: 0 }}
+        <ResponsiveContainer
+          width='100%'
+          className={cx({
+            TotalMarketcapWidget__chart: true,
+            list: !!TOTAL_LIST_MARKET
+          })}
         >
-          <XAxis dataKey='datetime' hide />
-          <Area
-            dataKey='marketcap'
-            type='monotone'
-            strokeWidth={1}
-            stroke='#2d5e39'
-            fill='rgba(214, 235, 219, .8)'
-            isAnimationActive={false}
-          />
-          {restAreas}
-        </AreaChart>
-      </ResponsiveContainer>
-    </Widget>
-  )
+          <AreaChart
+            data={marketcapDataset}
+            margin={{ top: 0, right: 0, left: 0, bottom: 0 }}
+          >
+            <XAxis dataKey='datetime' hide />
+            <Area
+              dataKey='marketcap'
+              type='monotone'
+              strokeWidth={1}
+              stroke='#2d5e39'
+              fill='rgba(214, 235, 219, .8)'
+              isAnimationActive={false}
+            />
+            {restAreas}
+          </AreaChart>
+        </ResponsiveContainer>
+      </Widget>
+    )
+  }
 }
 
 export default TotalMarketcapWidget

--- a/app/src/components/TotalMarketcapWidget/TotalMarketcapWidget.scss
+++ b/app/src/components/TotalMarketcapWidget/TotalMarketcapWidget.scss
@@ -48,20 +48,9 @@
   }
   &__chart {
     margin-top: 20px;
-    // min-height: 125px;
     max-height: 125px;
-    // position: relative;
 
-    // &::after {
-    //   content: '';
-    //   display: block;
-    //   position: absolute;
-    //   top: 0;
-    //   left: 0;
-    //   height: 100%;
-    //   width: 100%;
-    //   background: linear-gradient(rgba(255, 255, 255, 0) 90%, #fff);
-    // }
+
     &.list {
       max-height: 91px;
     }

--- a/app/src/components/TotalMarketcapWidget/TotalMarketcapWidget.scss
+++ b/app/src/components/TotalMarketcapWidget/TotalMarketcapWidget.scss
@@ -78,6 +78,10 @@
       text-decoration: underline;
     }
   }
+
+  & svg:not(:root) {
+    overflow: visible;
+  }
 }
 @keyframes loading {
   0% {

--- a/app/src/components/TotalMarketcapWidget/TotalMarketcapWidget.scss
+++ b/app/src/components/TotalMarketcapWidget/TotalMarketcapWidget.scss
@@ -82,6 +82,11 @@
   & svg:not(:root) {
     overflow: visible;
   }
+
+  &__change {
+    display: inline-block;
+    font-size: 13px;
+  }
 }
 @keyframes loading {
   0% {

--- a/app/src/components/TotalMarketcapWidget/TotalMarketcapWidget.scss
+++ b/app/src/components/TotalMarketcapWidget/TotalMarketcapWidget.scss
@@ -48,8 +48,35 @@
   }
   &__chart {
     margin-top: 20px;
-    min-height: 125px;
+    // min-height: 125px;
     max-height: 125px;
+    // position: relative;
+
+    // &::after {
+    //   content: '';
+    //   display: block;
+    //   position: absolute;
+    //   top: 0;
+    //   left: 0;
+    //   height: 100%;
+    //   width: 100%;
+    //   background: linear-gradient(rgba(255, 255, 255, 0) 90%, #fff);
+    // }
+    &.list {
+      max-height: 91px;
+    }
+  }
+
+  &__view-btn {
+    border: none;
+    color: #ccc;
+    cursor: pointer;
+    outline: none;
+
+    &.active {
+      color: #000;
+      text-decoration: underline;
+    }
   }
 }
 @keyframes loading {

--- a/app/src/components/TotalMarketcapWidget/totalMarketcapWidgetUtils.js
+++ b/app/src/components/TotalMarketcapWidget/totalMarketcapWidgetUtils.js
@@ -1,0 +1,107 @@
+import React from 'react'
+
+import { formatNumber } from '../../utils/formatting'
+import { mergeTimeseriesByKey } from '../../utils/utils'
+import { Area } from 'recharts'
+
+const COLORS = ['#dda000', '#1111bb', '#ab47bc']
+const COLORS_TEXT = ['#aa7000', '#111199', '#8a43ac']
+
+const currencyFormatOptions = {
+  currency: 'USD',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0
+}
+
+export const generateWidgetData = historyPrice => {
+  if (!historyPrice || historyPrice.length === 0) return {}
+
+  const historyPriceLastIndex = historyPrice.length - 1
+
+  const marketcapDataset = historyPrice.map(data => ({
+    datetime: data.datetime,
+    marketcap: data.marketcap
+  }))
+
+  const volumeAmplitude =
+    historyPrice[historyPriceLastIndex].volume -
+    historyPrice[historyPriceLastIndex - 1].volume
+
+  const volumeAmplitudePrice = formatNumber(
+    volumeAmplitude,
+    currencyFormatOptions
+  )
+
+  const totalmarketCapPrice = formatNumber(
+    historyPrice[historyPriceLastIndex].marketcap,
+    currencyFormatOptions
+  )
+
+  return {
+    totalmarketCapPrice,
+    volumeAmplitudePrice,
+    marketcapDataset
+  }
+}
+
+const constructProjectMarketcapKey = projectName => `${projectName}-marketcap`
+
+export const combineDataset = (totalMarketHistory, restProjects) => {
+  const LAST_INDEX = totalMarketHistory.length - 1
+  if (LAST_INDEX < 0) {
+    return
+  }
+
+  const restProjectTimeseries = Object.keys(restProjects).map(key =>
+    (restProjects[key] || []).map(({ marketcap, datetime }) => ({
+      datetime,
+      [constructProjectMarketcapKey(key)]: marketcap
+    }))
+  )
+
+  const result = mergeTimeseriesByKey({
+    timeseries: [totalMarketHistory, ...restProjectTimeseries],
+    key: 'datetime'
+  })
+
+  return result
+}
+
+export const getTop3Area = restProjects => {
+  return Object.keys(restProjects).map((key, i) => {
+    const rightMarginByIndex = (i + 1) * 16
+    return (
+      <Area
+        key={key}
+        dataKey={constructProjectMarketcapKey(key)}
+        type='monotone'
+        strokeWidth={1}
+        stroke={COLORS[i]}
+        label={({ x, y, index }) => {
+          if (index === rightMarginByIndex) {
+            return (
+              <text
+                x={x}
+                y={y}
+                dy={-8}
+                fill={COLORS_TEXT[i]}
+                fontSize={12}
+                textAnchor='middle'
+              >
+                {key}
+              </text>
+            )
+          }
+          return ''
+        }}
+        fill={COLORS[i] + '2c'}
+        isAnimationActive={false}
+      />
+    )
+  })
+}
+
+export const WidgetMarketView = {
+  LIST: 'List',
+  TOTAL: 'Total'
+}

--- a/app/src/components/TotalMarketcapWidget/totalMarketcapWidgetUtils.js
+++ b/app/src/components/TotalMarketcapWidget/totalMarketcapWidgetUtils.js
@@ -1,8 +1,8 @@
 import React from 'react'
+import { Area } from 'recharts'
 
 import { formatNumber } from '../../utils/formatting'
 import { mergeTimeseriesByKey } from '../../utils/utils'
-import { Area } from 'recharts'
 
 const COLORS = ['#dda000', '#1111bb', '#ab47bc']
 const COLORS_TEXT = ['#aa7000', '#111199', '#8a43ac']
@@ -27,6 +27,12 @@ export const generateWidgetData = historyPrice => {
     historyPrice[historyPriceLastIndex].volume -
     historyPrice[historyPriceLastIndex - 1].volume
 
+  const volume24PercentChange =
+    (1 -
+      historyPrice[historyPriceLastIndex].volume /
+        historyPrice[historyPriceLastIndex - 1].volume) *
+    -100
+
   const volumeAmplitudePrice = formatNumber(
     volumeAmplitude,
     currencyFormatOptions
@@ -40,6 +46,7 @@ export const generateWidgetData = historyPrice => {
   return {
     totalmarketCapPrice,
     volumeAmplitudePrice,
+    volume24PercentChange,
     marketcapDataset
   }
 }
@@ -99,9 +106,4 @@ export const getTop3Area = restProjects => {
       />
     )
   })
-}
-
-export const WidgetMarketView = {
-  LIST: 'List',
-  TOTAL: 'Total'
 }

--- a/app/src/components/Widget/WidgetList.js
+++ b/app/src/components/Widget/WidgetList.js
@@ -3,10 +3,10 @@ import GetTotalMarketcap from '../TotalMarketcapWidget/GetTotalMarketcap'
 import InsightsWidget from '../InsightsWidget/InsightsWidget'
 import LatestWatchlistsWidget from '../LatestWatchlistsWidget/LatestWatchlistsWidget'
 import './WidgetList.scss'
-const WidgetList = ({ type, isLoggedIn }) => {
+const WidgetList = ({ type, isLoggedIn, listName }) => {
   return (
     <div className='WidgetList'>
-      <GetTotalMarketcap type={type} />
+      <GetTotalMarketcap type={type} listName={listName} />
       {isLoggedIn && <InsightsWidget />}
       <LatestWatchlistsWidget />
     </div>

--- a/app/src/pages/assets/AssetsPage.js
+++ b/app/src/pages/assets/AssetsPage.js
@@ -32,7 +32,11 @@ const AssetsPage = props => (
       <link rel='canonical' href={`${getOrigin()}/assets`} />
     </Helmet>
     {props.isBetaModeEnabled && (
-      <WidgetList type={props.type} isLoggedIn={props.isLoggedIn} />
+      <WidgetList
+        listName={getHeadTitle(props.type, props.location.search)}
+        type={props.type}
+        isLoggedIn={props.isLoggedIn}
+      />
     )}
     <div className='page-head page-head-projects'>
       <div className='page-head-projects__left'>


### PR DESCRIPTION
#### Summary
This PR enhances `TotalMarketcapWidget`. 
- Now it's possible to compare list `historyPrice` to `TOTAL_MARKET` `historyPrice`.
- Showing 24h volume percent change for the current list.

#### Screenshots
Non-watchlist widget
![image](https://user-images.githubusercontent.com/25135650/49331524-66592400-f5af-11e8-9c80-d985b4a665de.png)
Watchlist widget + view: `List`
![image](https://user-images.githubusercontent.com/25135650/49331516-4d507300-f5af-11e8-9de8-f8b88d5fb230.png)
Watchlist widget + view: `Total`
![image](https://user-images.githubusercontent.com/25135650/49331519-58a39e80-f5af-11e8-9de1-f69041c955b4.png)


