### PR TITLE
Cache the heavier queries for longer. 

### DIFF
--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -29,7 +29,7 @@ defmodule SanbaseWeb.Graphql.Schema do
     UserFollowerResolver
   }
 
-  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1]
+  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1, cache_resolve: 2]
 
   alias SanbaseWeb.Graphql.Complexity
 
@@ -281,7 +281,7 @@ defmodule SanbaseWeb.Graphql.Schema do
 
       complexity(&Complexity.from_to_interval/3)
       middleware(ApiTimeframeRestriction, %{allow_historical_data: true})
-      cache_resolve(&GithubResolver.dev_activity/3)
+      cache_resolve(&GithubResolver.dev_activity/3, ttl: 600, max_ttl_offset: 600)
     end
 
     @desc "Fetch the current data for a Twitter account (currently includes only Twitter followers)."
@@ -632,7 +632,7 @@ defmodule SanbaseWeb.Graphql.Schema do
 
       complexity(&Complexity.from_to_interval/3)
       middleware(ApiTimeframeRestriction)
-      cache_resolve(&TechIndicatorsResolver.topic_search/3)
+      cache_resolve(&TechIndicatorsResolver.topic_search/3, ttl: 600, max_ttl_offset: 240)
     end
 
     @desc ~s"""
@@ -657,7 +657,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:to, non_null(:datetime))
 
       middleware(ApiTimeframeRestriction, %{allow_realtime_data: true})
-      cache_resolve(&SocialDataResolver.trending_words/3)
+      cache_resolve(&SocialDataResolver.trending_words/3, ttl: 600, max_ttl_offset: 240)
     end
 
     @desc ~s"""
@@ -680,7 +680,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:to, non_null(:datetime))
 
       middleware(ApiTimeframeRestriction, %{allow_realtime_data: true})
-      cache_resolve(&SocialDataResolver.word_trend_score/3)
+      cache_resolve(&SocialDataResolver.word_trend_score/3, ttl: 600, max_ttl_offset: 240)
     end
 
     @desc ~s"""
@@ -705,7 +705,7 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:to, non_null(:datetime))
 
       middleware(ApiTimeframeRestriction, %{allow_realtime_data: true})
-      cache_resolve(&SocialDataResolver.word_context/3)
+      cache_resolve(&SocialDataResolver.word_context/3, ttl: 600, max_ttl_offset: 240)
     end
 
     @desc "Fetch a list of all exchange wallets. This query requires basic authentication."
@@ -721,7 +721,11 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:to, non_null(:datetime))
 
       complexity(&Complexity.from_to_interval/3)
-      cache_resolve(&ProjectTransactionsResolver.eth_spent_by_erc20_projects/3)
+
+      cache_resolve(&ProjectTransactionsResolver.eth_spent_by_erc20_projects/3,
+        ttl: 600,
+        max_ttl_offset: 240
+      )
     end
 
     @desc ~s"""
@@ -734,7 +738,11 @@ defmodule SanbaseWeb.Graphql.Schema do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      cache_resolve(&ProjectTransactionsResolver.eth_spent_over_time_by_erc20_projects/3)
+
+      cache_resolve(&ProjectTransactionsResolver.eth_spent_over_time_by_erc20_projects/3,
+        ttl: 600,
+        max_ttl_offset: 240
+      )
     end
 
     @desc "Fetch all favourites lists for current_user."

--- a/lib/sanbase_web/graphql/schema/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/project_types.ex
@@ -4,7 +4,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
 
   import Absinthe.Resolution.Helpers
 
