### PR TITLE
Do not throw a 500 error when fetching BTC top holders

### DIFF
--- a/lib/sanbase/clickhouse/top_holders.ex
+++ b/lib/sanbase/clickhouse/top_holders.ex
@@ -18,11 +18,13 @@ defmodule Sanbase.Clickhouse.TopHolders do
   @spec percent_of_total_supply(
           String.t(),
           non_neg_integer(),
+          non_neg_integer(),
           DateTime.t(),
           DateTime.t()
         ) :: {:ok, list(percent_of_total_supply)} | {:error, String.t()}
-  def percent_of_total_supply(slug, number_of_holders, from, to) do
-    {query, args} = percent_of_total_supply_query(slug, number_of_holders, from, to)
+  def percent_of_total_supply(contract, token_decimals, number_of_holders, from, to) do
+    {query, args} =
+      percent_of_total_supply_query(contract, token_decimals, number_of_holders, from, to)
 
     ClickhouseRepo.query_transform(
       query,
@@ -38,10 +40,9 @@ defmodule Sanbase.Clickhouse.TopHolders do
     )
   end
 
-  defp percent_of_total_supply_query(slug, number_of_holders, from, to) do
+  defp percent_of_total_supply_query(contract, token_decimals, number_of_holders, from, to) do
     from_datetime_unix = DateTime.to_unix(from)
     to_datetime_unix = DateTime.to_unix(to)
-    {:ok, contract, token_decimals} = Project.contract_info_by_slug(slug)
     interval = DateTimeUtils.compound_duration_to_seconds("1d")
 
     query = """

--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -26,10 +26,17 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
         %{slug: slug, number_of_holders: number_of_holders, from: from, to: to},
         _resolution
       ) do
-    case TopHolders.percent_of_total_supply(slug, number_of_holders, from, to) do
-      {:ok, percent_of_total_supply} ->
-        {:ok, percent_of_total_supply}
-
+    with {:ok, contract, token_decimals} <- Project.contract_info_by_slug(slug),
+         {:ok, percent_of_total_supply} <-
+           TopHolders.percent_of_total_supply(
+             contract,
+             token_decimals,
+             number_of_holders,
+             from,
+             to
+           ) do
+      {:ok, percent_of_total_supply}
+    else
       {:error, error} ->
         error_msg = "Can't calculate top holders - percent of total supply for slug: #{slug}."
         Logger.warn(error_msg <> " Reason: #{inspect(error)}")

--- a/test/sanbase/clickhouse/top_holders_test.exs
+++ b/test/sanbase/clickhouse/top_holders_test.exs
@@ -11,6 +11,8 @@ defmodule Sanbase.Clickhouse.TopHoldersTest do
 
     [
       slug: project.coinmarketcap_id,
+      contract: "ETH",
+      token_decimals: 18,
       number_of_holders: 10,
       from: from_iso8601!("2019-01-01T00:00:00Z"),
       to: from_iso8601!("2019-01-03T00:00:00Z")
@@ -30,7 +32,8 @@ defmodule Sanbase.Clickhouse.TopHoldersTest do
       end do
       result =
         TopHolders.percent_of_total_supply(
-          context.slug,
+          context.contract,
+          context.token_decimals,
           context.number_of_holders,
           context.from,
           context.to
@@ -59,7 +62,8 @@ defmodule Sanbase.Clickhouse.TopHoldersTest do
     with_mock Sanbase.ClickhouseRepo, query: fn _, _ -> {:ok, %{rows: []}} end do
       result =
         TopHolders.percent_of_total_supply(
-          context.slug,
+          context.contract,
+          context.token_decimals,
           context.number_of_holders,
           context.from,
           context.to

--- a/test/sanbase_web/graphql/exchanges_test.exs
+++ b/test/sanbase_web/graphql/exchanges_test.exs
@@ -26,7 +26,7 @@ defmodule SanbaseWeb.Graphql.ExchangesTest do
       |> post("/graphql", query_skeleton(query, "allExchanges"))
 
     exchanges = json_response(response, 200)["data"]["allExchanges"]
-    assert exchanges == ["Binance", "Bitfinex"]
+    assert Enum.sort(exchanges) == Enum.sort(["Binance", "Bitfinex"])
   end
 
   test "test fetching volume for exchange", context do


### PR DESCRIPTION
The BTC top holders is still not implemented, but we should not be
throwing a 500 error when calling this API. A properly formatted error
should be returned.

The problem is that we don't fetch the contract info about BTC in the
canonical way.
