### PR TITLE
Implement historical balances with the balances table

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -7,6 +7,7 @@
     "file_column_width": 100
   },
   "skip_files": [
+    "lib/prometheus",
     "lib/mix",
     "lib/sanbase_web/admin",
     "lib/sanbase_web/channels",

--- a/lib/sanbase/clickhouse/common.ex
+++ b/lib/sanbase/clickhouse/common.ex
@@ -1,54 +1,6 @@
 defmodule Sanbase.Clickhouse.Common do
   alias Sanbase.DateTimeUtils
 
-  def convert_historical_balance_result({:ok, []}, _, _, _), do: []
-
-  def convert_historical_balance_result({:ok, result}, from_datetime, to_datetime, interval) do
-    from_datetime_unix = DateTime.to_unix(from_datetime)
-    to_datetime_unix = DateTime.to_unix(to_datetime)
-    interval_points = div(to_datetime_unix - from_datetime_unix, interval) + 1
-
-    intervals =
-      from_datetime_unix
-      |> Stream.iterate(fn dt_unix -> dt_unix + interval end)
-      |> Enum.take(interval_points)
-
-    initial_intervals = intervals |> Enum.map(fn int -> {int, 0} end) |> Enum.into(%{})
-    filled_intervals = fill_intervals_with_balance(intervals, result)
-
-    calculate_balances_for_intervals(initial_intervals, filled_intervals)
-  end
-
-  def convert_historical_balance_result(_, _, _, _), do: []
-
-  def calculate_balances_for_intervals(initial_intervals, filled_intervals) do
-    initial_intervals
-    |> Map.merge(filled_intervals)
-    |> Enum.sort_by(fn {k, _} -> k end)
-    |> Enum.map(fn {dt, value} ->
-      %{
-        datetime: DateTime.from_unix!(dt),
-        balance: value
-      }
-    end)
-  end
-
-  defp fill_intervals_with_balance(intervals, balances) do
-    {_, last_balance} = balances |> List.last()
-
-    for int <- intervals,
-        {dt, balance} <- balances do
-      if int >= dt do
-        {int, balance}
-      else
-        {int, nil}
-      end
-    end
-    |> Enum.filter(fn {_, v} -> v != nil end)
-    |> List.update_at(-1, fn {k, _} -> {k, last_balance} end)
-    |> Enum.into(%{})
-  end
-
   def datetime_rounding_for_interval(interval) do
     if interval < DateTimeUtils.compound_duration_to_seconds("1d") do
       "toStartOfHour(dt)"

--- a/lib/sanbase/clickhouse/eth_transfers.ex
+++ b/lib/sanbase/clickhouse/eth_transfers.ex
@@ -33,7 +33,6 @@ defmodule Sanbase.Clickhouse.EthTransfers do
   require Sanbase.ClickhouseRepo, as: ClickhouseRepo
 
   alias Sanbase.Model.Project
-  alias Sanbase.Clickhouse.Common, as: ClickhouseCommon
 
   @table "eth_transfers"
   @eth_decimals 1_000_000_000_000_000_000

--- a/lib/sanbase/clickhouse/historical_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance.ex
@@ -1,0 +1,116 @@
+defmodule Sanbase.Clickhouse.HistoricalBalance.EthBalance do
+  @doc ~s"""
+  Returns the historical balances of given ethereum address in all intervals between two datetimes.
+  """
+
+  use Ecto.Schema
+
+  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+
+  @eth_decimals 1_000_000_000_000_000_000
+  @type historical_balance :: %{
+          datetime: non_neg_integer(),
+          balance: float
+        }
+
+  @table "eth_balances"
+  schema @table do
+    field(:datetime, :utc_datetime, source: :dt)
+    field(:contract, :string)
+    field(:address, :string, source: :to)
+    field(:value, :float)
+    field(:sign, :integer)
+  end
+
+  @spec changeset(any(), any()) :: no_return()
+  def changeset(_, _attrs \\ %{}),
+    do: raise("Should not try to change eth daily active addresses")
+
+  @spec historical_balance(
+          String.t(),
+          DateTime.t(),
+          DateTime.t(),
+          non_neg_integer()
+        ) :: {:ok, list(historical_balance)}
+  def historical_balance(address, from, to, interval) do
+    {query, args} =
+      String.downcase(address)
+      |> historical_balance_query(from, to, interval)
+
+    ClickhouseRepo.query_transform(query, args, fn [dt, value, sign] ->
+      %{datetime: Sanbase.DateTimeUtils.from_erl!(dt), balance: value / @eth_decimals, sign: sign}
+    end)
+    |> case do
+      {:ok, result} ->
+        # Clickhouse fills empty buckets with 0 while we need it filled with the last
+        # seen value. As the balance changes happen only when a transfer occurs
+        # then we need to fetch the whole history of changes in order to find the balance
+        result =
+          result
+          |> Enum.reduce({0, []}, fn
+            %{sign: 1, balance: balance, datetime: dt}, {_last_seen, acc} ->
+              {balance, [%{balance: balance, datetime: dt} | acc]}
+
+            %{sign: 0, datetime: dt}, {last_seen, acc} ->
+              {last_seen, [%{balance: last_seen, datetime: dt} | acc]}
+          end)
+          |> elem(1)
+          |> Enum.reverse()
+          |> Enum.drop_while(fn %{datetime: dt} -> DateTime.compare(dt, from) == :lt end)
+
+        {:ok, result}
+
+      error ->
+        error
+    end
+  end
+
+  @hardcoded_eth_from_unix ~N[2014-05-13 00:00:00]
+                           |> DateTime.from_naive!("Etc/UTC")
+                           |> DateTime.to_unix()
+  defp historical_balance_query(address, _from, to, interval) do
+    interval = Sanbase.DateTimeUtils.compound_duration_to_seconds(interval)
+    to_unix = DateTime.to_unix(to)
+    span = div(to_unix - @hardcoded_eth_from_unix, interval) |> max(1)
+
+    query = """
+    SELECT time, SUM(value), toInt32(SUM(sign))
+      FROM (
+        SELECT
+          toDateTime(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) as time,
+          toFloat64(0) AS value,
+          toInt32(0) as sign
+        FROM numbers(?2)
+
+        UNION ALL
+
+    SELECT toDateTime(intDiv(toUInt32(dt), ?1) * ?1) as time, argMax(value, dt), argMax(sign, dt)
+      FROM (
+        SELECT any(value) as value, dt, 1 as sign
+        FROM #{@table}
+        PREWHERE address = ?3
+        AND sign = 1
+        AND dt >= toDateTime(?4)
+        AND dt <= toDateTime(?5)
+        GROUP BY address, dt
+      )
+      GROUP BY time
+      ORDER BY time
+    )
+    GROUP BY time
+    ORDER BY time
+    """
+
+    args = [
+      interval,
+      span,
+      address,
+      @hardcoded_eth_from_unix,
+      to_unix
+    ]
+
+    # args = [interval, address, from_unix, to_unix]
+
+    {query, args}
+  end
+end

--- a/lib/sanbase/clickhouse/historical_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance.ex
@@ -1,116 +1,27 @@
-defmodule Sanbase.Clickhouse.HistoricalBalance.EthBalance do
-  @doc ~s"""
-  Returns the historical balances of given ethereum address in all intervals between two datetimes.
-  """
+defmodule Sanbase.Clickhouse.HistoricalBalance do
+  alias Sanbase.Model.Project
 
-  use Ecto.Schema
+  def historical_balance(address, slug, from, to, interval) do
+    with {:ok, contract, token_decimals} <- Project.contract_info_by_slug(slug) do
+      case contract do
+        "ETH" ->
+          __MODULE__.EthBalance.historical_balance(
+            address,
+            from,
+            to,
+            interval
+          )
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
-
-  @eth_decimals 1_000_000_000_000_000_000
-  @type historical_balance :: %{
-          datetime: non_neg_integer(),
-          balance: float
-        }
-
-  @table "eth_balances"
-  schema @table do
-    field(:datetime, :utc_datetime, source: :dt)
-    field(:contract, :string)
-    field(:address, :string, source: :to)
-    field(:value, :float)
-    field(:sign, :integer)
-  end
-
-  @spec changeset(any(), any()) :: no_return()
-  def changeset(_, _attrs \\ %{}),
-    do: raise("Should not try to change eth daily active addresses")
-
-  @spec historical_balance(
-          String.t(),
-          DateTime.t(),
-          DateTime.t(),
-          non_neg_integer()
-        ) :: {:ok, list(historical_balance)}
-  def historical_balance(address, from, to, interval) do
-    {query, args} =
-      String.downcase(address)
-      |> historical_balance_query(from, to, interval)
-
-    ClickhouseRepo.query_transform(query, args, fn [dt, value, sign] ->
-      %{datetime: Sanbase.DateTimeUtils.from_erl!(dt), balance: value / @eth_decimals, sign: sign}
-    end)
-    |> case do
-      {:ok, result} ->
-        # Clickhouse fills empty buckets with 0 while we need it filled with the last
-        # seen value. As the balance changes happen only when a transfer occurs
-        # then we need to fetch the whole history of changes in order to find the balance
-        result =
-          result
-          |> Enum.reduce({0, []}, fn
-            %{sign: 1, balance: balance, datetime: dt}, {_last_seen, acc} ->
-              {balance, [%{balance: balance, datetime: dt} | acc]}
-
-            %{sign: 0, datetime: dt}, {last_seen, acc} ->
-              {last_seen, [%{balance: last_seen, datetime: dt} | acc]}
-          end)
-          |> elem(1)
-          |> Enum.reverse()
-          |> Enum.drop_while(fn %{datetime: dt} -> DateTime.compare(dt, from) == :lt end)
-
-        {:ok, result}
-
-      error ->
-        error
+        _ ->
+          __MODULE__.Erc20Balance.historical_balance(
+            address,
+            contract,
+            token_decimals,
+            from,
+            to,
+            interval
+          )
+      end
     end
-  end
-
-  @hardcoded_eth_from_unix ~N[2014-05-13 00:00:00]
-                           |> DateTime.from_naive!("Etc/UTC")
-                           |> DateTime.to_unix()
-  defp historical_balance_query(address, _from, to, interval) do
-    interval = Sanbase.DateTimeUtils.compound_duration_to_seconds(interval)
-    to_unix = DateTime.to_unix(to)
-    span = div(to_unix - @hardcoded_eth_from_unix, interval) |> max(1)
-
-    query = """
-    SELECT time, SUM(value), toInt32(SUM(sign))
-      FROM (
-        SELECT
-          toDateTime(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) as time,
-          toFloat64(0) AS value,
-          toInt32(0) as sign
-        FROM numbers(?2)
-
-        UNION ALL
-
-    SELECT toDateTime(intDiv(toUInt32(dt), ?1) * ?1) as time, argMax(value, dt), argMax(sign, dt)
-      FROM (
-        SELECT any(value) as value, dt, 1 as sign
-        FROM #{@table}
-        PREWHERE address = ?3
-        AND sign = 1
-        AND dt >= toDateTime(?4)
-        AND dt <= toDateTime(?5)
-        GROUP BY address, dt
-      )
-      GROUP BY time
-      ORDER BY time
-    )
-    GROUP BY time
-    ORDER BY time
-    """
-
-    args = [
-      interval,
-      span,
-      address,
-      @hardcoded_eth_from_unix,
-      to_unix
-    ]
-
-    # args = [interval, address, from_unix, to_unix]
-
-    {query, args}
   end
 end

--- a/lib/sanbase/clickhouse/historical_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance.ex
@@ -22,6 +22,8 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
             interval
           )
       end
