### PR TITLE
Resolve some warnings

### DIFF
--- a/lib/sanbase/clickhouse/erc20_transfers.ex
+++ b/lib/sanbase/clickhouse/erc20_transfers.ex
@@ -19,8 +19,6 @@ defmodule Sanbase.Clickhouse.Erc20Transfers do
 
   require Sanbase.ClickhouseRepo, as: ClickhouseRepo
 
-  alias Sanbase.Clickhouse.Common, as: ClickhouseCommon
-
   @table "erc20_transfers"
 
   @primary_key false
@@ -55,62 +53,6 @@ defmodule Sanbase.Clickhouse.Erc20Transfers do
       token_top_transfers_query(contract, from_datetime, to_datetime, limit, token_decimals)
 
     ClickhouseRepo.query_transform(query, args)
-  end
-
-  @doc ~s"""
-  Returns the historical balances of given address in tokens in all intervals between two datetimes.
-  """
-  def historical_balance(
-        contract,
-        address,
-        from_datetime,
-        to_datetime,
-        interval,
-        token_decimals \\ 0
-      ) do
-    token_decimals = Sanbase.Math.ipow(10, token_decimals)
-
-    address = String.downcase(address)
-    {query, args} = historical_balance_query(contract, address, interval, token_decimals)
-
-    balances =
-      query
-      |> ClickhouseRepo.query_transform(args, fn [dt, value] -> {dt, value} end)
-
-    {:ok, balances}
-  end
-
-  # Private functions
-
-  defp historical_balance_query(contract, address, interval, token_decimals) do
-    args = [contract, address]
-
-    dt_round = ClickhouseCommon.datetime_rounding_for_interval(interval)
-
-    query = """
-    SELECT dt, runningAccumulate(state) AS total_balance FROM (
-      SELECT dt, sumState(value) AS state FROM (
-        SELECT
-          toUnixTimestamp(#{dt_round}) as dt, from AS address, sum(-value / #{token_decimals}) AS value
-        FROM #{@table}
-        PREWHERE contract = ?1 AND from = ?2
-        GROUP BY dt, address
-
-        UNION ALL
-
-        SELECT
-          toUnixTimestamp(#{dt_round}) AS dt, to AS address, sum(value / #{token_decimals}) AS value
-        FROM #{@table}
-        PREWHERE contract = ?1 AND to = ?2
-        GROUP BY dt, address
-      )
-      GROUP BY dt
-      ORDER BY dt
-    )
-    ORDER BY dt
-    """
-
-    {query, args}
   end
 
   defp token_top_transfers_query(contract, from_datetime, to_datetime, limit, token_decimals) do

--- a/lib/sanbase/clickhouse/erc20_transfers.ex
+++ b/lib/sanbase/clickhouse/erc20_transfers.ex
@@ -76,7 +76,6 @@ defmodule Sanbase.Clickhouse.Erc20Transfers do
     balances =
       query
       |> ClickhouseRepo.query_transform(args, fn [dt, value] -> {dt, value} end)
-      |> ClickhouseCommon.convert_historical_balance_result(from_datetime, to_datetime, interval)
 
     {:ok, balances}
   end

--- a/lib/sanbase/clickhouse/historical_balance/eth_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/eth_balance.ex
@@ -62,11 +62,10 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EthBalance do
   @first_datetime ~N[2015-07-29 00:00:00]
                   |> DateTime.from_naive!("Etc/UTC")
                   |> DateTime.to_unix()
-  defp historical_balance_query(address, from, to, interval) do
+  defp historical_balance_query(address, _from, to, interval) do
     interval = Sanbase.DateTimeUtils.compound_duration_to_seconds(interval)
-    from_unix = DateTime.to_unix(from)
     to_unix = DateTime.to_unix(to)
-    span = div(to_unix - @first_datetime, interval) |> max(1) |> IO.inspect(label: "SPAN")
+    span = div(to_unix - @first_datetime, interval) |> max(1)
 
     # The balances table is like a stack. For each balance change there is a record
     # with sign = -1 that is the old balance and with sign = 1 which is the new balance

--- a/lib/sanbase/signals/history/prices_history.ex
+++ b/lib/sanbase/signals/history/prices_history.ex
@@ -1,6 +1,6 @@
 defmodule Sanbase.Signals.History.PricesHistory do
   @moduledoc """
-  Implementations of historical trigger points for price_percent_change and 
+  Implementations of historical trigger points for price_percent_change and
   price_absolute_change triggers. Historical prices are bucketed at `1 hour` intervals and goes
   `90 days` back.
   """