-  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1]
+  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1, cache_resolve: 2]
 
   alias SanbaseWeb.Graphql.Resolvers.{
     ProjectResolver,
@@ -85,7 +85,10 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     end
 
     field :funds_raised_icos, list_of(:currency_amount) do
-      cache_resolve(&ProjectResolver.funds_raised_icos/3)
+      cache_resolve(&ProjectResolver.funds_raised_icos/3,
+        ttl: 600,
+        max_ttl_offset: 600
+      )
     end
 
     field :roi_usd, :decimal do
@@ -121,17 +124,28 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     field :average_dev_activity, :float do
       description("Average dev activity for the last `days` days")
       arg(:days, :integer, default_value: 30)
-      cache_resolve(&ProjectResolver.average_dev_activity/3)
+
+      cache_resolve(&ProjectResolver.average_dev_activity/3,
+        ttl: 600,
+        max_ttl_offset: 600
+      )
     end
 
     field :average_github_activity, :float do
       description("Average github activity for the last `days` days")
       arg(:days, :integer, default_value: 30)
-      cache_resolve(&ProjectResolver.average_github_activity/3)
+
+      cache_resolve(&ProjectResolver.average_github_activity/3,
+        ttl: 600,
+        max_ttl_offset: 600
+      )
     end
 
     field :twitter_data, :twitter_data do
-      cache_resolve(&TwitterResolver.twitter_data/3)
+      cache_resolve(&TwitterResolver.twitter_data/3,
+        ttl: 600,
+        max_ttl_offset: 600
+      )
     end
 
     field :marketcap_usd, :float do
@@ -159,19 +173,28 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     end
 
     field :funds_raised_usd_ico_end_price, :float do
-      cache_resolve(&ProjectResolver.funds_raised_usd_ico_end_price/3)
+      cache_resolve(&ProjectResolver.funds_raised_usd_ico_end_price/3,
+        ttl: 600,
+        max_ttl_offset: 600
+      )
     end
 
     field :funds_raised_eth_ico_end_price, :float do
-      cache_resolve(&ProjectResolver.funds_raised_eth_ico_end_price/3)
+      cache_resolve(&ProjectResolver.funds_raised_eth_ico_end_price/3,
+        ttl: 600,
+        max_ttl_offset: 600
+      )
     end
 
     field :funds_raised_btc_ico_end_price, :float do
-      cache_resolve(&ProjectResolver.funds_raised_btc_ico_end_price/3)
+      cache_resolve(&ProjectResolver.funds_raised_btc_ico_end_price/3,
+        ttl: 600,
+        max_ttl_offset: 600
+      )
     end
 
     field :initial_ico, :ico do
-      cache_resolve(&ProjectResolver.initial_ico/3)
+      cache_resolve(&ProjectResolver.initial_ico/3, ttl: 600, max_ttl_offset: 600)
     end
 
     field(:icos, list_of(:ico), resolve: assoc(:icos))
@@ -192,7 +215,10 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     field :eth_spent, :float do
       arg(:days, :integer, default_value: 30)
 
-      cache_resolve(&ProjectTransactionsResolver.eth_spent/3)
+      cache_resolve(&ProjectTransactionsResolver.eth_spent/3,
+        ttl: 600,
+        max_ttl_offset: 240
+      )
     end
 
     @desc "ETH spent for each `interval` from the project's team wallet and time period"
@@ -202,7 +228,11 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      cache_resolve(&ProjectTransactionsResolver.eth_spent_over_time/3)
+
+      cache_resolve(&ProjectTransactionsResolver.eth_spent_over_time/3,
+        ttl: 600,
+        max_ttl_offset: 240
+      )
     end
 
     @desc "Top ETH transactions for project's team wallets"
@@ -231,7 +261,10 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       arg(:from, :datetime)
       arg(:to, :datetime)
 
-      cache_resolve(&EtherbiResolver.average_daily_active_addresses/3)
+      cache_resolve(&EtherbiResolver.average_daily_active_addresses/3,
+        ttl: 600,
+        max_ttl_offset: 240
+      )
     end
   end
 

--- a/lib/sanbase_web/graphql/schema/social_data_types.ex
+++ b/lib/sanbase_web/graphql/schema/social_data_types.ex
@@ -2,7 +2,7 @@ defmodule SanbaseWeb.Graphql.SocialDataTypes do
   use Absinthe.Schema.Notation
 
   alias SanbaseWeb.Graphql.Resolvers.SocialDataResolver
-  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1]
+  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1, cache_resolve: 2]
 
   enum :trending_words_sources do
     value(:telegram)


### PR DESCRIPTION
#### Summary
Make the max_ttl_offset bigger so less queries expire at the same time
The bigger TTLs are for queries that return data that does not change that often:
- Github data (updated once an hour)
- Ethereum spent
- Social data stats

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->