### PR TITLE
Change the default basic auth name and password in dev mode

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -92,8 +92,8 @@ config :sanbase, Sanbase.ExternalServices.Etherscan.RateLimiter,
   time_between_requests: 250
 
 config :sanbase, SanbaseWeb.Graphql.ContextPlug,
-  basic_auth_username: "user",
-  basic_auth_password: "pass"
+  basic_auth_username: "admin",
+  basic_auth_password: "admin"
 
 config :arc,
   storage: Arc.Storage.Local,


### PR DESCRIPTION
This is because the browser remembers the basic auth for /admin on dev
and sends the same authorization header to /graphiql which returns
an error

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
