### PR TITLE
Correctly cache the user triggers

### DIFF
--- a/lib/sanbase/signals/evaluator/evaluator.ex
+++ b/lib/sanbase/signals/evaluator/evaluator.ex
@@ -22,12 +22,13 @@ defmodule Sanbase.Signals.Evaluator do
   end
 
   defp evaluate(%UserTrigger{trigger: trigger} = user_trigger) do
-    Cache.get_or_store(
-      Trigger.cache_key(trigger),
-      fn ->
-        %UserTrigger{user_trigger | trigger: Trigger.evaluate(trigger)}
-      end
-    )
+    trigger =
+      Cache.get_or_store(
+        Trigger.cache_key(trigger),
+        fn -> Trigger.evaluate(trigger) end
+      )
+
+    %UserTrigger{user_trigger | trigger: trigger}
   end
 
   defp triggered?(%UserTrigger{trigger: trigger}) do


### PR DESCRIPTION
The old version causes overriding the user_id so one user can get more
than 1 signal sent to them. Meanwhile, some users won't get any signal

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
