### PR TITLE
Moderating insights

### DIFF
--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -12,8 +12,12 @@ defmodule Sanbase.Insight.Post do
 
   alias Sanbase.Repo
 
+  # state
+  @awaiting_approval "awaiting_approval"
   @approved "approved"
   @declined "declined"
+
+  # ready_state
   @draft "draft"
   @published "published"
 
@@ -26,7 +30,7 @@ defmodule Sanbase.Insight.Post do
     field(:short_desc, :string)
     field(:link, :string)
     field(:text, :string)
-    field(:state, :string, default: @approved)
+    field(:state, :string, default: @awaiting_approval)
     field(:moderation_comment, :string)
     field(:ready_state, :string, default: @draft)
     field(:discourse_topic_url, :string)
@@ -75,6 +79,7 @@ defmodule Sanbase.Insight.Post do
     |> cast(attrs, [:ready_state, :discourse_topic_url])
   end
 
+  def awaiting_approval_state(), do: @awaiting_approval
   def approved_state(), do: @approved
   def declined_state(), do: @declined
 
@@ -160,7 +165,7 @@ defmodule Sanbase.Insight.Post do
   def published_posts(page, page_size) do
     from(
       p in Post,
-      where: p.ready_state == ^@published,
+      where: p.ready_state == ^@published and p.state == ^@approved,
       order_by: [desc: p.updated_at],
       limit: ^page_size,
       offset: ^((page - 1) * page_size)

--- a/lib/sanbase_web/admin/insights/post.ex
+++ b/lib/sanbase_web/admin/insights/post.ex
@@ -39,10 +39,18 @@ defmodule Sanbase.ExAdmin.Insight.Post do
         input(
           post,
           :is_featured,
-          collection: ~w[true false]
+          collection: ~w[true false],
+          selected: true
         )
 
-        input(post, :state, collection: [Post.approved_state(), Post.declined_state()])
+        input(post, :state,
+          collection: [
+            Post.awaiting_approval_state(),
+            Post.approved_state(),
+            Post.declined_state()
+          ]
+        )
+
         input(post, :moderation_comment)
       end
     end

--- a/test/sanbase/voting/post_test.exs
+++ b/test/sanbase/voting/post_test.exs
@@ -24,7 +24,7 @@ defmodule Sanbase.Insight.PostTest do
       })
       |> Repo.insert!()
 
-    assert post.state == Post.approved_state()
+    assert post.state == Post.awaiting_approval_state()
   end
 
   test "changes the owner to the fallback user" do

--- a/test/sanbase_web/graphql/post_test.exs
+++ b/test/sanbase_web/graphql/post_test.exs
@@ -164,7 +164,7 @@ defmodule SanbaseWeb.Graphql.PostTest do
            ] == json_response(result, 200)["data"]["allInsights"]
   end
 
-  test "excluding draft posts from allInsights", %{
+  test "excluding draft and not approved posts from allInsights", %{
     conn: conn,
     poll: poll,
     user: user,
@@ -174,6 +174,13 @@ defmodule SanbaseWeb.Graphql.PostTest do
       poll: poll,
       user: user,
       state: Post.approved_state(),
+      ready_state: Post.published()
+    )
+
+    insert(:post,
+      poll: poll,
+      user: user,
+      state: Post.awaiting_approval_state(),
       ready_state: Post.published()
     )
 
@@ -367,7 +374,7 @@ defmodule SanbaseWeb.Graphql.PostTest do
 
       assert sanbasePost["id"] != nil
       assert sanbasePost["title"] == "Awesome post"
-      assert sanbasePost["state"] == Post.approved_state()
+      assert sanbasePost["state"] == Post.awaiting_approval_state()
       assert sanbasePost["user"]["id"] == user.id |> Integer.to_string()
       assert sanbasePost["votes"]["totalSanVotes"] == 0
 

--- a/test/support/sanbase_factory.ex
+++ b/test/support/sanbase_factory.ex
@@ -46,7 +46,7 @@ defmodule Sanbase.Factory do
       title: "Awesome analysis",
       link: "http://example.com",
       text: "Text of the post",
-      state: Post.approved_state()
+      state: Post.awaiting_approval_state()
     }
   end
 
@@ -55,7 +55,7 @@ defmodule Sanbase.Factory do
       title: "Awesome analysis",
       link: "http://example.com",
       text: "Text of the post",
-      state: Post.approved_state()
+      state: Post.awaiting_approval_state()
     }
   end
 


### PR DESCRIPTION
Add `awaiting_approval` as default state in insights. Admin can update it to `approved` or `declined`.
`AllInsights` excludes `draft` and NOT `approved` insights.