### PR TITLE
Add assets held by an address GraphQL API

### DIFF
--- a/lib/sanbase/clickhouse/historical_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance.ex
@@ -5,6 +5,8 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
   for many different database tables and schemas.
   """
 
+  use AsyncWith
+
   alias Sanbase.Model.Project
   alias Sanbase.Clickhouse.HistoricalBalance.{EthBalance, Erc20Balance}
 
@@ -25,11 +27,14 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
   This can be combined with the historical balance query to see the historical
   balance of all currently owned assets
   """
-  @spec assets_held_by_address(address) :: list(slug)
+  @spec assets_held_by_address(address) :: {:ok, list(slug)} | {:erorr, String.t()}
   def assets_held_by_address(address) do
-    with {:ok, erc20_assets} <- Erc20Balance.assets_held_by_address(address),
-         {:ok, ethereum} <- EthBalance.assets_held_by_address(address) do
+    async with {:ok, erc20_assets} <- Erc20Balance.assets_held_by_address(address),
+               {:ok, ethereum} <- EthBalance.assets_held_by_address(address) do
       {:ok, ethereum ++ erc20_assets}
+    else
+      error ->
+        error
     end
   end
 

--- a/lib/sanbase/clickhouse/historical_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance.ex
@@ -27,7 +27,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
   This can be combined with the historical balance query to see the historical
   balance of all currently owned assets
   """
-  @spec assets_held_by_address(address) :: {:ok, list(slug)} | {:erorr, String.t()}
+  @spec assets_held_by_address(address) :: {:ok, list(slug)} | {:error, String.t()}
   def assets_held_by_address(address) do
     async with {:ok, erc20_assets} <- Erc20Balance.assets_held_by_address(address),
                {:ok, ethereum} <- EthBalance.assets_held_by_address(address) do

--- a/lib/sanbase/clickhouse/historical_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance.ex
@@ -19,6 +19,21 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
   @type interval :: String.t()
 
   @doc ~s"""
+  Return a list of the assets that a given address currently holds or
+  has held in the past.
+
+  This can be combined with the historical balance query to see the historical
+  balance of all currently owned assets
+  """
+  @spec assets_held_by_address(address) :: list(slug)
+  def assets_held_by_address(address) do
+    with {:ok, erc20_assets} <- Erc20Balance.assets_held_by_address(address),
+         {:ok, ethereum} <- EthBalance.assets_held_by_address(address) do
+      {:ok, ethereum ++ erc20_assets}
+    end
+  end
+
+  @doc ~s"""
   For a given address or list of addresses returns the ethereum balance change for the
   from-to period. The returned lists indicates the address, before balance, after balance
   and the balance change.

--- a/lib/sanbase/model/project/project_list.ex
+++ b/lib/sanbase/model/project/project_list.ex
@@ -222,13 +222,23 @@ defmodule Sanbase.Model.Project.List do
     |> Repo.all()
   end
 
-  def slugs_by_ids(ids) do
+  def slugs_by_field(values, field) do
     from(
       p in Project,
-      where: p.id in ^ids and not is_nil(p.coinmarketcap_id),
+      where: field(p, ^field) in ^values and not is_nil(p.coinmarketcap_id),
       select: p.coinmarketcap_id
     )
     |> Repo.all()
+  end
+
+  def field_slug_map(values, field) do
+    from(
+      p in Project,
+      where: field(p, ^field) in ^values and not is_nil(p.coinmarketcap_id),
+      select: {field(p, ^field), p.coinmarketcap_id}
+    )
+    |> Repo.all()
+    |> Map.new()
   end
 
   def slug_price_change_map() do
@@ -254,6 +264,12 @@ defmodule Sanbase.Model.Project.List do
   def by_slugs(slugs) when is_list(slugs) do
     projects_query()
     |> where([p], p.coinmarketcap_id in ^slugs)
+    |> Repo.all()
+  end
+
+  def by_field(values, field) when is_list(values) do
+    projects_query()
+    |> where([p], field(p, ^field) in ^values)
     |> Repo.all()
   end
 end

--- a/lib/sanbase/signals/trigger/trigger.ex
+++ b/lib/sanbase/signals/trigger/trigger.ex
@@ -152,7 +152,7 @@ defmodule Sanbase.Signals.Trigger do
 
     list_items
     |> Enum.map(fn %{project_id: id} -> id end)
