### PR TITLE
Add ability to pass desired tests to bin/test.sh

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 
+if [ $# -eq 0 ]; then
+  tests_to_execute="test_all"
+else
+  tests_to_execute="test $@"
+fi
+
+test_command="mix $tests_to_execute"
+
+echo "Will execute: $test_command"
+
 docker-compose build && \
   docker-compose run \
     -e DATABASE_URL=postgres://postgres:postgres@postgres:5432/sanbase_test \
     -e TIMESCALE_DATABASE_URL=postgres://postgres:postgres@postgres:5432/sanbase_timescale_test \
     -e INFLUXDB_HOST=influxdb \
     -e MIX_ENV=test \
-    sanbase sh -c "mix test_all"
+    sanbase sh -c "$test_command"


### PR DESCRIPTION
#### Summary
Adds the ability to pass a single or multiple tests as arguments to `bin/test.sh`. If no arguments are present `mix test_all` will be executed. 

