### PR TITLE
Add active addresses and deposits  to share of deposits

### DIFF
--- a/lib/sanbase_web/graphql/schema/clickhouse_types.ex
+++ b/lib/sanbase_web/graphql/schema/clickhouse_types.ex
@@ -13,6 +13,8 @@ defmodule SanbaseWeb.Graphql.ClickhouseTypes do
 
   object :share_of_deposits do
     field(:datetime, non_null(:datetime))
+    field(:active_addresses, non_null(:integer))
+    field(:active_deposits, non_null(:integer))
     field(:share_of_deposits, :float)
   end
 

--- a/test/sanbase_web/graphql/clickhouse/share_of_deposits_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/share_of_deposits_test.exs
@@ -58,6 +58,8 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ShareOfDepositsTest do
             to: "#{context.to}")
           {
             datetime
+            activeAddresses
+            activeDeposits
             shareOfDeposits
           }
         }
@@ -156,10 +158,14 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ShareOfDepositsTest do
 
       assert results == [
                %{
+                 "activeAddresses" => 100,
+                 "activeDeposits" => 10,
                  "shareOfDeposits" => 10.0,
                  "datetime" => "2019-01-01T00:00:00Z"
                },
                %{
+                 "activeAddresses" => 200,
+                 "activeDeposits" => 10,
                  "shareOfDeposits" => 5.0,
                  "datetime" => "2019-01-02T00:00:00Z"
                }
@@ -205,10 +211,14 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ShareOfDepositsTest do
 
       assert results == [
                %{
+                 "activeAddresses" => 100,
+                 "activeDeposits" => 10,
                  "shareOfDeposits" => 10.0,
                  "datetime" => "2019-01-01T00:00:00Z"
                },
                %{
+                 "activeAddresses" => 200,
+                 "activeDeposits" => 10,
                  "shareOfDeposits" => 5.0,
                  "datetime" => "2019-01-02T00:00:00Z"
                }
@@ -237,6 +247,8 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ShareOfDepositsTest do
         interval: "#{interval}"
       )
       {
+        activeAddresses
+        activeDeposits
         datetime
         shareOfDeposits
       }


### PR DESCRIPTION
#### Summary
They were temporary removed, after DAA was refactored to get the data from Clickhouse we can safely bring them back.

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