+    else
+      {:error, error} -> {:error, inspect(error)}
     end
   end
 end

--- a/lib/sanbase/clickhouse/historical_balance/erc20_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/erc20_balance.ex
@@ -1,0 +1,124 @@
+defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20Balance do
+  @doc ~s"""
+  Returns the historical balances of given address and erc20 contract
+  in all intervals between two datetimes.
+  """
+
+  use Ecto.Schema
+
+  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+
+  @type historical_balance :: %{
+          datetime: non_neg_integer(),
+          balance: float
+        }
+
+  @table "erc20_balances"
+  schema @table do
+    field(:datetime, :utc_datetime, source: :dt)
+    field(:contract, :string)
+    field(:address, :string, source: :to)
+    field(:value, :float)
+    field(:sign, :integer)
+  end
+
+  @spec changeset(any(), any()) :: no_return()
+  def changeset(_, _attrs \\ %{}),
+    do: raise("Should not try to change eth daily active addresses")
+
+  @spec historical_balance(
+          String.t(),
+          String.t(),
+          non_neg_integer(),
+          DateTime.t(),
+          DateTime.t(),
+          non_neg_integer()
+        ) :: {:ok, list(historical_balance)}
+  def historical_balance(address, contract, token_decimals, from, to, interval) do
+    token_decimals = Sanbase.Math.ipow(10, token_decimals)
+    address = String.downcase(address)
+    contract = String.downcase(contract)
+
+    {query, args} = historical_balance_query(address, contract, from, to, interval)
+
+    ClickhouseRepo.query_transform(query, args, fn [dt, value, sign] ->
+      %{
+        datetime: Sanbase.DateTimeUtils.from_erl!(dt),
+        balance: value / token_decimals,
+        sign: sign
+      }
+    end)
+    |> case do
+      {:ok, result} ->
+        # Clickhouse fills empty buckets with 0 while we need it filled with the last
+        # seen value. As the balance changes happen only when a transfer occurs
+        # then we need to fetch the whole history of changes in order to find the balance
+        result =
+          result
+          |> Enum.reduce({0, []}, fn
+            %{sign: 1, balance: balance, datetime: dt}, {_last_seen, acc} ->
+              {balance, [%{balance: balance, datetime: dt} | acc]}
+
+            %{sign: 0, datetime: dt}, {last_seen, acc} ->
+              {last_seen, [%{balance: last_seen, datetime: dt} | acc]}
+          end)
+          |> elem(1)
+          |> Enum.reverse()
+          |> Enum.drop_while(fn %{datetime: dt} -> DateTime.compare(dt, from) == :lt end)
+
+        {:ok, result}
+
+      error ->
+        error
+    end
+  end
+
+  @first_datetime ~N[2015-10-29 00:00:00]
+                  |> DateTime.from_naive!("Etc/UTC")
+                  |> DateTime.to_unix()
+  defp historical_balance_query(address, contract, _from, to, interval) do
+    interval = Sanbase.DateTimeUtils.compound_duration_to_seconds(interval)
+    to_unix = DateTime.to_unix(to)
+    span = div(to_unix - @first_datetime, interval) |> max(1)
+
+    query = """
+    SELECT time, SUM(value), toInt32(SUM(sign))
+      FROM (
+        SELECT
+          toDateTime(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) as time,
+          toFloat64(0) AS value,
+          toInt32(0) as sign
+        FROM numbers(?2)
+
+        UNION ALL
+
+    SELECT toDateTime(intDiv(toUInt32(dt), ?1) * ?1) as time, argMax(value, dt), argMax(sign, dt)
+      FROM (
+        SELECT any(value) as value, dt, 1 as sign
+        FROM #{@table}
+        PREWHERE address = ?3
+        AND contract = ?4
+        AND sign = 1
+        AND dt >= toDateTime(?5)
+        AND dt <= toDateTime(?6)
+        GROUP BY address, dt
+      )
+      GROUP BY time
+      ORDER BY time
+    )
+    GROUP BY time
+    ORDER BY time
+    """
+
+    args = [
+      interval,
+      span,
+      address,
+      contract,
+      @first_datetime,
+      to_unix
+    ]
+
+    {query, args}
+  end
+end

