### PR TITLE
 Use TOTAL_ERC20 in historyPrice returning combined mcap and volume for all ERC20 projects

### DIFF
--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -51,6 +51,38 @@ defmodule Sanbase.Prices.Store do
     end
   end
 
+  def fetch_prices_with_resolution("TOTAL_ERC20", from, to, resolution) do
+    measurements =
+      Sanbase.Model.Project.List.erc20_projects()
+      |> Enum.map(&Sanbase.Influxdb.Measurement.name_from/1)
+
+    total_erc20 =
+      measurements
+      |> Enum.chunk_every(100)
+      |> Sanbase.Parallel.pmap(fn measurements ->
+        {:ok, result} =
+          fetch_combined_mcap_volume(
+            measurements,
+            from,
+            to,
+            resolution
+          )
+
+        result
+      end)
+      |> Enum.zip()
+      |> Enum.map(&Tuple.to_list/1)
+      |> Enum.map(fn [%{datetime: dt} | _rest] = l ->
+        %{
+          datetime: dt,
+          volume: Enum.reduce(l, 0, fn %{volume: v}, acc -> acc + v end),
+          marketcap: Enum.reduce(l, 0, fn %{marketcap: m}, acc -> acc + m end)
+        }
+      end)
+
+    {:ok, total_erc20}
+  end
+
   def fetch_prices_with_resolution(measurement, from, to, resolution) do
     fetch_prices_with_resolution_query(measurement, from, to, resolution)
     |> Store.query()

--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -72,11 +72,11 @@ defmodule Sanbase.Prices.Store do
       end)
       |> Enum.zip()
       |> Enum.map(&Tuple.to_list/1)
