### PR TITLE
Rework the filtered_target_list

### DIFF
--- a/lib/map_utils.ex
+++ b/lib/map_utils.ex
@@ -1,0 +1,5 @@
+defmodule Sanbase.MapUtils do
+  def drop_diff_keys(left, right) do
+    Map.drop(left, Map.keys(left) -- Map.keys(right))
+  end
+end

--- a/lib/map_utils.ex
+++ b/lib/map_utils.ex
@@ -1,4 +1,24 @@
 defmodule Sanbase.MapUtils do
+  @doc ~s"""
+  Return a subset of `left` map that has only the keys that are also present in `right`.
+
+  #### Examples:
+
+  iex> Sanbase.MapUtils.drop_diff_keys(%{}, %{})
+  %{}
+
+  iex> Sanbase.MapUtils.drop_diff_keys(%{a: 1}, %{a: 1})
+  %{a: 1}
+
+  iex> Sanbase.MapUtils.drop_diff_keys(%{a: 1, b: 2}, %{a: 1})
+  %{a: 1}
+
+  iex> Sanbase.MapUtils.drop_diff_keys(%{a: 1}, %{a: "ASDASDASDA"})
+  %{a: 1}
+
+  iex> Sanbase.MapUtils.drop_diff_keys(%{a: 1, d: 555, e: "string"}, %{b: 2, c: 3, f: 19})
+  %{}
+  """
   def drop_diff_keys(left, right) do
     Map.drop(left, Map.keys(left) -- Map.keys(right))
   end

--- a/lib/sanbase/signals/history/daily_active_addresses_history.ex
+++ b/lib/sanbase/signals/history/daily_active_addresses_history.ex
@@ -34,13 +34,13 @@ defmodule Sanbase.Signals.History.DailyActiveAddressesHistory do
             {:ok, list(DailyActiveAddressesHistory.historical_trigger_points_type())}
             | {:error, String.t()}
     def historical_trigger_points(
-          %DailyActiveAddressesSettings{target: target} = settings,
+          %DailyActiveAddressesSettings{target: %{slug: slug}} = settings,
           cooldown
         )
-        when is_binary(target) do
-      with {:ok, contract, _token_decimals} <- Project.contract_info_by_slug(settings.target),
+        when is_binary(slug) do
+      with {:ok, contract, _token_decimals} <- Project.contract_info_by_slug(slug),
            measurement when not is_nil(measurement) <-
-             Measurement.name_from_slug(settings.target),
+             Measurement.name_from_slug(slug),
            {from, to, interval} <- get_timeseries_params(),
            {:ok, daa_result} when is_list(daa_result) and daa_result != [] <-
              get_daily_active_addresses(contract, from, to, interval),
@@ -64,7 +64,7 @@ defmodule Sanbase.Signals.History.DailyActiveAddressesHistory do
         active_addresses =
           daa_result |> Enum.map(fn %{active_addresses: active_addresses} -> active_addresses end)
 
-        # chunk in time window days + 1 buckets, 
+        # chunk in time window days + 1 buckets,
         # calculate percent changes between average of all but last and last value
         # calculate tuples {percent_change, is_trigger_point} where is_trigger_point considers cooldown
         percent_change_calculations =
@@ -76,7 +76,7 @@ defmodule Sanbase.Signals.History.DailyActiveAddressesHistory do
             cooldown_in_days
           )
 
-        # for the first time_window days we don't check whether they are trigger points  
+        # for the first time_window days we don't check whether they are trigger points
         empty_calculations = Stream.cycle([{0.0, false}]) |> Enum.take(time_window_in_days)
 
         # add percent_change and boolean triggered? to the daily_active_addresses and prices

--- a/lib/sanbase/signals/history/prices_history.ex
+++ b/lib/sanbase/signals/history/prices_history.ex
@@ -26,8 +26,8 @@ defmodule Sanbase.Signals.History.PricesHistory do
           triggered?: boolean()
         }
 
