### PR TITLE
Signal trending words

### DIFF
--- a/config/notifications_config.exs
+++ b/config/notifications_config.exs
@@ -70,5 +70,9 @@ config :sanbase, Sanbase.Scheduler,
     price_absolute_change_sonar_singal: [
       schedule: "4-59/5 * * * *",
       task: {Sanbase.Signals.Scheduler, :run_price_absolute_change_signals, []}
+    ],
+    trending_words_sonar_singal: [
+      schedule: "@hourly",
+      task: {Sanbase.Signals.Scheduler, :run_trending_words_signals, []}
     ]
   ]

--- a/config/notifications_config.exs
+++ b/config/notifications_config.exs
@@ -72,7 +72,7 @@ config :sanbase, Sanbase.Scheduler,
       task: {Sanbase.Signals.Scheduler, :run_price_absolute_change_signals, []}
     ],
     trending_words_sonar_singal: [
-      schedule: "@hourly",
+      schedule: "*/5 * * * *",
       task: {Sanbase.Signals.Scheduler, :run_trending_words_signals, []}
     ]
   ]

--- a/lib/sanbase/signals/evaluator/scheduler.ex
+++ b/lib/sanbase/signals/evaluator/scheduler.ex
@@ -2,7 +2,8 @@ defmodule Sanbase.Signals.Scheduler do
   alias Sanbase.Signals.Trigger.{
     DailyActiveAddressesSettings,
     PricePercentChangeSettings,
-    PriceAbsoluteChangeSettings
+    PriceAbsoluteChangeSettings,
+    TrendingWordsTriggerSettings
   }
 
   alias Sanbase.Signals.UserTrigger
@@ -24,6 +25,11 @@ defmodule Sanbase.Signals.Scheduler do
   def run_daily_active_addresses_signals() do
     DailyActiveAddressesSettings.type()
     |> run
+  end
+
+  def run_trending_words_signals() do
+    TrendingWordsTriggerSettings.type()
+    |> run()
   end
 
   # Private functions

--- a/lib/sanbase/signals/trigger/daily_active_addresses_settings.ex
+++ b/lib/sanbase/signals/trigger/daily_active_addresses_settings.ex
@@ -112,12 +112,12 @@ defmodule Sanbase.Signals.Trigger.DailyActiveAddressesSettings do
     end
 
     def cache_key(%DailyActiveAddressesSettings{} = settings) do
-      data =
-        [settings.type, settings.target, settings.time_window, settings.percent_threshold]
-        |> Jason.encode!()
-
-      :crypto.hash(:sha256, data)
-      |> Base.encode16()
+      construct_cache_key([
+        settings.type,
+        settings.target,
+        settings.time_window,
+        settings.percent_threshold
+      ])
     end
 
     defp chart_url(project) do

--- a/lib/sanbase/signals/trigger/daily_active_addresses_settings.ex
+++ b/lib/sanbase/signals/trigger/daily_active_addresses_settings.ex
@@ -32,21 +32,19 @@ defmodule Sanbase.Signals.Trigger.DailyActiveAddressesSettings do
 
   use Vex.Struct
   import Sanbase.Signals.Utils
+  import Sanbase.Signals.Validation
 
   alias __MODULE__
   alias Sanbase.Model.Project
   alias Sanbase.Clickhouse.{Erc20DailyActiveAddresses, EthDailyActiveAddresses}
   alias Sanbase.Signals.Evaluator.Cache
 
-  validates(:channel, inclusion: notification_channels)
-  validates(:time_window, format: ~r/^\d+[mhdw]$/)
-  validates(:percent_threshold, &__MODULE__.valid_percent?/1)
+  validates(:channel, inclusion: valid_notification_channels)
+  validates(:time_window, &valid_time_window?/1)
+  validates(:percent_threshold, &valid_percent?/1)
 
   @spec type() :: String.t()
   def type(), do: @trigger_type
-
-  def valid_percent?(percent) when is_float(percent), do: percent > 0
-  def valid_percent?(_), do: false
 
   def get_data(settings) do
     {:ok, contract, _token_decimals} = Project.contract_info_by_slug(settings.target)

