### PR TITLE
Fix the price-volume diff when result size argument is not 0

### DIFF
--- a/lib/sanbase/clickhouse/historical_balance/eth_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/eth_balance.ex
@@ -66,7 +66,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EthBalance do
     interval = Sanbase.DateTimeUtils.compound_duration_to_seconds(interval)
     from_unix = DateTime.to_unix(from)
     to_unix = DateTime.to_unix(to)
-    span = div(to_unix - @first_datetime, interval) |> max(1) |> IO.inspect(label: "SPAN")
+    span = div(to_unix - @first_datetime, interval) |> max(1)
 
     # The balances table is like a stack. For each balance change there is a record
     # with sign = -1 that is the old balance and with sign = 1 which is the new balance

--- a/lib/sanbase/tech_indicators/price_volume_difference.ex
+++ b/lib/sanbase/tech_indicators/price_volume_difference.ex
@@ -32,8 +32,8 @@ defmodule Sanbase.TechIndicators.PriceVolumeDifference do
   def price_volume_diff(
         %Project{ticker: ticker, coinmarketcap_id: slug} = project,
         currency,
-        from_datetime,
-        to_datetime,
+        from,
+        to,
         aggregate_interval,
         window_type,
         approximation_window,
@@ -43,11 +43,11 @@ defmodule Sanbase.TechIndicators.PriceVolumeDifference do
     url = "#{tech_indicators_url()}/indicator/pricevolumediff/ma"
 
     # Workaround an issue with the usability of the tech_indicators api.
-    # The calculation needs to start from before the `from_datetime` so the
+    # The calculation needs to start from before the `from` so the
     # moving average can be calculated for the specified time. Shift the datetime
     # and drop the same number of points from the result
-    from_datetime =
-      Timex.shift(from_datetime,
+    shifted_from =
+      Timex.shift(from,
         seconds:
           -Sanbase.DateTimeUtils.compound_duration_to_seconds(aggregate_interval) *
             (approximation_window + comparison_window)
@@ -58,8 +58,8 @@ defmodule Sanbase.TechIndicators.PriceVolumeDifference do
       params: [
         {"ticker_slug", ticker <> "_" <> slug},
         {"currency", currency},
-        {"from_timestamp", DateTime.to_unix(from_datetime)},
-        {"to_timestamp", DateTime.to_unix(to_datetime)},
+        {"from_timestamp", DateTime.to_unix(shifted_from)},
+        {"to_timestamp", DateTime.to_unix(to)},
         {"aggregate_interval", aggregate_interval},
         {"window_type", window_type},
         {"approximation_window", approximation_window},
@@ -71,8 +71,14 @@ defmodule Sanbase.TechIndicators.PriceVolumeDifference do
     http_client().get(url, [], options)
     |> handle_result(project)
     |> case do
-      {:ok, result} -> {:ok, result |> Enum.drop(approximation_window + comparison_window)}
-      error -> error
+      {:ok, result} ->
+        {:ok,
+         Enum.drop_while(result, fn %{datetime: datetime} ->
+           DateTime.compare(datetime, from) == :lt
+         end)}
+
+      {:error, error} ->
+        {:error, error}
     end
   end
 

--- a/test/sanbase/notifications/price_volume_diff_test.exs
+++ b/test/sanbase/notifications/price_volume_diff_test.exs
@@ -90,7 +90,9 @@ defmodule Sanbase.Notifications.PriceVolumeDiffTest do
          body: """
           [
             #{Sanbase.TechIndicatorsTestResponse.price_volume_diff_prepend_response()},
-            {"price_volume_diff": 123.456, "price_change": 0.04862261825993345, "volume_change": -0.030695260272520467, "timestamp": 1516752000}
+            {"price_volume_diff": 123.456, "price_change": 0.04862261825993345, "volume_change": -0.030695260272520467, "timestamp": #{
+           DateTime.utc_now() |> DateTime.to_unix()
+         }}
           ]
          """,
          status_code: 200

--- a/test/sanbase/signals/trigger_price_volume_diff_test.exs
+++ b/test/sanbase/signals/trigger_price_volume_diff_test.exs
@@ -85,7 +85,9 @@ defmodule Sanbase.Signals.PriceVolumeDiffTest do
            body: """
            [
              #{Sanbase.TechIndicatorsTestResponse.price_volume_diff_prepend_response()},
-             {"price_volume_diff": 0.01, "price_change": 0.04, "volume_change": 0.03, "timestamp": 1516752000}
+             {"price_volume_diff": 0.01, "price_change": 0.04, "volume_change": 0.03, "timestamp": #{
+             DateTime.utc_now() |> DateTime.to_unix()
+           }}
            ]
            """,
            status_code: 200

--- a/test/support/tech_indicators_response.ex
+++ b/test/support/tech_indicators_response.ex
@@ -12,7 +12,7 @@ defmodule Sanbase.TechIndicatorsTestResponse do
         "price_volume_diff": 0,
         "price_change": 0.04862261825993345,
         "volume_change": 0.030695260272520467,
-        "timestamp": 1516406400
+        "timestamp": 1116406400
       }
     /
     |> List.wrap()


### PR DESCRIPTION
The shift is in concrete number of intervals but the drop must not be.
To support in a single operation both `size = 0` (return all datapoint from tech_indicators) and `size > 0` (return only the last size results) we can use `drop_while` instead of dropping concrete number of points.

If we drop a concrete number of datapoint the behavior is broken for example in the case of `size=1`. This is because we'll try to remove ~21 number of points from a result with only 1 point.

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->