-  def get_prices(%{target: target}) when is_binary(target) do
-    with measurement when not is_nil(measurement) <- Measurement.name_from_slug(target),
+  def get_prices(%{target: %{slug: slug}}) when is_binary(slug) do
+    with measurement when not is_nil(measurement) <- Measurement.name_from_slug(slug),
          {from, to, interval} <- get_timeseries_params(),
          {:ok, price_list} when is_list(price_list) and price_list != [] <-
            PricesStore.fetch_prices_with_resolution(measurement, from, to, interval) do
@@ -78,7 +78,7 @@ defmodule Sanbase.Signals.History.PricesHistory do
     @spec historical_trigger_points(%PriceAbsoluteChangeSettings{}, String.t()) ::
             {:ok, list(PricesHistory.historical_trigger_points_type())} | {:error, String.t()}
     def historical_trigger_points(
-          %PriceAbsoluteChangeSettings{target: target} = settings,
+          %PriceAbsoluteChangeSettings{target: %{slug: target}} = settings,
           cooldown
         )
         when is_binary(target) do
@@ -122,7 +122,7 @@ defmodule Sanbase.Signals.History.PricesHistory do
     @spec historical_trigger_points(%PricePercentChangeSettings{}, String.t()) ::
             {:ok, list(PricesHistory.historical_trigger_points_type())} | {:error, String.t()}
     def historical_trigger_points(
-          %PricePercentChangeSettings{target: target} = settings,
+          %PricePercentChangeSettings{target: %{slug: target}} = settings,
           cooldown
         )
         when is_binary(target) do

--- a/lib/sanbase/signals/struct_map_transformation.ex
+++ b/lib/sanbase/signals/struct_map_transformation.ex
@@ -21,17 +21,10 @@ defmodule Sanbase.Signals.StructMapTransformation do
     %{trigger | settings: settings}
   end
 
-  def load_in_struct(trigger_settings) when is_map(trigger_settings) do
-    trigger_settings =
-      for {key, val} <- trigger_settings, into: %{} do
-        if is_atom(key) do
-          {key, val}
-        else
-          {String.to_existing_atom(key), val}
-        end
-      end
-
-    struct_from_map(trigger_settings)
+  def load_in_struct(map) when is_map(map) do
+    map
+    |> atomize_keys()
+    |> struct_from_map()
   end
 
   def load_in_struct(_), do: :error
@@ -72,4 +65,18 @@ defmodule Sanbase.Signals.StructMapTransformation do
     do: {:ok, Map.from_struct(trigger_settings)}
 
   def map_from_struct(_), do: :error
+
+  # Private functions
+
+  defp atomize_keys(map) when is_map(map) do
+    for {key, val} <- map, into: %{} do
+      if is_atom(key) do
+        {key, atomize_keys(val)}
+      else
+        {String.to_existing_atom(key), atomize_keys(val)}
+      end
+    end
+  end
+
+  defp atomize_keys(data), do: data
 end

--- a/lib/sanbase/signals/trigger/settings/daily_active_addresses_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/daily_active_addresses_settings.ex
@@ -14,12 +14,12 @@ defmodule Sanbase.Signals.Trigger.DailyActiveAddressesSettings do
   alias Sanbase.Clickhouse.DailyActiveAddresses
   alias Sanbase.Signals.Evaluator.Cache
 
-  @derive {Jason.Encoder, except: [:filtered_target_list, :payload, :triggered?]}
+  @derive {Jason.Encoder, except: [:filtered_target, :payload, :triggered?]}
   @trigger_type "daily_active_addresses"
   @enforce_keys [:type, :target, :channel, :time_window, :percent_threshold]
   defstruct type: @trigger_type,
             target: nil,
-            filtered_target_list: [],
+            filtered_target: %{list: []},
             channel: nil,
             time_window: nil,
             percent_threshold: nil,
@@ -44,7 +44,7 @@ defmodule Sanbase.Signals.Trigger.DailyActiveAddressesSettings do
   @spec type() :: Type.trigger_type()
   def type(), do: @trigger_type
 
