### PR TITLE
Add historical stats to the watchlist GQL type

### DIFF
--- a/lib/sanbase_web/graphql/schema/types/user_list_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_list_types.ex
@@ -2,6 +2,7 @@ defmodule SanbaseWeb.Graphql.UserListTypes do
   use Absinthe.Schema.Notation
 
   import Absinthe.Resolution.Helpers
+  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1]
 
   alias SanbaseWeb.Graphql.SanbaseRepo
   alias SanbaseWeb.Graphql.Resolvers.UserListResolver
@@ -26,5 +27,13 @@ defmodule SanbaseWeb.Graphql.UserListTypes do
     field(:list_items, list_of(:list_item), resolve: &UserListResolver.list_items/3)
     field(:inserted_at, non_null(:naive_datetime))
     field(:updated_at, non_null(:naive_datetime))
+
+    field(:historical_stats, list_of(:combined_projects_stats)) do
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+      arg(:interval, non_null(:string), default_value: "1d")
+
+      cache_resolve(&UserListResolver.historical_stats/3)
+    end
   end
 end

--- a/lib/sanbase_web/graphql/schema/types/user_list_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_list_types.ex
@@ -31,7 +31,7 @@ defmodule SanbaseWeb.Graphql.UserListTypes do
     field(:historical_stats, list_of(:combined_projects_stats)) do
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
-      arg(:interval, non_null(:string), default_value: "1d")
+      arg(:interval, :string, default_value: "1d")
 
       cache_resolve(&UserListResolver.historical_stats/3)
     end

