### PR TITLE
Use dataloader to resolve the project balances

### DIFF
--- a/lib/sanbase/external_services/coinmarketcap/ticker_fetcher.ex
+++ b/lib/sanbase/external_services/coinmarketcap/ticker_fetcher.ex
@@ -92,7 +92,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcher do
   end
 
   defp find_or_init_project(%Project{coinmarketcap_id: coinmarketcap_id} = project) do
-    case Repo.get_by(Project, coinmarketcap_id: coinmarketcap_id) do
+    case Project.by_slug(coinmarketcap_id) do
       nil ->
         Project.changeset(project)
 

--- a/lib/sanbase/external_services/coinmarketcap2/ticker_fetcher.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/ticker_fetcher.ex
@@ -117,7 +117,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcher2 do
   end
 
   defp find_or_init_project(%Project{coinmarketcap_id: coinmarketcap_id} = project) do
-    case Repo.get_by(Project, coinmarketcap_id: coinmarketcap_id) do
+    case Project.by_slug(coinmarketcap_id) do
       nil ->
         Project.changeset(project)
 

--- a/lib/sanbase/model/ico.ex
+++ b/lib/sanbase/model/ico.ex
@@ -70,7 +70,7 @@ defmodule Sanbase.Model.Ico do
 
   def funds_raised_usd_ico_end_price(%Ico{end_date: end_date, project_id: project_id} = ico)
       when not is_nil(end_date) do
-    project = Repo.get(Project, project_id)
+    project = Project.by_id(project_id)
     funds_raised_ico_end_price_from_currencies(project, ico, "USD", end_date)
   end
 
@@ -78,7 +78,7 @@ defmodule Sanbase.Model.Ico do
 
   def funds_raised_eth_ico_end_price(%Ico{end_date: end_date, project_id: project_id} = ico)
       when not is_nil(end_date) do
-    project = Repo.get(Project, project_id)
+    project = Project.by_id(project_id)
     funds_raised_ico_end_price_from_currencies(project, ico, "ETH", end_date)
   end
 
@@ -86,7 +86,7 @@ defmodule Sanbase.Model.Ico do
 
   def funds_raised_btc_ico_end_price(%Ico{end_date: end_date, project_id: project_id} = ico)
       when not is_nil(end_date) do
-    project = Repo.get(Project, project_id)
+    project = Project.by_id(project_id)
     funds_raised_ico_end_price_from_currencies(project, ico, "BTC", end_date)
   end
 

--- a/lib/sanbase/model/project/project.ex
+++ b/lib/sanbase/model/project/project.ex
@@ -18,6 +18,12 @@ defmodule Sanbase.Model.Project do
 
   import Ecto.Query
 
+  @preloads [
+    :eth_addresses,
+    :latest_coinmarketcap_data,
+    icos: [ico_currencies: [:currency]]
+  ]
+
   schema "project" do
     field(:name, :string)
     field(:ticker, :string)
@@ -310,6 +316,14 @@ defmodule Sanbase.Model.Project do
   def by_slug(slug) when is_binary(slug) do
     Project
     |> where([p], p.coinmarketcap_id == ^slug)
+    |> preload(^@preloads)
+    |> Repo.one()
+  end
+
+  def by_id(id) when is_integer(id) do
+    Project
+    |> where([p], p.id == ^id)
+    |> preload(^@preloads)
     |> Repo.one()
   end
 

--- a/lib/sanbase/model/project/project_list.ex
+++ b/lib/sanbase/model/project/project_list.ex
@@ -4,6 +4,12 @@ defmodule Sanbase.Model.Project.List do
 
   alias Sanbase.Model.{Project, Infrastructure}
 
+  @preloads [
+    :eth_addresses,
+    :latest_coinmarketcap_data,
+    icos: [ico_currencies: [:currency]]
+  ]
+
   @doc ~s"""
   Return all erc20 projects
   """
@@ -45,10 +51,7 @@ defmodule Sanbase.Model.Project.List do
       order_by: latest_cmc.rank,
       limit: ^page_size,
       offset: ^((page - 1) * page_size),
-      preload: [
-        :latest_coinmarketcap_data,
-        icos: [ico_currencies: [:currency]]
-      ]
+      preload: ^@preloads
     )
     |> Repo.all()
   end