-  def get_data(%__MODULE__{filtered_target_list: target_list} = settings)
+  def get_data(%__MODULE__{filtered_target: %{list: target_list}} = settings)
       when is_list(target_list) do
     time_window_sec = Sanbase.DateTimeUtils.compound_duration_to_seconds(settings.time_window)
     from = Timex.shift(Timex.now(), seconds: -time_window_sec)

--- a/lib/sanbase/signals/trigger/settings/price_absolute_change_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/price_absolute_change_settings.ex
@@ -14,12 +14,12 @@ defmodule Sanbase.Signals.Trigger.PriceAbsoluteChangeSettings do
   alias Sanbase.Model.Project
   alias Sanbase.Signals.Evaluator.Cache
 
-  @derive {Jason.Encoder, except: [:filtered_target_list, :payload, :triggered?]}
+  @derive {Jason.Encoder, except: [:filtered_target, :payload, :triggered?]}
   @trigger_type "price_absolute_change"
   @enforce_keys [:type, :target, :channel]
   defstruct type: @trigger_type,
             target: nil,
-            filtered_target_list: [],
+            filtered_target: %{list: []},
             channel: nil,
             above: nil,
             below: nil,
@@ -59,7 +59,7 @@ defmodule Sanbase.Signals.Trigger.PriceAbsoluteChangeSettings do
     )
   end
 
