### PR TITLE
Add pagination and cache to all_insights query

### DIFF
--- a/lib/sanbase/voting/post.ex
+++ b/lib/sanbase/voting/post.ex
@@ -134,6 +134,17 @@ defmodule Sanbase.Voting.Post do
     |> get_only_published_or_own_posts(user_id)
   end
 
+  def published_posts(page, page_size) do
+    from(
+      p in Post,
+      where: p.ready_state == ^@published,
+      order_by: [desc: p.updated_at],
+      limit: ^page_size,
+      offset: ^((page - 1) * page_size)
+    )
+    |> Repo.all()
+  end
+
   @doc """
     Change insights owner to be the fallback user
   """

--- a/lib/sanbase_web/graphql/resolvers/post_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/post_resolver.ex
@@ -22,20 +22,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.PostResolver do
     end
   end
 
-  def all_insights(_root, _args, %{
-        context: %{auth: %{current_user: %User{id: user_id}}}
-      }) do
+  def all_insights(_root, %{page: page, page_size: page_size}, _resolution) do
     posts =
-      user_id
-      |> Post.ranked_published_or_own_posts()
-      |> Repo.preload(@preloaded_assoc)
-
-    {:ok, posts}
-  end
-
-  def all_insights(_root, _args, _context) do
-    posts =
-      Post.ranked_published_posts()
+      Post.published_posts(page, page_size)
       |> Repo.preload(@preloaded_assoc)
 
     {:ok, posts}

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -434,8 +434,11 @@ defmodule SanbaseWeb.Graphql.Schema do
 
     @desc "Fetch a list of all posts/insights. The user must be logged in to access all fields for the post/insight."
     field :all_insights, list_of(:post) do
+      arg(:page, :integer, default_value: 1)
+      arg(:page_size, :integer, default_value: 20)
+
       middleware(PostPermissions)
-      resolve(&PostResolver.all_insights/3)
+      cache_resolve(&PostResolver.all_insights/3)
     end
 
     @desc "Fetch a list of all posts for given user ID."


### PR DESCRIPTION
Also all_insights now returns only the published posts but not the
current user's not published ones

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
