### PR TITLE
Share of deposits

### DIFF
--- a/lib/sanbase/clickhouse/share_of_deposits.ex
+++ b/lib/sanbase/clickhouse/share_of_deposits.ex
@@ -1,0 +1,17 @@
+defmodule Sanbase.Clickhouse.ShareOfDeposits do
+  @moduledoc ~s"""
+  Dispatch the calculations of share of deposits to the correct module
+  """
+  alias Sanbase.Clickhouse.Erc20ShareOfDeposits, as: Erc20
+  alias Sanbase.Clickhouse.EthShareOfDeposits, as: Eth
+
+  @ethereum ["ethereum", "ETH"]
+
+  def share_of_deposits(eth, from, to, interval) when eth in @ethereum do
+    Eth.share_of_deposits(from, to, interval)
+  end
+
+  def share_of_deposits(contract, from, to, interval) do
+    Erc20.share_of_deposits(contract, from, to, interval)
+  end
+end

--- a/lib/sanbase/clickhouse/share_of_deposits/erc20_share_of_deposits.ex
+++ b/lib/sanbase/clickhouse/share_of_deposits/erc20_share_of_deposits.ex
@@ -1,0 +1,125 @@
+defmodule Sanbase.Clickhouse.Erc20ShareOfDeposits do
+  @moduledoc ~s"""
+  Uses ClickHouse to calculate share of deposits from daily active addresses for an ERC20 token
+  """
+
+  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  import Sanbase.Math, only: [to_integer: 1]
+
+  alias Sanbase.DateTimeUtils
+
+  @type share_of_deposits :: %{
+          datetime: %DateTime{},
+          active_addresses: non_neg_integer(),
+          active_deposits: non_neg_integer(),
+          share_of_deposits: number()
+        }
+
+  @doc ~s"""
+  Returns the share of deposits from daily active addresses for contract chunked in intervals between [from, to]
+  If last day is included in the [from, to] the value is the realtime value in the current moment
+  """
+  @spec share_of_deposits(
+          String.t(),
+          %DateTime{},
+          %DateTime{},
+          String.t()
+        ) :: {:ok, list(share_of_deposits)} | {:error, String.t()}
+  def share_of_deposits(contract, from, to, interval) do
+    {query, args} = share_of_deposits_query(contract, from, to, interval)
+
+    ClickhouseRepo.query_transform(
+      query,
+      args,
+      fn [dt, active_addresses, active_deposits, share_of_deposits] ->
+        %{
+          datetime: DateTime.from_unix!(dt),
+          active_addresses: active_addresses |> to_integer(),
+          active_deposits: active_deposits |> to_integer(),
+          share_of_deposits: share_of_deposits
+        }
+      end
+    )
+  end
+
+  defp share_of_deposits_query(contract, from, to, interval) do
+    interval = DateTimeUtils.compound_duration_to_seconds(interval)
+    from_datetime_unix = DateTime.to_unix(from)
+    to_datetime_unix = DateTime.to_unix(to)
+    span = div(to_datetime_unix - from_datetime_unix, interval) |> max(1)
+
+    query = """
+    SELECT
+      toUnixTimestamp(time) AS dt,
+      SUM(addresses) AS active_addresses,
+      SUM(deposits) AS active_deposits,
+      if(SUM(addresses) != 0, SUM(deposits)/SUM(addresses), 0) * 100 AS share_of_deposits
+    FROM (
+      SELECT
+        toDateTime(intDiv(toUInt32(?4 + (number + 1) * ?1), ?1) * ?1) AS time,
+        toUInt32(0) AS addresses,
+        toUInt32(0) AS deposits
+      FROM numbers(?2)
+
+      UNION ALL
+
+      SELECT
+        toDateTime(intDiv(toUInt32(dt), ?1) * ?1) AS time,
+        total_addresses AS addresses,
+        deposits AS deposits
+      FROM (
+        SELECT
+          toStartOfDay(dt) AS dt,
+          anyLast(total_addresses) AS total_addresses
+        FROM erc20_daily_active_addresses
+        PREWHERE
+          contract = ?3 AND
+          dt < toDateTime(today()) AND
+          dt >= toDateTime(?4) AND
+          dt <= toDateTime(?5)
+        GROUP BY contract, dt
+
+        UNION ALL
+
+        SELECT
+          toStartOfDay(dt) AS dt,
+          uniq(address) AS total_addresses
+        FROM erc20_daily_active_addresses_list
+        PREWHERE
+          contract = ?3 AND
+          dt >= toDateTime(today()) AND
+          dt >= toDateTime(?4) AND
+          dt <= toDateTime(?5)
+        GROUP BY dt
+      )
+
+      ANY LEFT JOIN(
+        SELECT
+          sum(total_addresses) AS deposits,
+          dt
+        FROM(
+          SELECT DISTINCT
+            exchange,
+            dt,
+            contract,
+            total_addresses
+          FROM daily_active_deposits
+          PREWHERE
+            contract = ?3 AND
+            dt < toDateTime(today()) AND
+            dt >= toDateTime(?4) AND
+            dt <= toDateTime(?5)
+        )
+        GROUP BY dt
+      ) USING(dt)
+
+    )
+    GROUP BY dt
+    ORDER BY dt
+    """
+
+    args = [interval, span, contract, from_datetime_unix, to_datetime_unix]
+
+    {query, args}
+  end
+end

