### PR TITLE
Activate deactivate signal

### DIFF
--- a/lib/sanbase/signals/evaluator/scheduler.ex
+++ b/lib/sanbase/signals/evaluator/scheduler.ex
@@ -64,6 +64,9 @@ defmodule Sanbase.Signals.Scheduler do
     updated_user_triggers
     |> persist_sent_signals()
 
+    updated_user_triggers
+    |> deactivate_non_repeating()
+
     sent_list_results
     |> List.flatten()
     |> log_sent_messages_stats(type)
@@ -78,6 +81,17 @@ defmodule Sanbase.Signals.Scheduler do
         }
       } ->
         triggered?
+    end)
+  end
+
+  defp deactivate_non_repeating(triggers) do
+    triggers
+    |> Enum.filter(fn ut -> !ut.trigger.repeating end)
+    |> Enum.map(fn %UserTrigger{id: id, user: user} ->
+      UserTrigger.update_user_trigger(user, %{
+        id: id,
+        active: false
+      })
     end)
   end
 

--- a/lib/sanbase/signals/evaluator/scheduler.ex
+++ b/lib/sanbase/signals/evaluator/scheduler.ex
@@ -85,14 +85,12 @@ defmodule Sanbase.Signals.Scheduler do
   end
 
   defp deactivate_non_repeating(triggers) do
-    triggers
-    |> Enum.filter(fn ut -> !ut.trigger.repeating end)
-    |> Enum.map(fn %UserTrigger{id: id, user: user} ->
+    for %UserTrigger{id: id, user: user, trigger: %{repeating: false}} <- triggers do
       UserTrigger.update_user_trigger(user, %{
         id: id,
         active: false
       })
-    end)
+    end
   end
 
   # returns a tuple {updated_user_triggers, send_result_list}

--- a/lib/sanbase/signals/evaluator/scheduler.ex
+++ b/lib/sanbase/signals/evaluator/scheduler.ex
@@ -56,7 +56,7 @@ defmodule Sanbase.Signals.Scheduler do
   defp run(type) do
     {updated_user_triggers, sent_list_results} =
       type
-      |> UserTrigger.get_triggers_by_type()
+      |> UserTrigger.get_active_triggers_by_type()
       |> Evaluator.run()
       |> filter_triggered?()
       |> send_and_mark_as_sent()

--- a/lib/sanbase/signals/trigger/settings/daily_active_addresses_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/daily_active_addresses_settings.ex
@@ -23,7 +23,6 @@ defmodule Sanbase.Signals.Trigger.DailyActiveAddressesSettings do
             channel: nil,
             time_window: nil,
             percent_threshold: nil,
-            repeating: true,
             triggered?: false,
             payload: nil
 
@@ -31,7 +30,6 @@ defmodule Sanbase.Signals.Trigger.DailyActiveAddressesSettings do
   validates(:channel, &valid_notification_channel/1)
   validates(:time_window, &valid_time_window?/1)
   validates(:percent_threshold, &valid_percent?/1)
-  validates(:repeating, &is_boolean/1)
 
   @type t :: %__MODULE__{
           type: Type.trigger_type(),
@@ -39,7 +37,6 @@ defmodule Sanbase.Signals.Trigger.DailyActiveAddressesSettings do
           channel: Type.channel(),
           time_window: Type.time_window(),
           percent_threshold: number(),
-          repeating: boolean(),
           triggered?: boolean(),
           payload: Type.payload()
         }

--- a/lib/sanbase/signals/trigger/settings/price_absolute_change_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/price_absolute_change_settings.ex
@@ -102,7 +102,7 @@ defmodule Sanbase.Signals.Trigger.PriceAbsoluteChangeSettings do
 
     @doc ~s"""
     Construct a cache key only out of the parameters that determine the outcome.
-    Parameters like `channel` is discarded. The `type` is included
+    Parameters like `channel` are discarded. The `type` is included
     so different triggers with the same parameter names can be distinguished
     """
     def cache_key(%PriceAbsoluteChangeSettings{} = settings) do

--- a/lib/sanbase/signals/trigger/settings/price_absolute_change_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/price_absolute_change_settings.ex
@@ -23,7 +23,6 @@ defmodule Sanbase.Signals.Trigger.PriceAbsoluteChangeSettings do
             channel: nil,
             above: nil,
             below: nil,
-            repeating: true,
             triggered?: false,
             payload: nil
 
@@ -31,7 +30,6 @@ defmodule Sanbase.Signals.Trigger.PriceAbsoluteChangeSettings do
   validates(:channel, &valid_notification_channel/1)
   validates(:above, &valid_price?/1)
   validates(:below, &valid_price?/1)
-  validates(:repeating, &is_boolean/1)
 
   @type t :: %__MODULE__{
           type: Type.trigger_type(),
@@ -39,7 +37,6 @@ defmodule Sanbase.Signals.Trigger.PriceAbsoluteChangeSettings do
           channel: Type.channel(),
           above: number(),
           below: number(),
-          repeating: boolean(),
           triggered?: boolean(),
           payload: Type.payload()
         }
