### PR TITLE
Consistency of GraphQL query and mutation names

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/user/user_list_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/user_list_resolver.ex
@@ -80,6 +80,16 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserListResolver do
     UserList.fetch_all_public_lists()
   end
 
+  def watchlist(_root, %{id: id}, %{
+        context: %{auth: %{current_user: current_user}}
+      }) do
+    UserList.user_list(id, current_user)
+  end
+
+  def watchlist(_root, %{id: id}, _resolution) do
+    UserList.user_list(id, %User{id: nil})
+  end
+
   def user_list(_root, %{user_list_id: user_list_id}, %{
         context: %{auth: %{current_user: current_user}}
       }) do

--- a/lib/sanbase_web/graphql/schema/queries/insight_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/insight_queries.ex
@@ -25,6 +25,17 @@ defmodule SanbaseWeb.Graphql.Schema.InsightQueries do
     The user must be logged in to access all fields for the post/insight.
     """
     field :post, :post do
+      deprecate("Use `insight` instead")
+      arg(:id, non_null(:integer))
+
+      resolve(&PostResolver.post/3)
+    end
+
+    @desc ~s"""
+    Fetch the insight with the given ID.
+    The user must be logged in to access all fields for the post/insight.
+    """
+    field :insight, :post do
       arg(:id, non_null(:integer))
 
       resolve(&PostResolver.post/3)
@@ -80,6 +91,24 @@ defmodule SanbaseWeb.Graphql.Schema.InsightQueries do
     immutable and can no longer be updated.
     """
     field :create_post, :post do
+      deprecate("Use `createInsight` instead")
+      arg(:title, non_null(:string))
+      arg(:short_desc, :string)
+      arg(:link, :string)
+      arg(:text, :string)
+      arg(:image_urls, list_of(:string))
+      arg(:tags, list_of(:string))
+
+      middleware(JWTAuth)
+      resolve(&PostResolver.create_post/3)
+    end
+
+    @desc """
+    Create an insight. After creation the insight is not visible to anyone but the author.
+    To be visible to anyone, the insight must be published. By publishing it also becomes
+    immutable and can no longer be updated.
+    """
+    field :create_insight, :post do
       arg(:title, non_null(:string))
       arg(:short_desc, :string)
       arg(:link, :string)
@@ -96,6 +125,24 @@ defmodule SanbaseWeb.Graphql.Schema.InsightQueries do
     A post can be updated if it is not yet published.
     """
     field :update_post, :post do
+      deprecate("Use `updateInsight` instead")
+      arg(:id, non_null(:id))
+      arg(:title, :string)
+      arg(:short_desc, :string)
+      arg(:link, :string)
+      arg(:text, :string)
+      arg(:image_urls, list_of(:string))
+      arg(:tags, list_of(:string))
+
+      middleware(JWTAuth)
+      resolve(&PostResolver.update_post/3)
+    end
+
+    @desc """
+    Update an insight if and only if the currently logged in user is the creator of the insight
+    An insight can be updated if it is not yet published.
+    """
+    field :update_insight, :post do
       arg(:id, non_null(:id))
       arg(:title, :string)
       arg(:short_desc, :string)
@@ -110,6 +157,16 @@ defmodule SanbaseWeb.Graphql.Schema.InsightQueries do
 
     @desc "Delete a post. The post must be owned by the user currently logged in."
     field :delete_post, :post do
+      deprecate("Use `deleteInsight` instead")
+
+      arg(:id, non_null(:id))
+
+      middleware(JWTAuth)
+      resolve(&PostResolver.delete_post/3)
+    end
+
+    @desc "Delete an insight. The insight must be owned by the user currently logged in."
+    field :delete_insight, :post do
       arg(:id, non_null(:id))
 
       middleware(JWTAuth)
@@ -139,8 +196,8 @@ defmodule SanbaseWeb.Graphql.Schema.InsightQueries do
     Vote for an insight. The user must logged in.
     """
     field :vote, :post do
-      arg(:post_id, non_null(:integer))
-
+      arg(:post_id, :integer, deprecate: "Use `insightId` instead")
+      arg(:insight_id, :integer)
       middleware(JWTAuth)
       resolve(&InsightResolver.vote/3)
     end
