### PR TITLE
Skip days with no prices while scraping historical cmc data

### DIFF
--- a/lib/sanbase/external_services/coinmarketcap/graph_data.ex
+++ b/lib/sanbase/external_services/coinmarketcap/graph_data.ex
@@ -128,6 +128,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData do
     |> case do
       {:ok, %Tesla.Env{status: 429} = resp} ->
         wait_rate_limit(resp)
+        Process.exit(self(), :normal)
 
       {:ok, %Tesla.Env{status: 200, body: body}} ->
         body |> json_to_price_points()
@@ -143,6 +144,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData do
     |> case do
       {:ok, %Tesla.Env{status: 429} = resp} ->
         wait_rate_limit(resp)
+        Process.exit(self(), :normal)
 
       {:ok, %Tesla.Env{status: 200, body: body}} ->
         body |> json_to_price_points()
@@ -192,6 +194,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData do
     |> case do
       {:ok, %Tesla.Env{status: 429} = resp} ->
         wait_rate_limit(resp)
+        Process.exit(self(), :normal)
 
       {:ok, %Tesla.Env{status: 200, body: body}} ->
         body |> json_to_price_points()
@@ -264,6 +267,10 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData do
     "/global/marketcap-total/#{from_timestamp}/#{to_timestamp}/"
   end
 
+  # After invocation of this function the process should execute `Process.exit(self(), :normal)`
+  # There is no meaningful result to be returned here. If it does not exit
+  # this case should return a special case and it should be handeled so the
+  # `last_updated` is not updated when no points are written
   defp wait_rate_limit(%Tesla.Env{status: 429, headers: headers}) do
     {_, wait_period} =
       Enum.find(headers, fn {header, _} ->

--- a/lib/sanbase/external_services/coinmarketcap2/graph_data.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/graph_data.ex
@@ -53,6 +53,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
     end
   end
 
+  @spec fetch_and_store_prices(Sanbase.Model.Project.t(), any()) :: :ok
   def fetch_and_store_prices(%Project{coinmarketcap_id: coinmarketcap_id}, nil) do
     Logger.warn(
       "[CMC] Trying to fetch and store prices for project with coinmarketcap_id #{
@@ -73,7 +74,8 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
     )
 
     fetch_price_stream(coinmarketcap_id, last_fetched_datetime, DateTime.utc_now())
-    |> process_price_stream(project)
+    |> Enum.map(fn {stream, interval} -> {stream |> Enum.map(& &1), interval} end)
+    |> Enum.each(&process_price_list(&1, project))
   end
 
   def fetch_price_stream(coinmarketcap_id, from_datetime, to_datetime) do
@@ -96,7 +98,8 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
     )
 
     fetch_marketcap_total_stream(last_fetched_datetime, DateTime.utc_now())
-    |> process_marketcap_total_stream()
+    |> Enum.map(fn {stream, interval} -> {stream |> Enum.map(& &1), interval} end)
+    |> Enum.each(&process_marketcap_total_list/1)
   end
 
   def fetch_marketcap_total_stream(from_datetime, to_datetime) do
@@ -106,47 +109,62 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
 
   # Helper functions
 
-  defp process_marketcap_total_stream(marketcap_total_stream) do
+  defp process_marketcap_total_list({[], {_, end_datetime_unix}}) do
+    measurement_name = "TOTAL_MARKET_total-market"
+    datetime = DateTime.from_unix!(end_datetime_unix)
+    :ok = Store.update_last_history_datetime_cmc(measurement_name, datetime)
+  end
+
+  defp process_marketcap_total_list({marketcap_total_list, interval}) do
     measurement_name = "TOTAL_MARKET_total-market"
     Logger.info("[CMC] Processing stream for #{measurement_name}.")
 
     # Store each data point and the information when it was last updated
-    marketcap_total_stream
-    |> Stream.each(fn total_marketcap_info ->
-      measurement_points =
-        total_marketcap_info
-        |> Enum.flat_map(&PricePoint.price_points_to_measurements(&1, measurement_name))
+    measurement_points =
+      marketcap_total_list
+      |> Enum.map(&PricePoint.price_points_to_measurements(&1, measurement_name))
 
-      measurement_points |> Store.import()
+    measurement_points |> Store.import()
 
-      update_last_cmc_history_datetime(measurement_name, measurement_points)
-    end)
-    |> Stream.run()
+    update_last_cmc_history_datetime(measurement_name, measurement_points, interval)
   end
 