@@ -105,7 +102,7 @@ defmodule Sanbase.Signals.Trigger.PriceAbsoluteChangeSettings do
 
     @doc ~s"""
     Construct a cache key only out of the parameters that determine the outcome.
-    Parameters like `repeating` and `channel` are discarded. The `type` is included
+    Parameters like `channel` is discarded. The `type` is included
     so different triggers with the same parameter names can be distinguished
     """
     def cache_key(%PriceAbsoluteChangeSettings{} = settings) do

--- a/lib/sanbase/signals/trigger/settings/price_percent_change_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/price_percent_change_settings.ex
@@ -120,7 +120,7 @@ defmodule Sanbase.Signals.Trigger.PricePercentChangeSettings do
 
     @doc ~s"""
     Construct a cache key only out of the parameters that determine the outcome.
-    Parameters like `channel` is discarded. The `type` is included
+    Parameters like `channel` are discarded. The `type` is included
     so different triggers with the same parameter names can be distinguished
     """
     def cache_key(%PricePercentChangeSettings{} = settings) do

--- a/lib/sanbase/signals/trigger/settings/price_percent_change_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/price_percent_change_settings.ex
@@ -22,7 +22,6 @@ defmodule Sanbase.Signals.Trigger.PricePercentChangeSettings do
             channel: nil,
             time_window: nil,
             percent_threshold: nil,
-            repeating: true,
             triggered?: false,
             payload: nil
 
@@ -32,7 +31,6 @@ defmodule Sanbase.Signals.Trigger.PricePercentChangeSettings do
           channel: Type.channel(),
           time_window: Type.time_window(),
           percent_threshold: number(),
-          repeating: boolean(),
           triggered?: boolean(),
           payload: Type.payload()
         }
@@ -41,7 +39,6 @@ defmodule Sanbase.Signals.Trigger.PricePercentChangeSettings do
   validates(:channel, &valid_notification_channel/1)
   validates(:time_window, &valid_time_window?/1)
   validates(:percent_threshold, &valid_percent?/1)
-  validates(:repeating, &is_boolean/1)
 
   @spec type() :: Type.trigger_type()
   def type(), do: @trigger_type
@@ -123,7 +120,7 @@ defmodule Sanbase.Signals.Trigger.PricePercentChangeSettings do
 
     @doc ~s"""
     Construct a cache key only out of the parameters that determine the outcome.
-    Parameters like `repeating` and `channel` are discarded. The `type` is included
+    Parameters like `channel` is discarded. The `type` is included
     so different triggers with the same parameter names can be distinguished
     """
     def cache_key(%PricePercentChangeSettings{} = settings) do

--- a/lib/sanbase/signals/trigger/settings/price_volume_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/price_volume_trigger_settings.ex
@@ -20,14 +20,12 @@ defmodule Sanbase.Signals.Trigger.PriceVolumeDifferenceTriggerSettings do
             window_type: "bohman",
             approximation_window: 14,
             comparison_window: 7,
-            repeating: true,
             triggered?: false,
             payload: nil
 
   validates(:target, &valid_target?/1)
   validates(:channel, &valid_notification_channel/1)
   validates(:threshold, &valid_threshold?/1)
