### PR TITLE
Add API for fetching the api call historical count for a user

### DIFF
--- a/lib/sanbase/clickhouse/api_call_data.ex
+++ b/lib/sanbase/clickhouse/api_call_data.ex
@@ -1,0 +1,50 @@
+defmodule Sanbase.Clickhouse.ApiCallData do
+  @moduledoc ~s"""
+  Get data about the API Calls that were made by users
+  """
+  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+
+  @doc ~s"""
+  Get a timeseries with the total number of api calls made by a user in a given interval
+  """
+  @spec api_call_history(non_neg_integer(), DateTime.t(), DateTime.t(), String.t()) ::
+          {:ok, list(%{datetime: DateTime.t(), api_calls_count: non_neg_integer()})}
+          | {:error, String.t()}
+  def api_call_history(user_id, from, to, interval) do
+    {query, args} = api_call_history_query(user_id, from, to, interval)
+
+    ClickhouseRepo.query_transform(query, args, fn [t, count] ->
+      %{
+        datetime: DateTime.from_unix!(t),
+        api_calls_count: count
+      }
+    end)
+  end
+
+  defp api_call_history_query(user_id, from, to, interval) do
+    interval_sec = Sanbase.DateTimeUtils.compound_duration_to_seconds(interval)
+
+    query = """
+    SELECT
+      toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS t,
+      toUInt32(count())
+    FROM
+      sanbase_api_call_data
+    PREWHERE
+      dt >= toDateTime(?2) AND
+      dt < toDateTime(?3) AND
+      user_id = ?4
+    GROUP BY t
+    ORDER BY t
+    """
+
+    args = [
+      interval_sec,
+      from,
+      to,
+      user_id
+    ]
+
+    {query, args}
+  end
+end

--- a/lib/sanbase_web/graphql/resolvers/user/account_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/account_resolver.ex
@@ -32,6 +32,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.AccountResolver do
     end
   end
 
+  def api_calls_history(%User{} = user, %{from: from, to: to, interval: interval}, _resolution) do
+    Sanbase.Clickhouse.ApiCallData.api_call_history(user.id, from, to, interval)
+  end
+
   def current_user(_root, _args, %{
         context: %{auth: %{current_user: user}}
       }) do

--- a/lib/sanbase_web/graphql/schema/queries/user_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/user_queries.ex
@@ -45,6 +45,10 @@ defmodule SanbaseWeb.Graphql.Schema.UserQueries do
       middleware(CreateOrDeleteSession)
     end
 
+    @desc ~s"""
+    Initiate email login. An email with a link that needs to be followed is sent
+    to the given email.
+    """
     field :email_login, :email_login_request do
       arg(:email, non_null(:string))
       arg(:username, :string)
@@ -53,6 +57,9 @@ defmodule SanbaseWeb.Graphql.Schema.UserQueries do
       resolve(&AccountResolver.email_login/2)
     end
 
+    @desc ~s"""
+    Verifies the email login. This mutation does the actual login.
+    """
     field :email_login_verify, :login do
       arg(:email, non_null(:string))
       arg(:token, non_null(:string))
@@ -67,6 +74,9 @@ defmodule SanbaseWeb.Graphql.Schema.UserQueries do
       middleware(CreateOrDeleteSession)
     end
 
+    @desc ~s"""
+    Verifies that the email change is valid. This mutation does the actual email change.
+    """
     field :email_change_verify, :login do
       arg(:email_candidate, non_null(:string))
       arg(:token, non_null(:string))
@@ -74,6 +84,10 @@ defmodule SanbaseWeb.Graphql.Schema.UserQueries do
       resolve(&AccountResolver.email_change_verify/2)
     end
 
+    @desc ~s"""
+    Initiate the email change process. This mutation will send an email that contains
+    a link that needs to be followed to complete the email change.
+    """
     field :change_email, :email_login_request do
       arg(:email, non_null(:string))
 
@@ -178,7 +192,7 @@ defmodule SanbaseWeb.Graphql.Schema.UserQueries do
       resolve(&TelegramResolver.revoke_telegram_deep_link/3)
     end
 
-    @desc "Follow chosen user"
+    @desc "Follow a chosen user"
     field :follow, :user do
       arg(:user_id, non_null(:id))
 
@@ -186,7 +200,7 @@ defmodule SanbaseWeb.Graphql.Schema.UserQueries do
       resolve(&UserFollowerResolver.follow/3)
     end
 
-    @desc "Unfollow chosen user"
+    @desc "Unfollow a chosen user"
     field :unfollow, :user do
       arg(:user_id, non_null(:id))
 

--- a/lib/sanbase_web/graphql/schema/types/account_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/account_types.ex
@@ -30,8 +30,21 @@ defmodule SanbaseWeb.Graphql.AccountTypes do
       cache_resolve(&AccountResolver.san_balance/3)
     end
 
