### PR TITLE
Impove the uniq filter for trending projects

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/user/user_list_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/user_list_resolver.ex
@@ -66,7 +66,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserListResolver do
       trending_words
       |> Enum.to_list()
       |> Project.List.by_name_ticker_slug()
-      |> Enum.uniq()
 
     %{
       trending_tickers: Enum.filter(trending_words, &Enum.member?(tickers_set, &1)),


### PR DESCRIPTION
Explicitly calling uniq is not needed as the Ecto query won't return
duplicates. Add a test for confirming this behavior

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
