### PR TITLE
Correctly transform the datetimes TTL for the cache

### DIFF
--- a/lib/sanbase_web/graphql/cache/cache.ex
+++ b/lib/sanbase_web/graphql/cache/cache.ex
@@ -228,7 +228,7 @@ defmodule SanbaseWeb.Graphql.Cache do
     args
     |> Enum.map(fn
       {k, %DateTime{} = v} ->
-        {k, div(DateTime.to_unix(v, :millisecond), ttl)}
+        {k, div(DateTime.to_unix(v, :second), ttl)}
 
       pair ->
         pair


### PR DESCRIPTION
#### Summary
Some time ago the ttl was changed from `:timer.minutes(5)` to just `300` but the datetime was not changed from `:millisecond` to `:second`. The output of `:timer.minutes(5)` is `300000` which is 300 seconds in milliseconds.
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
