### PR TITLE
Add four new fields to the user settings

### DIFF
--- a/lib/sanbase/auth/settings.ex
+++ b/lib/sanbase/auth/settings.ex
@@ -5,6 +5,10 @@ defmodule Sanbase.Auth.Settings do
   @newsletter_subscription_types ["DAILY", "WEEKLY", "OFF"]
 
   embedded_schema do
+    field(:theme, :string, default: "default")
+    field(:page_size, :integer, default: 20)
+    field(:is_beta_mode, :boolean, default: false)
+    field(:table_columns, :map, default: %{})
     field(:signal_notify_email, :boolean, default: false)
     field(:signal_notify_telegram, :boolean, default: false)
     field(:telegram_chat_id, :integer)
@@ -16,6 +20,10 @@ defmodule Sanbase.Auth.Settings do
   def changeset(schema, params) do
     schema
     |> cast(params, [
+      :theme,
+      :page_size,
+      :is_beta_mode,
+      :table_columns,
       :signal_notify_email,
       :signal_notify_telegram,
       :telegram_chat_id

--- a/lib/sanbase/auth/user_settings.ex
+++ b/lib/sanbase/auth/user_settings.ex
@@ -34,6 +34,10 @@ defmodule Sanbase.Auth.UserSettings do
     end
   end
 
+  def update_settings(%User{id: id}, params) do
+    settings_update(id, params)
+  end
+
   def toggle_notification_channel(%User{id: user_id}, params) do
     settings_update(user_id, params)
   end

--- a/lib/sanbase_web/graphql/resolvers/user_settings_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user_settings_resolver.ex
@@ -1,6 +1,8 @@
 defmodule SanbaseWeb.Graphql.Resolvers.UserSettingsResolver do
   require Logger
 
+  import SanbaseWeb.Graphql.Helpers.Utils, only: [error_details: 1]
+
   alias Sanbase.Auth.{User, UserSettings}
   alias SanbaseWeb.Graphql.Helpers.Utils
 
@@ -11,9 +13,13 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserSettingsResolver do
   def update_user_settings(_root, %{settings: settings}, %{
         context: %{auth: %{current_user: current_user}}
       }) do
-    {:ok, %{settings: settings}} = UserSettings.update_settings(current_user, settings)
+    case UserSettings.update_settings(current_user, settings) do
+      {:ok, %{settings: settings}} ->
+        {:ok, settings}
 
-    {:ok, settings}
+      {:error, changeset} ->
+        {:error, "Cannot update user settings. Reason: #{error_details(changeset)}"}
+    end
   end
 
   def settings_toggle_channel(_root, args, %{

--- a/lib/sanbase_web/graphql/resolvers/user_settings_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user_settings_resolver.ex
@@ -8,6 +8,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserSettingsResolver do
     {:ok, UserSettings.settings_for(user)}
   end
 
+  def update_user_settings(_root, %{settings: settings}, %{
+        context: %{auth: %{current_user: current_user}}
+      }) do
+    {:ok, %{settings: settings}} = UserSettings.update_settings(current_user, settings)
+
+    {:ok, settings}
+  end
+
   def settings_toggle_channel(_root, args, %{
         context: %{auth: %{current_user: current_user}}
       }) do

--- a/lib/sanbase_web/graphql/schema/queries/user_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/user_queries.ex
@@ -207,5 +207,11 @@ defmodule SanbaseWeb.Graphql.Schema.UserQueries do
       middleware(JWTAuth)
       resolve(&UserFollowerResolver.unfollow/3)
     end
+
+    field :update_user_settings, :user_settings do
+      arg(:settings, :user_settings_input_object)
+      middleware(JWTAuth)
+      resolve(&UserSettingsResolver.update_user_settings/3)
+    end
   end
 end

--- a/lib/sanbase_web/graphql/schema/types/user_settings_type.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_settings_type.ex
@@ -8,6 +8,21 @@ defmodule SanbaseWeb.Graphql.UserSettingsTypes do
   end
 
   object :user_settings do
+    field(:is_beta_mode, :boolean)
+    field(:theme, :string)
+    field(:page_size, :integer)
+    field(:table_columns, :json)
+    field(:has_telegram_connected, :boolean)
+    field(:signal_notify_telegram, :boolean)
+    field(:signal_notify_email, :boolean)
+    field(:newsletter_subscription, :newsletter_subscription_type)
+  end
+
+  input_object :user_settings_input_object do
+    field(:is_beta_mode, :boolean)
+    field(:theme, :string)
+    field(:page_size, :integer)
+    field(:table_columns, :json)
     field(:has_telegram_connected, :boolean)
     field(:signal_notify_telegram, :boolean)
     field(:signal_notify_email, :boolean)


### PR DESCRIPTION
#### Summary
The API uses an input object, so the params are passed as key-value pairs in the `settings` map
Examples:
The `tableColumns` is an arbitrary json map, the frontend can use whatever columns they like
```
mutation {
  updateUserSettings(
    settings: {tableColumns: \"{\\\"shown\\\":[\\\"price\\\",\\\"volume\\\",\\\"devActivity\\\"]}\"}
    ) {
      tableColumns
  }
}
```

```
mutation {
  updateUserSettings(
    settings: {isBetaMode: true}
    ) {
      isBetaMode
  }
}
```

```
mutation {
  updateUserSettings(
    settings: {pageSize: true}
    ) {
      pageSize
  }
}
```

`theme` is a string with a default value `default`
```
mutation {
  updateUserSettings(
    settings: {theme: "nightmode"}
    ) {
      theme
  }
}
```
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