-    |> Project.List.slugs_by_ids()
+    |> Project.List.slugs_by_field(:id)
     |> remove_targets_on_cooldown(trigger, :slug)
   end
 

--- a/lib/sanbase/utils/error_handling.ex
+++ b/lib/sanbase/utils/error_handling.ex
@@ -17,8 +17,10 @@ defmodule Sanbase.Utils.ErrorHandling do
     "[#{Ecto.UUID.generate()}] Can't fetch #{metric_name}"
   end
 
-  def graphql_error_msg(metric_name, slug) do
-    "[#{Ecto.UUID.generate()}] Can't fetch #{metric_name} for project with slug: #{slug}"
+  def graphql_error_msg(metric_name, identifier, opts \\ []) do
+    description = Keyword.get(opts, :description, "project with slug")
+
+    "[#{Ecto.UUID.generate()}] Can't fetch #{metric_name} for #{description}: #{identifier}"
   end
 
   def log_graphql_error(message, error) do

--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -338,14 +338,27 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
     end
   end
 
+  def assets_held_by_address(_root, %{address: address}, _resolution) do
+    case HistoricalBalance.assets_held_by_address(address) do
+      {:ok, result} ->
+        {:ok, result}
+
+      {:error, error} ->
+        error_msg = graphql_error_msg("Assets held by address", address)
+        log_graphql_error(error_msg, error)
+        {:error, error_msg}
+    end
+  end
+
   def historical_balance(
         _root,
         %{slug: slug, from: from, to: to, interval: interval, address: address},
         _resolution
       ) do
-    with {:ok, result} <- HistoricalBalance.historical_balance(address, slug, from, to, interval) do
-      {:ok, result}
-    else
+    case HistoricalBalance.historical_balance(address, slug, from, to, interval) do
+      {:ok, result} ->
+        {:ok, result}
+
       {:error, error} ->
         error_msg = graphql_error_msg("Historical Balances", slug)
         log_graphql_error(error_msg, error)

--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -9,7 +9,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
   alias SanbaseWeb.Graphql.SanbaseDataloader
 
   import Sanbase.Utils.ErrorHandling,
-    only: [log_graphql_error: 2, graphql_error_msg: 1, graphql_error_msg: 2]
+    only: [log_graphql_error: 2, graphql_error_msg: 1, graphql_error_msg: 2, graphql_error_msg: 3]
 
   alias Sanbase.Clickhouse.HistoricalBalance.MinersBalance
 
@@ -339,12 +339,13 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
   end
 
   def assets_held_by_address(_root, %{address: address}, _resolution) do
-    case HistoricalBalance.assets_held_by_address(address) do
+    HistoricalBalance.assets_held_by_address(address)
+    |> case do
       {:ok, result} ->
         {:ok, result}
 
       {:error, error} ->
-        error_msg = graphql_error_msg("Assets held by address", address)
+        error_msg = graphql_error_msg("Assets held by address", address, description: "address")
         log_graphql_error(error_msg, error)
         {:error, error_msg}
     end

--- a/lib/sanbase_web/graphql/schema/queries/blockchain_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/blockchain_queries.ex
@@ -322,6 +322,15 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     end
 
     @desc ~s"""
+    Return a list of assets that a wallet currently holds.
+    """
+    field :assets_held_by_address, list_of(:slug_balance) do
+      arg(:address, non_null(:string))
+
+      cache_resolve(&ClickhouseResolver.assets_held_by_address/3)
+    end
+
+    @desc ~s"""
     Historical balance for erc20 token or eth address.
     Returns the historical balance for a given address in the given interval.
     """

--- a/lib/sanbase_web/graphql/schema/types/clickhouse_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/clickhouse_types.ex
@@ -24,6 +24,11 @@ defmodule SanbaseWeb.Graphql.ClickhouseTypes do
     field(:gas_used, :integer)
   end
 
+  object :slug_balance do
+    field(:slug, non_null(:string))
+    field(:balance, non_null(:float))
+  end
+
   object :historical_balance do
     field(:datetime, non_null(:datetime))
     field(:balance, :float)