-  validates(:repeating, &is_boolean/1)
 
   @typedoc ~s"""
   threshold - the sensitivity of the trigger. Defaults to 0.002

--- a/lib/sanbase/signals/trigger/settings/trending_words_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/trending_words_trigger_settings.ex
@@ -29,15 +29,13 @@ defmodule Sanbase.Signals.Trigger.TrendingWordsTriggerSettings do
             triggered?: false,
             payload: %{},
             target: "all",
-            filtered_target_list: [],
-            repeating: true
+            filtered_target_list: []
 
   @type t :: %__MODULE__{
           type: Type.trigger_type(),
           channel: Type.channel(),
           trigger_time: String.t(),
           triggered?: boolean(),
-          repeating: boolean(),
           payload: Type.payload()
         }
 

--- a/lib/sanbase/signals/trigger/trigger.ex
+++ b/lib/sanbase/signals/trigger/trigger.ex
@@ -41,6 +41,7 @@ defmodule Sanbase.Signals.Trigger do
     field(:cooldown, :string, default: "24h")
     field(:icon_url, :string)
     field(:active, :boolean, default: true)
+    field(:repeating, :boolean, default: true)
   end
 
   @type t :: %__MODULE__{
@@ -51,7 +52,8 @@ defmodule Sanbase.Signals.Trigger do
           title: String.t(),
           description: String.t(),
           icon_url: String.t(),
-          active: boolean()
+          active: boolean(),
+          repeating: boolean()
         }
 
   @doc false
@@ -63,7 +65,8 @@ defmodule Sanbase.Signals.Trigger do
     :title,
     :description,
     :icon_url,
-    :active
+    :active,
+    :repeating
   ]
 
   def create_changeset(%__MODULE__{} = trigger, args \\ %{}) do

--- a/lib/sanbase/signals/trigger/trigger.ex
+++ b/lib/sanbase/signals/trigger/trigger.ex
@@ -40,6 +40,7 @@ defmodule Sanbase.Signals.Trigger do
     field(:last_triggered, :map, default: %{})
     field(:cooldown, :string, default: "24h")
     field(:icon_url, :string)
+    field(:active?, :boolean, default: true)
   end
 
   @type t :: %__MODULE__{
@@ -49,7 +50,8 @@ defmodule Sanbase.Signals.Trigger do
           last_triggered: map(),
           title: String.t(),
           description: String.t(),
-          icon_url: String.t()
+          icon_url: String.t(),
+          active?: boolean()
         }
 
   @doc false
@@ -60,7 +62,8 @@ defmodule Sanbase.Signals.Trigger do
     :last_triggered,
     :title,
     :description,
-    :icon_url
+    :icon_url,
+    :active?
   ]
 
   def create_changeset(%__MODULE__{} = trigger, args \\ %{}) do

--- a/lib/sanbase/signals/trigger/trigger.ex
+++ b/lib/sanbase/signals/trigger/trigger.ex
@@ -40,7 +40,7 @@ defmodule Sanbase.Signals.Trigger do
     field(:last_triggered, :map, default: %{})
     field(:cooldown, :string, default: "24h")
     field(:icon_url, :string)
-    field(:active?, :boolean, default: true)
+    field(:active, :boolean, default: true)
   end
 
   @type t :: %__MODULE__{
@@ -51,7 +51,7 @@ defmodule Sanbase.Signals.Trigger do
           title: String.t(),
           description: String.t(),
           icon_url: String.t(),
-          active?: boolean()
+          active: boolean()
         }
 
   @doc false
@@ -63,7 +63,7 @@ defmodule Sanbase.Signals.Trigger do
     :title,
     :description,
     :icon_url,
-    :active?
+    :active
   ]
 
   def create_changeset(%__MODULE__{} = trigger, args \\ %{}) do

--- a/lib/sanbase/signals/trigger/trigger_query.ex
+++ b/lib/sanbase/signals/trigger/trigger_query.ex
@@ -29,6 +29,14 @@ defmodule Sanbase.Signals.TriggerQuery do
     end
   end
 
+  defmacro trigger_is_active() do
+    quote do
+      fragment("""
+      trigger->>'active' = 'true'
+      """)
+    end
+  end
+
   defmacro trigger_id_one_of(ids) do
     quote do
       fragment(

--- a/lib/sanbase/signals/user_trigger.ex
+++ b/lib/sanbase/signals/user_trigger.ex
@@ -115,14 +115,14 @@ defmodule Sanbase.Signals.UserTrigger do
   end
 
   @doc ~s"""
