### PR TITLE
GitHub average metrics

### DIFF
--- a/app/src/pages/Projects/ProjectCard.js
+++ b/app/src/pages/Projects/ProjectCard.js
@@ -59,7 +59,7 @@ const ProjectCard = ({
   percentChange24h,
   volumeUsd,
   volumeChange24h,
-  averageDevActivity,
+  averageGithubActivity,
   twitterData,
   ethSpent,
   ethBalance = 0,
@@ -207,11 +207,11 @@ const ProjectCard = ({
             <StatisticElement
               name='Dev Activity 30d'
               value={
-                averageDevActivity
-                  ? parseFloat(averageDevActivity).toFixed(2)
+                averageGithubActivity
+                  ? parseFloat(averageGithubActivity).toFixed(2)
                   : '---'
               }
-              disabled={!averageDevActivity}
+              disabled={!averageGithubActivity}
             />
             <HiddenElements>
               <StatisticElement

--- a/app/src/pages/Projects/ProjectsTable.js
+++ b/app/src/pages/Projects/ProjectsTable.js
@@ -284,7 +284,7 @@ const ProjectsTable = ({
       Header: 'Dev activity (30D)',
       id: 'github_activity',
       maxWidth: 110,
-      accessor: d => d.averageDevActivity,
+      accessor: d => d.averageGithubActivity,
       Cell: ({ value }) => (
         <div className='overview-devactivity'>
           {value ? parseFloat(value).toFixed(2) : ''}

--- a/app/src/pages/Projects/allProjectsGQL.js
+++ b/app/src/pages/Projects/allProjectsGQL.js
@@ -29,7 +29,7 @@ const project = gql`
     volumeUsd
     volumeChange24h
     ethSpent
-    averageDevActivity
+    averageGithubActivity
     averageDailyActiveAddresses
     marketcapUsd
     ethBalance

--- a/app/src/pages/Projects/withProjectsDataMobile.js
+++ b/app/src/pages/Projects/withProjectsDataMobile.js
@@ -17,7 +17,7 @@ const mapDataToProps = type => ({ Projects, ownProps }) => {
   let filteredProjects = [...projects]
     .sort((a, b) => {
       if (ownProps.sortBy === 'github_activity') {
-        return simpleSort(+a.averageDevActivity, +b.averageDevActivity)
+        return simpleSort(+a.averageGithubActivity, +b.averageGithubActivity)
       }
       return simpleSort(+a.marketcapUsd, +b.marketcapUsd)
     })

--- a/app/src/pages/assets/asset-columns.js
+++ b/app/src/pages/assets/asset-columns.js
@@ -154,7 +154,7 @@ const columns = preload => [
     Header: 'Dev activity (30D)',
     id: 'github_activity',
     maxWidth: 110,
-    accessor: d => d.averageDevActivity,
+    accessor: d => d.averageGithubActivity,
     Cell: ({ value }) => (
       <div className='overview-devactivity'>
         {value ? parseFloat(value).toFixed(2) : ''}

--- a/lib/sanbase_web/graphql/schema/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/project_types.ex
@@ -118,8 +118,15 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     end
 
     field :average_dev_activity, :float do
-      description("Average dev activity for the last 30 days")
+      description("Average dev activity for the last `days` days")
+      arg(:days, :integer, default_value: 30)
       cache_resolve_async(&ProjectResolver.average_dev_activity/3)
+    end
+
+    field :average_github_activity, :float do
+      description("Average github activity for the last `days` days")
+      arg(:days, :integer, default_value: 30)
+      cache_resolve_async(&ProjectResolver.average_github_activity/3)
     end
 
     field :twitter_data, :twitter_data do


### PR DESCRIPTION
#### Summary
Rename the project type `averageDevActivty` to the more accurate `averageGithubActivity`. Add a new `avereageDevActivity` field that excludes non-dev events.
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