@@ -26,7 +26,7 @@ defmodule Sanbase.Signals.History.PricesHistory do
           triggered?: boolean()
         }
 
-  def get_prices(%{target: target} = settings) when is_binary(target) do
+  def get_prices(%{target: target}) when is_binary(target) do
     with measurement when not is_nil(measurement) <- Measurement.name_from_slug(target),
          {from, to, interval} <- get_timeseries_params(),
          {:ok, price_list} when is_list(price_list) and price_list != [] <-
@@ -116,7 +116,7 @@ defmodule Sanbase.Signals.History.PricesHistory do
   defimpl Sanbase.Signals.History, for: PricePercentChangeSettings do
     alias Sanbase.Signals.History.PricesHistory
 
-    # Minimal time window is set to 2 hours. That is due to interval buckets being 1 hour each. 
+    # Minimal time window is set to 2 hours. That is due to interval buckets being 1 hour each.
     @minimal_time_window 2
 
     @spec historical_trigger_points(%PricePercentChangeSettings{}, String.t()) ::

--- a/lib/sanbase_web/views/api_examples_view.ex
+++ b/lib/sanbase_web/views/api_examples_view.ex
@@ -4,8 +4,6 @@ defmodule SanbaseWeb.ApiExamplesView do
   require Logger
   require Sanbase.Utils.Config, as: Config
 
-  alias SanbaseWeb.Graphql.Middlewares.ApiTimeframeRestriction
-
   def render("apiexample_view.html", _assigns) do
     Phoenix.View.render_to_string(SanbaseWeb.ApiExamplesView, "examples.html", %{
       api_url: SanbaseWeb.Endpoint.api_url(),

--- a/test/sanbase/signals/target_user_list_test.exs
+++ b/test/sanbase/signals/target_user_list_test.exs
@@ -1,4 +1,4 @@
-defmodule SanbaseWeb.Graphql.UserListTest do
+defmodule SanbaseWeb.Graphql.TargetUserListTest do
   use Sanbase.DataCase, async: false
   alias Sanbase.UserLists.UserList
   alias Sanbase.Signals.UserTrigger

--- a/test/sanbase_web/cache/cachex_provider_test.exs
+++ b/test/sanbase_web/cache/cachex_provider_test.exs
@@ -29,7 +29,7 @@ defmodule SanbaseWeb.Graphql.CachexProviderTest do
     assert {:ok, value} == CacheProvider.get(@cache_name, key)
   end
 
-  test "value is actually cached and not precalculated", context do
+  test "value is actually cached and not precalculated" do
     key = "somekey"
     test_pid = self()
 

--- a/test/sanbase_web/graphql/clickhouse/historical_balances_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/historical_balances_test.exs
@@ -3,7 +3,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
 
   import SanbaseWeb.Graphql.TestHelpers
   import Mock
-  import Sanbase.DateTimeUtils, only: [from_iso8601_to_unix!: 1, from_iso8601!: 1]
+  import Sanbase.DateTimeUtils, only: [from_iso8601!: 1]
   import ExUnit.CaptureLog
   import Sanbase.Factory
 
@@ -247,10 +247,9 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
         )
 
       assert capture_log(fn ->
-               result =
-                 context.conn
-                 |> post("/graphql", query_skeleton(query, "historicalBalance"))
-                 |> json_response(200)
+               context.conn
+               |> post("/graphql", query_skeleton(query, "historicalBalance"))
+               |> json_response(200)
              end) =~
                ~s/[warn] Can't calculate historical balances for project with coinmarketcap_id someid2. Reason: "something bad happened"/
     end


### PR DESCRIPTION
#### Summary
There were a lot of warnings in the beginning of tests execution. Resolved most of them but few are left, I don't feel confident enough yet to touch them, so help is welcomed.

```
warning: variable "notification" is unused
  lib/ex_admin/show.ex:5

warning: def run_query/4 has multiple clauses and also declares default values. In such cases, the default values should be defined in a header. Instead of:

    def foo(:first_clause, b \\ :default) do ... end
    def foo(:second_clause, b) do ... end

one should write:

    def foo(a, b \\ :default)
    def foo(:first_clause, b) do ... end
    def foo(:second_clause, b) do ... end

  lib/sanbase_web/admin/model/ico.ex:10

warning: SanbaseWeb.Graphql.Resolvers.PriceResolver.history_price/3 is deprecated. Use history price by slug
  lib/sanbase_web/graphql/schema.ex:188
```
[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