@@ -94,10 +97,7 @@ defmodule Sanbase.Model.Project.List do
       order_by: latest_cmc.rank,
       limit: ^page_size,
       offset: ^((page - 1) * page_size),
-      preload: [
-        :latest_coinmarketcap_data,
-        icos: [ico_currencies: [:currency]]
-      ]
+      preload: ^@preloads
     )
     |> Repo.all()
   end
@@ -119,7 +119,7 @@ defmodule Sanbase.Model.Project.List do
   end
 
   defp projects_query() do
-    from(p in Project, where: not is_nil(p.coinmarketcap_id))
+    from(p in Project, where: not is_nil(p.coinmarketcap_id), preload: ^@preloads)
   end
 
   @doc ~s"""
@@ -132,10 +132,7 @@ defmodule Sanbase.Model.Project.List do
       order_by: latest_cmc.rank,
       limit: ^page_size,
       offset: ^((page - 1) * page_size),
-      preload: [
-        :latest_coinmarketcap_data,
-        icos: [ico_currencies: [:currency]]
-      ]
+      preload: ^@preloads
     )
     |> Repo.all()
   end

--- a/lib/sanbase/model/project/project_list.ex
+++ b/lib/sanbase/model/project/project_list.ex
@@ -32,7 +32,8 @@ defmodule Sanbase.Model.Project.List do
       on: p.infrastructure_id == infr.id,
       where:
         not is_nil(p.coinmarketcap_id) and not is_nil(p.main_contract_address) and
-          infr.code == "ETH"
+          infr.code == "ETH",
+      preload: ^@preloads
     )
   end
 
@@ -78,7 +79,8 @@ defmodule Sanbase.Model.Project.List do
       inner_join: infr in Infrastructure,
       on: p.infrastructure_id == infr.id,
       where:
-        not is_nil(p.coinmarketcap_id) and (is_nil(p.main_contract_address) or infr.code != "ETH")
+        not is_nil(p.coinmarketcap_id) and (is_nil(p.main_contract_address) or infr.code != "ETH"),
+      preload: ^@preloads
     )
   end
 

--- a/lib/sanbase_web/graphql/parity_dataloader.ex
+++ b/lib/sanbase_web/graphql/parity_dataloader.ex
@@ -1,0 +1,20 @@
+defmodule SanbaseWeb.Graphql.ParityDataloader do
+  alias Sanbase.InternalServices.Parity
+  alias Sanbase.Model.Project
+
+  import Ecto.Query
+
+  def data() do
+    Dataloader.KV.new(&fetch/2)
+  end
+
+  def fetch(_batch_key, arg_maps) do
+    addresses =
+      Enum.flat_map(arg_maps, fn project ->
+        {:ok, eth_addresses} = Project.eth_addresses(project)
+        eth_addresses
+      end)
+
+    Parity.get_eth_balance(addresses)
+  end
+end

--- a/lib/sanbase_web/graphql/price_store.ex
+++ b/lib/sanbase_web/graphql/price_store.ex
@@ -15,6 +15,8 @@ defmodule SanbaseWeb.Graphql.PriceStore do
     |> Map.new()
   end
 
+  def query(queryable, _), do: queryable
+
   # Helper functions
 
   # TODO: not covered in tests

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -60,16 +60,17 @@ defmodule SanbaseWeb.Graphql.Schema do
   import_types(SanbaseWeb.Graphql.ExchangeTypes)
 
   def dataloader() do
-    alias SanbaseWeb.Graphql.SanbaseRepo
-    alias SanbaseWeb.Graphql.PriceStore
+    alias SanbaseWeb.Graphql.{SanbaseRepo, PriceStore, ParityDataloader}
 
     Dataloader.new()
     |> Dataloader.add_source(SanbaseRepo, SanbaseRepo.data())
     |> Dataloader.add_source(PriceStore, PriceStore.data())
+    |> Dataloader.add_source(ParityDataloader, ParityDataloader.data())
   end
 
   def context(ctx) do
-    Map.put(ctx, :loader, dataloader())
+    ctx
+    |> Map.put(:loader, dataloader())
   end
 
   def plugins do


### PR DESCRIPTION
Make a single call to Parity instead of one call per each ETH address
Automatically preload eth_addresses as they are often used

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
