### PR TITLE
Add word trend score api

### DIFF
--- a/lib/sanbase/social_data/social_data.ex
+++ b/lib/sanbase/social_data/social_data.ex
@@ -70,6 +70,33 @@ defmodule Sanbase.SocialData do
     end
   end
 
+  def word_trend_score(
+        word,
+        source,
+        from_datetime,
+        to_datetime
+      ) do
+    word_trend_score_request(
+      word,
+      source,
+      from_datetime,
+      to_datetime
+    )
+    |> case do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        {:ok, result} = Jason.decode(body)
+        word_trend_score_result(result)
+
+      {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
+        error_result("Error status #{status} fetching word_trend_score for word #{word}: #{body}")
+
+      {:error, %HTTPoison.Error{} = error} ->
+        error_result(
+          "Cannot fetch word_trend_score for word #{word}: #{HTTPoison.Error.message(error)}"
+        )
+    end
+  end
+
   defp trending_words_request(
          source,
          size,
@@ -139,10 +166,55 @@ defmodule Sanbase.SocialData do
     http_client().get(url, [], options)
   end
 
+  defp word_trend_score_request(
+         word,
+         source,
+         from_datetime,
+         to_datetime
+       ) do
+    from_unix = DateTime.to_unix(from_datetime)
+    to_unix = DateTime.to_unix(to_datetime)
+
+    url = "#{tech_indicators_url()}/indicator/word_trend_score"
+
+    options = [
+      recv_timeout: @recv_timeout,
+      params: [
+        {"word", word},
+        {"source", source |> Atom.to_string()},
+        {"from_timestamp", from_unix},
+        {"to_timestamp", to_unix}
+      ]
+    ]
+
+    http_client().get(url, [], options)
+  end
+
   defp word_context_result(result) do
     result =
       result
       |> Enum.map(fn {k, v} -> %{word: k, score: v["score"]} end)
+      |> Enum.sort(&(&1.score >= &2.score))
+
+    {:ok, result}
+  end
+
+  defp word_trend_score_result(result) do
+    result =
+      result
+      |> Enum.map(fn %{
+                       "timestamp" => timestamp,
+                       "score" => score,
+                       "hour" => hour,
+                       "source" => source
+                     } ->
+        %{
+          datetime: DateTime.from_unix!(timestamp),
+          score: score,
+          hour: hour,
+          source: source
+        }
+      end)
       |> Enum.sort(&(&1.score >= &2.score))
 
     {:ok, result}

--- a/lib/sanbase/social_data/social_data.ex
+++ b/lib/sanbase/social_data/social_data.ex
@@ -209,9 +209,8 @@ defmodule Sanbase.SocialData do
                        "source" => source
                      } ->
         %{
-          datetime: DateTime.from_unix!(timestamp),
+          datetime: combine_unix_dt_and_hour(timestamp, hour),
           score: score,
-          hour: hour,
           source: String.to_existing_atom(source)
         }
       end)
@@ -222,5 +221,12 @@ defmodule Sanbase.SocialData do
 
   defp tech_indicators_url() do
     Config.module_get(Sanbase.TechIndicators, :url)
+  end
+
+  def combine_unix_dt_and_hour(unix_dt, hour) do
+    unix_dt
+    |> DateTime.from_unix!()
+    |> Timex.beginning_of_day()
+    |> Timex.shift(hours: Sanbase.Utils.Math.to_integer(hour))
   end
 end

--- a/lib/sanbase/social_data/social_data.ex
+++ b/lib/sanbase/social_data/social_data.ex
@@ -212,7 +212,7 @@ defmodule Sanbase.SocialData do
           datetime: DateTime.from_unix!(timestamp),
           score: score,
           hour: hour,
-          source: source
+          source: String.to_existing_atom(source)
         }
       end)
       |> Enum.sort(&(&1.score >= &2.score))

--- a/lib/sanbase_web/graphql/resolvers/social_data_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/social_data_resolver.ex
@@ -28,4 +28,17 @@ defmodule SanbaseWeb.Graphql.Resolvers.SocialDataResolver do
     size = Enum.min([size, 100])
     Sanbase.SocialData.word_context(word, source, size, from, to)
   end
