### PR TITLE
Improve some of the graphql warning logs

### DIFF
--- a/lib/sanbase_web/graphql/document/document_provider.ex
+++ b/lib/sanbase_web/graphql/document/document_provider.ex
@@ -82,6 +82,10 @@ defmodule SanbseWeb.Graphql.Phase.Document.Execution.CacheDocument do
         {:ok, bp_root}
 
       result ->
+        # Storing it again `touch`es it and the TTL timer is restarted.
+        # his can lead to infinite storing the same value
+        Process.put(:do_not_cache_query, true)
+
         {:jump, %{bp_root | result: result},
          SanbseWeb.Graphql.Phase.Document.Execution.Idempotent}
     end

--- a/lib/sanbase_web/graphql/document/document_provider.ex
+++ b/lib/sanbase_web/graphql/document/document_provider.ex
@@ -83,7 +83,7 @@ defmodule SanbseWeb.Graphql.Phase.Document.Execution.CacheDocument do
 
       result ->
         # Storing it again `touch`es it and the TTL timer is restarted.
-        # his can lead to infinite storing the same value
+        # This can lead to infinite storing the same value
         Process.put(:do_not_cache_query, true)
 
         {:jump, %{bp_root | result: result},

--- a/lib/sanbase_web/graphql/resolvers/project/project_transactions_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_transactions_resolver.ex
@@ -143,7 +143,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectTransactionsResolver do
   end
 
   defp calculate_eth_spent(%Project{} = project, from_datetime, to_datetime) do
-    with {:eth_addresses, {:ok, eth_addresses}} <-
+    with {:eth_addresses, {:ok, eth_addresses}} when eth_addresses != [] <-
            {:eth_addresses, Project.eth_addresses(project)},
          {:ok, eth_spent} <-
            Clickhouse.EthTransfers.eth_spent(eth_addresses, from_datetime, to_datetime) do
@@ -175,7 +175,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectTransactionsResolver do
   end
 
   defp calculate_eth_spent_over_time(%Project{} = project, from, to, interval) do
-    with {:eth_addresses, {:ok, eth_addresses}} <-
+    with {:eth_addresses, {:ok, eth_addresses}} when eth_addresses != [] <-
            {:eth_addresses, Project.eth_addresses(project)},
          {:ok, eth_spent_over_time} <-
            Clickhouse.EthTransfers.eth_spent_over_time(eth_addresses, from, to, interval) do
@@ -203,11 +203,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectTransactionsResolver do
        }) do
     limit = Enum.min([limit, 100])
 
-    with {:eth_addresses, {:ok, project_addresses}} <-
+    with {:eth_addresses, {:ok, eth_addresses}} when eth_addresses != [] <-
            {:eth_addresses, Project.eth_addresses(project)},
          {:ok, eth_transactions} <-
            Clickhouse.EthTransfers.top_wallet_transfers(
-             project_addresses,
+             eth_addresses,
              from,
              to,
              limit,

--- a/test/sanbase_web/graphql/projects/project_api_wallet_transactions_test.exs
+++ b/test/sanbase_web/graphql/projects/project_api_wallet_transactions_test.exs
@@ -11,6 +11,8 @@ defmodule SanbaseWeb.Graphql.ProjectApiWalletTransactionsTest do
 
   import Mock
   import SanbaseWeb.Graphql.TestHelpers
+  import Sanbase.Factory
+  import ExUnit.CaptureLog
 
   @datetime1 DateTime.from_naive!(~N[2017-05-13 15:00:00], "Etc/UTC")
   @datetime2 DateTime.from_naive!(~N[2017-05-14 16:00:00], "Etc/UTC")
@@ -265,6 +267,34 @@ defmodule SanbaseWeb.Graphql.ProjectApiWalletTransactionsTest do
                "trxValue" => 45_000.0
              } in trx_all
     end
+  end
+
+  test "project without wallets does won't log warnings", context do
+    project = insert(:project, %{name: "Bitcoin", ticker: "BTC", coinmarketcap_id: "bitcoin"})
+
+    query = """
+    {
+      projectBySlug(slug: "#{project.coinmarketcap_id}") {
+        ethTopTransactions(
+          from: "#{context.datetime_from}",
+          to: "#{context.datetime_to}",
+          transaction_type: ALL){
+            datetime,
+            trxValue,
+        }
+      }
+    }
+    """
+
+    log =
+      capture_log(fn ->
+        result =
+          context.conn
+          |> post("/graphql", query_skeleton(query, "projectBySlug"))
+      end)
+
+    assert {:ok, []} == Project.eth_addresses(project)
+    refute String.contains?(log, "Cannot fetch top ETH transactions")
   end
 
   # Private functions

--- a/test/sanbase_web/graphql/projects/project_api_wallet_transactions_test.exs
+++ b/test/sanbase_web/graphql/projects/project_api_wallet_transactions_test.exs
@@ -269,7 +269,7 @@ defmodule SanbaseWeb.Graphql.ProjectApiWalletTransactionsTest do
     end
   end
 
-  test "project without wallets does won't log warnings", context do
+  test "project without wallets does not log warnings", context do
     project = insert(:project, %{name: "Bitcoin", ticker: "BTC", coinmarketcap_id: "bitcoin"})
 
     query = """


### PR DESCRIPTION
Add a check for no eth addresses and avoid logging a warning when
calculatig ETH top transactions like bitcoin

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