--- a/lib/sanbase/clickhouse/share_of_deposits/erc20_share_of_deposits.ex
+++ b/lib/sanbase/clickhouse/share_of_deposits/erc20_share_of_deposits.ex
@@ -106,7 +106,7 @@ defmodule Sanbase.Clickhouse.Erc20ShareOfDeposits do
           FROM daily_active_deposits
           PREWHERE
             contract = ?3 AND
-            dt < toDateTime(today()) AND
+            dt <= toDateTime(today()) AND
             dt >= toDateTime(?4) AND
             dt <= toDateTime(?5)
         )

--- a/lib/sanbase/clickhouse/share_of_deposits/eth_share_of_deposits.ex
+++ b/lib/sanbase/clickhouse/share_of_deposits/eth_share_of_deposits.ex
@@ -1,0 +1,117 @@
+defmodule Sanbase.Clickhouse.EthShareOfDeposits do
+  @moduledoc ~s"""
+  Uses ClickHouse to calculate share of deposits from daily active addresses for ETH
+  """
+
+  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  import Sanbase.Math, only: [to_integer: 1]
+
+  alias Sanbase.DateTimeUtils
+
+  @type share_of_deposits :: %{
+          datetime: %DateTime{},
+          active_addresses: non_neg_integer(),
+          active_deposits: non_neg_integer(),
+          share_of_deposits: number()
+        }
+
+  @spec share_of_deposits(
+          %DateTime{},
+          %DateTime{},
+          String.t()
+        ) :: {:ok, list(share_of_deposits)} | {:error, String.t()}
+  def share_of_deposits(from, to, interval) do
+    {query, args} = share_of_deposits_query(from, to, interval)
+
+    ClickhouseRepo.query_transform(
+      query,
+      args,
+      fn [dt, active_addresses, active_deposits, share_of_deposits] ->
+        %{
+          datetime: DateTime.from_unix!(dt),
+          active_addresses: active_addresses |> to_integer(),
+          active_deposits: active_deposits |> to_integer(),
+          share_of_deposits: share_of_deposits
+        }
+      end
+    )
+  end
+
+  defp share_of_deposits_query(from, to, interval) do
+    interval = DateTimeUtils.compound_duration_to_seconds(interval)
+    from_datetime_unix = DateTime.to_unix(from)
+    to_datetime_unix = DateTime.to_unix(to)
+    span = div(to_datetime_unix - from_datetime_unix, interval) |> max(1)
+
+    query = """
+    SELECT
+      toUnixTimestamp(time) AS dt,
+      SUM(addresses) AS active_addresses,
+      SUM(deposits) AS active_deposits,
+      if(SUM(addresses) != 0, SUM(deposits)/SUM(addresses), 0) * 100 AS share_of_deposits
+    FROM (
+      SELECT
+        toDateTime(intDiv(toUInt32(?3 + (number + 1) * ?1), ?1) * ?1) AS time,
+        toUInt32(0) AS addresses,
+        toUInt32(0) AS deposits
+      FROM numbers(?2)
+
+      UNION ALL
+
+      SELECT
+        toDateTime(intDiv(toUInt32(dt), ?1) * ?1) AS time,
+        total_addresses AS addresses,
+        deposits AS deposits
+      FROM (
+        SELECT
+          toStartOfDay(dt) AS dt,
+          anyLast(total_addresses) AS total_addresses
+        FROM eth_daily_active_addresses
+        PREWHERE
+          dt < toDateTime(today()) AND
+          dt >= toDateTime(?3) AND
+          dt <= toDateTime(?4)
+        GROUP BY dt
+
+        UNION ALL
+
+        SELECT
+          toStartOfDay(dt) AS dt,
+          uniq(address) AS total_addresses
+        FROM eth_daily_active_addresses_list
+        PREWHERE
+          dt >= toDateTime(today()) AND
+          dt >= toDateTime(?3) AND
+          dt <= toDateTime(?4)
+        GROUP BY dt
+      )
+
+      ANY LEFT JOIN(
+        SELECT
+          sum(total_addresses) AS deposits,
+          dt
+        FROM(
+          SELECT DISTINCT
+            exchange,
+            dt,
+            contract,
+            total_addresses
+          FROM daily_active_deposits
+          PREWHERE
+            dt < toDateTime(today()) AND
+            dt >= toDateTime(?3) AND
+            dt <= toDateTime(?4)
+        )
+        GROUP BY dt
+      ) USING(dt)
+
+    )
+    GROUP BY dt
+    ORDER BY dt
+    """
+
+    args = [interval, span, from_datetime_unix, to_datetime_unix]
+
+    {query, args}
+  end
+end

