### PR TITLE
Add available_metrics field in the project type

### DIFF
--- a/lib/sanbase/model/project/available_metrics.ex
+++ b/lib/sanbase/model/project/available_metrics.ex
@@ -1,0 +1,222 @@
+defmodule Sanbase.Model.Project.AvailableMetrics do
+  @moduledoc ~s"""
+  Module for determining what metrics are available for a given project
+  """
+
+  alias Sanbase.Model.Project
+  require SanbaseWeb.Graphql.Schema
+
+  @doc ~s"""
+  Return a list of all GraphQL query names that have an argument `slug`
+  """
+  @spec all :: [String.t()]
+  def all() do
+    project_queries()
+  end
+
+  @doc ~s"""
+  Return a listo of all GraphQL query names that have data for the provided
+  project identified by a `slug` argument.
+
+  In order to determine which metrics are available a list of rules is appled.
+  These rules include checking for twitter link, github link, ethereum or
+  bitcoin addresses, icos, presence in the list of project with social metrics,
+  etc.
+  """
+  @spec get(Sanbase.Model.Project.t()) :: [String.t()]
+  def get(%Project{} = project) do
+    [
+      &slug_metrics/1,
+      &github_metrics/1,
+      &twitter_metrics/1,
+      &social_metrics/1,
+      &blockchain_metrics/1,
+      &database_defined_metrics/1,
+      &wallets_metrics/1,
+      &ico_metrics/1
+    ]
+    |> Enum.flat_map(fn fun -> fun.(project) end)
+    |> Enum.uniq()
+  end
+
+  # Metrics can also be added from the admin dashboard
+  defp database_defined_metrics(%Project{} = _project) do
+    []
+  end
+
+  defp ico_metrics(%Project{} = project) do
+    project
+    |> Sanbase.Repo.preload([:icos])
+    |> case do
+      %Project{icos: icos} when icos != [] ->
+        [
+          "icos",
+          "icoPrice",
+          "initialIco",
+          "fundsRaisedUsdIcoEndPrice",
+          "fundsRaisedEthIcoEndPrice",
+          "fundsRaisedBtcIcoEndPrice"
+        ]
+
+      _ ->
+        []
+    end
+  end
+
+  defp wallets_metrics(%Project{} = project) do
+    project =
+      project
+      |> Sanbase.Repo.preload([:eth_addresses, :btc_addresses])
+
+    eth_wallet_metrics =
+      case project do
+        %Project{eth_addresses: addresses} when addresses != [] ->
+          ["ethSpent", "ethSpentOverTime", "ethTopTransactions", "ethBalance", "usdBalance"]
+
+        _ ->
+          []
+      end
+
+    btc_wallet_metrics =
+      case project do
+        %Project{btc_addresses: addresses} when addresses != [] ->
+          ["btcBalance", "usdBalance"]
+
+        _ ->
+          []
+      end
+
+    btc_wallet_metrics ++ eth_wallet_metrics
+  end
+
+  defp slug_metrics(%Project{coinmarketcap_id: slug}) do
+    case slug do
+      slug when is_binary(slug) and slug != "" ->
+        ["historyPrice", "ohlc", "priceVolumeDiff"]
+
+      _ ->
+        []
+    end
+  end
+
+  defp github_metrics(%Project{} = project) do
+    case Project.github_organization(project) do
+      {:ok, _} ->
+        [
+          "devActivity",
+          "githubActivity",
+          "aveargeDevActivity",
+          "averageGithubActivity"
+        ]
+
+      _ ->
+        []
+    end
+  end
+
+  defp twitter_metrics(%Project{twitter_link: twitter_link}) do
+    case twitter_link do
+      l when is_binary(l) and l != "" -> ["historyTwitterData", "twitterData"]
+      _ -> []
+    end
+  end
+
+  defp social_metrics(%Project{coinmarketcap_id: slug}) do
+    common_social_metrics = [
+      "socialGainersLosersStatus"
+    ]
+
+    case slug in social_volume_projects() do
+      true -> common_social_metrics ++ ["socialVolume", "socialDominance"]
+      false -> common_social_metrics
+    end
+  end
+
+  @mineable_specific_metrics ["exchangeWallets", "allExchanges"]
+
+  @ethereum_specific_metrics [
+    "exchangeWallets",
+    "miningPoolsDistribution",
+    "dailyActiveDeposits",
+    "gasUsed"
+  ]
+
+  @erc20_specific_metrics [
+    "exchangeFundsFlow",
+    "historicalBalance",
+    "topHoldersPercentOfTotalSupply",
+    "percentOfTokenSupplyOnExchanges",
+    "shareOfDeposits",
+    "tokenTopTransactions"
+  ]
+
+  @bitcoin_specific_metrics []
+
+  @common_blockchain_metrics [
+    "realizedValue",
+    "networkGrowth",
+    "mvrvRatio",
+    "dailyActiveAddresses",
+    "tokenAgeConsumed",
+    "burnRate",
+    "averageTokenAgeConsumedInDays",
+    "tokenVelocity",
+    "nvtRatio",
+    "transactionVolume",
+    "tokenCirculation"
+  ]
+
+  defp blockchain_metrics(%Project{} = project) do
+    is_erc20? = Project.is_erc20?(project)
+
+    case {project, is_erc20?} do
+      {%Project{coinmarketcap_id: "ethereum"}, _} ->
+        @mineable_specific_metrics ++
+          @ethereum_specific_metrics ++ @erc20_specific_metrics ++ @common_blockchain_metrics
+
+      {%Project{coinmarketcap_id: "bitcoin"}, _} ->
+        @mineable_specific_metrics ++ @bitcoin_specific_metrics ++ @common_blockchain_metrics
+
+      {_, true} ->
+        @erc20_specific_metrics ++ @common_blockchain_metrics
+
+      _ ->
+        []
+    end
+  end
+
+  defp project_queries() do
+    {:ok, result} = Absinthe.run(available_queries_query(), SanbaseWeb.Graphql.Schema, [])
+    %{data: %{"__schema" => %{"queryType" => %{"fields" => fields}}}} = result
+
+    fields
+    |> Enum.filter(fn %{"args" => args} ->
+      Enum.any?(args, fn elem -> elem == %{"name" => "slug"} end)
+    end)
+    |> Enum.reject(fn %{"isDeprecated" => is_deprecated} -> is_deprecated == true end)
+    |> Enum.map(& &1["name"])
+  end
+
+  defp available_queries_query() do
+    """
+    query availableQueries {
+      __schema {
+        queryType {
+          fields {
+            isDeprecated
+            name
+            args{
+              name
+            }
+          }
+        }
+      }
+    }
+    """
+  end
+
+  defp social_volume_projects() do
+    {:ok, projeccts} = Sanbase.TechIndicators.social_volume_projects()
+    projeccts
+  end
+end

