### PR TITLE
Change the scrapers log level to error

### DIFF
--- a/lib/sanbase/application.ex
+++ b/lib/sanbase/application.ex
@@ -91,6 +91,9 @@ defmodule Sanbase.Application do
         Sanbase.Application.Signals.init()
 
       "scrapers" ->
+        # Set the warning level here instead inside of `init/0` because
+        # it will be executed in the tests and tests checking for logs will fail
+        Logger.configure(level: :error)
         Sanbase.Application.Scrapers.init()
 
       _ ->


### PR DESCRIPTION
#### Summary
We need update ex_admin in order to update ecto to 3.x.
In ecto 2.x they still use `Decimal.new` instead of `Decimal.from_float` which causes hundreds of thousands of log warnings which fills the disk space.

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->