--- a/lib/sanbase/clickhouse/share_of_deposits/eth_share_of_deposits.ex
+++ b/lib/sanbase/clickhouse/share_of_deposits/eth_share_of_deposits.ex
@@ -98,7 +98,7 @@ defmodule Sanbase.Clickhouse.EthShareOfDeposits do
             total_addresses
           FROM daily_active_deposits
           PREWHERE
-            dt < toDateTime(today()) AND
+            dt <= toDateTime(today()) AND
             dt >= toDateTime(?3) AND
             dt <= toDateTime(?4)
         )

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -442,6 +442,20 @@ defmodule SanbaseWeb.Graphql.Schema do
       cache_resolve(&ClickhouseResolver.daily_active_deposits/3)
     end
 
+    @desc ~s"""
+    Fetch share of deposits from Daily Active Addresses.
+    """
+    field :share_of_deposits, list_of(:share_of_deposits) do
+      arg(:slug, non_null(:string))
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+      arg(:interval, :string, default_value: "1d")
+
+      complexity(&Complexity.from_to_interval/3)
+      middleware(ApiTimeframeRestriction)
+      cache_resolve(&ClickhouseResolver.share_of_deposits/3)
+    end
+
     @desc "Fetch the currently running poll."
     field :current_poll, :poll do
       cache_resolve(&InsightResolver.current_poll/3)

--- a/lib/sanbase_web/graphql/schema/clickhouse_types.ex
+++ b/lib/sanbase_web/graphql/schema/clickhouse_types.ex
@@ -6,6 +6,13 @@ defmodule SanbaseWeb.Graphql.ClickhouseTypes do
     field(:active_deposits, non_null(:integer))
   end
 
+  object :share_of_deposits do
+    field(:datetime, non_null(:datetime))
+    field(:active_addresses, non_null(:integer))
+    field(:active_deposits, non_null(:integer))
+    field(:share_of_deposits, :float)
+  end
+
   object :gas_used do
     field(:datetime, non_null(:datetime))
     field(:eth_gas_used, :integer)

--- a/lib/sanbase_web/graphql/schema/clickhouse_types.ex
+++ b/lib/sanbase_web/graphql/schema/clickhouse_types.ex
@@ -8,8 +8,6 @@ defmodule SanbaseWeb.Graphql.ClickhouseTypes do
 
   object :share_of_deposits do
     field(:datetime, non_null(:datetime))