--- a/lib/sanbase/model/project/available_metrics.ex
+++ b/lib/sanbase/model/project/available_metrics.ex
@@ -215,8 +215,16 @@ defmodule Sanbase.Model.Project.AvailableMetrics do
     """
   end
 
+  # Fetch and cache the social volume projects for 30 minutes
   defp social_volume_projects() do
-    {:ok, projeccts} = Sanbase.TechIndicators.social_volume_projects()
-    projeccts
+    SanbaseWeb.Graphql.Cache.func(
+      fn ->
+        {:ok, projects} = Sanbase.TechIndicators.social_volume_projects()
+        projects
+      end,
+      :social_volume_projects_list,
+      %{},
+      ttl: 1800
+    ).()
   end
 end

--- a/lib/sanbase/model/project/available_metrics.ex
+++ b/lib/sanbase/model/project/available_metrics.ex
@@ -15,7 +15,7 @@ defmodule Sanbase.Model.Project.AvailableMetrics do
   end
 
   @doc ~s"""
-  Return a listo of all GraphQL query names that have data for the provided
+  Return a list of all GraphQL query names that have data for the provided
   project identified by a `slug` argument.
 
   In order to determine which metrics are available a list of rules is appled.

--- a/lib/sanbase/model/project/project.ex
+++ b/lib/sanbase/model/project/project.ex
@@ -307,6 +307,14 @@ defmodule Sanbase.Model.Project do
   def is_erc20?(%Project{} = project) do
     project
     |> Repo.preload(:infrastructure)
+    |> case do
+      %Project{main_contract_address: contract, infrastructure: %Infrastructure{code: "ETH"}}
+      when not is_nil(contract) ->
+        true
+
+      _ ->
+        false
+    end
   end
 
   def preloads(), do: @preloads

--- a/lib/sanbase/signals.ex
+++ b/lib/sanbase/signals.ex
@@ -14,7 +14,7 @@ defmodule Sanbase.Application.Signals do
       Sanbase.TimescaleRepo,
 
       # Start the Clickhouse Repo
