### PR TITLE
Allow realtime data for word context and trend score

### DIFF
--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -679,7 +679,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
 
-      middleware(ApiTimeframeRestriction)
+      middleware(ApiTimeframeRestriction, %{allow_realtime_data: true})
       cache_resolve(&SocialDataResolver.word_trend_score/3)
     end
 
@@ -704,7 +704,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
 
-      middleware(ApiTimeframeRestriction)
+      middleware(ApiTimeframeRestriction, %{allow_realtime_data: true})
       cache_resolve(&SocialDataResolver.word_context/3)
     end
 


### PR DESCRIPTION
#### Summary
We allowed realtime access to trending words but for context and score it still has limitation. We need to have either all realtime access or all restricted. Having different restrictions is confusing

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
