### PR TITLE
Limit the number of exchange wallets that can be returned

### DIFF
--- a/lib/sanbase/model/exchange_address.ex
+++ b/lib/sanbase/model/exchange_address.ex
@@ -47,6 +47,18 @@ defmodule Sanbase.Model.ExchangeAddress do
 
   def exchange_names_by_infrastructure(_), do: []
 
+  @doc ~s"List all exchange wallets"
+  @spec exchange_wallets_by_infrastructure(%Infrastructure{}) :: list(String.t())
+  def exchange_wallets_by_infrastructure(%Infrastructure{} = infr) do
+    from(e in __MODULE__,
+      where: e.infrastructure_id == ^infr.id,
+      limit: 5000
+    )
+    |> Repo.all()
+  end
+
+  def exchange_wallets_by_infrastructure(_), do: []
+
   # TODO: This limit is temporary and the whole logic should be reworked so
   # the Bitcoin addresses are also present in CH and does not need to be loaded
   # in sanbase in order to calculate them
@@ -56,7 +68,7 @@ defmodule Sanbase.Model.ExchangeAddress do
     from(e in __MODULE__,
       where: e.name == ^exchange,
       select: e.address,
-      limit: 100
+      limit: 5000
     )
     |> Repo.all()
     |> case do

--- a/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
@@ -6,8 +6,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
   import Sanbase.Utils.ErrorHandling,
     only: [log_graphql_error: 2, graphql_error_msg: 2]
 
-  alias Sanbase.Repo
-  alias Sanbase.Model.{Project, ExchangeAddress}
+  alias Sanbase.Model.{Infrastructure, Project, ExchangeAddress}
 
   alias Sanbase.Blockchain.{
     TokenVelocity,
@@ -231,7 +230,15 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
     end
   end
 
-  def exchange_wallets(_root, _args, _resolution) do
-    {:ok, ExchangeAddress |> Repo.all() |> Repo.preload(:infrastructure)}
+  def exchange_wallets(_root, %{slug: "ethereum"}, _resolution) do
+    {:ok, ExchangeAddress.exchange_wallets_by_infrastructure(Infrastructure.get("ETH"))}
+  end
+
+  def exchange_wallets(_root, %{slug: "bitcoin"}, _resolution) do
+    {:ok, ExchangeAddress.exchange_wallets_by_infrastructure(Infrastructure.get("BTC"))}
+  end
+
+  def exchange_wallets(_, _, _) do
+    {:error, "Currently only ethereum and bitcoin exchanges are supported"}
   end
 end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -731,6 +731,7 @@ defmodule SanbaseWeb.Graphql.Schema do
 
     @desc "Fetch a list of all exchange wallets. This query requires basic authentication."
     field :exchange_wallets, list_of(:wallet) do
+      arg(:slug, :string, default_value: "ethereum")
       middleware(BasicAuth)
 
       cache_resolve(&EtherbiResolver.exchange_wallets/3)

--- a/test/sanbase_web/graphql/blockchain/etherbi_exchange_wallets_api_test.exs
+++ b/test/sanbase_web/graphql/blockchain/etherbi_exchange_wallets_api_test.exs
@@ -3,10 +3,8 @@ defmodule Sanbase.Etherbi.ExchangeWalletsApiTest do
   @moduletag checkout_repo: [Sanbase.Repo, Sanbase.TimescaleRepo]
   @moduletag timescaledb: true
 
-  alias Sanbase.Model.ExchangeAddress
-  alias Sanbase.Repo
-
   import SanbaseWeb.Graphql.TestHelpers
+  import Sanbase.Factory
 
   setup do
     [
@@ -53,16 +51,15 @@ defmodule Sanbase.Etherbi.ExchangeWalletsApiTest do
   end
 
   test "returning a list of wallets from the DB", context do
-    %ExchangeAddress{name: "Binance", address: "0x12345"}
-    |> Repo.insert!()
+    infr = insert(:infrastructure_eth)
 
-    %ExchangeAddress{name: "Kraken", address: "0x54321"}
-    |> Repo.insert!()
+    insert(:exchange_address, %{address: "0x12345", name: "Binance", infrastructure_id: infr.id})
+    insert(:exchange_address, %{address: "0x54321", name: "Kraken", infrastructure_id: infr.id})
 
     query = """
     {
       exchangeWallets{
-        address,
+        address
         name
       }
     }


### PR DESCRIPTION
There was no filtering on infrastructure so it fetched all 1.7 million
Bitcoin wallets. This lead to OOM as they were loaded into memory

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
