### PR TITLE
Make the histogram instrumenter buckets linear

### DIFF
--- a/lib/sanbase_web/graphql/prometheus/histogram_instrumenter.ex
+++ b/lib/sanbase_web/graphql/prometheus/histogram_instrumenter.ex
@@ -1,5 +1,13 @@
 defmodule SanbaseWeb.Graphql.Prometheus.HistogramInstrumenter do
   use AbsintheMetrics,
     adapter: AbsintheMetrics.Backend.PrometheusHistogram,
-    arguments: [buckets: {:exponential, 10, 2, 12}]
+    arguments: [
+      buckets: [10, 50, 100, 200, 300, 400, 500, 700, 1000, 1500] ++ buckets(2000, 1000, 20)
+    ]
+
+  # Returns a list of `number` elements starting from `from` with a step `step`
+  defp buckets(from, step, number) do
+    Stream.unfold(from, fn x -> {x, x + step} end)
+    |> Enum.take(number)
+  end
 end

--- a/lib/sanbase_web/graphql/prometheus/histogram_instrumenter.ex
+++ b/lib/sanbase_web/graphql/prometheus/histogram_instrumenter.ex
@@ -1,4 +1,11 @@
 defmodule SanbaseWeb.Graphql.Prometheus.HistogramInstrumenter do
+  @moduledoc ~s"""
+  Stores data about the queries that is used to build prometheus histograms
+  https://prometheus.io/docs/practices/histograms/
+
+  Each bucket's number represents milliseconds. A query with a runtime of X seconds
+  falls in the last bucket with value Y where X < Y
+  """
   use AbsintheMetrics,
     adapter: AbsintheMetrics.Backend.PrometheusHistogram,
     arguments: [


### PR DESCRIPTION
When they were exponential the buckets were 100ms, 1s, 10s, 100s and
this is not very informative about the query times really

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