--- a/test/sanbase_web/graphql/watchlist/watchlist_historical_stats_api_test.exs
+++ b/test/sanbase_web/graphql/watchlist/watchlist_historical_stats_api_test.exs
@@ -1,0 +1,170 @@
+defmodule SanbaseWeb.Graphql.WatchlistHistoricalStatsApiTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import Sanbase.TestHelpers
+
+  alias Sanbase.UserList
+  alias Sanbase.Influxdb.Measurement
+  alias Sanbase.Prices.Store
+
+  import SanbaseWeb.Graphql.TestHelpers
+  import Sanbase.Factory
+
+  setup do
+    clean_task_supervisor_children()
+
+    user = insert(:user)
+    conn = setup_jwt_auth(build_conn(), user)
+
+    p1 = insert(:random_erc20_project)
+    p2 = insert(:random_erc20_project)
+
+    %{from: from, to: to} = setup_pricing_db(p1, p2)
+
+    {:ok, watchlist} = UserList.create_user_list(user, %{name: "test watchlist"})
+    {:ok, watchlist2} = UserList.create_user_list(user, %{name: "test watchlist2"})
+
+    {:ok, watchlist} =
+      UserList.update_user_list(%{
+        id: watchlist.id,
+        list_items: [%{project_id: p1.id}, %{project_id: p2.id}]
+      })
+
+    {:ok,
+     conn: conn, user: user, watchlist: watchlist, from: from, to: to, empty_watchlist: watchlist2}
+  end
+
+  test "historical data for watchlists", context do
+    query = """
+    {
+      watchlist(id: #{context.watchlist.id}){
+        historicalStats(from: "#{context.from}", to: "#{context.to}", interval: "1d") {
+          datetime
+          marketcap
+          volume
+        }
+      }
+    }
+    """
+
+    result =
+      context.conn
+      |> post("/graphql", query_skeleton(query, "watchlist"))
+      |> json_response(200)
+
+    expected_result = %{
+      "data" => %{
+        "watchlist" => %{
+          "historicalStats" => [
+            %{
+              "datetime" => "2017-05-13T00:00:00Z",
+              "marketcap" => 545,
+              "volume" => 220
+            },
+            %{
+              "datetime" => "2017-05-14T00:00:00Z",
+              "marketcap" => 2000,
+              "volume" => 1400
+            },
+            %{
+              "datetime" => "2017-05-15T00:00:00Z",
+              "marketcap" => 2600,
+              "volume" => 1600
+            },
+            %{
+              "datetime" => "2017-05-16T00:00:00Z",
+              "marketcap" => 1800,
+              "volume" => 1300
+            }
+          ]
+        }
+      }
+    }
+
+    assert result == expected_result
+  end
+
+  test "historical data for watchlists with no  projects", context do
+    query = """
+    {
+      watchlist(id: #{context.empty_watchlist.id}){
+        historicalStats(from: "#{context.from}", to: "#{context.to}", interval: "1d") {
+          datetime
+          marketcap
+          volume
+        }
+      }
+    }
+    """
+
+    result =
+      context.conn
+      |> post("/graphql", query_skeleton(query, "watchlist"))
+      |> json_response(200)
+
+    expected_result = %{
+      "data" => %{
+        "watchlist" => %{
+          "historicalStats" => []
+        }
+      }
+    }
+
+    assert result == expected_result
+  end
+
+  def setup_pricing_db(p1, p2) do
+    measurement1 = Measurement.name_from(p1)
+    measurement2 = Measurement.name_from(p2)
+
+    datetime1 = DateTime.from_naive!(~N[2017-05-13 21:45:00], "Etc/UTC")
+    datetime2 = DateTime.from_naive!(~N[2017-05-14 21:45:00], "Etc/UTC")
+    datetime3 = DateTime.from_naive!(~N[2017-05-15 21:45:00], "Etc/UTC")
+    datetime4 = DateTime.from_naive!(~N[2017-05-16 21:45:00], "Etc/UTC")
+    datetime5 = DateTime.from_naive!(~N[2017-05-16 23:59:59], "Etc/UTC")
+
+    Store.create_db()
+    Store.drop_measurement(measurement1)
+    Store.drop_measurement(measurement2)
+
+    Store.import([
+      %Measurement{
+        timestamp: datetime1 |> DateTime.to_unix(:nanosecond),
+        fields: %{price_usd: 25, price_btc: 1, volume_usd: 220, marketcap_usd: 545},
+        name: measurement1
+      },
+      %Measurement{
+        timestamp: datetime2 |> DateTime.to_unix(:nanosecond),
+        fields: %{price_usd: 20, price_btc: 1000, volume_usd: 200, marketcap_usd: 500},
+        name: measurement1
+      },
+      %Measurement{
+        timestamp: datetime3 |> DateTime.to_unix(:nanosecond),
+        fields: %{price_usd: 22, price_btc: 1200, volume_usd: 300, marketcap_usd: 800},
+        name: measurement1
+      },
+      %Measurement{
+        timestamp: datetime3 |> DateTime.to_unix(:nanosecond),
+        fields: %{price_usd: 20, price_btc: 1, volume_usd: 5, marketcap_usd: 500},
+        name: measurement2
+      },
+      %Measurement{
+        timestamp: datetime2 |> DateTime.to_unix(:nanosecond),
+        fields: %{volume_usd: 1200, marketcap_usd: 1500},
+        name: measurement2
+      },
+      %Measurement{
+        timestamp: datetime3 |> DateTime.to_unix(:nanosecond),
+        fields: %{volume_usd: 1300, marketcap_usd: 1800},
+        name: measurement2
+      },
+      %Measurement{
+        timestamp: datetime4 |> DateTime.to_unix(:nanosecond),
+        fields: %{volume_usd: 1300, marketcap_usd: 1800},
+        name: measurement2
+      }
+    ])
+
+    %{from: datetime1, to: datetime5}
+  end
+end


### PR DESCRIPTION
#### Summary
Instead of fetching the whole watchlist and then passing the list of slugs back to the backend to obtain the historical stats, now it can be done with a single query:
```
{
  watchlist(id: 344) {
    historicalStats(from: "2019-06-01T00:00:00Z", to: "2019-06-10T00:00:00Z", interval: "1d") {
      datetime
      marketcap
      volume
    }
    listItems {
      project {
        slug
      }
    }
  }
}
```
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->