### PR TITLE
Handle invalid slugs when fetching github organizations

### DIFF
--- a/lib/sanbase/model/project/project.ex
+++ b/lib/sanbase/model/project/project.ex
@@ -280,7 +280,14 @@ defmodule Sanbase.Model.Project do
   end
 
   def github_organizations(slug) when is_binary(slug) do
-    {:ok, id_by_slug(slug) |> Project.GithubOrganization.organizations_of()}
+    case id_by_slug(slug) do
+      nil ->
+        {:error,
+         "Cannot fetch github organizations for #{slug}. Reason: There is no project with that slug."}
+
+      id ->
+        {:ok, Project.GithubOrganization.organizations_of(id)}
+    end
   end
 
   def github_organizations(%Project{} = project) do

--- a/test/sanbase_web/graphql/projects/projects_by_function_test.exs
+++ b/test/sanbase_web/graphql/projects/projects_by_function_test.exs
@@ -63,11 +63,9 @@ defmodule SanbaseWeb.Graphql.ProjectsByFunctionTest do
 
     result = execute_query(conn, query(function))
     projects = result["data"]["allProjectsByFunction"]
+    slugs = Enum.map(projects, & &1["slug"]) |> Enum.sort()
 
-    assert projects == [
-             %{"slug" => "dai"},
-             %{"slug" => "tether"}
-           ]
+    assert slugs == ["dai", "tether"]
   end
 
   test "dynamic watchlist for top erc20 projects", %{conn: conn} do


### PR DESCRIPTION
#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