-    field(:active_addresses, non_null(:integer))
-    field(:active_deposits, non_null(:integer))
     field(:share_of_deposits, :float)
   end
 

--- a/test/sanbase/clickhouse/share_of_deposits/erc20_share_of_deposits_test.exs
+++ b/test/sanbase/clickhouse/share_of_deposits/erc20_share_of_deposits_test.exs
@@ -1,0 +1,58 @@
+defmodule Sanbase.Clickhouse.Erc20ShareOfDepositsTest do
+  use Sanbase.DataCase
+  require Sanbase.ClickhouseRepo
+  import Mock
+  import Sanbase.Factory
+  import Sanbase.DateTimeUtils, only: [from_iso8601_to_unix!: 1, from_iso8601!: 1]
+  alias Sanbase.Clickhouse.Erc20ShareOfDeposits
+
+  setup do
+    project = insert(:project, %{main_contract_address: "0x123"})
+
+    [
+      project: project,
+      contract: project.main_contract_address,
+      from: from_iso8601!("2019-01-01T00:00:00Z"),
+      to: from_iso8601!("2019-01-03T00:00:00Z")
+    ]
+  end
+
+  test "returns share of deposits from daily active addresses",
+       context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:ok,
+         %{
+           rows: [
+             [from_iso8601_to_unix!("2019-01-01T00:00:00Z"), 200_000, 20_000, 10.0],
+             [from_iso8601_to_unix!("2019-01-02T00:00:00Z"), 100_000, 10_000, 10.0]
+           ]
+         }}
+      end do
+      result =
+        Erc20ShareOfDeposits.share_of_deposits(
+          context.contract,
+          context.from,
+          context.to,
+          "1d"
+        )
+
+      assert result ==
+               {:ok,
+                [
+                  %{
+                    datetime: from_iso8601!("2019-01-01T00:00:00Z"),
+                    active_addresses: 200_000,
+                    active_deposits: 20_000,
+                    share_of_deposits: 10.0
+                  },
+                  %{
+                    datetime: from_iso8601!("2019-01-02T00:00:00Z"),
+                    active_addresses: 100_000,
+                    active_deposits: 10_000,
+                    share_of_deposits: 10.0
+                  }
+                ]}
+    end
+  end
+end

--- a/test/sanbase/clickhouse/share_of_deposits/eth_share_of_deposits_test.exs
+++ b/test/sanbase/clickhouse/share_of_deposits/eth_share_of_deposits_test.exs
@@ -1,0 +1,52 @@
+defmodule Sanbase.Clickhouse.DailyActiveAddresses.EthShareOfDepositsTest do
+  use Sanbase.DataCase
+  require Sanbase.ClickhouseRepo
+  import Mock
+  import Sanbase.DateTimeUtils, only: [from_iso8601_to_unix!: 1, from_iso8601!: 1]
+  alias Sanbase.Clickhouse.EthShareOfDeposits
+
+  setup do
+    [
+      from: from_iso8601!("2019-01-01T00:00:00Z"),
+      to: from_iso8601!("2019-01-03T00:00:00Z")
+    ]
+  end
+
+  test "returns share of deposits from daily active addresses",
+       context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:ok,
+         %{
+           rows: [
+             [from_iso8601_to_unix!("2019-01-01T00:00:00Z"), 200_000, 20_000, 10.0],
+             [from_iso8601_to_unix!("2019-01-02T00:00:00Z"), 100_000, 10_000, 10.0]
+           ]
+         }}
+      end do
+      result =
+        EthShareOfDeposits.share_of_deposits(
+          context.from,
+          context.to,
+          "1d"
+        )
+
+      assert result ==
+               {:ok,
+                [
+                  %{
+                    datetime: from_iso8601!("2019-01-01T00:00:00Z"),
+                    active_addresses: 200_000,
+                    active_deposits: 20_000,
+                    share_of_deposits: 10.0
+                  },
+                  %{
+                    datetime: from_iso8601!("2019-01-02T00:00:00Z"),
+                    active_addresses: 100_000,
+                    active_deposits: 10_000,
+                    share_of_deposits: 10.0
+                  }
+                ]}
+    end
+  end
+end

