### PR TITLE
Add API query for draft insights

### DIFF
--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -146,6 +146,17 @@ defmodule Sanbase.Insight.Post do
     |> Repo.all()
   end
 
+  @doc """
+  All draft insights for given user_id
+  """
+  def user_draft_insights(user_id) do
+    from(
+      p in Post,
+      where: p.user_id == ^user_id and p.ready_state == ^@draft
+    )
+    |> Repo.all()
+  end
+
   def published_posts(page, page_size) do
     from(
       p in Post,

--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -136,6 +136,17 @@ defmodule Sanbase.Insight.Post do
   end
 
   @doc """
+  All insights for given user_id
+  """
+  def user_insights(user_id) do
+    from(
+      p in Post,
+      where: p.user_id == ^user_id
+    )
+    |> Repo.all()
+  end
+
+  @doc """
   All published insights for given user_id
   """
   def user_published_insights(user_id) do

--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -157,17 +157,6 @@ defmodule Sanbase.Insight.Post do
     |> Repo.all()
   end
 
-  @doc """
-  All draft insights for given user_id
-  """
-  def user_draft_insights(user_id) do
-    from(
-      p in Post,
-      where: p.user_id == ^user_id and p.ready_state == ^@draft
-    )
-    |> Repo.all()
-  end
-
   def published_posts(page, page_size) do
     from(
       p in Post,

--- a/lib/sanbase_web/graphql/resolvers/post_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/post_resolver.ex
@@ -15,6 +15,15 @@ defmodule SanbaseWeb.Graphql.Resolvers.PostResolver do
 
   @preloaded_assoc [:votes, :user, :images, :tags]
 
+  def insights(%User{} = user, _args, _resolution) do
+    posts =
+      user.id
+      |> Post.user_insights()
+      |> Repo.preload(@preloaded_assoc)
+
+    {:ok, posts}
+  end
+
   def post(_root, %{id: post_id}, _resolution) do
     case Repo.get(Post, post_id) do
       nil -> {:error, "There is no post with id #{post_id}"}
@@ -37,10 +46,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.PostResolver do
       |> Repo.preload(@preloaded_assoc)
 
     {:ok, posts}
-  end
-
-  def all_draft_insights_for_user(_root, _args, _resolution) do
-    {:ok, "On logged in users can call this method"}
   end
 
   def all_insights_user_voted_for(_root, %{user_id: user_id}, _context) do

--- a/lib/sanbase_web/graphql/resolvers/post_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/post_resolver.ex
@@ -39,6 +39,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.PostResolver do
     {:ok, posts}
   end
 
+  def all_draft_insights_for_user(_root, _args, _resolution) do
+    {:ok, "On logged in users can call this method"}
+  end
+
   def all_insights_user_voted_for(_root, %{user_id: user_id}, _context) do
     query =
       from(

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -472,6 +472,11 @@ defmodule SanbaseWeb.Graphql.Schema do
       resolve(&PostResolver.all_insights_for_user/3)
     end
 
+    @desc "Fetch a list of all posts for the currently logged in user"
+    field :all_draft_insights_for_user, list_of(:post) do
+      resolve(&PostResolver.all_draft_insights_for_user/3)
+    end
+
     @desc "Fetch a list of all posts for which a user has voted."
     field :all_insights_user_voted, list_of(:post) do
       arg(:user_id, non_null(:integer))

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -472,11 +472,6 @@ defmodule SanbaseWeb.Graphql.Schema do
       resolve(&PostResolver.all_insights_for_user/3)
     end
 
-    @desc "Fetch a list of all posts for the currently logged in user"
-    field :all_draft_insights_for_user, list_of(:post) do
-      resolve(&PostResolver.all_draft_insights_for_user/3)
-    end
-
     @desc "Fetch a list of all posts for which a user has voted."
     field :all_insights_user_voted, list_of(:post) do
       arg(:user_id, non_null(:integer))

--- a/lib/sanbase_web/graphql/schema/account_types.ex
+++ b/lib/sanbase_web/graphql/schema/account_types.ex
@@ -8,7 +8,8 @@ defmodule SanbaseWeb.Graphql.AccountTypes do
     EthAccountResolver,
     UserSettingsResolver,
     UserTriggerResolver,
-    SignalsHistoricalActivityResolver
+    SignalsHistoricalActivityResolver,
+    PostResolver
   }
 
   object :user do
@@ -39,6 +40,10 @@ defmodule SanbaseWeb.Graphql.AccountTypes do
 
     field :triggers, list_of(:trigger) do
       resolve(&UserTriggerResolver.triggers/3)
+    end
+
+    field :insights, list_of(:post) do
+      resolve(&PostResolver.insights/3)
     end
   end
 


### PR DESCRIPTION
Returns all insights for the current user.

Drafts: `readyState` = `draft`, published: `readyState`: `published`

```graphql
    {
      currentUser {
        insights {
          id,
          text,
          readyState
        }
      }
    }
```