-  def get_data(%__MODULE__{filtered_target_list: target_list}) when is_list(target_list) do
+  def get_data(%__MODULE__{filtered_target: %{list: target_list}}) when is_list(target_list) do
     target_list
     |> Enum.map(fn slug ->
       {slug, get_data_by_slug(slug)}

--- a/lib/sanbase/signals/trigger/settings/price_percent_change_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/price_percent_change_settings.ex
@@ -13,12 +13,12 @@ defmodule Sanbase.Signals.Trigger.PricePercentChangeSettings do
   alias Sanbase.DateTimeUtils
   alias Sanbase.Signals.Evaluator.Cache
 
-  @derive {Jason.Encoder, except: [:filtered_target_list, :payload, :triggered?]}
+  @derive {Jason.Encoder, except: [:filtered_target, :payload, :triggered?]}
   @trigger_type "price_percent_change"
   @enforce_keys [:type, :target, :channel, :time_window]
   defstruct type: @trigger_type,
             target: nil,
-            filtered_target_list: [],
+            filtered_target: %{list: []},
             channel: nil,
             time_window: nil,
             percent_threshold: nil,
@@ -44,9 +44,10 @@ defmodule Sanbase.Signals.Trigger.PricePercentChangeSettings do
   def type(), do: @trigger_type
 
   @spec get_data(__MODULE__.t()) :: list({Type.target(), any()})
-  def get_data(%__MODULE__{filtered_target_list: target} = settings) when is_list(target) do
+  def get_data(%__MODULE__{filtered_target: %{list: target_list}} = settings)
+      when is_list(target_list) do
     time_window_sec = DateTimeUtils.compound_duration_to_seconds(settings.time_window)
-    projects = Project.by_slugs(target)
+    projects = Project.by_slugs(target_list)
     to = Timex.now()
     from = Timex.shift(to, seconds: -time_window_sec)
 

--- a/lib/sanbase/signals/trigger/settings/price_volume_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/price_volume_trigger_settings.ex
@@ -7,13 +7,13 @@ defmodule Sanbase.Signals.Trigger.PriceVolumeDifferenceTriggerSettings do
   alias Sanbase.Model.Project
   alias Sanbase.TechIndicators.PriceVolumeDifference
 
-  @derive {Jason.Encoder, except: [:filtered_target_list, :payload, :triggered?]}
+  @derive {Jason.Encoder, except: [:filtered_target, :payload, :triggered?]}
   @trigger_type "price_volume_difference"
   @enforce_keys [:type, :target, :channel, :threshold]
 
   defstruct type: @trigger_type,
             target: nil,
-            filtered_target_list: [],
+            filtered_target: %{list: []},
             channel: nil,
             threshold: 0.002,
             aggregate_interval: "1d",
@@ -55,8 +55,9 @@ defmodule Sanbase.Signals.Trigger.PriceVolumeDifferenceTriggerSettings do
   @spec type() :: Type.trigger_type()
   def type(), do: @trigger_type
 
-  def get_data(%{filtered_target_list: target} = settings) when is_list(target) do
-    target
+  def get_data(%__MODULE__{filtered_target: %{list: target_list}} = settings)
+      when is_list(target_list) do
+    target_list
     |> Enum.map(fn slug -> get_data_for_single_project(slug, settings) end)
   end
 

--- a/lib/sanbase/signals/trigger/settings/trending_words_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/trending_words_trigger_settings.ex
@@ -16,7 +16,7 @@ defmodule Sanbase.Signals.Trigger.TrendingWordsTriggerSettings do
   alias __MODULE__
   alias Sanbase.Signals.Type
 
-  @derive {Jason.Encoder, except: [:filtered_target_list, :payload, :triggered?]}
+  @derive {Jason.Encoder, except: [:filtered_target, :payload, :triggered?]}
   @trigger_type "trending_words"
   @trending_words_size 10
   @trending_words_hours [1, 8, 14]
@@ -29,7 +29,7 @@ defmodule Sanbase.Signals.Trigger.TrendingWordsTriggerSettings do
             triggered?: false,
             payload: %{},
             target: "all",
-            filtered_target_list: []
+            filtered_target: %{list: []}
 
   @type t :: %__MODULE__{
           type: Type.trigger_type(),
@@ -51,10 +51,10 @@ defmodule Sanbase.Signals.Trigger.TrendingWordsTriggerSettings do
   @spec type() :: String.t()
   def type(), do: @trigger_type
 
-  @spec get_data(%TrendingWordsTriggerSettings{}) :: {:ok, list(top_word_type)} | :error
-  def get_data(%TrendingWordsTriggerSettings{filtered_target_list: []}), do: :error
+  @spec get_data(%__MODULE__{}) :: {:ok, list(top_word_type)} | :error
+  def get_data(%__MODULE__{filtered_target: %{list: []}}), do: :error
 
-  def get_data(%TrendingWordsTriggerSettings{trigger_time: trigger_time}) do
+  def get_data(%__MODULE__{trigger_time: trigger_time}) do
     now = Timex.now()
     trigger_time = Time.from_iso8601!(trigger_time)
     now_time = DateTime.to_time(now)

--- a/lib/sanbase/signals/trigger/validation.ex
+++ b/lib/sanbase/signals/trigger/validation.ex
@@ -40,11 +40,11 @@ defmodule Sanbase.Signals.Validation do
 
   def valid_iso8601_datetime_string?(_), do: {:error, "Not valid ISO8601 time"}
 
-  def valid_target?(target) when is_binary(target), do: :ok
   def valid_target?(%{user_list: int}) when is_integer(int), do: :ok
+  def valid_target?(%{slug: slug}) when is_binary(slug), do: :ok
 
-  def valid_target?(list) when is_list(list) do
-    Enum.find(list, fn elem -> not is_binary(elem) end)
+  def valid_target?(%{slug: slugs}) when is_list(slugs) do
+    Enum.find(slugs, fn slug -> not is_binary(slug) end)
     |> case do
       nil -> :ok
       _ -> {:error, "The target list contains elements that are not string"}
@@ -52,6 +52,23 @@ defmodule Sanbase.Signals.Validation do
   end
 
   def valid_target?(target),
+    do: {:error, "#{inspect(target)} is not a valid target"}
+
+  def valid_eth_wallet_target?(%{eth_address: address})
+      when is_binary(address) or is_list(address) do
+    address
+    |> List.wrap()
+    |> Enum.find(fn elem -> not is_binary(elem) end)
+    |> case do
+      nil -> :ok
+      _ -> {:error, "The target list contains elements that are not string"}
+    end
+  end
+
+  def valid_eth_wallet_target?(%{project: slug}) when is_binary(slug), do: :ok
+  def valid_eth_wallet_target?(%{user_list: int}) when is_integer(int), do: :ok
+
+  def valid_eth_wallet_target?(target),
     do: {:error, "#{inspect(target)} is not a valid target"}
 
   def valid_url?(url) do

--- a/test/sanbase/signals/target_user_list_test.exs
+++ b/test/sanbase/signals/target_user_list_test.exs
@@ -38,7 +38,7 @@ defmodule SanbaseWeb.Graphql.TargetUserListTest do
   test "create trigger with a single target", context do
     trigger_settings = %{
       type: "price_absolute_change",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "telegram",
       above: 300.0,
       below: 200.0
@@ -95,7 +95,7 @@ defmodule SanbaseWeb.Graphql.TargetUserListTest do
   test "create trigger with lists of slugs target", context do
     trigger_settings = %{
       type: "price_absolute_change",
-      target: ["santiment", "ethereum", "bitcoin"],
+      target: %{slug: ["santiment", "ethereum", "bitcoin"]},
       channel: "telegram",
       above: 300.0,
       below: 200.0
@@ -125,7 +125,7 @@ defmodule SanbaseWeb.Graphql.TargetUserListTest do
                settings: trigger_settings
              }) ==
                {:error,
-                "Trigger structure is invalid. Key `settings` is not valid. Reason: [\"The target list contains elements that are not string\"]"}
+                "Trigger structure is invalid. Key `settings` is not valid. Reason: [\"[\\\"santiment\\\", \\\"ethereum\\\", \\\"bitcoin\\\", 12] is not a valid target\"]"}
     end) =~
       ~s/UserTrigger struct is not valid: [{:error, :target, :by, "The target list contains elements that are not string"}]/
   end

