### PR TITLE
Lowercase the exchange addresses taken from postgres

### DIFF
--- a/lib/sanbase/clickhouse/mark_exchanges.ex
+++ b/lib/sanbase/clickhouse/mark_exchanges.ex
@@ -44,7 +44,7 @@ defmodule Sanbase.Clickhouse.MarkExchanges do
   def handle_continue(:set_state, _) do
     exchanges =
       ExchangeAddress.list_all()
-      |> Enum.map(fn %ExchangeAddress{address: address} -> address end)
+      |> Enum.map(fn %ExchangeAddress{address: address} -> address |> String.downcase() end)
       |> MapSet.new()
 
     new_state = Map.put(%{}, :exchange_wallets_set, exchanges)

--- a/lib/sanbase/model/exchange_address.ex
+++ b/lib/sanbase/model/exchange_address.ex
@@ -23,6 +23,7 @@ defmodule Sanbase.Model.ExchangeAddress do
     exchange_address
     |> cast(attrs, [:address, :name, :source, :comments, :is_dex, :infrastructure_id])
     |> validate_required([:address, :name])
+    |> update_change(:address, &String.downcase/1)
     |> unique_constraint(:address)
   end
 


### PR DESCRIPTION
All clickhouse addresses are lowercase, but we have addresses in
postgres that could contain upper letters. This leads to wrong
comparisons.

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
