### PR TITLE
Increase the dataloader timeout to 11 seconds.

### DIFF
--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -76,7 +76,8 @@ defmodule SanbaseWeb.Graphql.Schema do
       SanbaseDataloader
     }
 
-    Dataloader.new()
+    # 11 seconds is 1s more than the influxdb timeout
+    Dataloader.new(timeout: :timer.seconds(11))
     |> Dataloader.add_source(SanbaseRepo, SanbaseRepo.data())
     |> Dataloader.add_source(SanbaseDataloader, SanbaseDataloader.data())
   end


### PR DESCRIPTION
After the increase of influxdb timeout from 5 to 10  seconds the
dataloder started to raise errors as it still had 5 seconds timeout.
The default get_policy is raise_on_error and the query failed.
Increasing to 1s more than influxdb will let influxdb timeout and not
cause an error but return an error tuple

In the future the get_policy should be replaced with `tuples` and be
handled better
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
