### PR TITLE
Add top holders api - percent of total supply

### DIFF
--- a/lib/sanbase/clickhouse/top_holders.ex
+++ b/lib/sanbase/clickhouse/top_holders.ex
@@ -1,0 +1,123 @@
+defmodule Sanbase.Clickhouse.TopHolders do
+  @moduledoc ~s"""
+  Uses ClickHouse to calculate the supply in exchanges
+  """
+
+  import Sanbase.Math, only: [to_integer: 1]
+
+  alias Sanbase.DateTimeUtils
+  alias Sanbase.Model.Project
+
+  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+
+  @type top_holders :: %{
+          datetime: DateTime.t(),
+          percent_total_supply_in_exchanges: float(),
+          percent_total_supply_outside_exchange: float(),
+          percent_total_supply_in_holders: float()
+        }
+
+  @spec top_holders(
+          String.t(),
+          non_neg_integer(),
+          DateTime.t(),
+          DateTime.t()
+        ) :: {:ok, list(top_holders)} | {:error, String.t()}
+  def top_holders(slug, number_of_holders, from, to) do
+    {query, args} = top_holders_query(slug, number_of_holders, from, to)
+
+    ClickhouseRepo.query_transform(
+      query,
+      args,
+      fn [dt, in_exchanges, outside_exchanges, in_holders] ->
+        %{
+          datetime: DateTime.from_unix!(dt),
+          percent_total_supply_in_exchanges: in_exchanges,
+          percent_total_supply_outside_exchange: outside_exchanges,
+          percent_total_supply_in_holders: in_holders
+        }
+      end
+    )
+  end
+
+  defp top_holders_query(slug, number_of_holders, from, to) do
+    from_datetime_unix = DateTime.to_unix(from)
+    to_datetime_unix = DateTime.to_unix(to)
+    {:ok, contract, token_decimals} = Project.contract_info_by_slug(slug)
+
+    query = """
+    SELECT
+      toUnixTimestamp(intDiv(toUInt32(toDateTime(dt)), 86400) * 86400) AS time,
+      sumIf(partOfTotal, isExchange = 1) * 100 AS tse,
+      sumIf(partOfTotal, isExchange = 0) * 100 AS tsne,
+      sum(partOfTotal) * 100 AS tsth
+    FROM
+    (
+      SELECT
+        dt,
+        contract,
+        address,
+        rank,
+        value,
+        partOfTotal
+      FROM
+      (
+        SELECT *
+        FROM
+        (
+          SELECT
+            dt,
+            contract,
+            address,
+            rank,
+            value,
+            partOfTotal
+          FROM
+          (
+            SELECT
+              dt,
+              contract,
+              address,
+              rank,
+              value / pow(10, ?1) AS value,
+              multiIf(valueTotal > 0, value / (valueTotal / pow(10, ?1)), 0) AS partOfTotal
+            FROM
+            (
+              SELECT *
+              FROM eth_top_holders
+              PREWHERE (contract = ?2) AND
+                (rank <= ?3) AND
+                ((dt >= toStartOfDay(toDateTime(?4))) AND
+                (dt <= toStartOfDay(toDateTime(?5))))
+            )
+            GLOBAL ANY LEFT JOIN
+            (
+              SELECT
+                dt,
+                sum(value) AS valueTotal
+              FROM eth_top_holders
+              PREWHERE (contract = ?2) AND
+               (address IN ('TOTAL', 'freeze')) AND
+               ((dt >= toStartOfDay(toDateTime(?4))) AND (dt <= toStartOfDay(toDateTime(?5))))
+              GROUP BY dt
+            ) USING (dt)
+          )
+        )
+      )
+    )
+    GLOBAL ANY LEFT JOIN
+    (
+      SELECT
+        address,
+        1 AS isExchange
+      FROM exchange_addresses
+    ) USING (address)
+    GROUP BY dt
+    ORDER BY dt ASC
+    """
+
+    args = [token_decimals, contract, number_of_holders, from_datetime_unix, to_datetime_unix]
+
+    {query, args}
+  end
+end

