### PR TITLE
Better handle errors from user_by_token function

### DIFF
--- a/lib/sanbase/auth/apikey/apikey.ex
+++ b/lib/sanbase/auth/apikey/apikey.ex
@@ -29,10 +29,14 @@ defmodule Sanbase.Auth.Apikey do
   @spec apikey_to_user(String.t()) :: {:ok, %User{}} | {:error, String.t()}
   def apikey_to_user(apikey) do
     with {:ok, {token, _rest}} <- Hmac.split_apikey(apikey),
-         {:valid?, true} <- {:valid?, Hmac.apikey_valid?(token, apikey)} do
-      UserApikeyToken.user_by_token(token)
+         {:valid?, true} <- {:valid?, Hmac.apikey_valid?(token, apikey)},
+         {:user?, {:ok, user}} <- {:user?, UserApikeyToken.user_by_token(token)} do
+      {:ok, user}
     else
       {:valid?, false} ->
+        {:error, "Apikey '#{apikey}' is not valid"}
+
+      {:user?, _} ->
         {:error, "Apikey '#{apikey}' is not valid"}
 
       {:error, error} ->

--- a/test/sanbase/auth/apikey/apikey_test.exs
+++ b/test/sanbase/auth/apikey/apikey_test.exs
@@ -51,7 +51,7 @@ defmodule Sanbase.Auth.ApiKeyTest do
 
     # Revoke the apikey and expect it to be non valid
     :ok = Apikey.revoke_apikey(user, apikey)
-    assert {:error, "Apikey not valid or malformed"} == Apikey.apikey_to_user(apikey)
+    assert {:error, "Apikey '#{apikey}' is not valid"} == Apikey.apikey_to_user(apikey)
   end
 
   test "get list of apikeys", %{user: user} do


### PR DESCRIPTION
Unify the error messages when the provided apikey is not valid
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->