--- a/lib/sanbase/clickhouse/historical_balance/erc20_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/erc20_balance.ex
@@ -92,7 +92,6 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20Balance do
       PREWHERE address = ?3
       AND contract = ?4
       AND sign = 1
-      AND dt >= toDateTime(?5)
       AND dt <= toDateTime(?6)
       GROUP BY time
     )

--- a/lib/sanbase/clickhouse/historical_balance/erc20_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/erc20_balance.ex
@@ -80,26 +80,21 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20Balance do
     SELECT time, SUM(value), toInt32(SUM(sign))
       FROM (
         SELECT
-          toDateTime(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) as time,
+          toDateTime(intDiv(toUInt32(?5 + number * ?1), ?1) * ?1) AS time,
           toFloat64(0) AS value,
-          toInt32(0) as sign
+          toInt32(0) AS sign
         FROM numbers(?2)
 
-        UNION ALL
+    UNION ALL
 
-    SELECT toDateTime(intDiv(toUInt32(dt), ?1) * ?1) as time, argMax(value, dt), argMax(sign, dt)
-      FROM (
-        SELECT any(value) as value, dt, 1 as sign
-        FROM #{@table}
-        PREWHERE address = ?3
-        AND contract = ?4
-        AND sign = 1
-        AND dt >= toDateTime(?5)
-        AND dt <= toDateTime(?6)
-        GROUP BY address, dt
-      )
+    SELECT toDateTime(intDiv(toUInt32(dt), ?1) * ?1) AS time, argMax(value, dt), toInt32(1) AS sign
+      FROM #{@table}
+      PREWHERE address = ?3
+      AND contract = ?4
+      AND sign = 1
+      AND dt >= toDateTime(?5)
+      AND dt <= toDateTime(?6)
       GROUP BY time
-      ORDER BY time
     )
     GROUP BY time
     ORDER BY time

--- a/lib/sanbase/clickhouse/historical_balance/erc20_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/erc20_balance.ex
@@ -42,11 +42,11 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20Balance do
 
     {query, args} = historical_balance_query(address, contract, from, to, interval)
 