+    @desc ~s"""
+    A list of ethereum addresses owned by the user. A special message needs to be
+    signed in order to be confirmed that the address belongs to the user.
+    The combined SAN balance of the addresses is used for the `san_balance`
+    """
     field(:eth_accounts, list_of(:eth_account), resolve: assoc(:eth_accounts))
 
+    @desc ~s"""
+    A list of api keys. They are used by providing `Authorization` header to the
+    HTTP request with the value `Apikey <apikey>` (case sensitive). To generate
+    or revoke api keys check the `generateApikey` and `revokeApikey` mutations.
+
+    Using an apikey gives access to the queries, but not to the mutations. Every
+    api key has the same SAN balance and subsription as the whole account
+    """
     field :apikeys, list_of(:string) do
       resolve(&ApikeyResolver.apikeys_list/3)
     end
@@ -55,6 +68,10 @@ defmodule SanbaseWeb.Graphql.AccountTypes do
       resolve(&PricingResolver.subscriptions/3)
     end
 
+    @desc ~s"""
+    The total number of api calls made by the user in a given time range.
+    Counts all API calls made either with JWT or API Key authentication
+    """
     field :api_calls_history, list_of(:api_call_data) do
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))

--- a/lib/sanbase_web/graphql/schema/types/account_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/account_types.ex
@@ -2,6 +2,8 @@ defmodule SanbaseWeb.Graphql.AccountTypes do
   use Absinthe.Schema.Notation
   use Absinthe.Ecto, repo: Sanbase.Repo
 