--- a/test/sanbase_web/graphql/clickhouse/share_of_deposits_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/share_of_deposits_test.exs
@@ -1,0 +1,208 @@
+defmodule SanbaseWeb.Graphql.Clickhouse.ShareOfDepositsTest do
+  use SanbaseWeb.ConnCase
+
+  import SanbaseWeb.Graphql.TestHelpers
+  import Mock
+  import Sanbase.DateTimeUtils, only: [from_iso8601!: 1]
+  import ExUnit.CaptureLog
+  import Sanbase.Factory
+
+  alias Sanbase.Clickhouse.ShareOfDeposits
+
+  setup do
+    user = insert(:staked_user)
+    conn = setup_jwt_auth(build_conn(), user)
+
+    token = insert(:project, %{main_contract_address: "0x123"})
+
+    ethereum =
+      insert(:project, %{
+        coinmarketcap_id: "ethereum",
+        ticker: "ETH",
+        main_contract_address: "0x789"
+      })
+
+    [
+      conn: conn,
+      token: token,
+      ethereum: ethereum,
+      from: from_iso8601!("2019-01-01T00:00:00Z"),
+      to: from_iso8601!("2019-01-03T00:00:00Z"),
+      interval: "1d"
+    ]
+  end
+
+  test "logs warning when calculation errors", context do
+    with_mock ShareOfDeposits,
+      share_of_deposits: fn _, _, _, _ -> {:error, "Some error description here"} end do
+      assert capture_log(fn ->
+               response = execute_query(context, context.token.coinmarketcap_id)
+               result = parse_response(response)
+               assert result == nil
+             end) =~
+               ~s/[warn] Can't calculate Share of Deposits for project with coinmarketcap_id: santiment. Reason: "Some error description here"/
+    end
+  end
+
+  test "uses 1d as default interval", context do
+    with_mock ShareOfDeposits, share_of_deposits: fn _, _, _, _ -> {:ok, []} end do
+      query = """
+        {
+          shareOfDeposits(
+            slug: "#{context.token.coinmarketcap_id}",
+            from: "#{context.from}",
+            to: "#{context.to}")
+          {
+            datetime,
+            activeAddresses
+            activeDeposits
+            shareOfDeposits
+          }
+        }
+      """
+
+      context.conn
+      |> post("/graphql", query_skeleton(query, "shareOfDeposits"))
+
+      assert_called(
+        ShareOfDeposits.share_of_deposits(
+          context.token.main_contract_address,
+          context.from,
+          context.to,
+          "1d"
+        )
+      )
+    end
+  end
+
+  test "returns share of deposits from daily active addresses for tokens", context do
+    with_mock ShareOfDeposits,
+      share_of_deposits: fn _, _, _, _ ->
+        {:ok,
+         [
+           %{
+             active_addresses: 100,
+             active_deposits: 10,
+             share_of_deposits: 10.0,
+             datetime: from_iso8601!("2019-01-01T00:00:00Z")
+           },
+           %{
+             active_addresses: 200,
+             active_deposits: 10,
+             share_of_deposits: 5.0,
+             datetime: from_iso8601!("2019-01-02T00:00:00Z")
+           }
+         ]}
+      end do
+      response = execute_query(context, context.token.coinmarketcap_id)
+      results = parse_response(response)
+
+      assert_called(
+        ShareOfDeposits.share_of_deposits(
+          context.token.main_contract_address,
+          context.from,
+          context.to,
+          context.interval
+        )
+      )
+
+      assert results == [
+               %{
+                 "activeAddresses" => 100,
+                 "activeDeposits" => 10,
+                 "shareOfDeposits" => 10.0,
+                 "datetime" => "2019-01-01T00:00:00Z"
+               },
+               %{
+                 "activeAddresses" => 200,
+                 "activeDeposits" => 10,
+                 "shareOfDeposits" => 5.0,
+                 "datetime" => "2019-01-02T00:00:00Z"
+               }
+             ]
+    end
+  end
+
+  test "returns share of deposits from daily active addresses for ethereum", context do
+    with_mock ShareOfDeposits,
+      share_of_deposits: fn _, _, _, _ ->
+        {:ok,
+         [
+           %{
+             active_addresses: 100,
+             active_deposits: 10,
+             share_of_deposits: 10.0,
+             datetime: from_iso8601!("2019-01-01T00:00:00Z")
+           },
+           %{
+             active_addresses: 200,
+             active_deposits: 10,
+             share_of_deposits: 5.0,
+             datetime: from_iso8601!("2019-01-02T00:00:00Z")
+           }
+         ]}
+      end do
+      response =
+        execute_query(
+          context,
+          context.ethereum.coinmarketcap_id
+        )
+
+      results = parse_response(response)
+
+      assert_called(
+        ShareOfDeposits.share_of_deposits(
+          context.ethereum.ticker,
+          context.from,
+          context.to,
+          context.interval
+        )
+      )
+
+      assert results == [
+               %{
+                 "activeAddresses" => 100,
+                 "activeDeposits" => 10,
+                 "shareOfDeposits" => 10.0,
+                 "datetime" => "2019-01-01T00:00:00Z"
+               },
+               %{
+                 "activeAddresses" => 200,
+                 "activeDeposits" => 10,
+                 "shareOfDeposits" => 5.0,
+                 "datetime" => "2019-01-02T00:00:00Z"
+               }
+             ]
+    end
+  end
+
+  defp parse_response(response) do
+    json_response(response, 200)["data"]["shareOfDeposits"]
+  end
+
+  defp execute_query(context, slug) do
+    query = share_of_deposits_query(slug, context.from, context.to, context.interval)
+
+    context.conn
+    |> post("/graphql", query_skeleton(query, "shareOfDeposits"))
+  end
+
+  defp share_of_deposits_query(slug, from, to, interval) do
+    """
+    {
+      shareOfDeposits(
+        slug: "#{slug}",
+        from: "#{from}",
+        to: "#{to}",
+        interval: "#{interval}"
+      )
+      {
+        datetime,
+        activeAddresses
+        activeDeposits
+        shareOfDeposits
+      }
+    }
+    """
+  end
+end