--- a/lib/sanbase/signals/trigger/daily_active_addresses_settings.ex
+++ b/lib/sanbase/signals/trigger/daily_active_addresses_settings.ex
@@ -30,6 +30,7 @@ defmodule Sanbase.Signals.Trigger.DailyActiveAddressesSettings do
           payload: Type.payload()
         }
 
+  use Vex.Struct
   import Sanbase.Signals.Utils
 
   alias __MODULE__
@@ -37,8 +38,15 @@ defmodule Sanbase.Signals.Trigger.DailyActiveAddressesSettings do
   alias Sanbase.Clickhouse.{Erc20DailyActiveAddresses, EthDailyActiveAddresses}
   alias Sanbase.Signals.Evaluator.Cache
 
+  validates(:channel, inclusion: notification_channels)
+  validates(:time_window, format: ~r/^\d+[mhdw]$/)
+  validates(:percent_threshold, &__MODULE__.valid_percent?/1)
+
   @spec type() :: String.t()
   def type(), do: @trigger_type
+
+  def valid_percent?(percent) when is_float(percent), do: percent > 0
+  def valid_percent?(_), do: false
 
   def get_data(settings) do
     {:ok, contract, _token_decimals} = Project.contract_info_by_slug(settings.target)

--- a/lib/sanbase/signals/trigger/price_absolute_change_settings.ex
+++ b/lib/sanbase/signals/trigger/price_absolute_change_settings.ex
@@ -29,6 +29,7 @@ defmodule Sanbase.Signals.Trigger.PriceAbsoluteChangeSettings do
           payload: Type.payload()
         }
 
+  use Vex.Struct
   alias __MODULE__
   alias Sanbase.Model.Project
   alias Sanbase.Signals.Evaluator.Cache

--- a/lib/sanbase/signals/trigger/price_absolute_change_settings.ex
+++ b/lib/sanbase/signals/trigger/price_absolute_change_settings.ex
@@ -30,6 +30,7 @@ defmodule Sanbase.Signals.Trigger.PriceAbsoluteChangeSettings do
         }
 
   use Vex.Struct
+  import Sanbase.Signals.Utils
   alias __MODULE__
   alias Sanbase.Model.Project
   alias Sanbase.Signals.Evaluator.Cache
@@ -81,17 +82,12 @@ defmodule Sanbase.Signals.Trigger.PriceAbsoluteChangeSettings do
     so different triggers with the same parameter names can be distinguished
     """
     def cache_key(%PriceAbsoluteChangeSettings{} = settings) do
-      data =
-        [
-          settings.type,
-          settings.target,
-          settings.above,
-          settings.below
-        ]
-        |> Jason.encode!()
-
-      :crypto.hash(:sha256, data)
-      |> Base.encode16()
+      construct_cache_key([
+        settings.type,
+        settings.target,
+        settings.above,
+        settings.below
+      ])
     end
 
     defp chart_url(project) do

--- a/lib/sanbase/signals/trigger/price_percent_change_settings.ex
+++ b/lib/sanbase/signals/trigger/price_percent_change_settings.ex
@@ -29,10 +29,14 @@ defmodule Sanbase.Signals.Trigger.PricePercentChangeSettings do
           triggered?: boolean(),
           payload: Type.payload()
         }
+  use Vex.Struct
+  import Sanbase.Signals.Utils
 
   alias __MODULE__
   alias Sanbase.Model.Project
   alias Sanbase.Signals.Evaluator.Cache
+
+  validates(:channel, inclusion: notification_channels)
 
   def type(), do: @trigger_type
 

--- a/lib/sanbase/signals/trigger/price_percent_change_settings.ex
+++ b/lib/sanbase/signals/trigger/price_percent_change_settings.ex
@@ -96,17 +96,12 @@ defmodule Sanbase.Signals.Trigger.PricePercentChangeSettings do
     so different triggers with the same parameter names can be distinguished
     """
     def cache_key(%PricePercentChangeSettings{} = settings) do
-      data =
-        [
-          settings.type,
-          settings.target,
-          settings.time_window,
-          settings.percent_threshold
-        ]
-        |> Jason.encode!()
-
-      :crypto.hash(:sha256, data)
-      |> Base.encode16()
+      construct_cache_key([
+        settings.type,
+        settings.target,
+        settings.time_window,
+        settings.percent_threshold
+      ])
     end
 
     defp chart_url(project) do

