### PR TITLE
Change 404 & 500 errors to have details key

### DIFF
--- a/lib/sanbase_web/views/error_view.ex
+++ b/lib/sanbase_web/views/error_view.ex
@@ -2,11 +2,11 @@ defmodule SanbaseWeb.ErrorView do
   use SanbaseWeb, :view
 
   def render("404.json", _assigns) do
-    %{errors: %{detail: "Page not found"}}
+    %{errors: %{details: "Page not found"}}
   end
 
   def render("500.json", _assigns) do
-    %{errors: %{detail: "Internal server error"}}
+    %{errors: %{details: "Internal server error"}}
   end
 
   # In case no render clause matches or no

--- a/test/sanbase_web/views/error_view_test.exs
+++ b/test/sanbase_web/views/error_view_test.exs
@@ -5,16 +5,16 @@ defmodule SanbaseWeb.ErrorViewTest do
   import Phoenix.View
 
   test "renders 404.json" do
-    assert render(SanbaseWeb.ErrorView, "404.json", []) == %{errors: %{detail: "Page not found"}}
+    assert render(SanbaseWeb.ErrorView, "404.json", []) == %{errors: %{details: "Page not found"}}
   end
 
   test "render 500.json" do
     assert render(SanbaseWeb.ErrorView, "500.json", []) ==
-             %{errors: %{detail: "Internal server error"}}
+             %{errors: %{details: "Internal server error"}}
   end
 
   test "render any other" do
     assert render(SanbaseWeb.ErrorView, "505.json", []) ==
-             %{errors: %{detail: "Internal server error"}}
+             %{errors: %{details: "Internal server error"}}
   end
 end


### PR DESCRIPTION
#### Summary
Errors 404 & 500 will have "details" key.

Example: 
```json
{"errors": {"details": "Internal server error"}
```
instead of 
```json
{"errors": {"detail": "Internal server error"}
```

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
