### PR TITLE
Handle the error messages better

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -14,7 +14,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
     interval = DateTimeUtils.compound_duration_to_seconds(args.interval)
 
     with {:ok, contract, _} <- Project.contract_info_by_slug(args.slug),
-         {:ok, network_growth} =
+         {:ok, network_growth} <-
            NetworkGrowth.network_growth(contract, args.from, args.to, interval) do
       {:ok, network_growth}
     else
@@ -24,8 +24,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
         {:error, "Can't calculate network growth"}
     end
   rescue
-    e ->
-      Logger.error("Exception raised while calculating network growth. Reason: #{inspect(e)}")
+    error ->
+      Logger.error("Exception raised while calculating network growth. Reason: #{inspect(error)}")
 
       {:error, "Can't calculate network growth"}
   end
@@ -49,9 +49,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
         {:ok, []}
     end
   rescue
-    e ->
+    error ->
       Logger.error(
-        "Exception raised while calculating historical balances. Reason: #{inspect(e)}"
+        "Exception raised while calculating historical balances. Reason: #{inspect(error)}"
       )
 
       {:ok, []}

--- a/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
@@ -43,7 +43,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
 
       {:ok, result}
     else
-      error ->
+      {:error, error} ->
         error_msg = "Can't fetch burn rate for #{slug}"
         Logger.warn(error_msg <> "Reason: #{inspect(error)}")
         {:error, error_msg}
@@ -79,7 +79,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
            ) do
       {:ok, token_age |> Utils.fit_from_datetime(args)}
     else
-      error ->
+      {:error, error} ->
         error_msg = "Can't fetch average token age consumed in days for #{slug}"
         Logger.warn(error_msg <> "Reason: #{inspect(error)}")
         {:error, error_msg}
@@ -119,7 +119,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
 
       {:ok, result}
     else
-      error ->
+      {:error, error} ->
         error_msg = "Can't fetch transaction for #{slug}"
         Logger.warn(error_msg <> "Reason: #{inspect(error)}")
         {:error, error_msg}
@@ -158,7 +158,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
 
       {:ok, result}
     else
-      error ->
+      {:error, error} ->
         error_msg = "Can't fetch daily active addresses for #{slug}"
         Logger.warn(error_msg <> "Reason: #{inspect(error)}")
         {:error, error_msg}
@@ -203,7 +203,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
 
       {:ok, result}
     else
-      error ->
+      {:error, error} ->
         error_msg = "Can't fetch the exchange fund flow for #{slug}."
         Logger.warn(error_msg <> "Reason: #{inspect(error)}")
         {:error, error_msg}
@@ -244,7 +244,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
 
       {:ok, result}
     else
-      error ->
+      {:error, error} ->
         error_msg = "Can't fetch token circulation for #{slug}."
         Logger.warn(error_msg <> " Reason: #{inspect(error)}")
         {:error, error_msg}
@@ -293,7 +293,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
            Blockchain.DailyActiveAddresses.active_addresses(contract_address, from, to) do
       {:ok, active_addresses}
     else
-      error ->
+      {:error, error} ->
         error_msg = "Can't fetch daily active addresses for #{project.coinmarketcap_id}"
         Logger.warn(error_msg <> "Reason: #{inspect(error)}")
 

--- a/lib/sanbase_web/graphql/resolvers/project/project_transactions_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_transactions_resolver.ex
@@ -38,7 +38,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectTransactionsResolver do
         )
       )
     else
-      error ->
+      {:error, error} ->
         Logger.info("Cannot get token top transfers. Reason: #{inspect(error)}")
 
         {:ok, []}


### PR DESCRIPTION
Pattern match on the whole tuple to avoid having `:error` in the logs
when the log level is info/warn

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
