### PR TITLE
Jenkinsfile improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,10 @@
-podTemplate(label: 'sanbase-builder', containers: [
-  containerTemplate(name: 'docker', image: 'docker', ttyEnabled: true, command: 'cat', envVars: [
-    envVar(key: 'DOCKER_HOST', value: 'tcp://docker-host-docker-host:2375'),
-    envVar(key: 'DOCKER_BUILDKIT', value: '1')
-  ])
-]) {
-  node('sanbase-builder') {
+@Library('podTemplateLib')
+import net.santiment.utils.podTemplates
+
+slaveTemplates = new podTemplates()
+
+slaveTemplates.dockerTemplate { label ->
+  node(label) {
     stage('Run Tests') {
       container('docker') {
         def scmVars = checkout scm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,9 @@
 @Library('podTemplateLib')
 import net.santiment.utils.podTemplates
 
+
+properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '30', artifactNumToKeepStr: '', daysToKeepStr: '30', numToKeepStr: ''))])
+
 slaveTemplates = new podTemplates()
 
 slaveTemplates.dockerTemplate { label ->


### PR DESCRIPTION
#### Summary
- Generate the pod template from jenkins shared library. The shared lib is [here](https://github.com/santiment/jenkins-libs/blob/master/src/net/santiment/utils/podTemplates.groovy)
- Use the node's docker daemon to do the builds instead of the shared docker-host
- Set up discarding of builds older than 30 days


[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