@@ -149,8 +206,8 @@ defmodule SanbaseWeb.Graphql.Schema.InsightQueries do
     Remove your vote for an insight. The user must logged in.
     """
     field :unvote, :post do
-      arg(:post_id, non_null(:integer))
-
+      arg(:post_id, :integer, deprecate: "Use `insightId` instead")
+      arg(:insight_id, :integer)
       middleware(JWTAuth)
       resolve(&InsightResolver.unvote/3)
     end

--- a/lib/sanbase_web/graphql/schema/queries/watchlist_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/watchlist_queries.ex
@@ -16,16 +16,34 @@ defmodule SanbaseWeb.Graphql.Schema.WatchlistQueries do
   object :user_list_queries do
     @desc "Fetch all favourites lists for current_user."
     field :fetch_user_lists, list_of(:user_list) do
+      deprecate("Use `fetchWatchlists` instead")
+      resolve(&UserListResolver.fetch_user_lists/3)
+    end
+
+    @desc "Fetch all watchlists for the current user"
+    field :fetch_watchlists, list_of(:user_list) do
       resolve(&UserListResolver.fetch_user_lists/3)
     end
 
     @desc "Fetch all public favourites lists for current_user."
     field :fetch_public_user_lists, list_of(:user_list) do
+      deprecate("Use `fetchPublicWatchlists` instead")
+      resolve(&UserListResolver.fetch_public_user_lists/3)
+    end
+
+    @desc "Fetch all public watchlists for current_user."
+    field :fetch_public_watchlists, list_of(:user_list) do
       resolve(&UserListResolver.fetch_public_user_lists/3)
     end
 
     @desc "Fetch all public favourites lists"
     field :fetch_all_public_user_lists, list_of(:user_list) do
+      deprecate("Use `fetchAllPublicWatchlists` instead")
+      resolve(&UserListResolver.fetch_all_public_user_lists/3)
+    end
+
+    @desc "Fetch all public watchlists"
+    field :fetch_all_public_watchlists, list_of(:user_list) do
       resolve(&UserListResolver.fetch_all_public_user_lists/3)
     end
 
@@ -35,9 +53,15 @@ defmodule SanbaseWeb.Graphql.Schema.WatchlistQueries do
     This query returns either a single user list item or null.
     """
     field :user_list, :user_list do
+      deprecate("Use `watchlist` with argument `id` instead")
       arg(:user_list_id, non_null(:id))
 
       cache_resolve(&UserListResolver.user_list/3)
+    end
+
+    field :watchlist, :user_list do
+      arg(:id, non_null(:id))
+      cache_resolve(&UserListResolver.watchlist/3)
     end
   end
 
@@ -46,6 +70,20 @@ defmodule SanbaseWeb.Graphql.Schema.WatchlistQueries do
     Create user favourites list.
     """
     field :create_user_list, :user_list do
+      deprecate("Use `createWatchlist` instead")
+      arg(:name, non_null(:string))
+      arg(:is_public, :boolean)
+      arg(:color, :color_enum)
+      arg(:function, :json)
+
+      middleware(JWTAuth)
+      resolve(&UserListResolver.create_user_list/3)
+    end
+
+    @desc """
+    Create a watchlist.
+    """
+    field :create_watchlist, :user_list do
       arg(:name, non_null(:string))
       arg(:is_public, :boolean)
       arg(:color, :color_enum)
@@ -59,6 +97,22 @@ defmodule SanbaseWeb.Graphql.Schema.WatchlistQueries do
     Update user favourites list.
     """
     field :update_user_list, :user_list do
+      deprecate("Use `updateWatchlist` instead")
+      arg(:id, non_null(:integer))
+      arg(:name, :string)
+      arg(:is_public, :boolean)
+      arg(:color, :color_enum)
+      arg(:function, :json)
+      arg(:list_items, list_of(:input_list_item))
+
+      middleware(JWTAuth)
+      resolve(&UserListResolver.update_user_list/3)
+    end
+
+    @desc """
+    Update a watchlist
+    """
+    field :update_watchlist, :user_list do
       arg(:id, non_null(:integer))
       arg(:name, :string)
       arg(:is_public, :boolean)
@@ -72,6 +126,14 @@ defmodule SanbaseWeb.Graphql.Schema.WatchlistQueries do
 
     @desc "Remove user favourites list."
     field :remove_user_list, :user_list do
+      arg(:id, non_null(:integer))
+
+      middleware(JWTAuth)
+      resolve(&UserListResolver.remove_user_list/3)
+    end
+
+    @desc "Remove a watchlist."
+    field :remove_watchlist, :user_list do
       arg(:id, non_null(:integer))
 
       middleware(JWTAuth)


### PR DESCRIPTION
#### Summary
1.  Deprecate the queries and mutations that use 'user_list' in their names in favor of
'watchlist'

2. Deprecate the queries and mutations that use `post` in their names in favor of `insight`
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->