--- a/lib/sanbase/signals/trigger/trending_words_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/trending_words_trigger_settings.ex
@@ -22,7 +22,6 @@ defmodule Sanbase.Signals.Trigger.TrendingWordsTriggerSettings do
     def triggered?(%TrendingWordsTriggerSettings{triggered?: triggered}), do: triggered
 
     def evaluate(%TrendingWordsTriggerSettings{} = trigger) do
-
       with true <- time_to_signal?(trigger),
            {:ok, payload} <- trigger_payload() do
         %TrendingWordsTriggerSettings{

--- a/lib/sanbase/signals/trigger/trending_words_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/trending_words_trigger_settings.ex
@@ -41,7 +41,7 @@ defmodule Sanbase.Signals.Trigger.TrendingWordsTriggerSettings do
 
   # Validations
   validates(:channel, inclusion: valid_notification_channels)
-  validates(:trigger_time, &__MODULE__.valid_trigger_time?/1)
+  validates(:trigger_time, &valid_iso8601_datetime_string?/1)
 
   @spec type() :: String.t()
   def type(), do: @trigger_type
@@ -50,23 +50,12 @@ defmodule Sanbase.Signals.Trigger.TrendingWordsTriggerSettings do
   def get_data(%TrendingWordsTriggerSettings{trigger_time: trigger_time}) do
     now = Timex.now()
     trigger_time = Time.from_iso8601!(trigger_time)
+    now_time = DateTime.to_time(now)
 
-    if trigger_time.hour == now.hour do
+    if Time.compare(now_time, trigger_time) in [:gt, :eq] do
       get_today_top_words(now)
     end
   end
-
-  def valid_trigger_time?(trigger_time) when is_binary(trigger_time) do
-    case Time.from_iso8601(trigger_time) do
-      {:ok, _time} ->
-        :ok
-
-      _ ->
-        {:error, "#{trigger_time} isn't a valid iso time"}
-    end
-  end
-
-  def valid_trigger_time?(_), do: :error
 
   # private functions
 

--- a/lib/sanbase/signals/trigger/trending_words_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/trending_words_trigger_settings.ex
@@ -19,9 +19,10 @@ defmodule Sanbase.Signals.Trigger.TrendingWordsTriggerSettings do
   use Vex.Struct
   import Sanbase.Utils.Math, only: [to_integer: 1]
   import Sanbase.Signals.Utils
+  import Sanbase.Signals.Validation
   alias __MODULE__
 
-  validates(:channel, inclusion: notification_channels)
+  validates(:channel, inclusion: valid_notification_channels)
   validates(:trigger_time, &__MODULE__.valid_trigger_time?/1)
 
   def type(), do: @trigger_type

--- a/lib/sanbase/signals/trigger/trending_words_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/trending_words_trigger_settings.ex
@@ -15,7 +15,7 @@ defmodule Sanbase.Signals.Trigger.TrendingWordsTriggerSettings do
 
   def type(), do: @trigger_type
 
-  defimpl Sanbase.Signals.Triggerable, for: TrendingWordsTriggerSettings do
+  defimpl Sanbase.Signals.Settings, for: TrendingWordsTriggerSettings do
     @trending_words_size 10
     @trending_words_hours [1, 8, 14]
 

--- a/lib/sanbase/signals/trigger/trending_words_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/trending_words_trigger_settings.ex
@@ -1,8 +1,141 @@
 defmodule Sanbase.Signals.Trigger.TrendingWordsTriggerSettings do
   @derive [Jason.Encoder]
   @trigger_type "trending_words"
-  @enforce_keys [:type, :channel, :time_window]
+  @enforce_keys [:type, :channel, :trigger_time_iso_utc]
+
   defstruct type: @trigger_type,
+            channel: nil,
             # ISO8601 string time in UTC
-            trigger_time_iso_utc: nil
+            trigger_time_iso_utc: nil,
+            triggered?: false,
+            payload: nil
+
+  import Sanbase.Utils.Math, only: [to_integer: 1]
+  alias __MODULE__
+
+  def type(), do: @trigger_type
+
+  defimpl Sanbase.Signals.Triggerable, for: TrendingWordsTriggerSettings do
+    @trending_words_size 10
+    @trending_words_hours [1, 8, 14]
+
+    def triggered?(%TrendingWordsTriggerSettings{triggered?: triggered}), do: triggered
+
+    def evaluate(%TrendingWordsTriggerSettings{} = trigger) do
+      IO.inspect(trigger)
+
+      with true <- time_to_signal?(trigger),
+           {:ok, payload} <- trigger_payload() do
+        %TrendingWordsTriggerSettings{
+          trigger
+          | triggered?: true,
+            payload: payload
+        }
+      else
+        error ->
+          %TrendingWordsTriggerSettings{trigger | triggered?: false}
+      end
+    end
+
+    def cache_key(%TrendingWordsTriggerSettings{} = trigger) do
+      data =
+        [trigger.trigger_time_iso_utc]
+        |> Jason.encode!()
+
+      :crypto.hash(:sha256, data)
+      |> Base.encode16()
+    end
+
+    defp time_to_signal?(%TrendingWordsTriggerSettings{trigger_time_iso_utc: trigger_time}) do
+      case Time.from_iso8601(trigger_time) do
+        {:ok, time} ->
+          time.hour == Timex.now().hour
+
+        _ ->
+          false
+      end
+    end
+
+    defp get_trending_word_query_params() do
+      now = Timex.now()
+
+      @trending_words_hours
+      |> Enum.filter(&(&1 < now.hour))
+      |> case do
+        [] ->
+          {
+            Timex.beginning_of_day(Timex.shift(now, days: -1)),
+            Timex.end_of_day(Timex.shift(now, days: -1)),
+            @trending_words_hours |> Enum.max()
+          }
+
+        hours ->
+          {
+            Timex.beginning_of_day(now),
+            Timex.end_of_day(now),
+            hours |> Enum.max()
+          }
+      end
+    end
+
+    defp get_today_top_words() do
+      {from, to, hour} = get_trending_word_query_params()
+
+      Sanbase.SocialData.trending_words(
+        :all,
+        @trending_words_size,
+        hour,
+        from,
+        to
+      )
+      |> case do
+        {:ok, [%{top_words: top_words}]} ->
+          {:ok, top_words}
+
+        error ->
+          :error
+      end
+    end
+
+    defp get_max_len(top_words) do
+      top_words
+      |> Enum.map(fn tw -> String.length(tw.word) end)
+      |> Enum.max()
+    end
+
+    defp trigger_payload() do
+      get_today_top_words()
+      |> IO.inspect()
+      |> case do
+        {:ok, top_words} ->
+          max_len = get_max_len(top_words)
+          {:ok, build_payload(top_words, max_len) |> IO.inspect()}
+
+        _ ->
+          :error
+      end
+    end
+
+    defp build_payload(top_words, max_len) do
+      top_words_strings =
+        top_words
+        |> Enum.sort_by(fn tw -> tw.score end, &>=/2)
+        |> Enum.map(fn tw ->
+          ~s(#{String.pad_trailing(tw.word, max_len)} | #{to_integer(tw.score)})
+        end)
+
+      top_words_table = Enum.join(top_words_strings, "\n")
+
+      payload = """
+      Trending words for: `#{Date.to_string(DateTime.to_date(Timex.now()))}`
+
+      ```
+      #{String.pad_trailing("Word", max_len)} | Score
+      #{String.pad_trailing("-", max_len, "-")} | #{String.pad_trailing("-", max_len, "-")}
+      #{top_words_table}
+      ```
+      More info: https://app.santiment.net/sonar
+      """
+    end
+  end
 end

--- a/lib/sanbase/signals/trigger/trending_words_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/trending_words_trigger_settings.ex
@@ -1,4 +1,8 @@
 defmodule Sanbase.Signals.Trigger.TrendingWordsTriggerSettings do
+  @moduledoc ~s"""
+  Trigger settings for daily trending words signal
+  """
+
   @derive [Jason.Encoder]
   @trigger_type "trending_words"
   @trending_words_size 10
@@ -17,7 +21,7 @@ defmodule Sanbase.Signals.Trigger.TrendingWordsTriggerSettings do
   import Sanbase.Signals.Utils
   alias __MODULE__
 
-  validates(:channel, inclusion: available_channels)
+  validates(:channel, inclusion: notification_channels)
   validates(:trigger_time, &__MODULE__.valid_trigger_time?/1)
 
   def type(), do: @trigger_type
@@ -27,8 +31,6 @@ defmodule Sanbase.Signals.Trigger.TrendingWordsTriggerSettings do
 
     if trigger_time.hour == Timex.now().hour do
       get_today_top_words()
-    else
-      :error
     end
   end
 
@@ -105,7 +107,7 @@ defmodule Sanbase.Signals.Trigger.TrendingWordsTriggerSettings do
     end
 
     def cache_key(%TrendingWordsTriggerSettings{} = settings) do
-      Sanbase.Signals.Utils.calculate_cache_key([settings.trigger_time])
+      construct_cache_key([settings.trigger_time])
     end
 
     defp payload(top_words) do

--- a/lib/sanbase/signals/trigger/trending_words_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/trending_words_trigger_settings.ex
@@ -22,7 +22,6 @@ defmodule Sanbase.Signals.Trigger.TrendingWordsTriggerSettings do
     def triggered?(%TrendingWordsTriggerSettings{triggered?: triggered}), do: triggered
 
     def evaluate(%TrendingWordsTriggerSettings{} = trigger) do
-      IO.inspect(trigger)
 
       with true <- time_to_signal?(trigger),
            {:ok, payload} <- trigger_payload() do
@@ -105,11 +104,10 @@ defmodule Sanbase.Signals.Trigger.TrendingWordsTriggerSettings do
 
     defp trigger_payload() do
       get_today_top_words()
-      |> IO.inspect()
       |> case do
         {:ok, top_words} ->
           max_len = get_max_len(top_words)
-          {:ok, build_payload(top_words, max_len) |> IO.inspect()}
+          {:ok, build_payload(top_words, max_len)}
 
         _ ->
           :error

--- a/lib/sanbase/signals/trigger/utils.ex
+++ b/lib/sanbase/signals/trigger/utils.ex
@@ -1,4 +1,9 @@
 defmodule Sanbase.Signals.Utils do
+  @available_channels ["telegram", "email"]
+
+  def available_channels(), do: @available_channels
+
+  def percent_change(0, _current_daa), do: 0
   def percent_change(nil, _current_daa), do: 0
 
   def percent_change(previous, _current_daa) when is_number(previous) and previous <= 1.0e-6,
@@ -6,5 +11,12 @@ defmodule Sanbase.Signals.Utils do
 
   def percent_change(previous, current) when is_number(previous) and is_number(current) do
     Float.round((current - previous) / previous * 100)
+  end
+
+  def calculate_cache_key(keys) when is_list(keys) do
+    data = keys |> Jason.encode!()
+
+    :crypto.hash(:sha256, data)
+    |> Base.encode16()
   end
 end

--- a/lib/sanbase/signals/trigger/utils.ex
+++ b/lib/sanbase/signals/trigger/utils.ex
@@ -1,7 +1,7 @@
 defmodule Sanbase.Signals.Utils do
-  @available_channels ["telegram", "email"]
+  @notification_channels ["telegram", "email"]
 
-  def available_channels(), do: @available_channels
+  def notification_channels(), do: @notification_channels
 
   def percent_change(0, _current_daa), do: 0
   def percent_change(nil, _current_daa), do: 0
@@ -13,7 +13,7 @@ defmodule Sanbase.Signals.Utils do
     Float.round((current - previous) / previous * 100)
   end
 
-  def calculate_cache_key(keys) when is_list(keys) do
+  def construct_cache_key(keys) when is_list(keys) do
     data = keys |> Jason.encode!()
 
     :crypto.hash(:sha256, data)

--- a/lib/sanbase/signals/user_trigger.ex
+++ b/lib/sanbase/signals/user_trigger.ex
@@ -168,7 +168,7 @@ defmodule Sanbase.Signals.UserTrigger do
 
   defp struct_from_map(%{type: "price_absolute_change"} = trigger_settings),
     do: {:ok, struct!(PriceAbsoluteChangeSettings, trigger_settings)}
-  
+
   defp struct_from_map(%{type: "trending_words"} = trigger_settings),
     do: {:ok, struct!(TrendingWordsTriggerSettings, trigger_settings)}
 

--- a/lib/sanbase/signals/user_trigger.ex
+++ b/lib/sanbase/signals/user_trigger.ex
@@ -133,6 +133,7 @@ defmodule Sanbase.Signals.UserTrigger do
 
   defp is_valid?(trigger) do
     with {:ok, trigger_struct} <- load_in_struct(trigger),
+         true <- Vex.valid?(trigger_struct),
          {:ok, _trigger_map} <- map_from_struct(trigger_struct) do
       true
     else

--- a/lib/sanbase/signals/user_trigger.ex
+++ b/lib/sanbase/signals/user_trigger.ex
@@ -167,6 +167,12 @@ defmodule Sanbase.Signals.UserTrigger do
 
   defp struct_from_map(%{type: "price_absolute_change"} = trigger_settings),
     do: {:ok, struct!(PriceAbsoluteChangeSettings, trigger_settings)}
+  
+  defp struct_from_map(%{type: "trending_words"} = trigger_settings),
+    do: {:ok, struct!(TrendingWordsTriggerSettings, trigger_settings)}
+
+  defp struct_from_map(%{type: "price_volume"} = trigger_settings),
+    do: {:ok, struct!(PriceVolumeTriggerSettings, trigger_settings)}
 
   defp struct_from_map(_), do: :error
 

--- a/lib/sanbase/signals/validation.ex
+++ b/lib/sanbase/signals/validation.ex
@@ -7,7 +7,7 @@ defmodule Sanbase.Signals.Validation do
   def valid_percent?(_), do: false
 
   def valid_time_window?(time_window) when is_binary(time_window) do
-    Regex.match?(~r/^\d+[mhdw]$/, time_window)
+    Regex.match?(~r/^\d+[smhdw]$/, time_window)
   end
 
   def valid_time_window?(_), do: false

--- a/lib/sanbase/signals/validation.ex
+++ b/lib/sanbase/signals/validation.ex
@@ -3,7 +3,7 @@ defmodule Sanbase.Signals.Validation do
 
   def valid_notification_channels(), do: @notification_channels
 
-  def valid_percent?(percent) when is_float(percent), do: percent > 0
+  def valid_percent?(percent) when is_float(percent), do: true
   def valid_percent?(_), do: false
 
   def valid_time_window?(time_window) when is_binary(time_window) do

--- a/lib/sanbase/signals/validation.ex
+++ b/lib/sanbase/signals/validation.ex
@@ -1,0 +1,14 @@
+defmodule Sanbase.Signals.Validation do
+  @notification_channels ["telegram", "email"]
+
+  def valid_notification_channels(), do: @notification_channels
+
+  def valid_percent?(percent) when is_float(percent), do: percent > 0
+  def valid_percent?(_), do: false
+
+  def valid_time_window?(time_window) when is_binary(time_window) do
+    Regex.match?(~r/^\d+[mhdw]$/, time_window)
+  end
+
+  def valid_time_window?(_), do: false
+end

--- a/lib/sanbase/signals/validation.ex
+++ b/lib/sanbase/signals/validation.ex
@@ -11,4 +11,16 @@ defmodule Sanbase.Signals.Validation do
   end
 
   def valid_time_window?(_), do: false
+
+  def valid_iso8601_datetime_string?(time) when is_binary(time) do
+    case Time.from_iso8601(time) do
+      {:ok, _time} ->
+        :ok
+
+      _ ->
+        {:error, "#{time} isn't a valid ISO8601 time"}
+    end
+  end
+
+  def valid_iso8601_datetime_string?(_), do: :error
 end

--- a/mix.exs
+++ b/mix.exs
@@ -116,7 +116,8 @@ defmodule Sanbase.Mixfile do
       "ecto.setup": [
         "load_dotenv",
         "ecto.drop -r Sanbase.Repo",
-        "ecto.setup -r Sanbase.Repo"
+        "ecto.create -r Sanbase.Repo",
+        "ecto.load -r Sanbase.Repo"
       ],
       "ecto.migrate": [
         "load_dotenv",

--- a/mix.exs
+++ b/mix.exs
@@ -107,7 +107,8 @@ defmodule Sanbase.Mixfile do
       {:libcluster, "~> 3.0"},
       {:number, "~> 0.5.7"},
       {:remote_ip, "~> 0.1"},
-      {:cachex, "~> 3.1"}
+      {:cachex, "~> 3.1"},
+      {:vex, "~> 0.8.0", override: true}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -29,7 +29,7 @@
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "2.2.11", "4bb8f11718b72ba97a2696f65d247a379e739a0ecabf6a13ad1face79844791c", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "ecto_enum": {:hex, :ecto_enum, "1.1.0", "d44fe2ce6e1c0e907e7c3b6456a69e0f1d662348d8b4e2a662ba312223d8ff62", [:mix], [{:ecto, ">= 2.0.0", [hex: :ecto, repo: "hexpm", optional: false]}, {:mariaex, ">= 0.0.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:postgrex, ">= 0.0.0", [hex: :postgrex, repo: "hexpm", optional: true]}], "hexpm"},
-  "elasticsearch": {:hex, :elasticsearch, "0.5.4", "a287fc15f52c7858c528836bfb071768ffa500489b8e1ff13803a589f05976c4", [:mix], [{:httpoison, ">= 0.0.0", [hex: :httpoison, repo: "hexpm", optional: false]}, {:maybe, "~> 1.0.0", [hex: :maybe, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: true]}, {:vex, "~> 0.6.0", [hex: :vex, repo: "hexpm", optional: false]}], "hexpm"},
+  "elasticsearch": {:hex, :elasticsearch, "0.6.1", "35a5df352c5f2183366afcd149b063d4e53df90b2bc1b25535a6d1da645f25db", [:mix], [{:httpoison, ">= 0.0.0", [hex: :httpoison, repo: "hexpm", optional: false]}, {:maybe, "~> 1.0.0", [hex: :maybe, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: true]}, {:vex, "~> 0.6.0", [hex: :vex, repo: "hexpm", optional: false]}], "hexpm"},
   "envy": {:hex, :envy, "1.1.1", "0bc9bd654dec24fcdf203f7c5aa1b8f30620f12cfb28c589d5e9c38fe1b07475", [:mix], [], "hexpm"},
   "erlex": {:hex, :erlex, "0.1.6", "c01c889363168d3fdd23f4211647d8a34c0f9a21ec726762312e08e083f3d47e", [:mix], [], "hexpm"},
   "eternal": {:hex, :eternal, "1.2.1", "d5b6b2499ba876c57be2581b5b999ee9bdf861c647401066d3eeed111d096bc4", [:mix], [], "hexpm"},
@@ -113,6 +113,6 @@
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
   "unsafe": {:hex, :unsafe, "1.0.1", "a27e1874f72ee49312e0a9ec2e0b27924214a05e3ddac90e91727bc76f8613d8", [:mix], [], "hexpm"},
   "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"},
-  "vex": {:hex, :vex, "0.6.0", "4e79b396b2ec18cd909eed0450b19108d9631842598d46552dc05031100b7a56", [:mix], [], "hexpm"},
+  "vex": {:hex, :vex, "0.8.0", "0a04e3aebe5ec443525c88f3833b4481d97de272f891243b62b18efbda85b121", [:mix], [], "hexpm"},
   "xain": {:hex, :xain, "0.6.0", "5b61cfe3ffc17904759ee30a699f9e0b1aefd943e996ee4cafea76e5b2f59e3a", [:mix], [], "hexpm"},
 }

--- a/test/sanbase/signals/triggers_test.exs
+++ b/test/sanbase/signals/triggers_test.exs
@@ -34,7 +34,7 @@ defmodule Sanbase.Signals.TriggersTest do
   test "try creating user trigger with unknown type" do
     user = insert(:user)
 
-    trigger = %{
+    trigger_settings = %{
       type: "unknown",
       target: "santiment",
       channel: "telegram",
@@ -44,7 +44,27 @@ defmodule Sanbase.Signals.TriggersTest do
     }
 
     {:error, message} =
-      UserTrigger.create_user_trigger(user, %{is_public: true, trigger: trigger})
+      UserTrigger.create_user_trigger(user, %{is_public: true, settings: trigger_settings})
+
+    assert message == "Trigger structure is invalid"
+  end
+
+  test "try creating user trigger with unknown channel" do
+    user = insert(:user)
+
+    trigger_settings = %{
+      type: "daily_active_addresses",
+      target: "santiment",
+      channel: "unknown",
+      time_window: "1d",
+      percent_threshold: 300.0,
+      repeating: false,
+      triggered?: false,
+      payload: nil
+    }
+
+    {:error, message} =
+      UserTrigger.create_user_trigger(user, %{is_public: true, settings: trigger_settings})
 
     assert message == "Trigger structure is invalid"
   end
@@ -52,7 +72,7 @@ defmodule Sanbase.Signals.TriggersTest do
   test "try creating user trigger with required field in struct" do
     user = insert(:user)
 
-    trigger = %{
+    settings = %{
       type: "daily_active_addresses",
       target: "santiment",
       time_window: "1d",
@@ -61,7 +81,7 @@ defmodule Sanbase.Signals.TriggersTest do
     }
 
     {:error, message} =
-      UserTrigger.create_user_trigger(user, %{is_public: true, trigger: trigger})
+      UserTrigger.create_user_trigger(user, %{is_public: true, settings: settings})
 
     assert message == "Trigger structure is invalid"
   end

--- a/test/sanbase_web/graphql/triggers_api_test.exs
+++ b/test/sanbase_web/graphql/triggers_api_test.exs
@@ -278,6 +278,39 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
     assert result |> hd() |> Map.get("settings") == trigger_settings
   end
 
+  test "create trending words trigger", %{conn: conn} do
+    trigger_settings = %{
+      "type" => "trending_words",
+      "channel" => "telegram",
+      "trigger_time_iso_utc" => "12:00:00"
+    }
+
+    trigger_settings_json = trigger_settings |> Jason.encode!()
+
+    query =
+      ~s|
+    mutation {
+      createTrigger(
+        settings: '#{trigger_settings_json}'
+      ) {
+        id
+        settings
+      }
+    }
+    |
+      |> format_interpolated_json()
+      |> IO.inspect()
+
+    result =
+      conn
+      |> post("/graphql", %{"query" => query})
+
+    created_trigger = json_response(result, 200)["data"]["createTrigger"]
+
+    assert created_trigger |> Map.get("settings") == trigger_settings
+    assert created_trigger |> Map.get("id") != nil
+  end
+
   defp format_interpolated_json(string) do
     string
     |> String.replace(~r|\"|, ~S|\\"|)

--- a/test/sanbase_web/graphql/triggers_api_test.exs
+++ b/test/sanbase_web/graphql/triggers_api_test.exs
@@ -282,7 +282,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
     trigger_settings = %{
       "type" => "trending_words",
       "channel" => "telegram",
-      "trigger_time_iso_utc" => "12:00:00"
+      "trigger_time" => "12:00:00"
     }
 
     trigger_settings_json = trigger_settings |> Jason.encode!()

--- a/test/sanbase_web/graphql/triggers_api_test.exs
+++ b/test/sanbase_web/graphql/triggers_api_test.exs
@@ -299,7 +299,6 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
     }
     |
       |> format_interpolated_json()
-      |> IO.inspect()
 
     result =
       conn


### PR DESCRIPTION
#### Summary
Send trending words signal

Create trending words trigger.
`trigger_time`: ISO UTC string

```graphql
mutation {
      createTrigger(
        cooldown: "24h",
        settings: "{\"channel\":\"telegram\",\"trigger_time\":\"12:00:00\",\"type\":\"trending_words\"}"
      ) {
        id
        settings
      }
    }
```

#### Screenshots
<!-- (if appropriate) -->
![image](https://user-images.githubusercontent.com/122794/52345465-f55a4080-2a25-11e9-87fd-8afc61f836ef.png)