-  defp process_price_stream(price_stream, %Project{coinmarketcap_id: coinmarketcap_id} = project) do
+  defp process_price_list({[], {_, end_datetime_unix}}, %Project{} = project) do
+    measurement_name = Measurement.name_from(project)
+    datetime = DateTime.from_unix!(end_datetime_unix)
+    :ok = Store.update_last_history_datetime_cmc(measurement_name, datetime)
+  end
+
+  defp process_price_list(
+         {price_list, interval},
+         %Project{coinmarketcap_id: coinmarketcap_id} = project
+       ) do
     Logger.info("[CMC] Processing price stream for #{coinmarketcap_id}")
 
     # Store each data point and the information when it was last updated
-    price_stream
-    |> Stream.each(fn prices ->
-      measurement_points =
-        prices
-        |> Enum.flat_map(&PricePoint.price_points_to_measurements(&1, project))
 
-      measurement_points |> Store.import()
+    measurement_points =
+      price_list
+      |> Enum.map(&PricePoint.price_points_to_measurements(&1, project))
 
-      update_last_cmc_history_datetime(Measurement.name_from(project), measurement_points)
-    end)
-    |> Stream.run()
+    measurement_points |> Store.import()
+
+    update_last_cmc_history_datetime(
+      Measurement.name_from(project),
+      measurement_points,
+      interval
+    )
   end
 
-  def update_last_cmc_history_datetime(%Project{coinmarketcap_id: coinmarketcap_id}, []) do
-    Logger.info(
-      "[CMC] Cannot update last cmc history datetime for #{coinmarketcap_id}. Reason: No price points fetched"
-    )
-
-    :ok
+  @spec update_last_cmc_history_datetime(String.t(), [], {integer(), integer()}) ::
+          :ok | no_return()
+  def update_last_cmc_history_datetime(
+        measurement_name,
+        [],
+        {_, end_unix_datetime}
+      ) do
+    end_datetime = DateTime.from_unix!(end_unix_datetime)
+    :ok = Store.update_last_history_datetime_cmc(measurement_name, end_datetime)
   end
 
   def update_last_cmc_history_datetime(measurement_name, points) do
@@ -181,6 +199,15 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
     |> convert_to_price_points()
   end
 
+  defp json_to_price_points(json, interval) do
+    result =
+      json
+      |> Poison.decode!(as: %GraphData{})
+      |> convert_to_price_points()
+
+    {result, interval}
+  end
+
   defp all_time_project_price_points(coinmarketcap_id) do
     all_time_project_url(coinmarketcap_id)
     |> get()
@@ -198,14 +225,14 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
           }"
         )
 
-        nil
+        Process.exit(self(), :normal)
 
       {:error, error} ->
         Logger.error(
           "[CMC] Error fetching prices for #{coinmarketcap_id}. Reason: #{inspect(error)}"
         )
 
-        nil
+        Process.exit(self(), :normal)
     end
   end
 
@@ -226,12 +253,12 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
           }"
         )
 
-        nil
+        Process.exit(self(), :normal)
 
       {:error, error} ->
         Logger.error("[CMC] Error fetching prices for TOTAL_MARKET. Reason: #{inspect(error)}")
 
-        nil
+        Process.exit(self(), :normal)
     end
   end
 
@@ -269,7 +296,10 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
     end)
   end
 
-  defp extract_price_points_for_interval("TOTAL_MARKET", {start_interval_sec, end_interval_sec}) do
+  defp extract_price_points_for_interval(
+         "TOTAL_MARKET",
+         {start_interval_sec, end_interval_sec} = interval
+       ) do
     total_market_interval_url(start_interval_sec * 1000, end_interval_sec * 1000)
     |> get()
     |> case do
@@ -277,23 +307,23 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
         wait_rate_limit(resp)
 
       {:ok, %Tesla.Env{status: 200, body: body}} ->
-        body |> json_to_price_points()
+        body |> json_to_price_points(interval)
 
       {:ok, %Tesla.Env{status: status, body: body}} ->
         Logger.error(
-          "[CMC] Error fetching graph data for TOTAL_MARKET. Status code: #{status}, body: #{
+          "[CMC] Error fetching graph data for TOTAL_M ARKET. Status code: #{status}, body: #{
             inspect(body)
           }"
         )
 
-        []
+        Process.exit(self(), :normal)
 
       {:error, error} ->
         Logger.error(
           "[CMC] Error fetching graph data for TOTAL_MARKET. Reason: #{inspect(error)}"
         )
 
-        []
+        Process.exit(self(), :normal)
     end
   end
 
@@ -316,7 +346,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
         wait_rate_limit(resp)
 
       {:ok, %Tesla.Env{status: 200, body: body}} ->
-        body |> json_to_price_points()
+        body |> json_to_price_points(interval)
 
       {:ok, %Tesla.Env{status: status, body: body}} ->
         Logger.error(
@@ -325,14 +355,14 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
           }"
         )
 