-      start_in({Sanbase.ClickhouseRepo, []}, [:dev, :prod]),
+      start_in({Sanbase.ClickhouseRepo, []}, [:prod]),
 
       # Start the signal evaluator cache
       Supervisor.child_spec(

--- a/lib/sanbase/web.ex
+++ b/lib/sanbase/web.ex
@@ -19,7 +19,7 @@ defmodule Sanbase.Application.Web do
       Sanbase.TimescaleRepo,
 
       # Start the Clickhouse Repo
-      start_in({Sanbase.ClickhouseRepo, []}, [:dev, :prod]),
+      start_in({Sanbase.ClickhouseRepo, []}, [:prod]),
 
       # Start the Elasticsearch Cluster connection
       Sanbase.Elasticsearch.Cluster,

--- a/lib/sanbase_web/graphql/middlewares/api_usage.ex
+++ b/lib/sanbase_web/graphql/middlewares/api_usage.ex
@@ -93,4 +93,6 @@ defmodule SanbaseWeb.Graphql.Middlewares.ApiUsage do
     Logger.reset_metadata([{:query, definition.name} | metadata])
     resolution
   end
+
+  def call(resolution, _), do: resolution
 end

--- a/lib/sanbase_web/graphql/middlewares/project_permissions.ex
+++ b/lib/sanbase_web/graphql/middlewares/project_permissions.ex
@@ -28,7 +28,8 @@ defmodule SanbaseWeb.Graphql.Middlewares.ProjectPermissions do
       "funds_raised_icos",
       "funds_raised_eth_ico_end_price",
       "funds_raised_usd_ico_end_price",
-      "funds_raised_btc_ico_end_price"
+      "funds_raised_btc_ico_end_price",
+      "available_metrics"
     ]
 
     requested_fields = requested_fields(resolution)

--- a/lib/sanbase_web/graphql/resolvers/project/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_resolver.ex
@@ -16,6 +16,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
   alias SanbaseWeb.Graphql.Resolvers.ProjectBalanceResolver
   alias SanbaseWeb.Graphql.SanbaseDataloader
 
+  def available_metrics(%Project{} = project, _args, _resolution) do
+    available_metrics = Project.AvailableMetrics.get(project)
+    {:ok, available_metrics}
+  end
+
   def projects_count(_root, args, _resolution) do
     min_volume = Map.get(args, :min_volume)
 

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -529,7 +529,7 @@ defmodule SanbaseWeb.Graphql.Schema do
     Returns a list of slugs for which there is social volume data.
     """
     field :social_volume_projects, list_of(:string) do
-      resolve(&TechIndicatorsResolver.social_volume_projects/3)
+      cache_resolve(&TechIndicatorsResolver.social_volume_projects/3)
     end
 
     @desc ~s"""