--- a/test/sanbase/clickhouse/historical_balance/assets_held_by_address_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/assets_held_by_address_test.exs
@@ -73,11 +73,11 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.AssetsHeldByAdderssTest do
   test "clickhouse returns error", _context do
     with_mock Sanbase.ClickhouseRepo,
       query: fn _, _ ->
-        {:eror, "Cannot execute query due to error"}
+        {:error, "Cannot execute query due to error"}
       end do
       assert HistoricalBalance.assets_held_by_address("0x123") ==
                {:error,
-                "Cannot execute ClickHouse query. Reason: no case clause matching: {:eror, \"Cannot execute query due to error\"}\n"}
+                "Cannot execute ClickHouse query. Reason: no case clause matching: {:error, \"Cannot execute query due to error\"}\n"}
     end
   end
 end

--- a/test/sanbase/clickhouse/historical_balance/assets_held_by_address_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/assets_held_by_address_test.exs
@@ -1,0 +1,83 @@
+defmodule Sanbase.Clickhouse.HistoricalBalance.AssetsHeldByAdderssTest do
+  use Sanbase.DataCase
+
+  import Mock
+  import Sanbase.Factory
+
+  alias Sanbase.Clickhouse.HistoricalBalance
+
+  require Sanbase.ClickhouseRepo
+
+  setup do
+    p1 = insert(:random_erc20_project)
+    p2 = insert(:random_erc20_project)
+
+    eth_project =
+      insert(:project, %{name: "Ethereum", coinmarketcap_id: "ethereum", ticker: "ETH"})
+
+    {:ok, [p1: p1, p2: p2, eth_project: eth_project]}
+  end
+
+  test "clickhouse returns list of results", context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn query, _ ->
+        # If the query contains `contract` return erc20 data, ethereum data otherwise
+        case String.contains?(query, "contract") do
+          true ->
+            {:ok,
+             %{
+               rows: [
+                 [
+                   context.p1.main_contract_address,
+                   Sanbase.Math.ipow(10, context.p1.token_decimals) * 100
+                 ],
+                 [
+                   context.p2.main_contract_address,
+                   Sanbase.Math.ipow(10, context.p1.token_decimals) * 200
+                 ]
+               ]
+             }}
+
+          false ->
+            {:ok,
+             %{
+               rows: [
+                 [Sanbase.Math.ipow(10, 18) * 1000]
+               ]
+             }}
+        end
+      end do
+      assert HistoricalBalance.assets_held_by_address("0x123") ==
+               {:ok,
+                [
+                  %{slug: context.eth_project.coinmarketcap_id, balance: 1000.0},
+                  %{slug: context.p1.coinmarketcap_id, balance: 100.0},
+                  %{slug: context.p2.coinmarketcap_id, balance: 200.0}
+                ]}
+    end
+  end
+
+  test "clickhouse returns no results", _context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:ok,
+         %{
+           rows: []
+         }}
+      end do
+      assert HistoricalBalance.assets_held_by_address("0x123") ==
+               {:ok, []}
+    end
+  end
+
+  test "clickhouse returns error", _context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:eror, "Cannot execute query due to error"}
+      end do
+      assert HistoricalBalance.assets_held_by_address("0x123") ==
+               {:error,
+                "Cannot execute ClickHouse query. Reason: no case clause matching: {:eror, \"Cannot execute query due to error\"}\n"}
+    end
+  end
+end

--- a/test/sanbase/clickhouse/historical_balance/erc20_assets_held_by_address_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/erc20_assets_held_by_address_test.exs
@@ -71,8 +71,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20AssetsHeldByAdderssTest do
         {:error, "Cannot execute query due to error"}
       end do
       assert Erc20Balance.assets_held_by_address("0x123") ==
-               {:error,
-                "Cannot execute ClickHouse query. Reason: no case clause matching: {:error, \"Cannot execute query due to error\"}\n"}
+               {:error, "Cannot execute query due to error"}
     end
   end
 end