-        []
+        Process.exit(self(), :normal)
 
       {:error, error} ->
         Logger.error(
           "[CMC] Error fetching graph data for #{coinmarketcap_id}. Reason: #{inspect(error)}"
         )
 
-        []
+        Process.exit(self(), :normal)
     end
   end
 

--- a/lib/sanbase/external_services/coinmarketcap2/graph_data.ex
+++ b/lib/sanbase/external_services/coinmarketcap2/graph_data.ex
@@ -122,7 +122,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
     # Store each data point and the information when it was last updated
     measurement_points =
       marketcap_total_list
-      |> Enum.map(&PricePoint.price_points_to_measurements(&1, measurement_name))
+      |> Enum.flat_map(&PricePoint.price_points_to_measurements(&1, measurement_name))
 
     measurement_points |> Store.import()
 
@@ -167,7 +167,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphData2 do
     :ok = Store.update_last_history_datetime_cmc(measurement_name, end_datetime)
   end
 
-  def update_last_cmc_history_datetime(measurement_name, points) do
+  def update_last_cmc_history_datetime(measurement_name, points, _interval) do
     case points do
       [] ->
         Logger.info(

--- a/test/sanbase/external_services/coinmarketcap/graph_data_test.exs
+++ b/test/sanbase/external_services/coinmarketcap/graph_data_test.exs
@@ -28,9 +28,9 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphDataTest do
     to_datetime = DateTime.from_unix!(1_508_078_065_000, :millisecond)
 
     GraphData.fetch_price_stream("santiment", from_datetime, to_datetime)
-    |> Stream.flat_map(fn x -> x end)
-    |> Stream.take(1)
-    |> Enum.map(fn %PricePoint{datetime: datetime, price_usd: price_usd} ->
+    |> Enum.map(fn {stream, interval} -> {stream |> Enum.map(& &1), interval} end)
+    |> Enum.take(1)
+    |> Enum.map(fn {[%PricePoint{datetime: datetime, price_usd: price_usd} | _], _interval} ->
       assert datetime == from_datetime
       assert price_usd == 5704.29
     end)
@@ -63,15 +63,18 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphDataTest do
     to_datetime = DateTime.from_unix!(1_386_355_620_000, :millisecond)
 
     GraphData.fetch_marketcap_total_stream(from_datetime, to_datetime)
-    |> Stream.flat_map(fn x -> x end)
-    |> Stream.take(1)
-    |> Enum.map(fn %PricePoint{
-                     datetime: datetime,
-                     marketcap_usd: marketcap,
-                     volume_usd: volume_usd
-                   } ->
+    |> Enum.map(fn {stream, interval} -> {stream |> Enum.map(& &1), interval} end)
+    |> Enum.take(1)
+    |> Enum.map(fn {[
+                      %PricePoint{
+                        datetime: datetime,
+                        marketcap_usd: marketcap_usd,
+                        volume_usd: volume_usd
+                      }
+                      | _
+                    ], _interval} ->
       assert datetime == from_datetime
-      assert marketcap == 1_599_410_000
+      assert marketcap_usd == 1_599_410_000
       assert volume_usd == 0
     end)
   end

--- a/test/sanbase_web/graphql/projects/project_api_test.exs
+++ b/test/sanbase_web/graphql/projects/project_api_test.exs
@@ -3,13 +3,7 @@ defmodule Sanbase.Graphql.ProjectApiTest do
 
   require Sanbase.Utils.Config, as: Config
 
-  alias Sanbase.Model.{
-    Project,
-    Ico,
-    Currency,
-    IcoCurrencies,
-    ProjectEthAddress
-  }
+  alias Sanbase.Model.{Project, Ico, Currency, IcoCurrencies}
 
   alias Sanbase.Repo
 


### PR DESCRIPTION
#### Summary
<!-- (What does this pull request do in general terms?) -->
Now when there are missing days the scraper continues:
```
1425340467000000000 152555        0.0021945  0.606343  3
1425340766000000000 152595        0.00220067 0.606502  3
1425341066000000000 152250        0.00219512 0.605129  3
1425341366000000000 152071        0.00219751 0.604416  3
1425341666000000000 152306        0.00220351 0.605353  3
1425341966000000000 152440        0.00220204 0.605886  3
1425342268000000000 152527        0.00220135 0.606229  3
1425647366000000000 251600        0.00368827 1         108
1425647665000000000 251600        0.00368541 1         108
1425648566000000000 251600        0.00367408 1         7
1425648866000000000 251600        0.0036744  1         7
1425649165000000000 251600        0.00369173 1         115
1425649466000000000 251600        0.00368269 1         115
```
When the price jumps from `0.606229` to `1` there is a gap of 3-4 days and is now handled.
[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
