### PR TITLE
DocumentProvider: Try to transform all binary variables to datetime

### DIFF
--- a/lib/sanbase_web/graphql/document/utils.ex
+++ b/lib/sanbase_web/graphql/document/utils.ex
@@ -2,8 +2,6 @@ defmodule SanbaseWeb.Graphql.DocumentProvider.Utils do
   @compile :inline_list_funcs
   @compile {:inline, cache_key_from_params: 2}
 
-  @datetime_field_names ["from", "to"]
-
   @doc ~s"""
   Extract the query and variables from the params map and genenrate a cache key from them
   The query is fetched as is.
@@ -25,7 +23,7 @@ defmodule SanbaseWeb.Graphql.DocumentProvider.Utils do
         _ -> %{}
       end
       |> Enum.map(fn
-        {key, value} when key in @datetime_field_names and is_binary(value) ->
+        {key, value} when is_binary(value) ->
           case DateTime.from_iso8601(value) do
             {:ok, datetime, _} -> {key, datetime}
             _ -> {key, value}


### PR DESCRIPTION
Try to transform all binary variables to datetime instead of only the ones
named "from" and "to"

Even if the only argument names in the schema of type datetime are from
and to, the variable names are arbitrary. When more of them are used in
the same query it's likely for them to have different names

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->