### PR TITLE
Subscription changes

### DIFF
--- a/lib/sanbase/stripe_api.ex
+++ b/lib/sanbase/stripe_api.ex
@@ -84,4 +84,13 @@ defmodule Sanbase.StripeApi do
   def create_coupon(%{percent_off: percent_off, duration: duration}) do
     Stripe.Coupon.create(%{percent_off: percent_off, duration: duration})
   end
+
+  def list_payments(%User{stripe_customer_id: stripe_customer_id})
+      when is_binary(stripe_customer_id) do
+    Stripe.Charge.list(%{customer: stripe_customer_id})
+  end
+
+  def list_payments(_) do
+    {:ok, []}
+  end
 end

--- a/lib/sanbase_web/graphql/resolvers/pricing_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/pricing_resolver.ex
@@ -95,13 +95,15 @@ defmodule SanbaseWeb.Graphql.Resolvers.PricingResolver do
                      status: status,
                      amount: amount,
                      created: created,
-                     receipt_url: receipt_url
+                     receipt_url: receipt_url,
+                     description: description
                    } ->
       %{
         status: status,
         amount: amount,
         created_at: DateTime.from_unix!(created),
-        receipt_url: receipt_url
+        receipt_url: receipt_url,
+        description: description
       }
     end)
   end

--- a/lib/sanbase_web/graphql/schema/queries/pricing_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/pricing_queries.ex
@@ -16,6 +16,15 @@ defmodule SanbaseWeb.Graphql.Schema.PricingQueries do
     field :products_with_plans, list_of(:product) do
       resolve(&PricingResolver.products_with_plans/3)
     end
+
+    @desc ~s"""
+    List all user invoice payments.
+    """
+    field :payments, list_of(:payments) do
+      middleware(JWTAuth)
+
+      resolve(&PricingResolver.payments/3)
+    end
   end
 
   object :pricing_mutations do

--- a/lib/sanbase_web/graphql/schema/types/pricing_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/pricing_types.ex
@@ -27,4 +27,11 @@ defmodule SanbaseWeb.Graphql.Schema.PricingTypes do
     field(:is_scheduled_for_cancellation, :boolean)
     field(:scheduled_for_cancellation_at, :datetime)
   end
+
+  object :payments do
+    field(:receipt_url, :string)
+    field(:amount, :integer)
+    field(:created_at, :datetime)
+    field(:status, :string)
+  end
 end

--- a/lib/sanbase_web/graphql/schema/types/pricing_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/pricing_types.ex
@@ -33,5 +33,6 @@ defmodule SanbaseWeb.Graphql.Schema.PricingTypes do
     field(:amount, :integer)
     field(:created_at, :datetime)
     field(:status, :string)
+    field(:description, :string)
   end
 end

--- a/test/support/sanbase_factory.ex
+++ b/test/support/sanbase_factory.ex
@@ -320,13 +320,15 @@ defmodule Sanbase.Factory do
 
   def subscription_essential_factory() do
     %Subscription{
-      plan_id: 2
+      plan_id: 2,
+      current_period_end: Timex.shift(Timex.now(), days: 1)
     }
   end
 
   def subscription_pro_factory() do
     %Subscription{
-      plan_id: 3
+      plan_id: 3,
+      current_period_end: Timex.shift(Timex.now(), days: 1)
     }
   end
 


### PR DESCRIPTION
Changes in this PR: 
* Check only `current_period_end `  to determine if subscription is active
* add gratis of 1day - for payment of the next invoice (subscription stays active)
* update `current_period_end` on plan upgrade - this can change if the new plan has different billing cycle from old one. (example : `monthly` -> `yearly`)
* Add error message when trying to upgrade/downgrade or cancel already scheduled for cancellation subscription
* Add list of payments

```graphql
{
  payments {
    status
    createdAt
    amount,
    receiptUrl,
    description
  }
}
```

```graphql
{
  "data": {
    "payments": [
      {
        "amount": 9520,
        "createdAt": "2019-06-27T14:52:13Z",
        "description": "Payment for invoice 6E892445-0002",
        "receiptUrl": "https://pay.stripe.com/receipts/acct_1ECoqyCA0hGU8IEV/ch_1EpyxNCA0hGU8IEV9yDLqMHo/rcpt_FKeFGu44Ye2MfnCgiYtqtBIyveX5B3R",
        "status": "succeeded"
      },
      {
        "amount": 9520,
        "createdAt": "2019-06-24T14:02:35Z",
        "description": "Payment for invoice 6E892445-0001",
        "receiptUrl": "https://pay.stripe.com/receipts/acct_1ECoqyCA0hGU8IEV/ch_1EoskhCA0hGU8IEVsKP97j3f/rcpt_FJVmRZGFnvzE1dEVbIkjfjRWjeaaVCb",
        "status": "succeeded"
      }
    ]
  }
}
```


![image](https://user-images.githubusercontent.com/122794/60348617-9f803800-99c8-11e9-9925-e45ed7f298f9.png)