--- a/test/sanbase/clickhouse/historical_balance/erc20_assets_held_by_address_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/erc20_assets_held_by_address_test.exs
@@ -1,0 +1,119 @@
+defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20AssetsHeldByAdderssTest do
+  use Sanbase.DataCase
+  import Mock
+  import Sanbase.DateTimeUtils, only: [from_iso8601_to_unix!: 1, from_iso8601!: 1]
+  alias Sanbase.Clickhouse.HistoricalBalance.MinersBalance
+  require Sanbase.ClickhouseRepo
+
+  setup do
+    [
+      slug: "ethereum",
+      from: from_iso8601!("2019-01-01T00:00:00Z"),
+      to: from_iso8601!("2019-01-04T00:00:00Z")
+    ]
+  end
+
+  test "works for intervals in days", context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:ok,
+         %{
+           rows: [
+             [from_iso8601_to_unix!("2019-01-01T00:00:00Z"), 100_000],
+             [from_iso8601_to_unix!("2019-01-02T00:00:00Z"), 200_000],
+             [from_iso8601_to_unix!("2019-01-03T00:00:00Z"), 300_000],
+             [from_iso8601_to_unix!("2019-01-04T00:00:00Z"), 400_000]
+           ]
+         }}
+      end do
+      result = MinersBalance.historical_balance(context.slug, context.from, context.to, "1d")
+
+      assert result ==
+               {:ok,
+                [
+                  %{
+                    balance: 100_000,
+                    datetime: from_iso8601!("2019-01-01T00:00:00Z")
+                  },
+                  %{
+                    balance: 200_000,
+                    datetime: from_iso8601!("2019-01-02T00:00:00Z")
+                  },
+                  %{
+                    balance: 300_000,
+                    datetime: from_iso8601!("2019-01-03T00:00:00Z")
+                  },
+                  %{
+                    balance: 400_000,
+                    datetime: from_iso8601!("2019-01-04T00:00:00Z")
+                  }
+                ]}
+    end
+  end
+
+  test "works for intervals in hours", context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:ok,
+         %{
+           rows: [
+             [from_iso8601_to_unix!("2019-01-01T00:00:00Z"), 100_000],
+             [from_iso8601_to_unix!("2019-01-02T00:00:00Z"), 200_000],
+             [from_iso8601_to_unix!("2019-01-03T00:00:00Z"), 300_000],
+             [from_iso8601_to_unix!("2019-01-04T00:00:00Z"), 400_000]
+           ]
+         }}
+      end do
+      result = MinersBalance.historical_balance(context.slug, context.from, context.to, "24h")
+
+      assert result ==
+               {:ok,
+                [
+                  %{
+                    balance: 100_000,
+                    datetime: from_iso8601!("2019-01-01T00:00:00Z")
+                  },
+                  %{
+                    balance: 200_000,
+                    datetime: from_iso8601!("2019-01-02T00:00:00Z")
+                  },
+                  %{
+                    balance: 300_000,
+                    datetime: from_iso8601!("2019-01-03T00:00:00Z")
+                  },
+                  %{
+                    balance: 400_000,
+                    datetime: from_iso8601!("2019-01-04T00:00:00Z")
+                  }
+                ]}
+    end
+  end
+
+  test "returns empty array when query returns no rows", context do
+    with_mock Sanbase.ClickhouseRepo, query: fn _, _ -> {:ok, %{rows: []}} end do
+      result = MinersBalance.historical_balance(context.slug, context.from, context.to, "1d")
+
+      assert result == {:ok, []}
+    end
+  end
+
+  test "returns error when requested interval is less than a day", context do
+    result = MinersBalance.historical_balance(context.slug, context.from, context.to, "23h")
+
+    assert result == {:error, "The interval must consist of whole days!"}
+  end
+
+  test "returns error when something except ethereum is requested", context do
+    with_mock Sanbase.ClickhouseRepo, query: fn _, _ -> {:ok, %{rows: []}} end do
+      result =
+        MinersBalance.historical_balance(
+          "unsupported",
+          context.from,
+          context.to,
+          "1d"
+        )
+
+      assert result == {:error, "Currently only ethereum is supported!"}
+    end
+  end
+end

--- a/test/sanbase/clickhouse/historical_balance/erc20_assets_held_by_address_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/erc20_assets_held_by_address_test.exs
@@ -68,11 +68,11 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20AssetsHeldByAdderssTest do
   test "clickhouse returns error", _context do
     with_mock Sanbase.ClickhouseRepo,
       query: fn _, _ ->