--- a/lib/sanbase_web/graphql/schema/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/project_types.ex
@@ -23,6 +23,10 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
   A type fully describing a project.
   """
   object :project do
+    field :available_metrics, list_of(:string) do
+      cache_resolve(&ProjectResolver.available_metrics/3, ttl: 1800)
+    end
+
     field(:id, non_null(:id))
     field(:name, non_null(:string))
     field(:ticker, :string)

--- a/test/sanbase/project/project_available_metrics_test.exs
+++ b/test/sanbase/project/project_available_metrics_test.exs
@@ -1,0 +1,144 @@
+defmodule Sanbase.Project.AvailableMetricsTest do
+  use Sanbase.DataCase, async: false
+
+  import Mock
+  import Sanbase.Factory
+
+  alias Sanbase.Model.Project.AvailableMetrics
+
+  @slug_metrics [
+    "historyPrice",
+    "ohlc",
+    "priceVolumeDiff",
+    "socialGainersLosersStatus",
+    "socialVolume",
+    "socialDominance"
+  ]
+
+  setup_with_mocks([
+    {Sanbase.TechIndicators, [],
+     [social_volume_projects: fn -> {:ok, ["bitcoin", "ethereum", "santiment"]} end]}
+  ]) do
+    []
+  end
+
+  test "btcBalance present only when there are btc addresses" do
+    project_with_btc =
+      insert(:project, %{
+        coinmarketcap_id: rand_str(),
+        btc_addresses: [build(:project_btc_address)]
+      })
+
+    project_without_btc =
+      insert(:project, %{
+        coinmarketcap_id: rand_str(),
+        btc_addresses: []
+      })
+
+    assert "btcBalance" in AvailableMetrics.get(project_with_btc)
+    assert "btcBalance" not in AvailableMetrics.get(project_without_btc)
+  end
+
+  test "ethBalance present only when there are eth addresses" do
+    project_with_eth =
+      insert(:project, %{
+        coinmarketcap_id: rand_str(),
+        eth_addresses: [build(:project_eth_address)]
+      })
+
+    project_without_eth =
+      insert(:project, %{
+        coinmarketcap_id: rand_str(),
+        eth_addresses: []
+      })
+
+    assert "ethBalance" in AvailableMetrics.get(project_with_eth)
+    assert "ethBalance" not in AvailableMetrics.get(project_without_eth)
+  end
+
+  test "ethereum has specific metrics" do
+    project =
+      insert(:project, %{
+        coinmarketcap_id: "ethereum",
+        github_link: "https://github.com/ethereum",
+        eth_addresses: [build(:project_eth_address)]
+      })
+
+    available_metrics = AvailableMetrics.get(project)
+    assert "gasUsed" in available_metrics
+    assert "allExchanges" in available_metrics
+    assert "exchangeWallets" in available_metrics
+  end
+
+  test "bitcoin has specific metrics" do
+    project =
+      insert(:project, %{
+        coinmarketcap_id: "bitcoin",
+        github_link: "https://github.com/bitcoin"
+      })
+
+    available_metrics = AvailableMetrics.get(project)
+
+    # There is no gas used for Bitcoin
+    assert "gasUsed" not in available_metrics
+    assert "allExchanges" in available_metrics
+    assert "exchangeWallets" in available_metrics
+  end
+
+  test "project with slug only" do
+    # Override default values
+    project =
+      insert(:project, %{
+        coinmarketcap_id: "santiment",
+        github_link: nil,
+        infrastructure: nil,
+        main_contract_address: nil,
+        eth_addresses: []
+      })
+
+    assert AvailableMetrics.get(project) == @slug_metrics
+  end
+
+  test "project with slug, github, infrastructure, contract and eth addresses" do
+    project =
+      insert(:project, %{
+        coinmarketcap_id: "santiment",
+        github_link: "https://github.com/santiment",
+        infrastructure: build(:infrastructure, %{code: "ETH"}),
+        main_contract_address: "0x" <> rand_hex_str(),
+        eth_addresses: [build(:project_eth_address)]
+      })
+
+    available_metrics = AvailableMetrics.get(project)
+
+    # some github metrics
+    assert Enum.all?(
+             ["githubActivity", "aveargeDevActivity", "averageGithubActivity"],
+             &Enum.member?(available_metrics, &1)
+           )
+
+    # some slug metrics
+    assert Enum.all?(
+             @slug_metrics,
+             &Enum.member?(available_metrics, &1)
+           )
+
+    # some eth addresses metrics
+    assert Enum.all?(
+             ["ethSpent", "ethSpentOverTime", "ethTopTransactions", "ethBalance"],
+             &Enum.member?(available_metrics, &1)
+           )
+
+    # some ERC20 metrics
+    assert Enum.all?(
+             [
+               "dailyActiveAddresses",
+               "transactionVolume",
+               "tokenVelocity",
+               "exchangeFundsFlow",
+               "historicalBalance"
+             ],
+             &Enum.member?(available_metrics, &1)
+           )
+  end
+end

--- a/test/support/sanbase_factory.ex
+++ b/test/support/sanbase_factory.ex
@@ -10,6 +10,7 @@ defmodule Sanbase.Factory do
     Project,
     ExchangeAddress,
     ProjectEthAddress,
+    ProjectBtcAddress,
     Infrastructure,
     MarketSegment,
     LatestCoinmarketcapData,
@@ -129,6 +130,14 @@ defmodule Sanbase.Factory do
   def project_eth_address_factory() do
     %ProjectEthAddress{
       address: "0x" <> (:crypto.strong_rand_bytes(16) |> Base.encode16()),
+      source: "",
+      comments: ""
+    }
+  end
+
+  def project_btc_address_factory() do
+    %ProjectBtcAddress{
+      address: :crypto.strong_rand_bytes(16) |> Base.encode16(),
       source: "",
       comments: ""
     }


### PR DESCRIPTION
#### Summary
```grapqhl
{
  projectBySlug(slug: "sentiment"){ availableMetrics }
}
```

```graphql
{
  "data": {
    "projectBySlug": {
      "availableMetrics": ["devActivity", "ethSpentOverTime", "tokenAgeConsumed", "ethTopTransactions" ...]
    }
  }
}
```
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