-      |> Enum.map(fn [%{datetime: dt} | _rest] = l ->
+      |> Enum.map(fn [%{datetime: dt} | _rest] = list ->
         %{
           datetime: dt,
-          volume: Enum.reduce(l, 0, fn %{volume: v}, acc -> acc + v end),
-          marketcap: Enum.reduce(l, 0, fn %{marketcap: m}, acc -> acc + m end)
+          volume: Enum.reduce(list, 0, fn %{volume: v}, acc -> acc + v end),
+          marketcap: Enum.reduce(list, 0, fn %{marketcap: m}, acc -> acc + m end)
         }
       end)
 

--- a/lib/sanbase_web/graphql/dataloader/influxdb_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/influxdb_dataloader.ex
@@ -3,6 +3,8 @@ defmodule SanbaseWeb.Graphql.InfluxdbDataloader do
   alias SanbaseWeb.Graphql.Cache
   alias SanbaseWeb.Graphql.Helpers.Utils
 
+  @total_erc20 "TOTAL_ERC20"
+
   def data() do
     Dataloader.KV.new(&query/2)
   end

--- a/lib/sanbase_web/graphql/resolvers/price_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/price_resolver.ex
@@ -10,6 +10,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
 
   @total_market "TOTAL_MARKET"
   @total_market_measurement "TOTAL_MARKET_total-market"
+  @total_erc20 "TOTAL_ERC20"
 
   @doc """
     Returns a list of price points for the given ticker. Optimizes the number of queries
@@ -30,6 +31,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
     loader
     |> Dataloader.load(SanbaseDataloader, {:price, @total_market_measurement}, args)
     |> on_load(&total_market_history_price_on_load(&1, args))
+  end
+
+  def history_price(_root, %{slug: @total_erc20} = args, %{context: %{loader: loader}}) do
+    loader
+    |> Dataloader.load(SanbaseDataloader, {:price, @total_erc20}, args)
+    |> on_load(&total_erc20_history_price_on_load(&1, args))
   end
 
   @deprecated "Use history price by slug"
@@ -127,6 +134,13 @@ defmodule SanbaseWeb.Graphql.Resolvers.PriceResolver do
     else
       _ ->
         {:error, "Can't fetch total marketcap prices"}
+    end
+  end
+
+  defp total_erc20_history_price_on_load(loader, args) do
+    case Dataloader.get(loader, SanbaseDataloader, {:price, @total_erc20}, args) do
+      {:ok, total_erc20} -> {:ok, total_erc20}
+      _ -> {:error, "Can't fetch total volume and marketcap for all ERC20 projects"}
     end
   end
 

--- a/test/sanbase_web/graphql/prices_api_test.exs
+++ b/test/sanbase_web/graphql/prices_api_test.exs
@@ -3,6 +3,7 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
 
   import Plug.Conn
   import SanbaseWeb.Graphql.TestHelpers
+  import Sanbase.Factory
 
   alias Sanbase.Prices.Store
   alias Sanbase.Influxdb.Measurement
@@ -21,13 +22,23 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
     ticker_cmc_id1 = ticker1 <> "_" <> slug1
     ticker_cmc_id2 = ticker2 <> "_" <> slug2
 
-    %Project{}
-    |> Project.changeset(%{name: "Test project", coinmarketcap_id: slug1, ticker: ticker1})
-    |> Repo.insert!()
+    infr_eth = insert(:infrastructure_eth)
 
-    %Project{}
-    |> Project.changeset(%{name: "XYZ project", coinmarketcap_id: slug2, ticker: ticker2})
-    |> Repo.insert!()
+    insert(:project,
+      name: "Test project",
+      coinmarketcap_id: slug1,
+      ticker: ticker1,
+      infrastructure: infr_eth,
+      main_contract_address: "0x123"
+    )
+
+    insert(:project,
+      name: "XYZ project",
+      coinmarketcap_id: slug2,
+      ticker: ticker2,
+      infrastructure: infr_eth,
+      main_contract_address: "0x234"
+    )
 
     Store.drop_measurement(ticker_cmc_id1)
     Store.drop_measurement(ticker_cmc_id2)
@@ -81,24 +92,12 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
   test "no information is available for a non existing slug", context do
     Store.drop_measurement("SAN_USD")
 
-    query = """
-    {
-      historyPrice(
-        slug: "non_existing 1237819",
-        from: "#{context.datetime1}",
-        to: "#{context.datetime2}",
-        interval: "1h") {
-          datetime
-          priceUsd
-      }
-    }
-    """
+    query =
+      history_price_query("non_existing 1237819", context.datetime1, context.datetime2, "1h")
 
-    result =
-      context.conn
-      |> post("/graphql", query_skeleton(query, "historyPrice"))
+    result = context.conn |> execute_query(query, "historyPrice")
 
-    assert json_response(result, 200)["data"]["historyPrice"] == nil
+    assert result == nil
   end
 
   test "data aggregation for automatically calculated intervals", context do
@@ -188,20 +187,7 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
   end
 
   test "complexity is 0 with basic authentication", context do
-    query = """
-    {
-      historyPrice(
-        slug: "#{context.slug1}",
-        from: "#{context.years_ago}",
-        to: "#{context.datetime1}",
-        interval: "5m"){
-          priceUsd
-          priceBtc
-          datetime
-          volume
-      }
-    }
-    """
+    query = history_price_query(context.slug1, context.years_ago, context.datetime1, "5m")
 
     result =
       context.conn
@@ -214,70 +200,58 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
   test "no information is available for total marketcap", context do
     Store.drop_measurement(context.total_market_measurement)
 
-    query = """
-    {
-      historyPrice(
-        slug: "#{context.total_market_slug}",
-        from: "#{context.datetime1}",
-        to: "#{context.datetime2}",
-        interval: "1h") {
-          datetime
-          volume
-          marketcap
-      }
-    }
-    """
+    query =
+      history_price_query(context.total_market_slug, context.datetime1, context.datetime2, "1h")
 
-    result =
-      context.conn
-      |> post("/graphql", query_skeleton(query, "historyPrice"))
+    result = context.conn |> execute_query(query, "historyPrice")
 
-    assert json_response(result, 200)["data"]["historyPrice"] == []
+    assert result == []
+  end
+
+  test "historyPrice with TOTAL_ERC20 slug", context do
+    query = history_price_query("TOTAL_ERC20", context.datetime2, context.datetime3, "1d")
+
+    result = context.conn |> execute_query(query, "historyPrice")
+
+    assert result == [
+             %{
+               "datetime" => "2017-05-14T00:00:00Z",
+               "marketcap" => 500,
+               "priceBtc" => nil,
+               "priceUsd" => nil,
+               "volume" => 200
+             },
+             %{
+               "datetime" => "2017-05-15T00:00:00Z",
+               "marketcap" => 1300,
+               "priceBtc" => nil,
+               "priceUsd" => nil,
+               "volume" => 305
+             }
+           ]
   end
 
   test "the whole response is as it's expected to be", context do
-    query = """
-    {
-      historyPrice(
-        slug: "#{context.slug1}",
-        from: "#{context.datetime1}",
-        to: "#{context.datetime3}"
-        interval: "6h"){
-          datetime
-          volume
-          marketcap
-          priceUsd
-          priceBtc
-      }
-    }
-    """
+    query = history_price_query(context.slug1, context.datetime1, context.datetime3, "6h")
 
-    result =
-      context.conn
-      |> post("/graphql", query_skeleton(query, "historyPrice"))
-      |> json_response(200)
+    result = context.conn |> execute_query(query, "historyPrice")
 
-    assert result ==
+    assert result == [
              %{
-               "data" => %{
-                 "historyPrice" => [
-                   %{
-                     "datetime" => "2017-05-14T18:00:00Z",
-                     "marketcap" => 500,
-                     "priceBtc" => 1000,
-                     "priceUsd" => 20,
-                     "volume" => 200
-                   },
-                   %{
-                     "datetime" => "2017-05-15T18:00:00Z",
-                     "marketcap" => 800,
-                     "priceBtc" => 1200,
-                     "priceUsd" => 22,
-                     "volume" => 300
-                   }
-                 ]
-               }
+               "datetime" => "2017-05-14T18:00:00Z",
+               "marketcap" => 500,
+               "priceBtc" => 1000,
+               "priceUsd" => 20,
+               "volume" => 200
+             },
+             %{
+               "datetime" => "2017-05-15T18:00:00Z",
+               "marketcap" => 800,
+               "priceBtc" => 1200,
+               "priceUsd" => 22,
+               "volume" => 300
              }
+           ]
   end
 
   test "project group stats with existing slugs returns correct stats", context do
@@ -349,6 +323,24 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
         marketcap,
         slug,
         marketcapPercent
+      }
+    }
+    """
+  end
+
+  defp history_price_query(slug, from, to, interval) do
+    """
+    {
+      historyPrice(
+        slug: "#{slug}",
+        from: "#{from}",
+        to: "#{to}"
+        interval: "#{interval}"){
+          datetime
+          volume
+          marketcap
+          priceUsd
+          priceBtc
       }
     }
     """

--- a/test/support/sanbase_factory.ex
+++ b/test/support/sanbase_factory.ex
@@ -5,7 +5,7 @@ defmodule Sanbase.Factory do
   alias Sanbase.UserList
   alias Sanbase.Auth.{User, UserSettings}
   alias Sanbase.Insight.{Post, Poll}
-  alias Sanbase.Model.{Project, ExchangeAddress, ProjectEthAddress}
+  alias Sanbase.Model.{Project, ExchangeAddress, ProjectEthAddress, Infrastructure}
   alias Sanbase.Signals.{UserTrigger, HistoricalActivity}
 
   def user_factory() do
@@ -75,6 +75,12 @@ defmodule Sanbase.Factory do
       github_link: "https://github.com/santiment",
       infrastructure: nil,
       eth_addresses: [build(:project_eth_address)]
+    }
+  end
+
+  def infrastructure_eth_factory() do
+    %Infrastructure{
+      code: "ETH"
     }
   end
 