--- a/test/sanbase_web/graphql/clickhouse/share_of_deposits_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/share_of_deposits_test.exs
@@ -53,9 +53,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ShareOfDepositsTest do
             from: "#{context.from}",
             to: "#{context.to}")
           {
-            datetime,
-            activeAddresses
-            activeDeposits
+            datetime
             shareOfDeposits
           }
         }
@@ -108,14 +106,10 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ShareOfDepositsTest do
 
       assert results == [
                %{
-                 "activeAddresses" => 100,
-                 "activeDeposits" => 10,
                  "shareOfDeposits" => 10.0,
                  "datetime" => "2019-01-01T00:00:00Z"
                },
                %{
-                 "activeAddresses" => 200,
-                 "activeDeposits" => 10,
                  "shareOfDeposits" => 5.0,
                  "datetime" => "2019-01-02T00:00:00Z"
                }
@@ -161,14 +155,10 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ShareOfDepositsTest do
 
       assert results == [
                %{
-                 "activeAddresses" => 100,
-                 "activeDeposits" => 10,
                  "shareOfDeposits" => 10.0,
                  "datetime" => "2019-01-01T00:00:00Z"
                },
                %{
-                 "activeAddresses" => 200,
-                 "activeDeposits" => 10,
                  "shareOfDeposits" => 5.0,
                  "datetime" => "2019-01-02T00:00:00Z"
                }
@@ -197,9 +187,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ShareOfDepositsTest do
         interval: "#{interval}"
       )
       {
-        datetime,
-        activeAddresses
-        activeDeposits
+        datetime
         shareOfDeposits
       }
     }


### PR DESCRIPTION
#### Summary

Share of deposits from Daily Active Addresses

**Note**
`activeAddresses` & `activeDeposits` are temporary disabled due to
unconsistent data with Daily Active Addresses from TimescaleDB.

The fields will be bringed back after DAA is refactored to use
Clickhouse.

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
