### PR TITLE
Revert eth_spent to not use the dataloader

### DIFF
--- a/lib/sanbase/clickhouse/eth_transfers.ex
+++ b/lib/sanbase/clickhouse/eth_transfers.ex
@@ -81,12 +81,10 @@ defmodule Sanbase.Clickhouse.EthTransfers do
   def eth_spent(wallets, from_datetime, to_datetime) do
     {query, args} = eth_spent_query(wallets, from_datetime, to_datetime)
 
-    ClickhouseRepo.query_transform(query, args, fn [from, value] ->
-      {from, value / @eth_decimals}
-    end)
+    ClickhouseRepo.query_transform(query, args, fn [value] -> value / @eth_decimals end)
     |> case do
       {:ok, result} ->
-        {:ok, result}
+        {:ok, result |> List.first()}
 
       {:error, error} ->
         {:error, error}
@@ -291,29 +289,21 @@ defmodule Sanbase.Clickhouse.EthTransfers do
     from_datetime_unix = DateTime.to_unix(from_datetime)
     to_datetime_unix = DateTime.to_unix(to_datetime)
 
-    prewhere_clause =
-      wallets
-      |> Enum.map(fn list ->
-        list = list |> Enum.map(fn x -> ~s/'#{x}'/ end) |> Enum.join(", ")
-        "(from IN (#{list}) AND NOT to IN (#{list}))"
-      end)
-      |> Enum.join(" OR ")
-
     query = """
-    SELECT from, SUM(value)
+    SELECT SUM(value)
     FROM (
       SELECT any(value) as value, from
       FROM #{@table}
-      PREWHERE (#{prewhere_clause})
-      AND dt >= toDateTime(?1)
-      AND dt <= toDateTime(?2)
+      PREWHERE from IN (?1) AND NOT to IN (?1)
+      AND dt >= toDateTime(?2)
+      AND dt <= toDateTime(?3)
       AND type == 'call'
       GROUP BY from, type, to, dt, transactionHash
     )
-    GROUP BY from
     """
 
     args = [
+      wallets,
       from_datetime_unix,
       to_datetime_unix
     ]

--- a/lib/sanbase_web/graphql/resolvers/project/project_transactions_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_transactions_resolver.ex
@@ -47,31 +47,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectTransactionsResolver do
     end
   end
 
-  def token_top_transactions(
-        %Project{} = project,
-        %{from: from, to: to, limit: limit} = args,
-        _resolution
-      ) do
-  end
-
-  def eth_spent(%Project{} = project, %{days: days}, %{context: %{loader: loader}}) do
-    loader
-    |> Dataloader.load(ClickhouseDataloader, :eth_spent, %{
-      project: project,
-      from: Timex.shift(Timex.now(), days: -days),
-      to: Timex.now()
-    })
-    |> on_load(&eth_spent_from_loader(&1, project))
-  end
-
-  def eth_spent_from_loader(loader, %Project{id: id}) do
-    eth_spent =
-      loader
-      |> Dataloader.get(ClickhouseDataloader, :eth_spent, id)
-
-    {:ok, eth_spent}
-  end
-
   def eth_spent(%Project{} = project, %{days: days}, _resolution) do
     today = Timex.now()
     days_ago = Timex.shift(today, days: -days)

--- a/test/sanbase_web/graphql/projects/project_api_spent_eth_test.exs
+++ b/test/sanbase_web/graphql/projects/project_api_spent_eth_test.exs
@@ -51,7 +51,7 @@ defmodule SanbaseWeb.Graphql.ProjecApiEthSpentTest do
   test "project total eth spent whole interval", context do
     with_mock Sanbase.Clickhouse.EthTransfers,
       eth_spent: fn _, _, _ ->
-        {:ok, [{context.project_address, 20_000}]}
+        {:ok, 20_000}
       end do
       query = """
       {
@@ -76,7 +76,7 @@ defmodule SanbaseWeb.Graphql.ProjecApiEthSpentTest do
 
     with_mock Sanbase.Clickhouse.EthTransfers,
       eth_spent: fn _, _, _ ->
-        {:ok, [{context.project_address, eth_spent}]}
+        {:ok, eth_spent}
       end do
       query = """
       {


### PR DESCRIPTION
Counterintuitively, the introduction of dataloader increased the response time with 25%

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
