### PR TITLE
Reduce the DocumentProvider cache ttl settings

### DIFF
--- a/lib/sanbase_web/graphql/document/document_provider.ex
+++ b/lib/sanbase_web/graphql/document/document_provider.ex
@@ -72,7 +72,9 @@ defmodule SanbseWeb.Graphql.Phase.Document.Execution.CacheDocument do
     cache_key =
       SanbaseWeb.Graphql.Cache.cache_key(
         {"bp_root", permissions},
-        santize_blueprint(bp_root)
+        santize_blueprint(bp_root),
+        ttl: 120,
+        max_ttl_offset: 90
       )
 
     bp_root = add_cache_key_to_blueprint(bp_root, cache_key)


### PR DESCRIPTION
The main reason is that the resolver-level caches have random TTL
between 5 and 7 minutes. If we keep the same values for the
DocumentProvider cache we can reach 10+ minutes of cache length

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