-        {:eror, "Cannot execute query due to error"}
+        {:error, "Cannot execute query due to error"}
       end do
       assert Erc20Balance.assets_held_by_address("0x123") ==
                {:error,
-                "Cannot execute ClickHouse query. Reason: no case clause matching: {:eror, \"Cannot execute query due to error\"}\n"}
+                "Cannot execute ClickHouse query. Reason: no case clause matching: {:error, \"Cannot execute query due to error\"}\n"}
     end
   end
 end

--- a/test/sanbase/clickhouse/historical_balance/eth_assets_held_by_address_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/eth_assets_held_by_address_test.exs
@@ -48,11 +48,11 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EthAssetsHeldByAdderssTest do
   test "clickhouse returns error", _context do
     with_mock Sanbase.ClickhouseRepo,
       query: fn _, _ ->
-        {:eror, "Cannot execute query due to error"}
+        {:error, "Cannot execute query due to error"}
       end do
       assert EthBalance.assets_held_by_address("0x123") ==
                {:error,
-                "Cannot execute ClickHouse query. Reason: no case clause matching: {:eror, \"Cannot execute query due to error\"}\n"}
+                "Cannot execute ClickHouse query. Reason: no case clause matching: {:error, \"Cannot execute query due to error\"}\n"}
     end
   end
 end

--- a/test/sanbase/clickhouse/historical_balance/eth_assets_held_by_address_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/eth_assets_held_by_address_test.exs
@@ -1,0 +1,58 @@
+defmodule Sanbase.Clickhouse.HistoricalBalance.EthAssetsHeldByAdderssTest do
+  use Sanbase.DataCase
+
+  import Mock
+  import Sanbase.Factory
+
+  alias Sanbase.Clickhouse.HistoricalBalance.EthBalance
+
+  require Sanbase.ClickhouseRepo
+
+  setup do
+    project = insert(:project, %{name: "Ethereum", coinmarketcap_id: "ethereum", ticker: "ETH"})
+
+    {:ok, [project: project]}
+  end
+
+  test "clickhouse returns list of results", context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:ok,
+         %{
+           rows: [
+             [1000 * Sanbase.Math.ipow(10, 18)]
+           ]
+         }}
+      end do
+      assert EthBalance.assets_held_by_address("0x123") ==
+               {:ok,
+                [
+                  %{balance: 1000, slug: context.project.coinmarketcap_id}
+                ]}
+    end
+  end
+
+  test "clickhouse returns no results", _context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:ok,
+         %{
+           rows: []
+         }}
+      end do
+      assert EthBalance.assets_held_by_address("0x123") ==
+               {:ok, []}
+    end
+  end
+
+  test "clickhouse returns error", _context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:eror, "Cannot execute query due to error"}
+      end do
+      assert EthBalance.assets_held_by_address("0x123") ==
+               {:error,
+                "Cannot execute ClickHouse query. Reason: no case clause matching: {:eror, \"Cannot execute query due to error\"}\n"}
+    end
+  end
+end

--- a/test/sanbase/clickhouse/historical_balance/eth_assets_held_by_address_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/eth_assets_held_by_address_test.exs
@@ -51,8 +51,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EthAssetsHeldByAdderssTest do
         {:error, "Cannot execute query due to error"}
       end do
       assert EthBalance.assets_held_by_address("0x123") ==
-               {:error,
-                "Cannot execute ClickHouse query. Reason: no case clause matching: {:error, \"Cannot execute query due to error\"}\n"}
+               {:error, "Cannot execute query due to error"}
     end
   end
 end

--- a/test/sanbase_web/graphql/clickhouse/historical_balance/assets_held_by_address_api_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/historical_balance/assets_held_by_address_api_test.exs
@@ -6,10 +6,6 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
   import SanbaseWeb.Graphql.TestHelpers
   import ExUnit.CaptureLog
 
-  require Sanbase.ClickhouseRepo
-
-  @eth_decimals 1_000_000_000_000_000_000
-
   setup do
     p1 = insert(:random_erc20_project)
     p2 = insert(:random_erc20_project)
@@ -20,38 +16,24 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
     {:ok, [p1: p1, p2: p2, eth_project: eth_project]}
   end
 