-    ClickhouseRepo.query_transform(query, args, fn [dt, value, sign] ->
+    ClickhouseRepo.query_transform(query, args, fn [dt, value, has_changed] ->
       %{
         datetime: Sanbase.DateTimeUtils.from_erl!(dt),
         balance: value / token_decimals,
-        sign: sign
+        has_changed: has_changed
       }
     end)
     |> case do
@@ -77,17 +77,17 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20Balance do
     # The balances table is like a stack. For each balance change there is a record
     # with sign = -1 that is the old balance and with sign = 1 which is the new balance
     query = """
-    SELECT time, SUM(value), toInt32(SUM(sign))
+    SELECT time, SUM(value), toUInt8(SUM(has_changed))
       FROM (
         SELECT
           toDateTime(intDiv(toUInt32(?5 + number * ?1), ?1) * ?1) AS time,
           toFloat64(0) AS value,
-          toInt32(0) AS sign
+          toUInt8(0) AS has_changed
         FROM numbers(?2)
 
     UNION ALL
 
-    SELECT toDateTime(intDiv(toUInt32(dt), ?1) * ?1) AS time, argMax(value, dt), toInt32(1) AS sign
+    SELECT toDateTime(intDiv(toUInt32(dt), ?1) * ?1) AS time, argMax(value, dt), toUInt8(1) AS has_changed
       FROM #{@table}
       PREWHERE address = ?3
       AND contract = ?4

--- a/lib/sanbase/clickhouse/historical_balance/eth_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/eth_balance.ex
@@ -1,0 +1,113 @@
+defmodule Sanbase.Clickhouse.HistoricalBalance.EthBalance do
+  @doc ~s"""
+  Returns the historical balances of given ethereum address in all intervals between two datetimes.
+  """
+
+  use Ecto.Schema
+
+  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+
+  @eth_decimals 1_000_000_000_000_000_000
+  @type historical_balance :: %{
+          datetime: non_neg_integer(),
+          balance: float
+        }
+
+  @table "eth_balances"
+  schema @table do
+    field(:datetime, :utc_datetime, source: :dt)
+    field(:address, :string, source: :to)
+    field(:value, :float)
+    field(:sign, :integer)
+  end
+
+  @spec changeset(any(), any()) :: no_return()
+  def changeset(_, _attrs \\ %{}),
+    do: raise("Should not try to change eth daily active addresses")
+
+  @spec historical_balance(
+          String.t(),
+          DateTime.t(),
+          DateTime.t(),
+          non_neg_integer()
+        ) :: {:ok, list(historical_balance)}
+  def historical_balance(address, from, to, interval) do
+    {query, args} =
+      String.downcase(address)
+      |> historical_balance_query(from, to, interval)
+
+    ClickhouseRepo.query_transform(query, args, fn [dt, value, sign] ->
+      %{datetime: Sanbase.DateTimeUtils.from_erl!(dt), balance: value / @eth_decimals, sign: sign}
+    end)
+    |> case do
+      {:ok, result} ->
+        # Clickhouse fills empty buckets with 0 while we need it filled with the last
+        # seen value. As the balance changes happen only when a transfer occurs
+        # then we need to fetch the whole history of changes in order to find the balance
+        result =
+          result
+          |> Enum.reduce({0, []}, fn
+            %{sign: 1, balance: balance, datetime: dt}, {_last_seen, acc} ->
+              {balance, [%{balance: balance, datetime: dt} | acc]}
+
+            %{sign: 0, datetime: dt}, {last_seen, acc} ->
+              {last_seen, [%{balance: last_seen, datetime: dt} | acc]}
+          end)
+          |> elem(1)
+          |> Enum.reverse()
+          |> Enum.drop_while(fn %{datetime: dt} -> DateTime.compare(dt, from) == :lt end)
+
+        {:ok, result}
+
+      error ->
+        error
+    end
+  end
+
+  @first_datetime ~N[2015-07-29 00:00:00]
+                  |> DateTime.from_naive!("Etc/UTC")
+                  |> DateTime.to_unix()
+  defp historical_balance_query(address, _from, to, interval) do
+    interval = Sanbase.DateTimeUtils.compound_duration_to_seconds(interval)
+    to_unix = DateTime.to_unix(to)
+    span = div(to_unix - @first_datetime, interval) |> max(1)
+
+    query = """
+    SELECT time, SUM(value), toInt32(SUM(sign))
+      FROM (
+        SELECT
+          toDateTime(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) as time,
+          toFloat64(0) AS value,
+          toInt32(0) as sign
+        FROM numbers(?2)
+
+        UNION ALL
+
+    SELECT toDateTime(intDiv(toUInt32(dt), ?1) * ?1) as time, argMax(value, dt), argMax(sign, dt)
+      FROM (
+        SELECT any(value) as value, dt, 1 as sign
+        FROM #{@table}
+        PREWHERE address = ?3
+        AND sign = 1
+        AND dt >= toDateTime(?4)
+        AND dt <= toDateTime(?5)
+        GROUP BY address, dt
+      )
+      GROUP BY time
+      ORDER BY time
+    )
+    GROUP BY time
+    ORDER BY time
+    """
+
+    args = [
+      interval,
+      span,
+      address,
+      @first_datetime,
+      to_unix
+    ]
+
+    {query, args}
+  end
+end

--- a/lib/sanbase/clickhouse/historical_balance/eth_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/eth_balance.ex
@@ -69,25 +69,20 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EthBalance do
     SELECT time, SUM(value), toInt32(SUM(sign))
       FROM (
         SELECT
-          toDateTime(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) as time,
+          toDateTime(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) AS time,
           toFloat64(0) AS value,
-          toInt32(0) as sign
+          toInt32(0) AS sign
         FROM numbers(?2)
 
-        UNION ALL
+    UNION ALL
 
-    SELECT toDateTime(intDiv(toUInt32(dt), ?1) * ?1) as time, argMax(value, dt), argMax(sign, dt)
-      FROM (
-        SELECT any(value) as value, dt, 1 as sign
-        FROM #{@table}
-        PREWHERE address = ?3
-        AND sign = 1
-        AND dt >= toDateTime(?4)
-        AND dt <= toDateTime(?5)
-        GROUP BY address, dt
-      )
+    SELECT toDateTime(intDiv(toUInt32(dt), ?1) * ?1) AS time, argMax(value, dt), toInt32(1) AS sign
+      FROM #{@table}
+      PREWHERE address = ?3
+      AND sign = 1
+      AND dt >= toDateTime(?4)
+      AND dt <= toDateTime(?5)
       GROUP BY time
-      ORDER BY time
     )
     GROUP BY time
     ORDER BY time

--- a/lib/sanbase/clickhouse/historical_balance/eth_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/eth_balance.ex
@@ -58,10 +58,11 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EthBalance do
   @first_datetime ~N[2015-07-29 00:00:00]
                   |> DateTime.from_naive!("Etc/UTC")
                   |> DateTime.to_unix()
-  defp historical_balance_query(address, _from, to, interval) do
+  defp historical_balance_query(address, from, to, interval) do
     interval = Sanbase.DateTimeUtils.compound_duration_to_seconds(interval)
+    from_unix = DateTime.to_unix(from)
     to_unix = DateTime.to_unix(to)
-    span = div(to_unix - @first_datetime, interval) |> max(1)
+    span = div(to_unix - @first_datetime, interval) |> max(1) |> IO.inspect(label: "SPAN")
 
     # The balances table is like a stack. For each balance change there is a record
     # with sign = -1 that is the old balance and with sign = 1 which is the new balance
@@ -80,7 +81,6 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EthBalance do
       FROM #{@table}
       PREWHERE address = ?3
       AND sign = 1
-      AND dt >= toDateTime(?4)
       AND dt <= toDateTime(?5)
       GROUP BY time
     )

--- a/lib/sanbase/clickhouse/historical_balance/utils.ex
+++ b/lib/sanbase/clickhouse/historical_balance/utils.ex
@@ -19,10 +19,10 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Utils do
   def fill_gaps_last_seen_balance(values) do
     values
     |> Enum.reduce({[], 0}, fn
-      %{sign: 1, balance: balance, datetime: dt}, {acc, _last_seen} ->
+      %{has_changed: 1, balance: balance, datetime: dt}, {acc, _last_seen} ->
         {[%{balance: balance, datetime: dt} | acc], balance}
 
-      %{sign: 0, datetime: dt}, {acc, last_seen} ->
+      %{has_changed: 0, datetime: dt}, {acc, last_seen} ->
         {[%{balance: last_seen, datetime: dt} | acc], last_seen}
     end)
     |> elem(0)

--- a/lib/sanbase/clickhouse/historical_balance/utils.ex
+++ b/lib/sanbase/clickhouse/historical_balance/utils.ex
@@ -1,0 +1,31 @@
+defmodule Sanbase.Clickhouse.HistoricalBalance.Utils do
+  @type in_type :: %{
+          sign: non_neg_integer(),
+          balance: float(),
+          datetime: DateTime.t()
+        }
+
+  @type out_type :: %{
+          balance: float(),
+          datetime: DateTime.t()
+        }
+
+  @doc ~s"""
+  Clickhouse fills empty buckets with 0 while we need it filled with the last
+  seen value. As the balance changes happen only when a transfer occurs
+  then we need to fetch the whole history of changes in order to find the balance
+  """
+  @spec fill_gaps_last_seen_balance(list(in_type)) :: list(out_type)
+  def fill_gaps_last_seen_balance(values) do
+    values
+    |> Enum.reduce({[], 0}, fn
+      %{sign: 1, balance: balance, datetime: dt}, {acc, _last_seen} ->
+        {[%{balance: balance, datetime: dt} | acc], balance}
+
+      %{sign: 0, datetime: dt}, {acc, last_seen} ->
+        {[%{balance: last_seen, datetime: dt} | acc], last_seen}
+    end)
+    |> elem(0)
+    |> Enum.reverse()
+  end
+end

--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -1,14 +1,9 @@
 defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
   require Logger
 
-  alias Sanbase.DateTimeUtils
-  alias Sanbase.Clickhouse.EthTransfers
-  alias Sanbase.Clickhouse.Erc20Transfers
   alias Sanbase.Model.Project
-
-  alias Sanbase.Clickhouse.NetworkGrowth
-
-  @one_hour_seconds 3600
+  alias Sanbase.DateTimeUtils
+  alias Sanbase.Clickhouse.{HistoricalBalance, NetworkGrowth}
 
   def network_growth(_root, args, _resolution) do
     interval = DateTimeUtils.compound_duration_to_seconds(args.interval)
@@ -23,64 +18,24 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
 
         {:error, "Can't calculate network growth"}
     end
-  rescue
-    error ->
-      Logger.error("Exception raised while calculating network growth. Reason: #{inspect(error)}")
-
-      {:error, "Can't calculate network growth"}
   end
 
   def historical_balance(
         _root,
-        args,
+        %{slug: slug, from: from, to: to, interval: interval, address: address},
         _resolution
       ) do
-    with interval_seconds when interval_seconds >= @one_hour_seconds <-
-           DateTimeUtils.compound_duration_to_seconds(args.interval),
-         {:ok, result} <- calc_historical_balances(args, interval_seconds) do
+    with {:ok, result} <- HistoricalBalance.historical_balance(address, slug, from, to, interval) do
       {:ok, result}
     else
-      e when is_integer(e) ->
-        {:error, "Interval must be bigger than 1 hour"}
+      {:error, error} ->
+        Logger.warn(
+          "Can't calculate historical balances for project with coinmarketcap_id #{slug}. Reason: #{
+            inspect(error)
+          }"
+        )
 
-      error ->
-        Logger.warn("Can't calculate historical balances. Reason: #{inspect(error)}")
-
-        {:ok, []}
-    end
-  rescue
-    error ->
-      Logger.error(
-        "Exception raised while calculating historical balances. Reason: #{inspect(error)}"
-      )
-
-      {:ok, []}
-  end
-
-  defp calc_historical_balances(
-         %{slug: "ethereum", address: address, from: from, to: to},
-         interval_seconds
-       ) do
-    EthTransfers.historical_balance(address, from, to, interval_seconds)
-  end
-
-  defp calc_historical_balances(
-         %{slug: slug, address: address, from: from, to: to},
-         interval_seconds
-       ) do
-    with {:ok, contract, token_decimals} <- Project.contract_info_by_slug(slug),
-         {:ok, result} <-
-           Erc20Transfers.historical_balance(
-             contract,
-             address,
-             from,
-             to,
-             interval_seconds,
-             token_decimals
-           ) do
-      {:ok, result}
-    else
-      {:error, error} -> {:error, error}
+        {:error, "Can't calculate historical balances for project with coinmarketcap_id #{slug}"}
     end
   end
 end

--- a/test/sanbase_web/graphql/clickhouse/historical_balances_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/historical_balances_test.exs
@@ -10,7 +10,20 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
   require Sanbase.ClickhouseRepo
 
   setup do
+    project_without_contract = insert(:project, %{coinmarketcap_id: "someid1"})
+
+    project_with_contract =
+      insert(:project, %{
+        main_contract_address: "0x123",
+        coinmarketcap_id: "someid2",
+        token_decimals: 18
+      })
+
+    insert(:project, %{coinmarketcap_id: "ethereum", ticker: "ETH"})
+
     [
+      project_with_contract: project_with_contract,
+      project_without_contract: project_without_contract,
       address: "0x321321321",
       from: from_iso8601!("2017-05-11T00:00:00Z"),
       to: from_iso8601!("2017-05-20T00:00:00Z"),
@@ -24,146 +37,22 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
         {:ok,
          %{
            rows: [
-             [from_iso8601_to_unix!("2017-05-13T00:00:00Z"), 2000],
-             [from_iso8601_to_unix!("2017-05-14T00:00:00Z"), 1800],
-             [from_iso8601_to_unix!("2017-05-15T00:00:00Z"), 1800],
-             [from_iso8601_to_unix!("2017-05-16T00:00:00Z"), 1500],
-             [from_iso8601_to_unix!("2017-05-17T00:00:00Z"), 1900],
-             [from_iso8601_to_unix!("2017-05-18T00:00:00Z"), 1000]
-           ]
-         }}
-      end do
-      query = hist_balances_query(context.address, context.from, context.to, context.interval)
-
-      result =
-        context.conn
-        |> post("/graphql", query_skeleton(query, "historicalBalance"))
-
-      hist_balance = json_response(result, 200)["data"]["historicalBalance"]
-
-      assert hist_balance == [
-               %{"balance" => 0, "datetime" => "2017-05-11T00:00:00Z"},
-               %{"balance" => 0, "datetime" => "2017-05-12T00:00:00Z"},
-               %{"balance" => 2000, "datetime" => "2017-05-13T00:00:00Z"},
-               %{"balance" => 1800, "datetime" => "2017-05-14T00:00:00Z"},
-               %{"balance" => 1800, "datetime" => "2017-05-15T00:00:00Z"},
-               %{"balance" => 1500, "datetime" => "2017-05-16T00:00:00Z"},
-               %{"balance" => 1900, "datetime" => "2017-05-17T00:00:00Z"},
-               %{"balance" => 1000, "datetime" => "2017-05-18T00:00:00Z"},
-               %{"balance" => 1000, "datetime" => "2017-05-19T00:00:00Z"},
-               %{"balance" => 1000, "datetime" => "2017-05-20T00:00:00Z"}
-             ]
-    end
-  end
-
-  test "historical balances when last interval is not full", context do
-    with_mock Sanbase.ClickhouseRepo,
-      query: fn _, _ ->
-        {:ok,
-         %{
-           rows: [
-             [from_iso8601_to_unix!("2017-05-13T00:00:00Z"), 2000],
-             [from_iso8601_to_unix!("2017-05-14T00:00:00Z"), 1800],
-             [from_iso8601_to_unix!("2017-05-15T00:00:00Z"), 1800],
-             [from_iso8601_to_unix!("2017-05-16T00:00:00Z"), 1500],
-             [from_iso8601_to_unix!("2017-05-17T00:00:00Z"), 1900],
-             [from_iso8601_to_unix!("2017-05-18T00:00:00Z"), 1400]
-           ]
-         }}
-      end do
-      from = from_iso8601!("2017-05-13T00:00:00Z")
-      to = from_iso8601!("2017-05-18T00:00:00Z")
-      query = hist_balances_query(context.address, from, to, "2d")
-
-      result =
-        context.conn
-        |> post("/graphql", query_skeleton(query, "historicalBalance"))
-
-      hist_balance = json_response(result, 200)["data"]["historicalBalance"]
-
-      assert hist_balance == [
-               %{"balance" => 2000, "datetime" => "2017-05-13T00:00:00Z"},
-               %{"balance" => 1800, "datetime" => "2017-05-15T00:00:00Z"},
-               %{"balance" => 1400, "datetime" => "2017-05-17T00:00:00Z"}
-             ]
-    end
-  end
-
-  test "historical balances when query returns error", context do
-    with_mock Sanbase.ClickhouseRepo, query: fn _, _ -> {:error, :invalid} end do
-      query = hist_balances_query(context.address, context.from, context.to, context.interval)
-
-      result =
-        context.conn
-        |> post("/graphql", query_skeleton(query, "historicalBalance"))
-
-      hist_balance = json_response(result, 200)["data"]["historicalBalance"]
-      assert hist_balance == []
-    end
-  end
-
-  test "historical balances when query returns no rows", context do
-    with_mock Sanbase.ClickhouseRepo, query: fn _, _ -> {:ok, %{rows: []}} end do
-      query = hist_balances_query(context.address, context.from, context.to, context.interval)
-
-      result =
-        context.conn
-        |> post("/graphql", query_skeleton(query, "historicalBalance"))
-
-      hist_balance = json_response(result, 200)["data"]["historicalBalance"]
-      assert hist_balance == []
-    end
-  end
-
-  test "when interval is smaller than 1hr returns error", context do
-    query = hist_balances_query(context.address, context.from, context.to, "20m")
-
-    result =
-      context.conn
-      |> post("/graphql", query_skeleton(query, "historicalBalance"))
-
-    [error | _] = json_response(result, 200)["errors"]
-    assert String.contains?(error["message"], "Interval must be bigger than 1 hour")
-  end
-
-  test "historical balances when query raises", context do
-    with_mock Sanbase.ClickhouseRepo, query: fn _, _ -> raise("clickhouse error") end do
-      query = hist_balances_query(context.address, context.from, context.to, context.interval)
-
-      log =
-        capture_log(fn ->
-          result =
-            context.conn
-            |> post("/graphql", query_skeleton(query, "historicalBalance"))
-
-          hist_balance = json_response(result, 200)["data"]["historicalBalance"]
-          assert hist_balance == []
-        end)
-
-      assert log =~ "clickhouse error"
-    end
-  end
-
-  test "historical balances with project with contract", context do
-    project_with_contract = insert(:project, %{main_contract_address: "0x123"})
-
-    with_mock Sanbase.ClickhouseRepo,
-      query: fn _, _ ->
-        {:ok,
-         %{
-           rows: [
-             [from_iso8601_to_unix!("2017-05-13T00:00:00Z"), 2000],
-             [from_iso8601_to_unix!("2017-05-14T00:00:00Z"), 1800],
-             [from_iso8601_to_unix!("2017-05-15T00:00:00Z"), 1800],
-             [from_iso8601_to_unix!("2017-05-16T00:00:00Z"), 1500],
-             [from_iso8601_to_unix!("2017-05-17T00:00:00Z"), 1900],
-             [from_iso8601_to_unix!("2017-05-18T00:00:00Z"), 1000]
+             [{{2017, 05, 11}, {0, 0, 0}}, :math.pow(10, 18) * 0, 1],
+             [{{2017, 05, 12}, {0, 0, 0}}, :math.pow(10, 18) * 0, 1],
+             [{{2017, 05, 13}, {0, 0, 0}}, :math.pow(10, 18) * 2000, 1],
+             [{{2017, 05, 14}, {0, 0, 0}}, :math.pow(10, 18) * 1800, 1],
+             [{{2017, 05, 15}, {0, 0, 0}}, :math.pow(10, 18) * 0, 0],
+             [{{2017, 05, 16}, {0, 0, 0}}, :math.pow(10, 18) * 1500, 1],
+             [{{2017, 05, 17}, {0, 0, 0}}, :math.pow(10, 18) * 1900, 1],
+             [{{2017, 05, 18}, {0, 0, 0}}, :math.pow(10, 18) * 1000, 1],
+             [{{2017, 05, 19}, {0, 0, 0}}, :math.pow(10, 18) * 0, 0],
+             [{{2017, 05, 20}, {0, 0, 0}}, :math.pow(10, 18) * 0, 0]
            ]
          }}
       end do
       query =
-        hist_balances_with_slug_query(
-          project_with_contract.coinmarketcap_id,
+        historical_balances_query(
+          "ethereum",
           context.address,
           context.from,
           context.to,
@@ -174,66 +63,193 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
         context.conn
         |> post("/graphql", query_skeleton(query, "historicalBalance"))
 
-      hist_balance = json_response(result, 200)["data"]["historicalBalance"]
+      historical_balance = json_response(result, 200)["data"]["historicalBalance"]
 
-      assert hist_balance == [
-               %{"balance" => 0, "datetime" => "2017-05-11T00:00:00Z"},
-               %{"balance" => 0, "datetime" => "2017-05-12T00:00:00Z"},
-               %{"balance" => 2000, "datetime" => "2017-05-13T00:00:00Z"},
-               %{"balance" => 1800, "datetime" => "2017-05-14T00:00:00Z"},
-               %{"balance" => 1800, "datetime" => "2017-05-15T00:00:00Z"},
-               %{"balance" => 1500, "datetime" => "2017-05-16T00:00:00Z"},
-               %{"balance" => 1900, "datetime" => "2017-05-17T00:00:00Z"},
-               %{"balance" => 1000, "datetime" => "2017-05-18T00:00:00Z"},
-               %{"balance" => 1000, "datetime" => "2017-05-19T00:00:00Z"},
-               %{"balance" => 1000, "datetime" => "2017-05-20T00:00:00Z"}
+      assert historical_balance == [
+               %{"balance" => 0.0, "datetime" => "2017-05-11T00:00:00Z"},
+               %{"balance" => 0.0, "datetime" => "2017-05-12T00:00:00Z"},
+               %{"balance" => 2000.0, "datetime" => "2017-05-13T00:00:00Z"},
+               %{"balance" => 1800.0, "datetime" => "2017-05-14T00:00:00Z"},
+               %{"balance" => 1800.0, "datetime" => "2017-05-15T00:00:00Z"},
+               %{"balance" => 1500.0, "datetime" => "2017-05-16T00:00:00Z"},
+               %{"balance" => 1900.0, "datetime" => "2017-05-17T00:00:00Z"},
+               %{"balance" => 1000.0, "datetime" => "2017-05-18T00:00:00Z"},
+               %{"balance" => 1000.0, "datetime" => "2017-05-19T00:00:00Z"},
+               %{"balance" => 1000.0, "datetime" => "2017-05-20T00:00:00Z"}
+             ]
+    end
+  end
+
+  test "historical balances when last interval is not full", context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:ok,
+         %{
+           rows: [
+             [{{2017, 05, 13}, {0, 0, 0}}, :math.pow(10, 18) * 2000, 1],
+             [{{2017, 05, 15}, {0, 0, 0}}, :math.pow(10, 18) * 1800, 1],
+             [{{2017, 05, 17}, {0, 0, 0}}, :math.pow(10, 18) * 1400, 1]
+           ]
+         }}
+      end do
+      from = from_iso8601!("2017-05-13T00:00:00Z")
+      to = from_iso8601!("2017-05-18T00:00:00Z")
+      query = historical_balances_query("ethereum", context.address, from, to, "2d")
+
+      result =
+        context.conn
+        |> post("/graphql", query_skeleton(query, "historicalBalance"))
+        |> json_response(200)
+
+      historical_balance = result["data"]["historicalBalance"]
+
+      assert historical_balance == [
+               %{"balance" => 2000.0, "datetime" => "2017-05-13T00:00:00Z"},
+               %{"balance" => 1800.0, "datetime" => "2017-05-15T00:00:00Z"},
+               %{"balance" => 1400.0, "datetime" => "2017-05-17T00:00:00Z"}
+             ]
+    end
+  end
+
+  test "historical balances when query returns error", context do
+    with_mock Sanbase.ClickhouseRepo, query: fn _, _ -> {:error, :invalid} end do
+      query =
+        historical_balances_query(
+          "ethereum",
+          context.address,
+          context.from,
+          context.to,
+          context.interval
+        )
+
+      result =
+        context.conn
+        |> post("/graphql", query_skeleton(query, "historicalBalance"))
+        |> json_response(200)
+
+      historical_balance = result["data"]["historicalBalance"]
+      assert historical_balance == nil
+    end
+  end
+
+  test "historical balances when query returns no rows", context do
+    with_mock Sanbase.ClickhouseRepo, query: fn _, _ -> {:ok, %{rows: []}} end do
+      query =
+        historical_balances_query(
+          "ethereum",
+          context.address,
+          context.from,
+          context.to,
+          context.interval
+        )
+
+      result =
+        context.conn
+        |> post("/graphql", query_skeleton(query, "historicalBalance"))
+
+      historical_balance = json_response(result, 200)["data"]["historicalBalance"]
+      assert historical_balance == []
+    end
+  end
+
+  test "historical balances with project with contract", context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:ok,
+         %{
+           rows: [
+             [{{2017, 05, 11}, {0, 0, 0}}, :math.pow(10, 18) * 0, 1],
+             [{{2017, 05, 12}, {0, 0, 0}}, :math.pow(10, 18) * 0, 1],
+             [{{2017, 05, 13}, {0, 0, 0}}, :math.pow(10, 18) * 2000, 1],
+             [{{2017, 05, 14}, {0, 0, 0}}, :math.pow(10, 18) * 1800, 1],
+             [{{2017, 05, 15}, {0, 0, 0}}, :math.pow(10, 18) * 0, 0],
+             [{{2017, 05, 16}, {0, 0, 0}}, :math.pow(10, 18) * 1500, 1],
+             [{{2017, 05, 17}, {0, 0, 0}}, :math.pow(10, 18) * 1900, 1],
+             [{{2017, 05, 18}, {0, 0, 0}}, :math.pow(10, 18) * 1000, 1],
+             [{{2017, 05, 19}, {0, 0, 0}}, :math.pow(10, 18) * 0, 0],
+             [{{2017, 05, 20}, {0, 0, 0}}, :math.pow(10, 18) * 0, 0]
+           ]
+         }}
+      end do
+      query =
+        historical_balances_query(
+          context.project_with_contract.coinmarketcap_id,
+          context.address,
+          context.from,
+          context.to,
+          context.interval
+        )
+
+      result =
+        context.conn
+        |> post("/graphql", query_skeleton(query, "historicalBalance"))
+
+      historical_balance = json_response(result, 200)["data"]["historicalBalance"]
+
+      assert historical_balance == [
+               %{"balance" => 0.0, "datetime" => "2017-05-11T00:00:00Z"},
+               %{"balance" => 0.0, "datetime" => "2017-05-12T00:00:00Z"},
+               %{"balance" => 2000.0, "datetime" => "2017-05-13T00:00:00Z"},
+               %{"balance" => 1800.0, "datetime" => "2017-05-14T00:00:00Z"},
+               %{"balance" => 1800.0, "datetime" => "2017-05-15T00:00:00Z"},
+               %{"balance" => 1500.0, "datetime" => "2017-05-16T00:00:00Z"},
+               %{"balance" => 1900.0, "datetime" => "2017-05-17T00:00:00Z"},
+               %{"balance" => 1000.0, "datetime" => "2017-05-18T00:00:00Z"},
+               %{"balance" => 1000.0, "datetime" => "2017-05-19T00:00:00Z"},
+               %{"balance" => 1000.0, "datetime" => "2017-05-20T00:00:00Z"}
              ]
     end
   end
 
   test "historical balances with project without contract", context do
-    project_without_contract = insert(:project)
-
     query =
-      hist_balances_with_slug_query(
-        project_without_contract.coinmarketcap_id,
+      historical_balances_query(
+        context.project_without_contract.coinmarketcap_id,
         context.address,
         context.from,
         context.to,
         context.interval
       )
 
-    log =
-      capture_log(fn ->
-        result =
-          context.conn
-          |> post("/graphql", query_skeleton(query, "historicalBalance"))
+    assert capture_log(fn ->
+             result =
+               context.conn
+               |> post("/graphql", query_skeleton(query, "historicalBalance"))
+               |> json_response(200)
 
-        hist_balance = json_response(result, 200)["data"]["historicalBalance"]
-        assert hist_balance == []
-      end)
+             historical_balance = result["data"]["historicalBalance"]
+             assert historical_balance == nil
 
-    assert log =~ "Can't find contract address"
+             error = result["errors"] |> List.first()
+
+             assert error["message"] ==
+                      ~s/Can't calculate historical balances for project with coinmarketcap_id someid1/
+           end) =~
+             "{:missing_contract, \\\"Can't find contract address of project with coinmarketcap_id someid1\\\"}"
   end
 
-  defp hist_balances_query(address, from, to, interval) do
-    """
-      {
-        historicalBalance(
-            address: "#{address}",
-            from: "#{from}",
-            to: "#{to}",
-            interval: "#{interval}",
-            slug: "ethereum"
-        ){
-            datetime,
-            balance
-        }
-      }
-    """
+  test "clickhouse returns error", context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:error, "something bad happened"}
+      end do
+      query =
+        historical_balances_query(
+          context.project_with_contract.coinmarketcap_id,
+          context.address,
+          context.from,
+          context.to,
+          context.interval
+        )
+
+      result =
+        context.conn
+        |> post("/graphql", query_skeleton(query, "historicalBalance"))
+        |> json_response(200)
+    end
   end
 
-  defp hist_balances_with_slug_query(slug, address, from, to, interval) do
+  defp historical_balances_query(slug, address, from, to, interval) do
     """
       {
         historicalBalance(


### PR DESCRIPTION
#### Summary
Example usage:
```elixir
iex(1)>Sanbase.Clickhouse.HistoricalBalance.EthBalance.historical_balance(
  "0x447442a426b7f83A3a647120edD7a98420CeFe75",
   Timex.shift(Timex.now(), days: -110),
   Timex.now(),
   "4w")
{:ok,
  [
    %{balance: 0.0457971968247546, datetime: #DateTime<2018-11-29 00:00:00Z>},
    %{balance: 0.19575028849984766, datetime: #DateTime<2018-12-27 00:00:00Z>},
    %{balance: 0.02576241474915534, datetime: #DateTime<2019-01-24 00:00:00Z>},
    %{balance: 0.17211438421983474, datetime: #DateTime<2019-02-21 00:00:00Z>}
  ]}
```

Example GraphQL:
Request:
```
{
  historicalBalance(
    address:"0x6dd5a9f47cfbc44c04a0a4452f0ba792ebfbcc9a",
    slug:"ethereum",
    from:"2017-07-01T00:00:00Z",
    to:"2019-02-16T00:00:00Z",
  	interval:"4w") {
      datetime
      balance
  }
}
```

Response:
```
{
  "data": {
    "historicalBalance": [
      {
        "balance": 45000.95027004,
        "datetime": "2017-07-13T00:00:00Z"
      },
      {
        "balance": 41000.947750039995,
        "datetime": "2017-08-10T00:00:00Z"
      },
      {
        "balance": 37000.94607004,
        "datetime": "2017-09-07T00:00:00Z"
      },
      {
        "balance": 36000.94312976,
        "datetime": "2017-10-05T00:00:00Z"
      },
      {
        "balance": 33999.28656088823,
        "datetime": "2017-11-02T00:00:00Z"
      },
...
```
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