+
+  def word_trend_score(
+        _root,
+        %{
+          word: word,
+          source: source,
+          from: from,
+          to: to
+        },
+        _resolution
+      ) do
+    Sanbase.SocialData.word_trend_score(word, source, from, to)
+  end
 end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -643,6 +643,30 @@ defmodule SanbaseWeb.Graphql.Schema do
     end
 
     @desc ~s"""
+    Returns the historical score for a given word within a time interval
+
+    Arguments description:
+      * word - the word the historical score is requested for
+      * source - one of the following:
+        1. TELEGRAM
+        2. PROFESSIONAL_TRADERS_CHAT
+        3. REDDIT
+        4. ALL
+      * from - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
+      * to - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
+    """
+    field :word_trend_score, list_of(:word_trend_score) do
+      arg(:word, non_null(:string))
+      arg(:source, non_null(:trending_words_sources))
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+
+      middleware(ApiTimeframeRestriction)
+
+      resolve(&SocialDataResolver.word_trend_score/3)
+    end
+
+    @desc ~s"""
     Returns context for a trending word and the corresponding context score.
 
     Arguments description:

--- a/lib/sanbase_web/graphql/schema/social_data_types.ex
+++ b/lib/sanbase_web/graphql/schema/social_data_types.ex
@@ -18,6 +18,13 @@ defmodule SanbaseWeb.Graphql.SocialDataTypes do
     value(:all)
   end
 
+  object :word_trend_score do
+    field(:datetime, non_null(:datetime))
+    field(:score, non_null(:float))
+    field(:hour, non_null(:float))
+    field(:source, :string)
+  end
+
   object :word_context do
     field(:word, non_null(:string))
     field(:score, non_null(:float))

--- a/lib/sanbase_web/graphql/schema/social_data_types.ex
+++ b/lib/sanbase_web/graphql/schema/social_data_types.ex
@@ -27,7 +27,6 @@ defmodule SanbaseWeb.Graphql.SocialDataTypes do
   object :word_trend_score do
     field(:datetime, non_null(:datetime))
     field(:score, non_null(:float))
-    field(:hour, non_null(:float))
     field(:source, :trending_words_sources)
   end
 

--- a/lib/sanbase_web/graphql/schema/social_data_types.ex
+++ b/lib/sanbase_web/graphql/schema/social_data_types.ex
@@ -22,7 +22,7 @@ defmodule SanbaseWeb.Graphql.SocialDataTypes do
     field(:datetime, non_null(:datetime))
     field(:score, non_null(:float))
     field(:hour, non_null(:float))
-    field(:source, :string)
+    field(:source, :trending_words_sources)
   end
 
   object :word_context do

--- a/test/sanbase/social_data/social_data_test.exs
+++ b/test/sanbase/social_data/social_data_test.exs
@@ -177,10 +177,9 @@ defmodule Sanbase.SocialDataTest do
              {:ok,
               [
                 %{
-                  hour: 8.0,
                   score: 3725.6617392595313,
                   source: :telegram,
-                  datetime: DateTime.from_unix!(1_547_078_400)
+                  datetime: Sanbase.DateTimeUtils.from_iso8601!("2019-01-10T08:00:00Z")
                 }
               ]}
   end

--- a/test/sanbase/social_data/social_data_test.exs
+++ b/test/sanbase/social_data/social_data_test.exs
@@ -141,4 +141,47 @@ defmodule Sanbase.SocialDataTest do
                 %{score: 0.7592295345104334, word: "christmas"}
               ]}
   end
+
+  test "successfully fetch word trend score", _context do
+    body =
+      [
+        %{
+          "hour" => 8.0,
+          "score" => 3725.6617392595313,
+          "source" => "telegram",
+          "timestamp" => 1_547_078_400
+        }
+      ]
+      |> Jason.encode!()
+
+    mock(
+      HTTPoison,
+      :get,
+      {:ok,
+       %HTTPoison.Response{
+         body: body,
+         status_code: 200
+       }}
+    )
+
+    # As the HTTP call is mocked these arguemnts do no have much effect, though you should try to put the real ones that are used
+    result =
+      SocialData.word_trend_score(
+        "trx",
+        :telegram,
+        DateTime.from_unix!(1_547_046_000),
+        DateTime.from_unix!(1_547_111_478)
+      )
+
+    assert result ==
+             {:ok,
+              [
+                %{
+                  hour: 8.0,
+                  score: 3725.6617392595313,
+                  source: :telegram,
+                  datetime: DateTime.from_unix!(1_547_078_400)
+                }
+              ]}
+  end
 end

--- a/test/sanbase_web/graphql/social_data_api_test.exs
+++ b/test/sanbase_web/graphql/social_data_api_test.exs
@@ -232,7 +232,7 @@ defmodule Sanbase.SocialDataApiTest do
                  %{
                    "hour" => 8.0,
                    "score" => 3725.6617392595313,
-                   "source" => :telegram,
+                   "source" => "TELEGRAM",
                    "datetime" => "2019-01-10T00:00:00Z"
                  }
                ]

--- a/test/sanbase_web/graphql/social_data_api_test.exs
+++ b/test/sanbase_web/graphql/social_data_api_test.exs
@@ -183,6 +183,42 @@ defmodule Sanbase.SocialDataApiTest do
            }
   end
 
+  test "error 500 when fetch word context from tech-indicators", %{conn: conn} do
+    mock(
+      HTTPoison,
+      :get,
+      {:ok,
+       %HTTPoison.Response{
+         body: "Internal Server Error",
+         status_code: 500
+       }}
+    )
+
+    query = """
+    {
+      wordContext(
+        word: "merry", 
+        source: TELEGRAM,
+        size: 3,
+        from: "2018-12-22T00:00:00Z",
+        to:"2018-12-27T00:00:00Z"
+      ) {
+        word
+        score
+      }
+    }
+    """
+
+    result_fn = fn ->
+      conn
+      |> post("/graphql", query_skeleton(query, "wordTrendScore"))
+      |> json_response(200)
+    end
+
+    assert capture_log(result_fn) =~
+             "Error status 500 fetching context for word merry: Internal Server Error"
+  end
+
   test "successfully fetch word trend score", %{conn: conn} do
     body =
       [
@@ -236,5 +272,41 @@ defmodule Sanbase.SocialDataApiTest do
                ]
              }
            }
+  end
+
+  test "error 500 when fetch word trend score from tech-indicators", %{conn: conn} do
+    mock(
+      HTTPoison,
+      :get,
+      {:ok,
+       %HTTPoison.Response{
+         body: "Internal Server Error",
+         status_code: 500
+       }}
+    )
+
+    query = """
+    {
+      wordTrendScore(
+        word: "merry", 
+        source: TELEGRAM,
+        from: "2018-01-09T00:00:00Z",
+        to:"2018-01-10T00:00:00Z"
+      ) {
+        datetime,
+        score,
+        source
+      }
+    }
+    """
+
+    result_fn = fn ->
+      conn
+      |> post("/graphql", query_skeleton(query, "wordTrendScore"))
+      |> json_response(200)
+    end
+
+    assert capture_log(result_fn) =~
+             "Error status 500 fetching word_trend_score for word merry: Internal Server Error"
   end
 end

--- a/test/sanbase_web/graphql/social_data_api_test.exs
+++ b/test/sanbase_web/graphql/social_data_api_test.exs
@@ -182,4 +182,61 @@ defmodule Sanbase.SocialDataApiTest do
              }
            }
   end
+
+  test "successfully fetch word trend score", %{conn: conn} do
+    body =
+      [
+        %{
+          "hour" => 8.0,
+          "score" => 3725.6617392595313,
+          "source" => "telegram",
+          "timestamp" => 1_547_078_400
+        }
+      ]
+      |> Jason.encode!()
+
+    mock(
+      HTTPoison,
+      :get,
+      {:ok,
+       %HTTPoison.Response{
+         body: body,
+         status_code: 200
+       }}
+    )
+
+    query = """
+    {
+      wordTrendScore(
+        word: "merry", 
+        source: TELEGRAM,
+        from: "2018-01-09T00:00:00Z",
+        to:"2018-01-10T00:00:00Z"
+      ) {
+        datetime,
+        score,
+        source
+        hour
+      }
+    }
+    """
+
+    result =
+      conn
+      |> post("/graphql", query_skeleton(query, "wordTrendScore"))
+      |> json_response(200)
+
+    assert result == %{
+             "data" => %{
+               "wordTrendScore" => [
+                 %{
+                   "hour" => 8.0,
+                   "score" => 3725.6617392595313,
+                   "source" => :telegram,
+                   "datetime" => "2019-01-10T00:00:00Z"
+                 }
+               ]
+             }
+           }
+  end
 end

--- a/test/sanbase_web/graphql/social_data_api_test.exs
+++ b/test/sanbase_web/graphql/social_data_api_test.exs
@@ -216,7 +216,6 @@ defmodule Sanbase.SocialDataApiTest do
         datetime,
         score,
         source
-        hour
       }
     }
     """