-  test "clickhouse returns list of results", context do
-    with_mock Sanbase.ClickhouseRepo,
-      query: fn query, _ ->
-        # If the query contains `contract` return erc20 data, ethereum data otherwise
-        case String.contains?(query, "contract") do
-          true ->
-            {:ok,
-             %{
-               rows: [
-                 [
-                   context.p1.main_contract_address,
-                   Sanbase.Math.ipow(10, context.p1.token_decimals) * 100
-                 ],
-                 [
-                   context.p2.main_contract_address,
-                   Sanbase.Math.ipow(10, context.p1.token_decimals) * 200
-                 ]
-               ]
-             }}
-
-          false ->
-            {:ok,
-             %{
-               rows: [
-                 [@eth_decimals * 1000]
-               ]
-             }}
-        end
-      end do
+  test "historical balances returns lists of results", context do
+    with_mocks [
+      {Sanbase.Clickhouse.HistoricalBalance.Erc20Balance, [:passthrough],
+       assets_held_by_address: fn _ ->
+         {:ok,
+          [
+            %{balance: 100.0, slug: context.p1.coinmarketcap_id},
+            %{balance: 200.0, slug: context.p2.coinmarketcap_id}
+          ]}
+       end},
+      {Sanbase.Clickhouse.HistoricalBalance.EthBalance, [:passthrough],
+       assets_held_by_address: fn _ ->
+         {:ok, [%{balance: 1.0e3, slug: context.eth_project.coinmarketcap_id}]}
+       end}
+    ] do
       address = "0x123"
 
-      query = asses_held_by_address_query(address)
+      query = assets_held_by_address_query(address)
 
       result =
         context.conn
@@ -70,14 +52,20 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
     end
   end
 
-  test "clickhouse returns empty list", context do
-    with_mock Sanbase.ClickhouseRepo,
-      query: fn _, _ ->
-        {:ok, %{rows: []}}
-      end do
+  test "historical balances returns empty list", context do
+    with_mocks [
+      {Sanbase.Clickhouse.HistoricalBalance.Erc20Balance, [:passthrough],
+       assets_held_by_address: fn _ ->
+         {:ok, []}
+       end},
+      {Sanbase.Clickhouse.HistoricalBalance.EthBalance, [:passthrough],
+       assets_held_by_address: fn _ ->
+         {:ok, []}
+       end}
+    ] do
       address = "0x123"
 
-      query = asses_held_by_address_query(address)
+      query = assets_held_by_address_query(address)
 
       result =
         context.conn
@@ -88,14 +76,20 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
     end
   end
 
-  test "clickhouse returns error", context do
-    with_mock Sanbase.ClickhouseRepo,
-      query: fn _, _ ->
-        {:error, "Something went wrong"}
-      end do
+  test "one of the historical balances returns error", context do
+    with_mocks [
+      {Sanbase.Clickhouse.HistoricalBalance.Erc20Balance, [:passthrough],
+       assets_held_by_address: fn _ ->
+         {:ok, []}
+       end},
+      {Sanbase.Clickhouse.HistoricalBalance.EthBalance, [:passthrough],
+       assets_held_by_address: fn _ ->
+         {:error, "Something went wrong"}
+       end}
+    ] do
       address = "0x123"
 
