### PR TITLE
Add slug to Mining Pools Distribution metric

### DIFF
--- a/lib/sanbase/clickhouse/mining_pools_distribution.ex
+++ b/lib/sanbase/clickhouse/mining_pools_distribution.ex
@@ -15,11 +15,12 @@ defmodule Sanbase.Clickhouse.MiningPoolsDistribution do
         }
 
   @spec distribution(
+          String.t(),
           DateTime.t(),
           DateTime.t(),
           String.t()
         ) :: {:ok, list(distribution)} | {:error, String.t()}
-  def distribution(from, to, interval) do
+  def distribution("ethereum", from, to, interval) do
     {query, args} = distribution_query(from, to, interval)
 
     ClickhouseRepo.query_transform(
@@ -35,6 +36,8 @@ defmodule Sanbase.Clickhouse.MiningPoolsDistribution do
       end
     )
   end
+
+  def distribution(_, _, _, _), do: {:error, "Currently only ethereum is supported!"}
 
   defp distribution_query(from, to, interval) do
     from_datetime_unix = DateTime.to_unix(from)

--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -85,10 +85,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
 
   def mining_pools_distribution(
         _root,
-        %{from: from, to: to, interval: interval},
+        %{slug: slug, from: from, to: to, interval: interval},
         _resolution
       ) do
-    case MiningPoolsDistribution.distribution(from, to, interval) do
+    case MiningPoolsDistribution.distribution(slug, from, to, interval) do
       {:ok, distribution} ->
         {:ok, distribution}
 

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -918,6 +918,7 @@ defmodule SanbaseWeb.Graphql.Schema do
     Currently only ETH is supported.
     """
     field :mining_pools_distribution, list_of(:mining_pools_distribution) do
+      arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:interval, :string, default_value: "1d")

--- a/test/sanbase/clickhouse/mining_pools_distribution_test.exs
+++ b/test/sanbase/clickhouse/mining_pools_distribution_test.exs
@@ -7,6 +7,7 @@ defmodule Sanbase.Clickhouse.MiningPoolsDistributionTest do
 
   setup do
     [
+      slug: "ethereum",
       from: from_iso8601!("2019-01-01T00:00:00Z"),
       to: from_iso8601!("2019-01-03T00:00:00Z"),
       interval: "1d"
@@ -25,7 +26,13 @@ defmodule Sanbase.Clickhouse.MiningPoolsDistributionTest do
            ]
          }}
       end do
-      result = MiningPoolsDistribution.distribution(context.from, context.to, context.interval)
+      result =
+        MiningPoolsDistribution.distribution(
+          context.slug,
+          context.from,
+          context.to,
+          context.interval
+        )
 
       assert result ==
                {:ok,
@@ -65,7 +72,7 @@ defmodule Sanbase.Clickhouse.MiningPoolsDistributionTest do
            ]
          }}
       end do
-      result = MiningPoolsDistribution.distribution(context.from, context.to, "2d")
+      result = MiningPoolsDistribution.distribution(context.slug, context.from, context.to, "2d")
 
       assert result ==
                {:ok,
@@ -100,9 +107,29 @@ defmodule Sanbase.Clickhouse.MiningPoolsDistributionTest do
 
   test "returns empty array when query returns no rows", context do
     with_mock Sanbase.ClickhouseRepo, query: fn _, _ -> {:ok, %{rows: []}} end do
-      result = MiningPoolsDistribution.distribution(context.from, context.to, context.interval)
+      result =
+        MiningPoolsDistribution.distribution(
+          context.slug,
+          context.from,
+          context.to,
+          context.interval
+        )
 
       assert result == {:ok, []}
+    end
+  end
+
+  test "returns error when something except ethereum is requested", context do
+    with_mock Sanbase.ClickhouseRepo, query: fn _, _ -> {:ok, %{rows: []}} end do
+      result =
+        MiningPoolsDistribution.distribution(
+          "unsupported",
+          context.from,
+          context.to,
+          context.interval
+        )
+
+      assert result == {:error, "Currently only ethereum is supported!"}
     end
   end
 end


### PR DESCRIPTION
#### Summary
It was a mistake to omit the slug in this query, so introducing it here. 

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