@@ -230,10 +229,9 @@ defmodule Sanbase.SocialDataApiTest do
              "data" => %{
                "wordTrendScore" => [
                  %{
-                   "hour" => 8.0,
                    "score" => 3725.6617392595313,
                    "source" => "TELEGRAM",
-                   "datetime" => "2019-01-10T00:00:00Z"
+                   "datetime" => "2019-01-10T08:00:00Z"
                  }
                ]
              }


### PR DESCRIPTION
#### Summary

```graphql
{
  wordTrendScore(
    word: "trx",
    source: TELEGRAM,
    from: "2018-12-22T00:00:00Z",
    to:"2018-12-24T00:00:00Z",
  ) {
    datetime,
    source,
    score
  }
}
```

```graphql
{
  "data": {
    "wordTrendScore": [
      {
        "datetime": "2018-12-22T08:00:00Z",
        "score": 955.9762635692033,
        "source": "TELEGRAM"
      },
      {
        "datetime": "2018-12-22T01:00:00Z",
        "score": 702.8604900070991,
        "source": "TELEGRAM"
      },
      {
        "datetime": "2018-12-22T14:00:00Z",
        "score": 463.4801579986572,
        "source": "TELEGRAM"
      },
      {
        "datetime": "2018-12-23T01:00:00Z",
        "score": 128.18643119865334,
        "source": "TELEGRAM"
      },
      {
        "datetime": "2018-12-24T14:00:00Z",
        "score": 46.573611493031734,
        "source": "TELEGRAM"
      },
      {
        "datetime": "2018-12-23T08:00:00Z",
        "score": 43.39397738187617,
        "source": "TELEGRAM"
      },
      {
        "datetime": "2018-12-24T08:00:00Z",
        "score": 19.332721224555886,
        "source": "TELEGRAM"
      },
      {
        "datetime": "2018-12-23T14:00:00Z",
        "score": 5.028586316999088,
        "source": "TELEGRAM"
      },
      {
        "datetime": "2018-12-24T01:00:00Z",
        "score": 0.9883586380985638,
        "source": "TELEGRAM"
      }
    ]
  }
}
```