-  Get all triggers of a given type. Returns both public and private as it is used
+  Get all active triggers of a given type. Returns both public and private as it is used
   to run the signals evaluator and not in the public API.
   """
-  @spec get_triggers_by_type(String.t()) :: list(%__MODULE__{})
-  def get_triggers_by_type(type) do
+  @spec get_active_triggers_by_type(String.t()) :: list(%__MODULE__{})
+  def get_active_triggers_by_type(type) do
     from(
       ut in UserTrigger,
-      where: trigger_type_is(type),
+      where: trigger_type_is(type) and trigger_is_active(),
       preload: [{:user, :user_settings}]
     )
     |> Repo.all()

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -1115,6 +1115,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:is_public, :boolean)
       arg(:cooldown, :string)
       arg(:tags, list_of(:string))
+      arg(:active, :boolean)
       arg(:settings, :json)
 
       middleware(JWTAuth)

--- a/lib/sanbase_web/graphql/schema/user_trigger_types.ex
+++ b/lib/sanbase_web/graphql/schema/user_trigger_types.ex
@@ -8,13 +8,14 @@ defmodule SanbaseWeb.Graphql.UserTriggerTypes do
 
   object :trigger do
     field(:id, non_null(:integer))
-    field(:title, :string)
+    field(:title, non_null(:string))
     field(:description, :string)
     field(:icon_url, :string)
-    field(:settings, :json)
+    field(:settings, non_null(:json))
     field(:is_public, :boolean)
     field(:cooldown, :string)
     field(:tags, list_of(:tag))
     field(:active, non_null(:boolean))
+    field(:repeating, non_null(:boolean))
   end
 end

--- a/lib/sanbase_web/graphql/schema/user_trigger_types.ex
+++ b/lib/sanbase_web/graphql/schema/user_trigger_types.ex
@@ -15,5 +15,6 @@ defmodule SanbaseWeb.Graphql.UserTriggerTypes do
     field(:is_public, :boolean)
     field(:cooldown, :string)
     field(:tags, list_of(:tag))
+    field(:active, :boolean)
   end
 end

--- a/lib/sanbase_web/graphql/schema/user_trigger_types.ex
+++ b/lib/sanbase_web/graphql/schema/user_trigger_types.ex
@@ -7,7 +7,7 @@ defmodule SanbaseWeb.Graphql.UserTriggerTypes do
   end
 
   object :trigger do
-    field(:id, :integer)
+    field(:id, non_null(:integer))
     field(:title, :string)
     field(:description, :string)
     field(:icon_url, :string)
@@ -15,6 +15,6 @@ defmodule SanbaseWeb.Graphql.UserTriggerTypes do
     field(:is_public, :boolean)
     field(:cooldown, :string)
     field(:tags, list_of(:tag))
-    field(:active, :boolean)
+    field(:active, non_null(:boolean))
   end
 end

--- a/test/sanbase/signals/target_user_list_test.exs
+++ b/test/sanbase/signals/target_user_list_test.exs
@@ -41,8 +41,7 @@ defmodule SanbaseWeb.Graphql.TargetUserListTest do
       target: "santiment",
       channel: "telegram",
       above: 300.0,
-      below: 200.0,
-      repeating: false
+      below: 200.0
     }
 
     {:ok, _trigger} =
@@ -60,8 +59,7 @@ defmodule SanbaseWeb.Graphql.TargetUserListTest do
       target: 12,
       channel: "telegram",
       above: 300.0,
-      below: 200.0,
-      repeating: false
+      below: 200.0
     }
 
     assert capture_log(fn ->
@@ -81,8 +79,7 @@ defmodule SanbaseWeb.Graphql.TargetUserListTest do
       target: %{user_list: context.user_list.id},
       channel: "telegram",
       above: 300.0,
-      below: 200.0,
-      repeating: false
+      below: 200.0
     }
 
     {:ok, _trigger} =
@@ -99,8 +96,7 @@ defmodule SanbaseWeb.Graphql.TargetUserListTest do
       target: ["santiment", "ethereum", "bitcoin"],
       channel: "telegram",
       above: 300.0,
-      below: 200.0,
-      repeating: false
+      below: 200.0
     }
 
     {:ok, _trigger} =
@@ -117,8 +113,7 @@ defmodule SanbaseWeb.Graphql.TargetUserListTest do
       target: ["santiment", "ethereum", "bitcoin", 12],
       channel: "telegram",
       above: 300.0,
-      below: 200.0,
-      repeating: false
+      below: 200.0
     }
 
     capture_log(fn ->
@@ -138,8 +133,7 @@ defmodule SanbaseWeb.Graphql.TargetUserListTest do
       target: %{user_list: [1, 2, 3]},
       channel: "telegram",
       above: 300.0,
-      below: 200.0,
-      repeating: false
+      below: 200.0
     }
 
     assert capture_log(fn ->

--- a/test/sanbase/signals/trigger_evaluator_price_test.exs
+++ b/test/sanbase/signals/trigger_evaluator_price_test.exs
@@ -53,7 +53,7 @@ defmodule Sanbase.Signals.EvaluatorPriceTest do
   test "only some of price percent change signals triggered", context do
     [triggered | rest] =
       PricePercentChangeSettings.type()
-      |> UserTrigger.get_triggers_by_type()
+      |> UserTrigger.get_active_triggers_by_type()
       |> Evaluator.run()
 
     assert length(rest) == 0
@@ -64,7 +64,7 @@ defmodule Sanbase.Signals.EvaluatorPriceTest do
   test "only some of price absolute change signals triggered", context do
     [triggered | rest] =
       PriceAbsoluteChangeSettings.type()
-      |> UserTrigger.get_triggers_by_type()
+      |> UserTrigger.get_active_triggers_by_type()
       |> Evaluator.run()
 
     assert length(rest) == 0

--- a/test/sanbase/signals/trigger_evaluator_price_test.exs
+++ b/test/sanbase/signals/trigger_evaluator_price_test.exs
@@ -79,8 +79,7 @@ defmodule Sanbase.Signals.EvaluatorPriceTest do
 
     assert capture_log(fn ->
              Sanbase.Signals.Scheduler.run_price_absolute_change_signals()
-           end) =~
-             "In total 1/1 price_absolute_change signals were sent successfully"
+           end) =~ "In total 1/1 price_absolute_change signals were sent successfully"
 
     Sanbase.Signals.Evaluator.Cache.clear()
 

--- a/test/sanbase/signals/trigger_evaluator_price_test.exs
+++ b/test/sanbase/signals/trigger_evaluator_price_test.exs
@@ -158,8 +158,7 @@ defmodule Sanbase.Signals.EvaluatorPriceTest do
       target: "santiment",
       channel: "telegram",
       time_window: "6h",
-      percent_threshold: 15.0,
-      repeating: false
+      percent_threshold: 15.0
     }
 
     trigger_settings2 = %{
@@ -167,8 +166,7 @@ defmodule Sanbase.Signals.EvaluatorPriceTest do
       target: "santiment",
       channel: "telegram",
       above: 60,
-      below: 50,
-      repeating: false
+      below: 50
     }
 
     trigger_settings3 = %{
@@ -176,8 +174,7 @@ defmodule Sanbase.Signals.EvaluatorPriceTest do
       target: "santiment",
       channel: "telegram",
       time_window: "6h",
-      percent_threshold: 18.0,
-      repeating: false
+      percent_threshold: 18.0
     }
 
     trigger_settings4 = %{
@@ -185,8 +182,7 @@ defmodule Sanbase.Signals.EvaluatorPriceTest do
       target: "santiment",
       channel: "telegram",
       above: 70,
-      below: 50,
-      repeating: false
+      below: 50
     }
 
     {:ok, trigger1} =

--- a/test/sanbase/signals/trigger_evaluator_test.exs
+++ b/test/sanbase/signals/trigger_evaluator_test.exs
@@ -94,7 +94,7 @@ defmodule Sanbase.Signals.EvaluatorTest do
       end do
       [triggered1, triggered2 | rest] =
         DailyActiveAddressesSettings.type()
-        |> UserTrigger.get_triggers_by_type()
+        |> UserTrigger.get_active_triggers_by_type()
         |> Evaluator.run()
 
       # 2 signals triggered
@@ -111,7 +111,7 @@ defmodule Sanbase.Signals.EvaluatorTest do
       end do
       [triggered | rest] =
         DailyActiveAddressesSettings.type()
-        |> UserTrigger.get_triggers_by_type()
+        |> UserTrigger.get_active_triggers_by_type()
         |> Evaluator.run()
 
       # 1 signal triggered
@@ -127,7 +127,7 @@ defmodule Sanbase.Signals.EvaluatorTest do
       end do
       triggered =
         DailyActiveAddressesSettings.type()
-        |> UserTrigger.get_triggers_by_type()
+        |> UserTrigger.get_active_triggers_by_type()
         |> Evaluator.run()
 
       # 0 signals triggered
@@ -142,7 +142,7 @@ defmodule Sanbase.Signals.EvaluatorTest do
       end do
       [triggered] =
         TrendingWordsTriggerSettings.type()
-        |> UserTrigger.get_triggers_by_type()
+        |> UserTrigger.get_active_triggers_by_type()
         |> Evaluator.run()
 
       assert context.trigger_trending_words.id == triggered.id
@@ -195,6 +195,17 @@ defmodule Sanbase.Signals.EvaluatorTest do
       assert user_signal.user_id == context.user.id
       assert String.contains?(user_signal.payload["all"], "coinbase")
     end
+  end
+
+  test "Non active signals are filtered", context do
+    UserTrigger.update_user_trigger(context.user, %{
+      id: context.trigger_trending_words.trigger.id,
+      active: false
+    })
+
+    assert capture_log(fn ->
+             Sanbase.Signals.Scheduler.run_trending_words_signals()
+           end) =~ "There were no signals triggered of type"
   end
 
   defp top_words() do

--- a/test/sanbase/signals/trigger_evaluator_test.exs
+++ b/test/sanbase/signals/trigger_evaluator_test.exs
@@ -199,7 +199,7 @@ defmodule Sanbase.Signals.EvaluatorTest do
 
   test "Non active signals are filtered", context do
     UserTrigger.update_user_trigger(context.user, %{
-      id: context.trigger_trending_words.trigger.id,
+      id: context.trigger_trending_words.id,
       active: false
     })
 

--- a/test/sanbase/signals/trigger_evaluator_test.exs
+++ b/test/sanbase/signals/trigger_evaluator_test.exs
@@ -37,8 +37,7 @@ defmodule Sanbase.Signals.EvaluatorTest do
       target: "santiment",
       channel: "telegram",
       time_window: "1d",
-      percent_threshold: 300.0,
-      repeating: false
+      percent_threshold: 300.0
     }
 
     trigger_settings2 = %{
@@ -46,8 +45,7 @@ defmodule Sanbase.Signals.EvaluatorTest do
       target: "santiment",
       channel: "telegram",
       time_window: "1d",
-      percent_threshold: 200.0,
-      repeating: false
+      percent_threshold: 200.0
     }
 
     trending_words_settings = %{

--- a/test/sanbase/signals/trigger_price_volume_diff_test.exs
+++ b/test/sanbase/signals/trigger_price_volume_diff_test.exs
@@ -48,7 +48,7 @@ defmodule Sanbase.Signals.PriceVolumeDiffTest do
 
     triggered =
       PriceVolumeDifferenceTriggerSettings.type()
-      |> UserTrigger.get_triggers_by_type()
+      |> UserTrigger.get_active_triggers_by_type()
       |> Evaluator.run()
 
     assert length(triggered) == 0
@@ -70,7 +70,7 @@ defmodule Sanbase.Signals.PriceVolumeDiffTest do
       end do
       triggered =
         PriceVolumeDifferenceTriggerSettings.type()
-        |> UserTrigger.get_triggers_by_type()
+        |> UserTrigger.get_active_triggers_by_type()
         |> Evaluator.run()
 
       assert length(triggered) == 0
@@ -95,7 +95,7 @@ defmodule Sanbase.Signals.PriceVolumeDiffTest do
       end do
       [triggered | rest] =
         PriceVolumeDifferenceTriggerSettings.type()
-        |> UserTrigger.get_triggers_by_type()
+        |> UserTrigger.get_active_triggers_by_type()
         |> Evaluator.run()
 
       assert length(rest) == 0
@@ -116,7 +116,7 @@ defmodule Sanbase.Signals.PriceVolumeDiffTest do
       assert capture_log(fn ->
                triggered =
                  PriceVolumeDifferenceTriggerSettings.type()
-                 |> UserTrigger.get_triggers_by_type()
+                 |> UserTrigger.get_active_triggers_by_type()
                  |> Evaluator.run()
 
                assert triggered == []
@@ -135,7 +135,7 @@ defmodule Sanbase.Signals.PriceVolumeDiffTest do
       assert capture_log(fn ->
                triggered =
                  PriceVolumeDifferenceTriggerSettings.type()
-                 |> UserTrigger.get_triggers_by_type()
+                 |> UserTrigger.get_active_triggers_by_type()
                  |> Evaluator.run()
 
                assert triggered == []

--- a/test/sanbase/signals/trigger_price_volume_diff_test.exs
+++ b/test/sanbase/signals/trigger_price_volume_diff_test.exs
@@ -148,16 +148,14 @@ defmodule Sanbase.Signals.PriceVolumeDiffTest do
       type: "price_volume_difference",
       target: "santiment",
       channel: "telegram",
-      threshold: 0.002,
-      repeating: false
+      threshold: 0.002
     }
 
     trigger_settings2 = %{
       type: "price_volume_difference",
       target: "santiment",
       channel: "telegram",
-      threshold: 0.1,
-      repeating: false
+      threshold: 0.1
     }
 
     {:ok, trigger1} =

--- a/test/sanbase/signals/triggers_test.exs
+++ b/test/sanbase/signals/triggers_test.exs
@@ -17,7 +17,6 @@ defmodule Sanbase.Signals.TriggersTest do
       channel: "telegram",
       time_window: "1d",
       percent_threshold: 300.0,
-      repeating: false,
       triggered?: false,
       payload: nil
     }
@@ -46,8 +45,7 @@ defmodule Sanbase.Signals.TriggersTest do
       target: "santiment",
       channel: "telegram",
       time_window: "1d",
-      percent_threshold: 300.0,
-      repeating: false
+      percent_threshold: 300.0
     }
 
     {:error, message} =
@@ -68,8 +66,7 @@ defmodule Sanbase.Signals.TriggersTest do
       target: "santiment",
       channel: "telegram",
       time_window: "1d",
-      percent_threshold: 300.0,
-      repeating: false
+      percent_threshold: 300.0
     }
 
     {:error, changeset} =
@@ -92,7 +89,6 @@ defmodule Sanbase.Signals.TriggersTest do
       channel: "unknown",
       time_window: "1d",
       percent_threshold: 300.0,
-      repeating: false,
       triggered?: false,
       payload: nil
     }
@@ -117,8 +113,7 @@ defmodule Sanbase.Signals.TriggersTest do
       type: "daily_active_addresses",
       target: "santiment",
       time_window: "1d",
-      percent_threshold: 300.0,
-      repeating: false
+      percent_threshold: 300.0
     }
 
     {:error, message} =
@@ -139,8 +134,7 @@ defmodule Sanbase.Signals.TriggersTest do
       target: "santiment",
       percent_threshold: 20,
       channel: "telegram",
-      time_window: "1d",
-      repeating: false
+      time_window: "1d"
     }
 
     title = "Some title"
@@ -164,8 +158,7 @@ defmodule Sanbase.Signals.TriggersTest do
       target: "santiment",
       percent_threshold: 20,
       channel: "telegram",
-      time_window: "1d",
-      repeating: false
+      time_window: "1d"
     }
 
     title = "Generic title"
@@ -197,8 +190,7 @@ defmodule Sanbase.Signals.TriggersTest do
       target: "santiment",
       channel: "telegram",
       time_window: "1d",
-      percent_threshold: 300.0,
-      repeating: false
+      percent_threshold: 300.0
     }
 
     insert(:user_triggers,
@@ -213,8 +205,7 @@ defmodule Sanbase.Signals.TriggersTest do
       target: "santiment",
       channel: "email",
       time_window: "1d",
-      percent_threshold: 10.0,
-      repeating: false
+      percent_threshold: 10.0
     }
 
     {:ok, _} =
@@ -235,8 +226,7 @@ defmodule Sanbase.Signals.TriggersTest do
       target: "santiment",
       channel: "telegram",
       time_window: "1d",
-      percent_threshold: 300.0,
-      repeating: false
+      percent_threshold: 300.0
     }
 
     trigger_settings2 = %{
@@ -244,8 +234,7 @@ defmodule Sanbase.Signals.TriggersTest do
       target: "santiment",
       channel: "email",
       time_window: "1d",
-      percent_threshold: 10.0,
-      repeating: false
+      percent_threshold: 10.0
     }
 
     insert(:user_triggers,
@@ -265,8 +254,7 @@ defmodule Sanbase.Signals.TriggersTest do
       target: "santiment",
       channel: "telegram",
       time_window: "1d",
-      percent_threshold: 200.0,
-      repeating: true
+      percent_threshold: 200.0
     }
 
     new_title = "New title"
@@ -292,7 +280,6 @@ defmodule Sanbase.Signals.TriggersTest do
     %UserTrigger{trigger: trigger} =
       Enum.find(triggers, fn %UserTrigger{id: id} -> id == trigger_id end)
 
-    assert trigger.settings.repeating == true
     assert trigger.title == new_title
     assert trigger.description == new_description
     assert trigger.icon_url == new_icon_url
@@ -306,8 +293,7 @@ defmodule Sanbase.Signals.TriggersTest do
       target: "santiment",
       channel: "telegram",
       time_window: "1d",
-      percent_threshold: 200.0,
-      repeating: false
+      percent_threshold: 200.0
     }
 
     insert(:user_triggers,

--- a/test/sanbase_web/graphql/triggers_api_test.exs
+++ b/test/sanbase_web/graphql/triggers_api_test.exs
@@ -21,16 +21,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
         send(self(), {:telegram_to_self, text})
         :ok
       end do
-      trigger_settings = %{
-        "type" => "daily_active_addresses",
-        "target" => "santiment",
-        "channel" => "telegram",
-        "time_window" => "1d",
-        "percent_threshold" => 300.0,
-        "repeating" => false,
-        "payload" => nil,
-        "triggered?" => false
-      }
+      trigger_settings = default_trigger_settings()
 
       trigger_settings_json = trigger_settings |> Jason.encode!()
 
@@ -113,16 +104,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
   end
 
   test "update trigger", %{user: user, conn: conn} do
-    trigger_settings = %{
-      "type" => "daily_active_addresses",
-      "target" => "santiment",
-      "channel" => "telegram",
-      "time_window" => "1d",
-      "percent_threshold" => 300.0,
-      "repeating" => false,
-      "payload" => nil,
-      "triggered?" => false
-    }
+    trigger_settings = default_trigger_settings()
 
     insert(:user_triggers, user: user, trigger: %{is_public: false, settings: trigger_settings})
 
@@ -164,16 +146,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
   end
 
   test "remove trigger", %{user: user, conn: conn} do
-    trigger_settings = %{
-      "type" => "daily_active_addresses",
-      "target" => "santiment",
-      "channel" => "telegram",
-      "time_window" => "1d",
-      "percent_threshold" => 300.0,
-      "repeating" => false,
-      "payload" => nil,
-      "triggered?" => false
-    }
+    trigger_settings = default_trigger_settings()
 
     insert(:user_triggers, user: user, trigger: %{is_public: false, settings: trigger_settings})
 
@@ -204,17 +177,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
   end
 
   test "get trigger by id", %{user: user, conn: conn} do
-    trigger_settings = %{
-      "type" => "daily_active_addresses",
-      "target" => "santiment",
-      "filtered_target_list" => [],
-      "channel" => "telegram",
-      "time_window" => "1d",
-      "percent_threshold" => 300.0,
-      "repeating" => false,
-      "payload" => nil,
-      "triggered?" => false
-    }
+    trigger_settings = default_trigger_settings()
 
     insert(:user_triggers,
       user: user,
@@ -249,17 +212,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
   end
 
   test "fetches triggers for current user", %{user: user, conn: conn} do
-    trigger_settings = %{
-      "type" => "daily_active_addresses",
-      "target" => "santiment",
-      "filtered_target_list" => [],
-      "channel" => "telegram",
-      "time_window" => "1d",
-      "percent_threshold" => 300.0,
-      "repeating" => false,
-      "payload" => nil,
-      "triggered?" => false
-    }
+    trigger_settings = default_trigger_settings()
 
     insert(:user_triggers, user: user, trigger: %{is_public: false, settings: trigger_settings})
 
@@ -289,17 +242,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
   end
 
   test "fetches all public triggers", %{user: user, conn: conn} do
-    trigger_settings = %{
-      "type" => "daily_active_addresses",
-      "target" => "santiment",
-      "filtered_target_list" => [],
-      "channel" => "telegram",
-      "time_window" => "1d",
-      "percent_threshold" => 300.0,
-      "repeating" => false,
-      "payload" => nil,
-      "triggered?" => false
-    }
+    trigger_settings = default_trigger_settings()
 
     trigger_settings2 = Map.put(trigger_settings, "percent_threshold", 400.0)
 
@@ -332,17 +275,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
   test "fetches public user triggers", %{conn: conn} do
     user = insert(:user, email: "alabala@example.com")
 
-    trigger_settings = %{
-      "type" => "daily_active_addresses",
-      "target" => "santiment",
-      "filtered_target_list" => [],
-      "channel" => "telegram",
-      "time_window" => "1d",
-      "percent_threshold" => 300.0,
-      "repeating" => false,
-      "payload" => nil,
-      "triggered?" => false
-    }
+    trigger_settings = default_trigger_settings()
 
     trigger_settings2 = Map.put(trigger_settings, "percent_threshold", 400.0)
 
@@ -411,17 +344,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
   end
 
   test "fetches signals historical activity for current user", %{user: user, conn: conn} do
-    trigger_settings = %{
-      "type" => "daily_active_addresses",
-      "target" => "santiment",
-      "filtered_target_list" => [],
-      "channel" => "telegram",
-      "time_window" => "1d",
-      "percent_threshold" => 300.0,
-      "repeating" => false,
-      "payload" => nil,
-      "triggered?" => false
-    }
+    trigger_settings = default_trigger_settings()
 
     user_trigger =
       insert(:user_triggers,
@@ -567,6 +490,20 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
       |> json_response(200)
 
     result["data"]["signalsHistoricalActivity"]
+  end
+
+  defp default_trigger_settings do
+    %{
+      "type" => "daily_active_addresses",
+      "target" => "santiment",
+      "filtered_target_list" => [],
+      "channel" => "telegram",
+      "time_window" => "1d",
+      "percent_threshold" => 300.0,
+      "repeating" => false,
+      "payload" => nil,
+      "triggered?" => false
+    }
   end
 
   defp format_interpolated_json(string) do

--- a/test/sanbase_web/graphql/triggers_api_test.exs
+++ b/test/sanbase_web/graphql/triggers_api_test.exs
@@ -472,7 +472,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
       ~s|
     mutation {
       updateTrigger(
-        id: '#{ut.trigger.id}',
+        id: #{ut.id},
         active: false
       ) {
         trigger{
@@ -504,7 +504,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
       ~s|
     mutation {
       updateTrigger(
-        id: '#{ut.trigger.id}',
+        id: #{ut.id},
         active: true
       ) {
         trigger{

--- a/test/sanbase_web/graphql/triggers_api_test.exs
+++ b/test/sanbase_web/graphql/triggers_api_test.exs
@@ -461,6 +461,70 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
            ) == nil
   end
 
+  test "deactivate signal", %{user: user, conn: conn} do
+    trigger_settings = default_trigger_settings()
+
+    ut = insert(:user_triggers, user: user, trigger: %{settings: trigger_settings})
+
+    assert ut.trigger.active
+
+    query =
+      ~s|
+    mutation {
+      updateTrigger(
+        id: '#{ut.trigger.id}',
+        active: false
+      ) {
+        trigger{
+          active
+        }
+      }
+    }
+    |
+      |> format_interpolated_json()
+
+    result =
+      conn
+      |> post("/graphql", %{"query" => query})
+      |> json_response(200)
+
+    trigger = result["data"]["updateTrigger"]["trigger"]
+
+    assert trigger["active"] == false
+  end
+
+  test "activate signal", %{user: user, conn: conn} do
+    trigger_settings = default_trigger_settings()
+
+    ut = insert(:user_triggers, user: user, trigger: %{active: false, settings: trigger_settings})
+
+    refute ut.trigger.active
+
+    query =
+      ~s|
+    mutation {
+      updateTrigger(
+        id: '#{ut.trigger.id}',
+        active: true
+      ) {
+        trigger{
+          active
+        }
+      }
+    }
+    |
+      |> format_interpolated_json()
+
+    result =
+      conn
+      |> post("/graphql", %{"query" => query})
+      |> json_response(200)
+
+    trigger = result["data"]["updateTrigger"]["trigger"]
+
+    assert trigger["active"] == true
+  end
+
   defp current_user_signals_activity(conn, args_str) do
     query =
       ~s|

--- a/test/sanbase_web/graphql/triggers_api_test.exs
+++ b/test/sanbase_web/graphql/triggers_api_test.exs
@@ -65,7 +65,6 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
       "channel" => "telegram",
       "time_window" => "1d",
       "percent_threshold" => 300.0,
-      "repeating" => false,
       "payload" => nil,
       "triggered?" => false
     }
@@ -564,7 +563,6 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
       "channel" => "telegram",
       "time_window" => "1d",
       "percent_threshold" => 300.0,
-      "repeating" => false,
       "payload" => nil,
       "triggered?" => false
     }


### PR DESCRIPTION
Activate/deactivate trigger:

```graphql
     mutation {
        updateTrigger(
          id: 123,
          active: false
        ) {
          trigger{
            active
          }
        }
      }
```

Trigger is `repeating` by default. If not `repeating` then it is triggered once and deactivated.