### PR TITLE
Add network growth api

### DIFF
--- a/lib/sanbase/clickhouse/network_growth.ex
+++ b/lib/sanbase/clickhouse/network_growth.ex
@@ -1,0 +1,39 @@
+defmodule Sanbase.Clickhouse.NetworkGrowth do
+  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+
+  def network_growth(contract, from, to, interval) do
+    from_datetime_unix = DateTime.to_unix(from)
+    to_datetime_unix = DateTime.to_unix(to)
+    span = div(to_datetime_unix - from_datetime_unix, interval)
+
+    query = """
+    SELECT toUnixTimestamp(time) as dt, SUM(value) as new_addresses
+    FROM (
+      SELECT
+        toDateTime(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) as time,
+        toUInt32(0) AS value
+      FROM numbers(?2)
+
+      UNION ALL
+
+      SELECT toDateTime(intDiv(toUInt32(dt), ?1) * ?1) as time, sum(total_addresses) as value
+      FROM eth_network_growth
+      PREWHERE contract = ?3 and
+      dt >= toDateTime(?4) and
+      dt <= toDateTime(?5)
+      group by time
+    )
+    group by dt
+    order by dt
+    """
+
+    args = [interval, span, contract, from_datetime_unix, to_datetime_unix]
+
+    ClickhouseRepo.query_transform(query, args, fn [dt, new_addresses] ->
+      %{
+        datetime: DateTime.from_unix!(dt),
+        new_addresses: new_addresses
+      }
+    end)
+  end
+end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -680,6 +680,18 @@ defmodule SanbaseWeb.Graphql.Schema do
 
       cache_resolve(&ClickhouseResolver.historical_balance/3)
     end
+
+    @desc "Network growth returns the newly created addresses for a given timeframe"
+    field :network_growth, list_of(:network_growth) do
+      arg(:slug, :string)
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+      arg(:interval, non_null(:string), default_value: "1d")
+
+      middleware(ApiTimeframeRestriction)
+
+      cache_resolve(&ClickhouseResolver.network_growth/3)
+    end
   end
 
   mutation do

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -681,9 +681,9 @@ defmodule SanbaseWeb.Graphql.Schema do
       cache_resolve(&ClickhouseResolver.historical_balance/3)
     end
 
-    @desc "Network growth returns the newly created addresses for a given timeframe"
+    @desc "Network growth returns the newly created addresses for a project in a given timeframe"
     field :network_growth, list_of(:network_growth) do
-      arg(:slug, :string)
+      arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:interval, non_null(:string), default_value: "1d")

--- a/lib/sanbase_web/graphql/schema/clickhouse_types.ex
+++ b/lib/sanbase_web/graphql/schema/clickhouse_types.ex
@@ -5,4 +5,9 @@ defmodule SanbaseWeb.Graphql.ClickhouseTypes do
     field(:datetime, non_null(:datetime))
     field(:balance, :float)
   end
+
+  object :network_growth do
+    field(:datetime, non_null(:datetime))
+    field(:new_addresses, :integer)
+  end
 end

--- a/test/sanbase_web/graphql/clickhouse/network_growth_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/network_growth_test.exs
@@ -1,0 +1,55 @@
+defmodule SanbaseWeb.Graphql.Clickhouse.NtworkGrowthTest do
+  use SanbaseWeb.ConnCase
+  require Sanbase.ClickhouseRepo
+  import SanbaseWeb.Graphql.TestHelpers
+  import Sanbase.DateTimeUtils, only: [from_iso8601_to_unix!: 1]
+  import Mock
+  import Sanbase.Factory
+
+  setup do
+    project = insert(:project, %{main_contract_address: "0x123"})
+
+    [
+      project: project
+    ]
+  end
+
+  test "network growth works", context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:ok,
+         %{
+           rows: [
+             [from_iso8601_to_unix!("2018-12-01T00:00:00Z"), 5],
+             [from_iso8601_to_unix!("2018-12-02T00:00:00Z"), 8]
+           ]
+         }}
+      end do
+      query = """
+      {
+        networkGrowth(
+          slug: "#{context.project.coinmarketcap_id}",
+          from: "2018-12-01T00:00:00Z",
+          to: "2018-12-07T00:00:00Z",
+          interval: "1d"
+        )
+        {
+          datetime,
+          newAddresses
+        }
+      }
+      """
+
+      result =
+        context.conn
+        |> post("/graphql", query_skeleton(query, "networkGrowth"))
+
+      network_growth = json_response(result, 200)["data"]["networkGrowth"]
+
+      assert network_growth == [
+               %{"datetime" => "2018-12-01T00:00:00Z", "newAddresses" => 5},
+               %{"datetime" => "2018-12-02T00:00:00Z", "newAddresses" => 8}
+             ]
+    end
+  end
+end


### PR DESCRIPTION
```graphql
    {
      networkGrowth(
        slug: "santiment",
        from: "2018-12-01T00:00:00Z",
        to: "2018-12-05T00:00:00Z",
        interval: "1d"
      )
      {
        datetime,
        newAddresses
      }
    }
```
result:
```graphql
{
  "data": {
    "networkGrowth": [
      {
        "datetime": "2018-12-01T00:00:00Z",
        "newAddresses": "3"
      },
      {
        "datetime": "2018-12-02T00:00:00Z",
        "newAddresses": "2"
      },
      {
        "datetime": "2018-12-03T00:00:00Z",
        "newAddresses": "6"
      },
      {
        "datetime": "2018-12-04T00:00:00Z",
        "newAddresses": "2"
      },
      {
        "datetime": "2018-12-05T00:00:00Z",
        "newAddresses": "1"
      }
    ]
  }
}
```