### PR DESCRIPTION
**TODO** - add tests 

```graphql
{
  historyPrice(
    from: "2019-04-10T06:26:56Z", 
    to: "2019-04-17T06:26:56Z", 
    slug: "TOTAL_ERC20",
    interval:"1d"
) {
    datetime
   	marketcap,
    volume
  }
}
```
```
{
  "data": {
    "historyPrice": [
      {
        "datetime": "2019-04-10T00:00:00Z",
        "marketcap": 8836311527.056316,
        "volume": 973921469.2144265
      },
      {
        "datetime": "2019-04-11T00:00:00Z",
        "marketcap": 8164143429.799532,
        "volume": 1060768530.8284835
      },
      {
        "datetime": "2019-04-12T00:00:00Z",
        "marketcap": 8107297450.22629,
        "volume": 898096518.7432971
      },
      {
        "datetime": "2019-04-13T00:00:00Z",
        "marketcap": 8283760089.58144,
        "volume": 800561516.5699275
      },
      {
        "datetime": "2019-04-14T00:00:00Z",
        "marketcap": 8414500342.378368,
        "volume": 804779334.8218791
      },
      {
        "datetime": "2019-04-15T00:00:00Z",
        "marketcap": 8492956066.920276,
        "volume": 876235014.353876
      },
      {
        "datetime": "2019-04-16T00:00:00Z",
        "marketcap": 8399515706.078108,
        "volume": 799923682.2872059
      },
      {
        "datetime": "2019-04-17T00:00:00Z",
        "marketcap": 8541575631.927128,
        "volume": 763322517.3871572
      }
    ]
  }
}
```