--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -13,10 +13,27 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
     MVRV,
     NetworkGrowth,
     NVT,
-    RealizedValue
+    RealizedValue,
+    TopHolders
   }
 
   @one_hour_seconds 3600
+
+  def top_holders_percent_of_total_supply(
+        _root,
+        %{slug: slug, number_of_holders: number_of_holders, from: from, to: to},
+        _resolution
+      ) do
+    case TopHolders.percent_of_total_supply(slug, number_of_holders, from, to) do
+      {:ok, percent_of_total_supply} ->
+        {:ok, percent_of_total_supply}
+
+      {:error, error} ->
+        error_msg = "Can't calculate Top holders - percent of total supply."
+        Logger.warn(error_msg <> " Reason: #{inspect(error)}")
+        {:error, error_msg}
+    end
+  end
 
   def gas_used(
         _root,

--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -29,7 +29,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
         {:ok, percent_of_total_supply}
 
       {:error, error} ->
-        error_msg = "Can't calculate Top holders - percent of total supply."
+        error_msg = "Can't calculate top holders - percent of total supply for slug: #{slug}."
         Logger.warn(error_msg <> " Reason: #{inspect(error)}")
         {:error, error_msg}
     end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -860,7 +860,9 @@ defmodule SanbaseWeb.Graphql.Schema do
     end
 
     @desc """
-    Returns the top holders' percent of total supply - in exchanges, outside exchanges and combined.
+    Returns used Gas by a blockchain.
+    When you send tokens, interact with a contract or do anything else on the blockchain,
+    you must pay for that computation. That payment is calculated in Gas.
     """
     field :gas_used, list_of(:gas_used) do
       arg(:from, non_null(:datetime))
@@ -872,6 +874,15 @@ defmodule SanbaseWeb.Graphql.Schema do
       cache_resolve(&ClickhouseResolver.gas_used/3)
     end
 
+    @desc """
+    Returns the top holders' percent of total supply - in exchanges, outside exchanges and combined.
+
+    Arguments description:
+    * slug - a string uniquely identifying a project
+    * number_of_holders - take top `number_of_holders` into account when calculating.
+    * from - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
+    * to - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
+    """
     field :top_holders_percent_of_total_supply, list_of(:top_holders_percent_of_total_supply) do
       arg(:slug, non_null(:string))
       arg(:number_of_holders, non_null(:integer))

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -860,9 +860,7 @@ defmodule SanbaseWeb.Graphql.Schema do
     end
 
     @desc """
-    Returns used Gas by a blockchain.
-    When you send tokens, interact with a contract or do anything else on the blockchain,
-    you must pay for that computation. That payment is calculated in Gas.
+    Returns the top holders' percent of total supply - in exchanges, outside exchanges and combined.
     """
     field :gas_used, list_of(:gas_used) do
       arg(:from, non_null(:datetime))
@@ -872,6 +870,17 @@ defmodule SanbaseWeb.Graphql.Schema do
       complexity(&Complexity.from_to_interval/3)
       middleware(ApiTimeframeRestriction)
       cache_resolve(&ClickhouseResolver.gas_used/3)
+    end
+
+    field :top_holders_percent_of_total_supply, list_of(:top_holders_percent_of_total_supply) do
+      arg(:slug, non_null(:string))
+      arg(:number_of_holders, non_null(:integer))
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+
+      complexity(&Complexity.from_to_interval/3)
+      middleware(ApiTimeframeRestriction)
+      cache_resolve(&ClickhouseResolver.top_holders_percent_of_total_supply/3)
     end
 
     @desc """

--- a/lib/sanbase_web/graphql/schema/clickhouse_types.ex
+++ b/lib/sanbase_web/graphql/schema/clickhouse_types.ex
@@ -44,4 +44,11 @@ defmodule SanbaseWeb.Graphql.ClickhouseTypes do
     field(:realized_value, :integer)
     field(:non_exchange_realized_value, :integer)
   end
+
+  object :top_holders_percent_of_total_supply do
+    field(:datetime, non_null(:datetime))
+    field(:in_exchanges, :float)
+    field(:outside_exchanges, :float)
+    field(:in_top_holders_total, :float)
+  end
 end

--- a/test/sanbase/clickhouse/top_holders_test.exs
+++ b/test/sanbase/clickhouse/top_holders_test.exs
@@ -1,0 +1,71 @@
+defmodule Sanbase.Clickhouse.TopHoldersTest do
+  use Sanbase.DataCase
+  import Mock
+  import Sanbase.Factory
+  import Sanbase.DateTimeUtils, only: [from_iso8601_to_unix!: 1, from_iso8601!: 1]
+  alias Sanbase.Clickhouse.TopHolders
+  require Sanbase.ClickhouseRepo
+
+  setup do
+    project = insert(:project, %{coinmarketcap_id: "ethereum", ticker: "ETH"})
+
+    [
+      slug: project.coinmarketcap_id,
+      number_of_holders: 10,
+      from: from_iso8601!("2019-01-01T00:00:00Z"),
+      to: from_iso8601!("2019-01-03T00:00:00Z")
+    ]
+  end
+
+  test "returns data when clickhouse returns", context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:ok,
+         %{
+           rows: [
+             [from_iso8601_to_unix!("2019-01-01T00:00:00Z"), 7.6, 5.2, 12.8],
+             [from_iso8601_to_unix!("2019-01-02T00:00:00Z"), 7.1, 5.1, 12.2]
+           ]
+         }}
+      end do
+      result =
+        TopHolders.percent_of_total_supply(
+          context.slug,
+          context.number_of_holders,
+          context.from,
+          context.to
+        )
+
+      assert result ==
+               {:ok,
+                [
+                  %{
+                    in_exchanges: 7.6,
+                    outside_exchanges: 5.2,
+                    in_top_holders_total: 12.8,
+                    datetime: from_iso8601!("2019-01-01T00:00:00Z")
+                  },
+                  %{
+                    in_exchanges: 7.1,
+                    outside_exchanges: 5.1,
+                    in_top_holders_total: 12.2,
+                    datetime: from_iso8601!("2019-01-02T00:00:00Z")
+                  }
+                ]}
+    end
+  end
+
+  test "returns empty array when query returns no rows", context do
+    with_mock Sanbase.ClickhouseRepo, query: fn _, _ -> {:ok, %{rows: []}} end do
+      result =
+        TopHolders.percent_of_total_supply(
+          context.slug,
+          context.number_of_holders,
+          context.from,
+          context.to
+        )
+
+      assert result == {:ok, []}
+    end
+  end
+end

--- a/test/sanbase_web/graphql/clickhouse/top_holders_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/top_holders_test.exs
@@ -1,0 +1,140 @@
+defmodule SanbaseWeb.Graphql.Clickhouse.TopHoldersTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import SanbaseWeb.Graphql.TestHelpers
+  import Mock
+  import Sanbase.DateTimeUtils, only: [from_iso8601!: 1]
+  import ExUnit.CaptureLog
+  import Sanbase.Factory
+
+  alias Sanbase.Clickhouse.TopHolders
+
+  setup do
+    user = insert(:staked_user)
+    conn = setup_jwt_auth(build_conn(), user)
+    project = insert(:project, %{coinmarketcap_id: "ethereum", ticker: "ETH"})
+
+    [
+      conn: conn,
+      slug: project.coinmarketcap_id,
+      from: from_iso8601!("2019-01-01T00:00:00Z"),
+      to: from_iso8601!("2019-01-03T00:00:00Z"),
+      number_of_holders: 10
+    ]
+  end
+
+  test "returns data from TopHolders calculation", context do
+    with_mock TopHolders,
+      percent_of_total_supply: fn _, _, _, _ ->
+        {:ok,
+         [
+           %{
+             in_exchanges: 7.6,
+             outside_exchanges: 5.2,
+             in_top_holders_total: 12.8,
+             datetime: from_iso8601!("2019-01-01T00:00:00Z")
+           },
+           %{
+             in_exchanges: 7.1,
+             outside_exchanges: 5.1,
+             in_top_holders_total: 12.2,
+             datetime: from_iso8601!("2019-01-02T00:00:00Z")
+           }
+         ]}
+      end do
+      response = execute_query(context)
+      holders = parse_response(response)
+
+      assert_called(
+        TopHolders.percent_of_total_supply(
+          context.slug,
+          context.number_of_holders,
+          context.from,
+          context.to
+        )
+      )
+
+      assert holders == [
+               %{
+                 "in_exchanges" => 7.6,
+                 "outside_exchanges" => 5.2,
+                 "in_top_holders_total" => 12.8,
+                 "datetime" => "2019-01-01T00:00:00Z"
+               },
+               %{
+                 "in_exchanges" => 7.1,
+                 "outside_exchanges" => 5.1,
+                 "in_top_holders_total" => 12.2,
+                 "datetime" => "2019-01-02T00:00:00Z"
+               }
+             ]
+    end
+  end
+
+  test "returns empty array when there is no data", context do
+    with_mock TopHolders, percent_of_total_supply: fn _, _, _, _ -> {:ok, []} end do
+      response = execute_query(context)
+      holders = parse_response(response)
+
+      assert_called(
+        TopHolders.percent_of_total_supply(
+          context.slug,
+          context.number_of_holders,
+          context.from,
+          context.to
+        )
+      )
+
+      assert holders == []
+    end
+  end
+
+  test "logs warning when calculation errors", context do
+    with_mock TopHolders,
+      percent_of_total_supply: fn _, _, _, _ -> {:error, "error"} end do
+      assert capture_log(fn ->
+               response = execute_query(context)
+               holders = parse_response(response)
+               assert holders == nil
+             end) =~
+               ~s/[warn] Can't calculate top holders - percent of total supply for slug: #{
+                 context.slug
+               }. Reason: "error"/
+    end
+  end
+
+  defp parse_response(response) do
+    json_response(response, 200)["data"]["topHoldersPercentOfTotalSupply"]
+  end
+
+  defp execute_query(context) do
+    query =
+      top_holders_percent_supply_query(
+        context.slug,
+        context.number_of_holders,
+        context.from,
+        context.to
+      )
+
+    context.conn
+    |> post("/graphql", query_skeleton(query, "topHoldersPercentOfTotalSupply"))
+  end
+
+  defp top_holders_percent_supply_query(slug, number_of_holders, from, to) do
+    """
+      {
+        topHoldersPercentOfTotalSupply(
+          slug: "#{slug}",
+          number_of_holders: #{number_of_holders}
+          from: "#{from}",
+          to: "#{to}"
+        ){
+          datetime,
+          in_exchanges,
+          outside_exchanges,
+          in_top_holders_total
+        }
+      }
+    """
+  end
+end


### PR DESCRIPTION
```graphql
      {
        topHoldersPercentOfTotalSupply(
          slug: "ethereum",
          numberOfHolders: 10
          from: "2019-04-01T00:00:00Z",
          to: "2019-04-05T00:00:00Z"
        ){
          datetime,
          inExchanges,
          outsideExchanges,
          inTopHoldersTotal
        }
      }
```

```graphql
{
  "data": {
    "topHoldersPercentOfTotalSupply": [
      {
        "datetime": "2019-04-01T00:00:00Z",
        "inExchanges": 7.696077683261746,
        "inTopHoldersTotal": 12.977824840855403,
        "outsideExchanges": 5.2817471575936565
      },
      {
        "datetime": "2019-04-02T00:00:00Z",
        "inExchanges": 7.786291838559942,
        "inTopHoldersTotal": 13.066428062045373,
        "outsideExchanges": 5.28013622348543
      },
      {
        "datetime": "2019-04-03T00:00:00Z",
        "inExchanges": 7.847634001144911,
        "inTopHoldersTotal": 13.112234028469116,
        "outsideExchanges": 5.264600027324205
      },
      {
        "datetime": "2019-04-04T00:00:00Z",
        "inExchanges": 7.846615860562559,
        "inTopHoldersTotal": 13.117970446370848,
        "outsideExchanges": 5.2713545858082895
      }
    ]
  }
}
```