### PR TITLE
Docker-compose uses timescale 1.3

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.4"
 services:
   postgres:
-    image: timescale/timescaledb:0.10.1-pg10
+    image: timescale/timescaledb:1.3.0-pg10
     ports:
       - "5432"
     environment:


### PR DESCRIPTION
#### Summary
Use same version as in Jenkinsfile. 
With the old version I had local test failures.

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
