### PR TITLE
Migrate from Mix.Config to Config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,7 +3,7 @@
 #
 # This configuration file is loaded before any dependency and
 # is restricted to this project.
-use Mix.Config
+import Config
 
 # Latest version of timezone data (2019a) distributed by IANA has an error
 # Disable the autoupdate until it is fixed

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # For development, we disable any cache and enable
 # debugging and code reloading.

--- a/config/elasticsearch_config.exs
+++ b/config/elasticsearch_config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :sanbase, Sanbase.Elasticsearch.Cluster,
   url: "http://managed-elasticsearch-scraping-data.default.svc.cluster.local",

--- a/config/ex_admin_config.exs
+++ b/config/ex_admin_config.exs
@@ -3,7 +3,7 @@
 #
 # This configuration file is loaded before any dependency and
 # is restricted to this project.
-use Mix.Config
+import Config
 
 config :ex_admin,
   repo: Sanbase.Repo,

--- a/config/influxdb_config.exs
+++ b/config/influxdb_config.exs
@@ -3,7 +3,7 @@
 #
 # This configuration file is loaded before any dependency and
 # is restricted to this project.
-use Mix.Config
+import Config
 
 config :sanbase, Sanbase.Influxdb.Store,
   host: {:system, "INFLUXDB_HOST", "localhost"},

--- a/config/notifications_config.exs
+++ b/config/notifications_config.exs
@@ -3,7 +3,7 @@
 #
 # This configuration file is loaded before any dependency and
 # is restricted to this project.
-use Mix.Config
+import Config
 
 config :sanbase, Sanbase.Notifications.PriceVolumeDiff,
   webhook_url: {:system, "PRICE_VOLUME_DIFF_WEBHOOK_URL"},

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :sanbase, SanbaseWeb.Endpoint,
   http: [port: {:system, "PORT"}],

--- a/config/prometheus_config.exs
+++ b/config/prometheus_config.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/scrapers_config.exs
+++ b/config/scrapers_config.exs
@@ -3,7 +3,7 @@
 #
 # This configuration file is loaded before any dependency and
 # is restricted to this project.
-use Mix.Config
+import Config
 
 config :sanbase, Sanbase.ExternalServices.Coinmarketcap,
   update_interval: 5 * 1000 * 60,

--- a/config/stripe_config.exs
+++ b/config/stripe_config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :sanbase, Sanbase.StripeConfig, api_key: {:system, "STRIPE_SECRET_KEY", ""}
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.


### PR DESCRIPTION
#### Summary
`Mix.Config` is deprecated since 1.9 in favor of `Config`: https://hexdocs.pm/elixir/master/Config.html#module-migrating-from-use-mix-config

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->