### PR TITLE
Reduce the time between cmc total market and project scrapes

### DIFF
--- a/lib/sanbase/external_services/coinmarketcap2.ex
+++ b/lib/sanbase/external_services/coinmarketcap2.ex
@@ -44,8 +44,8 @@ defmodule Sanbase.ExternalServices.Coinmarketcap2 do
       {:ok,
        %{
          missing_info_update_interval: update_interval * 10,
-         total_market_update_interval: update_interval,
-         prices_update_interval: update_interval,
+         total_market_update_interval: update_interval / 5,
+         prices_update_interval: update_interval / 5,
          total_market_task_pid: nil
        }}
     else


### PR DESCRIPTION
#### Summary
If the scraping hits a rate limit it can kill all currently scraping processes. To solve this reduce the time between scheduling scrapes from 5 to 1 minute.

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
