### PR TITLE
Add votedAt to the allowed fields of the anon user

### DIFF
--- a/lib/sanbase_web/graphql/middlewares/post_permissions.ex
+++ b/lib/sanbase_web/graphql/middlewares/post_permissions.ex
@@ -14,6 +14,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.PostPermissions do
     "state",
     "readyState",
     "tags",
+    "votedAt",
     "__typename"
   ]
 


### PR DESCRIPTION
It was already implemented that calling this as anonymous user
returns just `nil` but it was not allowed to call it in the first place

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
