### PR TITLE
Add env variable DOCKER_BULIDKITT=1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 podTemplate(label: 'sanbase-builder', containers: [
   containerTemplate(name: 'docker', image: 'docker', ttyEnabled: true, command: 'cat', envVars: [
-    envVar(key: 'DOCKER_HOST', value: 'tcp://docker-host-docker-host:2375')
+    envVar(key: 'DOCKER_HOST', value: 'tcp://docker-host-docker-host:2375'),
+    envVar(key: 'DOCKER_BUILDKIT', value: '1')
   ])
 ]) {
   node('sanbase-builder') {
@@ -9,7 +10,11 @@ podTemplate(label: 'sanbase-builder', containers: [
         def scmVars = checkout scm
         def gitHead = scmVars.GIT_COMMIT.substring(0,7)
 
-        sh "docker build -t sanbase-test:${scmVars.GIT_COMMIT}-${env.BUILD_ID}-${env.CHANGE_ID} -f Dockerfile-test ."
+        sh "docker build \
+          -t sanbase-test:${scmVars.GIT_COMMIT}-${env.BUILD_ID}-${env.CHANGE_ID} \
+          -f Dockerfile-test . \
+          --progress plain"
+
         sh "docker run --rm --name test-postgres-${scmVars.GIT_COMMIT}-${env.BUILD_ID}-${env.CHANGE_ID} -d timescale/timescaledb:0.10.1-pg10"
         sh "docker run --rm --name test-influxdb-${scmVars.GIT_COMMIT}-${env.BUILD_ID}-${env.CHANGE_ID} -d influxdb:1.7-alpine"
         try {
@@ -41,7 +46,13 @@ podTemplate(label: 'sanbase-builder', containers: [
 
             def awsRegistry = "${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com"
             docker.withRegistry("https://${awsRegistry}", "ecr:eu-central-1:ecr-credentials") {
-              sh "docker build -t ${awsRegistry}/sanbase:${env.BRANCH_NAME} -t ${awsRegistry}/sanbase:${scmVars.GIT_COMMIT} --build-arg SECRET_KEY_BASE=${env.SECRET_KEY_BASE} --build-arg GIT_HEAD=${gitHead} ."
+              sh "docker build \
+                -t ${awsRegistry}/sanbase:${env.BRANCH_NAME} \
+                -t ${awsRegistry}/sanbase:${scmVars.GIT_COMMIT} \
+                --build-arg SECRET_KEY_BASE=${env.SECRET_KEY_BASE} \
+                --build-arg GIT_HEAD=${gitHead} . \
+                --progress plain"
+
               sh "docker push ${awsRegistry}/sanbase:${env.BRANCH_NAME}"
               sh "docker push ${awsRegistry}/sanbase:${scmVars.GIT_COMMIT}"
             }


### PR DESCRIPTION
It is used so the build time of each layer can be measured
If the Docker version is above 18.09 then the docker build would look like this
![image](https://user-images.githubusercontent.com/6518376/58717943-0fed6680-83d5-11e9-8666-bc9ac5b9d304.png)

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