--- a/test/sanbase/signals/trigger_evaluator_price_test.exs
+++ b/test/sanbase/signals/trigger_evaluator_price_test.exs
@@ -155,7 +155,7 @@ defmodule Sanbase.Signals.EvaluatorPriceTest do
   defp setup_triggers(user) do
     trigger_settings1 = %{
       type: "price_percent_change",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "telegram",
       time_window: "6h",
       percent_threshold: 15.0
@@ -163,7 +163,7 @@ defmodule Sanbase.Signals.EvaluatorPriceTest do
 
     trigger_settings2 = %{
       type: "price_absolute_change",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "telegram",
       above: 60,
       below: 50
@@ -171,7 +171,7 @@ defmodule Sanbase.Signals.EvaluatorPriceTest do
 
     trigger_settings3 = %{
       type: "price_percent_change",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "telegram",
       time_window: "6h",
       percent_threshold: 18.0
@@ -179,7 +179,7 @@ defmodule Sanbase.Signals.EvaluatorPriceTest do
 
     trigger_settings4 = %{
       type: "price_absolute_change",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "telegram",
       above: 70,
       below: 50

--- a/test/sanbase/signals/trigger_evaluator_test.exs
+++ b/test/sanbase/signals/trigger_evaluator_test.exs
@@ -34,7 +34,7 @@ defmodule Sanbase.Signals.EvaluatorTest do
 
     trigger_settings1 = %{
       type: "daily_active_addresses",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "telegram",
       time_window: "1d",
       percent_threshold: 300.0
@@ -42,7 +42,7 @@ defmodule Sanbase.Signals.EvaluatorTest do
 
     trigger_settings2 = %{
       type: "daily_active_addresses",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "telegram",
       time_window: "1d",
       percent_threshold: 200.0

--- a/test/sanbase/signals/trigger_history_test.exs
+++ b/test/sanbase/signals/trigger_history_test.exs
@@ -44,7 +44,7 @@ defmodule Sanbase.Signals.TriggerHistoryTest do
     ]) do
       trigger_settings = %{
         type: "daily_active_addresses",
-        target: "santiment",
+        target: %{slug: "santiment"},
         channel: "telegram",
         time_window: "2d",
         percent_threshold: 200.0
@@ -86,7 +86,7 @@ defmodule Sanbase.Signals.TriggerHistoryTest do
       [from_iso8601!("2018-11-26T00:00:00Z"), 21, 1000, 500, 200],
       # trigger point
       [from_iso8601!("2018-11-27T00:00:00Z"), 22, 1000, 500, 200],
-      # cooldown      
+      # cooldown
       [from_iso8601!("2018-11-28T00:00:00Z"), 25, 1000, 500, 200],
       # cooldown
       [from_iso8601!("2018-11-29T00:00:00Z"), 28, 1000, 500, 200],
@@ -110,7 +110,7 @@ defmodule Sanbase.Signals.TriggerHistoryTest do
         cooldown: "4h",
         settings: %{
           type: "price_percent_change",
-          target: "santiment",
+          target: %{slug: "santiment"},
           channel: "telegram",
           time_window: "4h",
           percent_threshold: percent_threshold
@@ -157,11 +157,11 @@ defmodule Sanbase.Signals.TriggerHistoryTest do
       [from_iso8601!("2018-11-23T00:00:00Z"), 20, 1000, 500, 200],
       [from_iso8601!("2018-11-24T00:00:00Z"), 20, 1000, 500, 200],
       [from_iso8601!("2018-11-25T00:00:00Z"), 20, 1000, 500, 200],
-      # trigger point      
+      # trigger point
       [from_iso8601!("2018-11-26T00:00:00Z"), 21, 1000, 500, 200],
       # cooldown
       [from_iso8601!("2018-11-27T00:00:00Z"), 22, 1000, 500, 200],
-      # cooldown      
+      # cooldown
       [from_iso8601!("2018-11-28T00:00:00Z"), 25, 1000, 500, 200],
       # cooldown
       [from_iso8601!("2018-11-29T00:00:00Z"), 28, 1000, 500, 200],
@@ -183,7 +183,7 @@ defmodule Sanbase.Signals.TriggerHistoryTest do
         cooldown: "4h",
         settings: %{
           type: "price_absolute_change",
-          target: "santiment",
+          target: %{slug: "santiment"},
           channel: "telegram",
           above: 21.0
         }

--- a/test/sanbase/signals/trigger_price_volume_diff_history_test.exs
+++ b/test/sanbase/signals/trigger_price_volume_diff_history_test.exs
@@ -26,7 +26,7 @@ defmodule Sanbase.Signals.PriceVolumeDiffHistoryTest do
       cooldown: "2h",
       settings: %{
         type: "price_volume_difference",
-        target: "santiment",
+        target: %{slug: "santiment"},
         channel: "telegram",
         threshold: 0.015
       }

--- a/test/sanbase/signals/trigger_price_volume_diff_test.exs
+++ b/test/sanbase/signals/trigger_price_volume_diff_test.exs
@@ -146,14 +146,14 @@ defmodule Sanbase.Signals.PriceVolumeDiffTest do
   defp setup_triggers(user) do
     trigger_settings1 = %{
       type: "price_volume_difference",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "telegram",
       threshold: 0.002
     }
 
     trigger_settings2 = %{
       type: "price_volume_difference",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "telegram",
       threshold: 0.1
     }

--- a/test/sanbase/signals/triggers_test.exs
+++ b/test/sanbase/signals/triggers_test.exs
@@ -4,6 +4,7 @@ defmodule Sanbase.Signals.TriggersTest do
   import Sanbase.Factory
   import ExUnit.CaptureLog
   import Sanbase.TestHelpers
+  import Sanbase.MapUtils
 
   alias Sanbase.Signals.UserTrigger
 
@@ -12,13 +13,10 @@ defmodule Sanbase.Signals.TriggersTest do
 
     trigger_settings = %{
       type: "daily_active_addresses",
-      target: "santiment",
-      filtered_target_list: [],
+      target: %{slug: "santiment"},
       channel: "telegram",
       time_window: "1d",
-      percent_threshold: 300.0,
-      triggered?: false,
-      payload: nil
+      percent_threshold: 300.0
     }
 
     {:ok, created_trigger} =
@@ -34,7 +32,8 @@ defmodule Sanbase.Signals.TriggersTest do
 
     {:ok, %UserTrigger{trigger: trigger}} = UserTrigger.get_trigger_by_id(user, trigger_id)
 
-    assert trigger.settings |> Map.from_struct() == trigger_settings
+    settings = trigger.settings |> Map.from_struct()
+    assert drop_diff_keys(settings, trigger_settings) == trigger_settings
   end
 
   test "try creating user trigger with unknown type" do
@@ -42,7 +41,7 @@ defmodule Sanbase.Signals.TriggersTest do
 
     trigger_settings = %{
       type: "unknown",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "telegram",
       time_window: "1d",
       percent_threshold: 300.0
@@ -64,7 +63,7 @@ defmodule Sanbase.Signals.TriggersTest do
 
     trigger_settings = %{
       type: "daily_active_addresses",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "telegram",
       time_window: "1d",
       percent_threshold: 300.0
@@ -86,7 +85,7 @@ defmodule Sanbase.Signals.TriggersTest do
 
     trigger_settings = %{
       type: "daily_active_addresses",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "unknown",
       time_window: "1d",
       percent_threshold: 300.0,
@@ -111,7 +110,7 @@ defmodule Sanbase.Signals.TriggersTest do
 
     settings = %{
       type: "daily_active_addresses",
-      target: "santiment",
+      target: %{slug: "santiment"},
       time_window: "1d",
       percent_threshold: 300.0
     }
@@ -130,7 +129,7 @@ defmodule Sanbase.Signals.TriggersTest do
 
     trigger_settings = %{
       type: "price_percent_change",
-      target: "santiment",
+      target: %{slug: "santiment"},
       percent_threshold: 20,
       channel: "telegram",
       time_window: "1d"
@@ -154,7 +153,7 @@ defmodule Sanbase.Signals.TriggersTest do
 
     trigger_settings = %{
       type: "price_percent_change",
-      target: "santiment",
+      target: %{slug: "santiment"},
       percent_threshold: 20,
       channel: "telegram",
       time_window: "1d"
@@ -186,7 +185,7 @@ defmodule Sanbase.Signals.TriggersTest do
 
     trigger_settings1 = %{
       type: "daily_active_addresses",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "telegram",
       time_window: "1d",
       percent_threshold: 300.0
@@ -201,7 +200,7 @@ defmodule Sanbase.Signals.TriggersTest do
 
     trigger_settings2 = %{
       type: "price_percent_change",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "email",
       time_window: "1d",
       percent_threshold: 10.0
@@ -222,7 +221,7 @@ defmodule Sanbase.Signals.TriggersTest do
 
     trigger_settings1 = %{
       type: "daily_active_addresses",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "telegram",
       time_window: "1d",
       percent_threshold: 300.0
@@ -230,7 +229,7 @@ defmodule Sanbase.Signals.TriggersTest do
 
     trigger_settings2 = %{
       type: "price_percent_change",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "email",
       time_window: "1d",
       percent_threshold: 10.0
@@ -250,7 +249,7 @@ defmodule Sanbase.Signals.TriggersTest do
 
     updated_trigger = %{
       type: "daily_active_addresses",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "telegram",
       time_window: "1d",
       percent_threshold: 200.0
@@ -289,7 +288,7 @@ defmodule Sanbase.Signals.TriggersTest do
 
     trigger_settings = %{
       type: "daily_active_addresses",
-      target: "santiment",
+      target: %{slug: "santiment"},
       channel: "telegram",
       time_window: "1d",
       percent_threshold: 200.0

--- a/test/sanbase/utils/map_utils_test.exs
+++ b/test/sanbase/utils/map_utils_test.exs
@@ -1,0 +1,4 @@
+defmodule Sanbase.MapUtilsTest do
+  use ExUnit.Case, async: true
+  doctest Sanbase.MapUtils
+end

--- a/test/sanbase_web/graphql/triggers_api_test.exs
+++ b/test/sanbase_web/graphql/triggers_api_test.exs
@@ -20,8 +20,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
         send(self(), {:telegram_to_self, text})
         :ok
       end do
-      trigger_settings = default_trigger_settings()
-
+      trigger_settings = default_trigger_settings_string_keys()
       trigger_settings_json = trigger_settings |> Jason.encode!()
 
       query =
@@ -103,7 +102,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
   end
 
   test "update trigger", %{user: user, conn: conn} do
-    trigger_settings = default_trigger_settings()
+    trigger_settings = default_trigger_settings_string_keys()
 
     insert(:user_trigger, user: user, trigger: %{is_public: false, settings: trigger_settings})
 
@@ -145,7 +144,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
   end
 
   test "remove trigger", %{user: user, conn: conn} do
-    trigger_settings = default_trigger_settings()
+    trigger_settings = default_trigger_settings_string_keys()
 
     insert(:user_trigger, user: user, trigger: %{is_public: false, settings: trigger_settings})
 
@@ -176,7 +175,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
   end
 
   test "get trigger by id", %{user: user, conn: conn} do
-    trigger_settings = default_trigger_settings()
+    trigger_settings = default_trigger_settings_string_keys()
 
     insert(:user_trigger,
       user: user,
@@ -211,7 +210,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
   end
 
   test "fetches triggers for current user", %{user: user, conn: conn} do
-    trigger_settings = default_trigger_settings()
+    trigger_settings = default_trigger_settings_string_keys()
 
     %{id: id} =
       insert(:user_trigger, user: user, trigger: %{is_public: false, settings: trigger_settings})
@@ -242,7 +241,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
   end
 
   test "fetches all public triggers", %{user: user, conn: conn} do
-    trigger_settings = default_trigger_settings()
+    trigger_settings = default_trigger_settings_string_keys()
 
     trigger_settings2 = Map.put(trigger_settings, "percent_threshold", 400.0)
 
@@ -275,7 +274,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
   test "fetches public user triggers", %{conn: conn} do
     user = insert(:user, email: "alabala@example.com")
 
-    trigger_settings = default_trigger_settings()
+    trigger_settings = default_trigger_settings_string_keys()
 
     trigger_settings2 = Map.put(trigger_settings, "percent_threshold", 400.0)
 
@@ -344,7 +343,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
   end
 
   test "fetches signals historical activity for current user", %{user: user, conn: conn} do
-    trigger_settings = default_trigger_settings()
+    trigger_settings = default_trigger_settings_string_keys()
 
     user_trigger =
       insert(:user_trigger,
@@ -462,7 +461,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
   end
 
   test "deactivate signal", %{user: user, conn: conn} do
-    trigger_settings = default_trigger_settings()
+    trigger_settings = default_trigger_settings_string_keys()
 
     ut = insert(:user_trigger, user: user, trigger: %{settings: trigger_settings})
 
@@ -474,7 +473,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
   end
 
   test "activate signal", %{user: user, conn: conn} do
-    trigger_settings = default_trigger_settings()
+    trigger_settings = default_trigger_settings_string_keys()
 
     ut = insert(:user_trigger, user: user, trigger: %{active: false, settings: trigger_settings})
 
@@ -538,10 +537,10 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
     result["data"]["updateTrigger"]["trigger"]
   end
 
-  defp default_trigger_settings do
+  defp default_trigger_settings_string_keys() do
     %{
       "type" => "daily_active_addresses",
-      "target" => "santiment",
+      "target" => %{"slug" => "santiment"},
       "channel" => "telegram",
       "time_window" => "1d",
       "percent_threshold" => 300.0


### PR DESCRIPTION
#### Summary
Now instead of just strings and lists it supports specifiying the type.
To keep the old behaviour strings and lists are treated as slugs and
lists of slugs. The new behaviour will require you to pass %{slug: slug}
maps as targets.

This is implemented so a single signal can support different types of targets.
An example is the signal for tracking ETH wallets. The signal target can be a
project's slug, so all of the project's wallets are tracked. The target can also be
a specific ETH address or a list of ETH addresses that the user finds interesting.

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