+  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1]
+
   alias SanbaseWeb.Graphql.Resolvers.{
     ApikeyResolver,
     AccountResolver,
@@ -25,7 +27,7 @@ defmodule SanbaseWeb.Graphql.AccountTypes do
     end
 
     field :san_balance, :float do
-      resolve(&AccountResolver.san_balance/3)
+      cache_resolve(&AccountResolver.san_balance/3)
     end
 
     field(:eth_accounts, list_of(:eth_account), resolve: assoc(:eth_accounts))
@@ -52,6 +54,19 @@ defmodule SanbaseWeb.Graphql.AccountTypes do
     field :subscriptions, list_of(:plan_subscription) do
       resolve(&PricingResolver.subscriptions/3)
     end
+
+    field :api_calls_history, list_of(:api_call_data) do
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+      arg(:interval, :string, default_value: "1d")
+
+      cache_resolve(&AccountResolver.api_calls_history/3)
+    end
+  end
+
+  object :api_call_data do
+    field(:datetime, non_null(:datetime))
+    field(:api_calls_count, non_null(:integer))
   end
 
   @desc ~s"""
@@ -62,7 +77,7 @@ defmodule SanbaseWeb.Graphql.AccountTypes do
     field(:address, non_null(:string))
 
     field :san_balance, non_null(:integer) do
-      resolve(&EthAccountResolver.san_balance/3)
+      cache_resolve(&EthAccountResolver.san_balance/3)
     end
   end
 

--- a/test/sanbase/clickhouse/api_call_data_test.exs
+++ b/test/sanbase/clickhouse/api_call_data_test.exs
@@ -1,0 +1,92 @@
+defmodule Sanbase.Clickhouse.ApiCallDataTest do
+  use Sanbase.DataCase
+
+  import Mock
+  import Sanbase.Factory
+  import Sanbase.DateTimeUtils, only: [from_iso8601_to_unix!: 1, from_iso8601!: 1]
+
+  alias Sanbase.Clickhouse.ApiCallData
+
+  setup do
+    user = insert(:user)
+
+    [user: user]
+  end
+
+  test "clickhouse returns data", context do
+    dt1_str = "2019-01-01T00:00:00Z"
+    dt2_str = "2019-01-02T00:00:00Z"
+    dt3_str = "2019-01-03T00:00:00Z"
+
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:ok,
+         %{
+           rows: [
+             [from_iso8601_to_unix!(dt1_str), 400],
+             [from_iso8601_to_unix!(dt2_str), 100],
+             [from_iso8601_to_unix!(dt3_str), 200]
+           ]
+         }}
+      end do
+      result =
+        ApiCallData.api_call_history(
+          context.user.id,
+          from_iso8601!(dt1_str),
+          from_iso8601!(dt3_str),
+          "1d"
+        )
+
+      assert result ==
+               {:ok,
+                [
+                  %{api_calls_count: 400, datetime: from_iso8601!(dt1_str)},
+                  %{api_calls_count: 100, datetime: from_iso8601!(dt2_str)},
+                  %{api_calls_count: 200, datetime: from_iso8601!(dt3_str)}
+                ]}
+    end
+  end
+
+  test "clickhouse returns empty list", context do
+    dt1_str = "2019-01-01T00:00:00Z"
+    dt2_str = "2019-01-02T00:00:00Z"
+    dt3_str = "2019-01-03T00:00:00Z"
+
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:ok, %{rows: []}}
+      end do
+      result =
+        ApiCallData.api_call_history(
+          context.user.id,
+          from_iso8601!(dt1_str),
+          from_iso8601!(dt3_str),
+          "1d"
+        )
+
+      assert result ==
+               {:ok, []}
+    end
+  end
+
+  test "clickhouse returns error", context do
+    dt1_str = "2019-01-01T00:00:00Z"
+    dt3_str = "2019-01-03T00:00:00Z"
+
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:error, "Something went wrong"}
+      end do
+      result =
+        ApiCallData.api_call_history(
+          context.user.id,
+          from_iso8601!(dt1_str),
+          from_iso8601!(dt3_str),
+          "1d"
+        )
+
+      assert result ==
+               {:error, "Something went wrong"}
+    end
+  end
+end

--- a/test/sanbase_web/graphql/user/user_api_call_data_api_test.exs
+++ b/test/sanbase_web/graphql/user/user_api_call_data_api_test.exs
@@ -1,0 +1,130 @@
+defmodule SanbaseWeb.Graphql.UserApiCallDataApiTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import Mock
+  import SanbaseWeb.Graphql.TestHelpers
+  import Sanbase.Factory
+  import Sanbase.DateTimeUtils, only: [from_iso8601!: 1]
+
+  setup do
+    user = insert(:user)
+    conn = setup_jwt_auth(build_conn(), user)
+    {:ok, conn: conn}
+  end
+
+  test "api call data module returns data", context do
+    dt1_str = "2019-01-01T00:00:00Z"
+    dt2_str = "2019-01-02T00:00:00Z"
+    dt3_str = "2019-01-03T00:00:00Z"
+
+    with_mock Sanbase.Clickhouse.ApiCallData,
+      api_call_history: fn _, _, _, _ ->
+        {:ok,
+         [
+           %{datetime: from_iso8601!(dt1_str), api_calls_count: 400},
+           %{datetime: from_iso8601!(dt2_str), api_calls_count: 100},
+           %{datetime: from_iso8601!(dt3_str), api_calls_count: 200}
+         ]}
+      end do
+      result =
+        fetch_user_api_calls_count(
+          context.conn,
+          from_iso8601!(dt1_str),
+          from_iso8601!(dt3_str),
+          "1d"
+        )
+
+      expected_result = %{
+        "data" => %{
+          "currentUser" => %{
+            "apiCallsHistory" => [
+              %{
+                "apiCallsCount" => 400,
+                "datetime" => "2019-01-01T00:00:00Z"
+              },
+              %{
+                "apiCallsCount" => 100,
+                "datetime" => "2019-01-02T00:00:00Z"
+              },
+              %{
+                "apiCallsCount" => 200,
+                "datetime" => "2019-01-03T00:00:00Z"
+              }
+            ]
+          }
+        }
+      }
+
+      assert result == expected_result
+    end
+  end
+
+  test "api call data module returns empty list", context do
+    dt1_str = "2019-01-01T00:00:00Z"
+    dt2_str = "2019-01-03T00:00:00Z"
+
+    with_mock Sanbase.Clickhouse.ApiCallData,
+      api_call_history: fn _, _, _, _ ->
+        {:ok, []}
+      end do
+      result =
+        fetch_user_api_calls_count(
+          context.conn,
+          from_iso8601!(dt1_str),
+          from_iso8601!(dt2_str),
+          "1d"
+        )
+
+      expected_result = %{
+        "data" => %{
+          "currentUser" => %{
+            "apiCallsHistory" => []
+          }
+        }
+      }
+
+      assert result == expected_result
+    end
+  end
+
+  test "api call data module returns error", context do
+    dt1_str = "2019-01-01T00:00:00Z"
+    dt2_str = "2019-01-03T00:00:00Z"
+
+    with_mock Sanbase.Clickhouse.ApiCallData,
+      api_call_history: fn _, _, _, _ ->
+        {:error, "Something went wrong"}
+      end do
+      result =
+        fetch_user_api_calls_count(
+          context.conn,
+          from_iso8601!(dt1_str),
+          from_iso8601!(dt2_str),
+          "1d"
+        )
+
+      %{"errors" => errors} = result
+
+      assert length(errors) == 1
+      error = errors |> List.first()
+      assert error["message"] == "Something went wrong"
+    end
+  end
+
+  defp fetch_user_api_calls_count(conn, from, to, interval) do
+    query = """
+    {
+      currentUser{
+        apiCallsHistory(from: "#{from}", to: "#{to}", interval: "#{interval}"){
+          datetime
+          apiCallsCount
+        }
+      }
+    }
+    """
+
+    conn
+    |> post("/graphql", query_skeleton(query, "currentUser"))
+    |> json_response(200)
+  end
+end


### PR DESCRIPTION
#### Summary
Request:
```
{
currentUser{
    apiCallsHistory(from: "#{from}", to: "#{to}", interval: "#{interval}"){
      datetime
      apiCallsCount
    }
  }
}
```

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
