### PR TITLE
Aggregate pricing data with LAST instead of MEAN

### DIFF
--- a/lib/sanbase/notifications/price_volume_diff.ex
+++ b/lib/sanbase/notifications/price_volume_diff.ex
@@ -45,7 +45,7 @@ defmodule Sanbase.Notifications.PriceVolumeDiff do
     measurement = Sanbase.Influxdb.Measurement.name_from(project)
 
     with {:ok, [[_dt, volume]]} <-
-           Sanbase.Prices.Store.fetch_mean_volume(measurement, from_datetime, to_datetime) do
+           Sanbase.Prices.Store.fetch_average_volume(measurement, from_datetime, to_datetime) do
       volume >= notification_volume_threshold()
     else
       _ -> false

--- a/lib/sanbase_web/graphql/dataloader/influxdb_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/influxdb_dataloader.ex
@@ -20,10 +20,10 @@ defmodule SanbaseWeb.Graphql.InfluxdbDataloader do
     |> Enum.chunk_every(80)
     |> Sanbase.Parallel.map(
       fn measurements ->
-        volumes_last_24h = Prices.Store.fetch_mean_volume(measurements, yesterday, now)
+        volumes_last_24h = Prices.Store.fetch_average_volume(measurements, yesterday, now)
 
         volumes_previous_24h_map =
-          Prices.Store.fetch_mean_volume(measurements, two_days_ago, yesterday) |> Map.new()
+          Prices.Store.fetch_average_volume(measurements, two_days_ago, yesterday) |> Map.new()
 
         volumes_last_24h
         |> Enum.map(fn {name, today_vol} ->

--- a/test/sanbase/external_services/coinmarketcap/graph_data_test.exs
+++ b/test/sanbase/external_services/coinmarketcap/graph_data_test.exs
@@ -99,7 +99,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphDataTest do
     to = DateTime.utc_now()
 
     {:ok, [[_datetime, mean_volume]]} =
-      Store.fetch_mean_volume(@total_market_measurement, from, to)
+      Store.fetch_average_volume(@total_market_measurement, from, to)
 
     assert mean_volume == 2_513_748_896.5741253
   end

--- a/test/sanbase_web/graphql/pricing/prices_api_test.exs
+++ b/test/sanbase_web/graphql/pricing/prices_api_test.exs
@@ -153,10 +153,10 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
     assert Enum.count(history_price) == 1
 
     [history_price | _] = history_price
-    assert history_price["priceUsd"] == 21
-    assert history_price["priceBtc"] == 1100
+    assert history_price["priceUsd"] == 22
+    assert history_price["priceBtc"] == 1200
     assert history_price["volume"] == 300
-    assert history_price["marketcap"] == 650
+    assert history_price["marketcap"] == 800
   end
 
   test "too complex queries are denied", context do


### PR DESCRIPTION
LAST is more stable and does not lead to radical differences in case
larger interval are aggregated

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