-      query = asses_held_by_address_query(address)
+      query = assets_held_by_address_query(address)
 
       assert capture_log(fn ->
                result =
@@ -111,7 +105,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
     end
   end
 
-  defp asses_held_by_address_query(address) do
+  defp assets_held_by_address_query(address) do
     """
       {
         assetsHeldByAddress(

--- a/test/sanbase_web/graphql/clickhouse/historical_balance/assets_held_by_address_api_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/historical_balance/assets_held_by_address_api_test.exs
@@ -1,0 +1,126 @@
+defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import Mock
+  import Sanbase.Factory
+  import SanbaseWeb.Graphql.TestHelpers
+  import ExUnit.CaptureLog
+
+  require Sanbase.ClickhouseRepo
+
+  @eth_decimals 1_000_000_000_000_000_000
+
+  setup do
+    p1 = insert(:random_erc20_project)
+    p2 = insert(:random_erc20_project)
+
+    eth_project =
+      insert(:project, %{name: "Ethereum", coinmarketcap_id: "ethereum", ticker: "ETH"})
+
+    {:ok, [p1: p1, p2: p2, eth_project: eth_project]}
+  end
+
+  test "clickhouse returns list of results", context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn query, _ ->
+        # If the query contains `contract` return erc20 data, ethereum data otherwise
+        case String.contains?(query, "contract") do
+          true ->
+            {:ok,
+             %{
+               rows: [
+                 [
+                   context.p1.main_contract_address,
+                   Sanbase.Math.ipow(10, context.p1.token_decimals) * 100
+                 ],
+                 [
+                   context.p2.main_contract_address,
+                   Sanbase.Math.ipow(10, context.p1.token_decimals) * 200
+                 ]
+               ]
+             }}
+
+          false ->
+            {:ok,
+             %{
+               rows: [
+                 [@eth_decimals * 1000]
+               ]
+             }}
+        end
+      end do
+      address = "0x123"
+
+      query = asses_held_by_address_query(address)
+
+      result =
+        context.conn
+        |> post("/graphql", query_skeleton(query, "assetsHeldByAddress"))
+        |> json_response(200)
+
+      assert result == %{
+               "data" => %{
+                 "assetsHeldByAddress" => [
+                   %{"balance" => 1.0e3, "slug" => context.eth_project.coinmarketcap_id},
+                   %{"balance" => 100.0, "slug" => context.p1.coinmarketcap_id},
+                   %{"balance" => 200.0, "slug" => context.p2.coinmarketcap_id}
+                 ]
+               }
+             }
+    end
+  end
+
+  test "clickhouse returns empty list", context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:ok, %{rows: []}}
+      end do
+      address = "0x123"
+
+      query = asses_held_by_address_query(address)
+
+      result =
+        context.conn
+        |> post("/graphql", query_skeleton(query, "assetsHeldByAddress"))
+        |> json_response(200)
+
+      assert result == %{"data" => %{"assetsHeldByAddress" => []}}
+    end
+  end
+
+  test "clickhouse returns error", context do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:error, "Something went wrong"}
+      end do
+      address = "0x123"
+
+      query = asses_held_by_address_query(address)
+
+      assert capture_log(fn ->
+               result =
+                 context.conn
+                 |> post("/graphql", query_skeleton(query, "assetsHeldByAddress"))
+                 |> json_response(200)
+
+               error = result["errors"] |> List.first()
+
+               assert error["message"] =~
+                        "Can't fetch Assets held by address for address: #{address}"
+             end) =~ "Can't fetch Assets held by address for address: #{address}"
+    end
+  end
+
+  defp asses_held_by_address_query(address) do
+    """
+      {
+        assetsHeldByAddress(
+          address: "#{address}"
+        ){
+            slug
+            balance
+        }
+      }
+    """
+  end
+end

--- a/test/support/sanbase_factory.ex
+++ b/test/support/sanbase_factory.ex
@@ -81,6 +81,21 @@ defmodule Sanbase.Factory do
     }
   end
 
+  def random_erc20_project_factory() do
+    %Project{
+      name: rand_str(),
+      ticker: rand_str(4),
+      coinmarketcap_id: rand_str(),
+      token_decimals: 18,
+      total_supply: :rand.uniform(50_000_000) + 10_000_000,
+      github_link: "https://github.com/#{rand_hex_str()}",
+      infrastructure:
+        Sanbase.Repo.get_by(Infrastructure, code: "ETH") || build(:infrastructure, %{code: "ETH"}),
+      eth_addresses: [build(:project_eth_address), build(:project_eth_address)],
+      main_contract_address: "0x" <> rand_hex_str()
+    }
+  end
+
   def project_factory() do
     %Project{
       name: "Santiment",


### PR DESCRIPTION
#### Summary
It returns a list of slugs and current balances.  If the balance is 0 that means that at some point the wallet had this asset in it, but currently doesn't 
Request:
```
{
  assetsHeldByAddress(address:"0x876eabf441b2ee5b5b0554fd502a8e0600950cfa"){
    slug
    balance
  }
}
```

Response:
```
{
  "data": {
    "assetsHeldByAddress": [
      {
        "balance": 44771.64181671821,
        "slug": "ethereum"
      },
      {
        "balance": 3252652.4976277547,
        "slug": "bnktothefuture"
      },
      {
        "balance": 5479900,
        "slug": "thorecoin"
      },
      {
        "balance": 28323.975729101625,
        "slug": "bancor"
      },
     {
        "balance": 0,
        "slug": "tron"
      },
 ....
}
```
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
