### PR TITLE
Timeframe restriction update

### DIFF
--- a/lib/sanbase/pricing/plan.ex
+++ b/lib/sanbase/pricing/plan.ex
@@ -32,6 +32,8 @@ defmodule Sanbase.Pricing.Plan do
   def plan_atom_name(%__MODULE__{} = plan) do
     case plan do
       %{name: "FREE"} -> :free
+      %{name: "BASIC"} -> :basic
+      # should be renamed to basic in the DB
       %{name: "ESSENTIAL"} -> :basic
       %{name: "PRO"} -> :pro
       %{name: "PREMIUM"} -> :premium

--- a/lib/sanbase/pricing/plan.ex
+++ b/lib/sanbase/pricing/plan.ex
@@ -7,10 +7,8 @@ defmodule Sanbase.Pricing.Plan do
   use Ecto.Schema
 
   import Ecto.Changeset
-  import Ecto.Query
   alias Sanbase.Repo
-  alias Sanbase.Pricing.{Product, Subscription}
-  alias __MODULE__
+  alias Sanbase.Pricing.{Plan.AccessSeed, Product, Subscription}
 
   schema "plans" do
     field(:name, :string)
@@ -29,6 +27,17 @@ defmodule Sanbase.Pricing.Plan do
   def changeset(%__MODULE__{} = plan, attrs \\ %{}) do
     plan
     |> cast(attrs, [:stripe_id, :access])
+  end
+
+  def plan_atom_name(%__MODULE__{} = plan) do
+    case plan do
+      %{name: "FREE"} -> :free
+      %{name: "ESSENTIAL"} -> :basic
+      %{name: "PRO"} -> :pro
+      %{name: "PREMIUM"} -> :premium
+      %{name: "CUSTOM"} -> :custom
+      %{name: name} -> String.downcase(name) |> String.to_existing_atom()
+    end
   end
 
   def by_id(plan_id) do
@@ -58,14 +67,7 @@ defmodule Sanbase.Pricing.Plan do
   Fetching only with `interval`=`month` because we have yearly metrics with the same metrics
   and names.
   """
-  def plans_with_metric(query) do
-    from(
-      p in Plan,
-      where: p.interval == "month" and fragment(~s(access @> ?), ^%{metrics: [query]}),
-      select: p.name
-    )
-    |> Repo.all()
-  end
+  defdelegate lowest_plan_with_metric(query), to: AccessSeed
 
   @doc """
   If a plan doesn't have filled `stripe_id` - create a plan in Stripe and update with the received

--- a/lib/sanbase/pricing/plan.ex
+++ b/lib/sanbase/pricing/plan.ex
@@ -8,7 +8,7 @@ defmodule Sanbase.Pricing.Plan do
 
   import Ecto.Changeset
   alias Sanbase.Repo
-  alias Sanbase.Pricing.{Plan.AccessSeed, Product, Subscription}
+  alias Sanbase.Pricing.{Plan.AccessChecker, Product, Subscription}
 
   schema "plans" do
     field(:name, :string)
@@ -69,7 +69,7 @@ defmodule Sanbase.Pricing.Plan do
   Fetching only with `interval`=`month` because we have yearly metrics with the same metrics
   and names.
   """
-  defdelegate lowest_plan_with_metric(query), to: AccessSeed
+  defdelegate lowest_plan_with_metric(query), to: AccessChecker
 
   @doc """
   If a plan doesn't have filled `stripe_id` - create a plan in Stripe and update with the received

--- a/lib/sanbase/pricing/plan.ex
+++ b/lib/sanbase/pricing/plan.ex
@@ -29,6 +29,10 @@ defmodule Sanbase.Pricing.Plan do
     |> cast(attrs, [:stripe_id, :access])
   end
 
+  def free_plan() do
+    %__MODULE__{name: "FREE"}
+  end
+
   def plan_atom_name(%__MODULE__{} = plan) do
     case plan do
       %{name: "FREE"} -> :free

--- a/lib/sanbase/pricing/plan/access_checker.ex
+++ b/lib/sanbase/pricing/plan/access_checker.ex
@@ -1,4 +1,4 @@
-defmodule Sanbase.Pricing.Plan.AccessSeed do
+defmodule Sanbase.Pricing.Plan.AccessChecker do
   @moduledoc """
   Module that contains functions for determining access based on the subscription
   plan.
@@ -150,6 +150,7 @@ defmodule Sanbase.Pricing.Plan.AccessSeed do
       :basic -> query in @basic_metrics_mapset
       :pro -> query in @pro_metrics_mapset
       :premium -> query in @premium_metrics_mapset
+      :custom -> query in @premium_metrics_mapset
       _ -> false
     end
   end

--- a/lib/sanbase/pricing/plan/access_checker.ex
+++ b/lib/sanbase/pricing/plan/access_checker.ex
@@ -43,13 +43,17 @@ defmodule Sanbase.Pricing.Plan.AccessChecker do
       end)
     end
 
+    def queries_without_subsciption_plan() do
+      get_metrics_with_subscription_plan(nil) -- [:__typename, :__type, :__schema]
+    end
+
     def mutations_mapset() do
       @mutations_mapset
     end
   end
 
   # Emit a compile time warning if there is any query without subscription plan
-  case Helper.get_metrics_with_subscription_plan(nil) -- [:__typename, :__type, :__schema] do
+  case Helper.queries_without_subsciption_plan() do
     [] ->
       :ok
 

--- a/lib/sanbase/pricing/plan/access_checker.ex
+++ b/lib/sanbase/pricing/plan/access_checker.ex
@@ -121,6 +121,26 @@ defmodule Sanbase.Pricing.Plan.AccessChecker do
     Helper.mutations_mapset()
   end
 
+  def historical_data_in_days(plan) do
+    case plan do
+      :free -> @free_plan_stats[:historical_data_in_days]
+      :basic -> @basic_plan_stats[:historical_data_in_days]
+      :pro -> @pro_plan_stats[:historical_data_in_days]
+      :premium -> @premium_plan_stats[:historical_data_in_days]
+      :custom -> @premium_plan_stats[:historical_data_in_days]
+    end
+  end
+
+  def realtime_data_cut_off_in_days(plan) do
+    case plan do
+      :free -> @free_plan_stats[:realtime_data_cut_off_in_days] || 0
+      :basic -> @basic_plan_stats[:realtime_data_cut_off_in_days] || 0
+      :pro -> @pro_plan_stats[:realtime_data_cut_off_in_days] || 0
+      :premium -> @premium_plan_stats[:realtime_data_cut_off_in_days] || 0
+      :custom -> @premium_plan_stats[:realtime_data_cut_off_in_days] || 0
+    end
+  end
+
   @doc ~s"""
   Check if a query full access is given only to users with a plan higher than free.
   A query can be restricted but still accessible by not-paid users or users with
@@ -161,7 +181,6 @@ defmodule Sanbase.Pricing.Plan.AccessChecker do
       :pro -> query in @pro_metrics_mapset
       :premium -> query in @premium_metrics_mapset
       :custom -> query in @premium_metrics_mapset
-      _ -> false
     end
   end
 end

--- a/lib/sanbase/pricing/plan/access_checker.ex
+++ b/lib/sanbase/pricing/plan/access_checker.ex
@@ -32,12 +32,19 @@ defmodule Sanbase.Pricing.Plan.AccessChecker do
     """
     require SanbaseWeb.Graphql.Schema
 
+    @mutation_type Absinthe.Schema.lookup_type(SanbaseWeb.Graphql.Schema, :mutation)
+    @mutations_mapset MapSet.new(@mutation_type.fields |> Map.keys())
+
     @query_type Absinthe.Schema.lookup_type(SanbaseWeb.Graphql.Schema, :query)
     @fields @query_type.fields |> Map.keys()
     def get_metrics_with_subscription_plan(plan) do
       Enum.filter(@fields, fn f ->
         Map.get(@query_type.fields, f) |> Absinthe.Type.meta(:subscription) == plan
       end)
+    end
+
+    def mutations_mapset() do
+      @mutations_mapset
     end
   end
 
@@ -110,6 +117,10 @@ defmodule Sanbase.Pricing.Plan.AccessChecker do
   def pro(), do: @pro_plan_stats
   def premium(), do: @premium_plan_stats
   def custom(), do: @custom_plan_stats
+
+  def mutations_mapset() do
+    Helper.mutations_mapset()
+  end
 
   @doc ~s"""
   Check if a query full access is given only to users with a plan higher than free.

--- a/lib/sanbase/pricing/plan/access_checker.ex
+++ b/lib/sanbase/pricing/plan/access_checker.ex
@@ -91,7 +91,6 @@ defmodule Sanbase.Pricing.Plan.AccessChecker do
     api_calls_minute: 60,
     api_calls_month: 10_000,
     historical_data_in_days: 6 * 30,
-    realtime_data_cut_off_in_days: 0,
     metrics: @basic_metrics
   }
 

--- a/lib/sanbase/pricing/plan/access_seed.ex
+++ b/lib/sanbase/pricing/plan/access_seed.ex
@@ -3,72 +3,105 @@ defmodule Sanbase.Pricing.Plan.AccessSeed do
   Module that holds the access control structure of the subscription plans.
   """
 
-  @standart_metrics [
-    "burn_rate",
-    "token_age_consumed",
-    "transaction_volume",
-    "average_token_age_consumed_in_days",
-    "token_circulation",
-    "token_velocity",
-    "daily_active_addresses",
-    "exchange_funds_flow",
-    "github_activity",
-    "dev_activity",
-    "network_growth",
-    "exchange_volume",
-    "share_of_deposits",
-    "historical_balance",
-    "percent_of_token_supply_on_exchanges",
-    "mining_pools_distribution",
-    "gas_used",
-    "top_holders_percent_of_total_supply"
-  ]
+  defmodule Helper do
+    require SanbaseWeb.Graphql.Schema
 
-  @advanced_metrics @standart_metrics ++
-                      [
-                        "daily_active_deposits",
-                        "realized_value",
-                        "mvrv_ratio",
-                        "nvt_ratio"
-                      ]
+    @query_type Absinthe.Schema.lookup_type(SanbaseWeb.Graphql.Schema, :query)
+    @fields @query_type.fields |> Map.keys()
+    def get_metrics_with_subscription_plan(plan) do
+      Enum.filter(@fields, fn f ->
+        Map.get(@query_type.fields, f) |> Absinthe.Type.meta(:subscription) == plan
+      end)
+    end
+  end
 
-  @free %{
+  @free_metrics Helper.get_metrics_with_subscription_plan(:free)
+  @free_metrics_mapset MapSet.new(@free_metrics)
+
+  @basic_metrics @free_metrics ++ Helper.get_metrics_with_subscription_plan(:basic)
+  @basic_metrics_mapset MapSet.new(@basic_metrics)
+
+  @pro_metrics @basic_metrics ++ Helper.get_metrics_with_subscription_plan(:pro)
+  @pro_metrics_mapset MapSet.new(@pro_metrics)
+
+  @premium_metrics @pro_metrics ++ Helper.get_metrics_with_subscription_plan(:premium)
+  @premium_metrics_mapset MapSet.new(@premium_metrics)
+  @all_restricted @premium_metrics -- @free_metrics
+  @all_restricted MapSet.new(@all_restricted)
+
+  @free_plan_stats %{
     api_calls_minute: 10,
     api_calls_month: 1000,
     historical_data_in_days: 3 * 30,
-    metrics: @standart_metrics
+    realtime_data_cut_off_in_days: 1,
+    metrics: @free_metrics
   }
 
-  @essential %{
+  @basic_plan_stats %{
     api_calls_minute: 60,
     api_calls_month: 10000,
     historical_data_in_days: 6 * 30,
-    metrics: @standart_metrics
+    realtime_data_cut_off_in_days: 0,
+    metrics: @basic_metrics
   }
 
-  @pro %{
+  @pro_plan_stats %{
     api_calls_minute: 120,
     api_calls_month: 150_000,
     historical_data_in_days: 18 * 30,
-    metrics: @advanced_metrics
+    metrics: @pro_metrics
   }
 
-  @premium %{
+  @premium_plan_stats %{
     api_calls_minute: 180,
     api_calls_month: 500_000,
-    metrics: @advanced_metrics
+    metrics: @premium_metrics
   }
 
-  @custom %{
-    metrics: @advanced_metrics
+  @custom_plan_stats %{
+    metrics: @premium_plan_stats
   }
 
-  def free(), do: @free
-  def essential(), do: @essential
-  def pro(), do: @pro
-  def premium(), do: @premium
-  def custom(), do: @custom
-  def standart_metrics(), do: @standart_metrics
-  def advanced_metrics(), do: @advanced_metrics
-  def all_restricted_metrics(), do: @advanced_metrics
+  def free(), do: @free_plan_stats
+  def essential(), do: @basic_plan_stats
+  def pro(), do: @pro_plan_stats
+  def premium(), do: @premium_plan_stats
+  def custom(), do: @custom_plan_stats
+
+  def standart_metrics(), do: @free_metrics
+  def advanced_metrics(), do: @basic_metrics
+  def all_restricted_metrics(), do: @all_restricted
+
+  def is_restricted?(query) do
+    query in @all_restricted
+  end
+
+  def needs_advanced_plan?(query) when is_atom(query) do
+    query in @premium_metrics_mapset and not (query in @basic_metrics_mapset)
+  end
+
+  def needs_advanced_plan?(query) when is_binary(query) do
+    String.to_existing_atom(query) in @premium_metrics_mapset and
+      not (query in @basic_metrics_mapset)
+  end
+
+  def lowest_plan_with_metric(query) do
+    cond do
+      query in @free_metrics_mapset -> :free
+      query in @basic_metrics_mapset -> :basic
+      query in @pro_metrics_mapset -> :pro
+      query in @premium_metrics_mapset -> :premium
+      true -> nil
+    end
+  end
+
+  def plan_has_access?(plan, query) do
+    case plan do
+      :free -> query in @free_metrics_mapset
+      :basic -> query in @basic_metrics_mapset
+      :pro -> query in @pro_metrics_mapset
+      :premium -> query in @premium_metrics_mapset
+      _ -> false
+    end
+  end
 end

--- a/lib/sanbase/pricing/plan/access_seed.ex
+++ b/lib/sanbase/pricing/plan/access_seed.ex
@@ -1,9 +1,35 @@
 defmodule Sanbase.Pricing.Plan.AccessSeed do
   @moduledoc """
-  Module that holds the access control structure of the subscription plans.
+  Module that contains functions for determining access based on the subscription
+  plan.
+
+  Adding new queries or updating the subscription plan does not require this
+  module to be changed.
+
+  The subscription plan needed for a given query is given in the query definition
+    ```
+    field :network_growth, list_of(:network_growth) do
+        meta(subscription: :basic)
+        ...
+    end
+    ```
+
+  This module knows how to inspect the GraphQL schema that is being build
+  compile-time and build the needed sets of data also compile time. There are no
+  checks for mutations - mutations
+
+  Additionally, this module will arise a compile-time warning if there is a
+  query without a subscription plan defined
   """
 
   defmodule Helper do
+    @moduledoc ~s"""
+    Contains a single function `get_metrics_with_subscription_plan/1` that examines
+    the Absinthe's compile-time build schema.
+
+    It is a different module because functions from the module where a module
+    attribute is defined cannot be used
+    """
     require SanbaseWeb.Graphql.Schema
 
     @query_type Absinthe.Schema.lookup_type(SanbaseWeb.Graphql.Schema, :query)
@@ -14,6 +40,25 @@ defmodule Sanbase.Pricing.Plan.AccessSeed do
       end)
     end
   end
+
+  # Emit a compile time warning if there is any query without subscription plan
+  case Helper.get_metrics_with_subscription_plan(nil) -- [:__typename, :__type, :__schema] do
+    [] ->
+      :ok
+
+    queries ->
+      IO.warn("""
+      There are GraphQL queries defined without specifying their subscription plan.
+      Subscription plan belonging is marked by the `meta` field inside the query
+      definition. Example: `meta(subscription: :pro)`
+
+      Queries without subscription plan: #{inspect(queries)}
+      """)
+  end
+
+  # Below are defined lists and sets (for fast member check) of all metrics
+  # available in a given plan. Each next plan contains all the metrics from theh
+  # lower plans plus some additional metrics
 
   @free_metrics Helper.get_metrics_with_subscription_plan(:free)
   @free_metrics_mapset MapSet.new(@free_metrics)
@@ -26,8 +71,6 @@ defmodule Sanbase.Pricing.Plan.AccessSeed do
 
   @premium_metrics @pro_metrics ++ Helper.get_metrics_with_subscription_plan(:premium)
   @premium_metrics_mapset MapSet.new(@premium_metrics)
-  @all_restricted @premium_metrics -- @free_metrics
-  @all_restricted MapSet.new(@all_restricted)
 
   @free_plan_stats %{
     api_calls_minute: 10,
@@ -39,7 +82,7 @@ defmodule Sanbase.Pricing.Plan.AccessSeed do
 
   @basic_plan_stats %{
     api_calls_minute: 60,
-    api_calls_month: 10000,
+    api_calls_month: 10_000,
     historical_data_in_days: 6 * 30,
     realtime_data_cut_off_in_days: 0,
     metrics: @basic_metrics
@@ -68,23 +111,26 @@ defmodule Sanbase.Pricing.Plan.AccessSeed do
   def premium(), do: @premium_plan_stats
   def custom(), do: @custom_plan_stats
 
-  def standart_metrics(), do: @free_metrics
-  def advanced_metrics(), do: @basic_metrics
-  def all_restricted_metrics(), do: @all_restricted
-
+  @doc ~s"""
+  Check if a query full access is given only to users with a plan higher than free.
+  A query can be restricted but still accessible by not-paid users or users with
+  lower plans. In this case historical and/or realtime data access can be cut off
+  """
   def is_restricted?(query) do
-    query in @all_restricted
+    not (query in @free_metrics_mapset)
   end
 
+  @doc ~s"""
+  Check if a query access is given only to users with an advanced plan
+  (pro or higher). No access is given to users with lower plans
+  """
   def needs_advanced_plan?(query) when is_atom(query) do
     query in @premium_metrics_mapset and not (query in @basic_metrics_mapset)
   end
 
-  def needs_advanced_plan?(query) when is_binary(query) do
-    String.to_existing_atom(query) in @premium_metrics_mapset and
-      not (query in @basic_metrics_mapset)
-  end
-
+  @doc ~s"""
+  Return the atom name of the lowest plan that gives access to a metric
+  """
   def lowest_plan_with_metric(query) do
     cond do
       query in @free_metrics_mapset -> :free
@@ -95,6 +141,9 @@ defmodule Sanbase.Pricing.Plan.AccessSeed do
     end
   end
 
+  @doc ~s"""
+  Check if a plan (defined as its atom name) has access to a query
+  """
   def plan_has_access?(plan, query) do
     case plan do
       :free -> query in @free_metrics_mapset

--- a/lib/sanbase/pricing/subscription.ex
+++ b/lib/sanbase/pricing/subscription.ex
@@ -144,12 +144,12 @@ defmodule Sanbase.Pricing.Subscription do
 
   def update_subscription_db(subscription, params) do
     subscription
-    |> Subscription.changeset(params)
+    |> changeset(params)
     |> Repo.update()
   end
 
   def sync_all() do
-    Subscription
+    __MODULE__
     |> Repo.all()
     |> Enum.each(&sync_with_stripe_subscription/1)
   end
@@ -163,7 +163,7 @@ defmodule Sanbase.Pricing.Subscription do
         },
         db_subscription
       ) do
-    Subscription.update_subscription_db(db_subscription, %{
+    update_subscription_db(db_subscription, %{
       current_period_end: DateTime.from_unix!(current_period_end),
       cancel_at_period_end: cancel_at_period_end,
       status: status,
@@ -171,7 +171,7 @@ defmodule Sanbase.Pricing.Subscription do
     })
   end
 
-  def sync_with_stripe_subscription(%Subscription{stripe_id: stripe_id} = subscription) do
+  def sync_with_stripe_subscription(%__MODULE__{stripe_id: stripe_id} = subscription) do
     StripeApi.retrieve_subscription(stripe_id)
     |> case do
       {:ok,
@@ -181,7 +181,7 @@ defmodule Sanbase.Pricing.Subscription do
          status: status,
          plan: %Stripe.Plan{id: stripe_plan_id}
        }} ->
-        Subscription.update_subscription_db(subscription, %{
+        update_subscription_db(subscription, %{
           current_period_end: DateTime.from_unix!(current_period_end),
           cancel_at_period_end: cancel_at_period_end,
           status: status,
@@ -315,8 +315,8 @@ defmodule Sanbase.Pricing.Subscription do
          user,
          plan
        ) do
-    %Subscription{}
-    |> Subscription.changeset(%{
+    %__MODULE__{}
+    |> changeset(%{
       stripe_id: stripe_id,
       user_id: user.id,
       plan_id: plan.id,

--- a/lib/sanbase/pricing/subscription.ex
+++ b/lib/sanbase/pricing/subscription.ex
@@ -234,15 +234,16 @@ defmodule Sanbase.Pricing.Subscription do
     subscription.plan.access["realtime_data_cut_off_in_days"]
   end
 
-  @doc """
-  Checks whether a query is in any plan.
+  @doc ~s"""
+  Check if a query full access is given only to users with a plan higher than free.
+  A query can be restricted but still accessible by not-paid users or users with
+  lower plans. In this case historical and/or realtime data access can be cut off
   """
-  def is_restricted?(query) do
-    AccessSeed.is_restricted?(query)
-  end
+  defdelegate is_restricted?(query), to: AccessSeed
 
-  @doc """
-  Query is in advanced subscription plans only
+  @doc ~s"""
+  Check if a query access is given only to users with an advanced plan
+  (pro or higher). No access is given to users with lower plans
   """
   defdelegate needs_advanced_plan?(query), to: AccessSeed
 

--- a/lib/sanbase/pricing/subscription.ex
+++ b/lib/sanbase/pricing/subscription.ex
@@ -10,7 +10,7 @@ defmodule Sanbase.Pricing.Subscription do
   import Ecto.Query
 
   alias Sanbase.Pricing.{Plan, Subscription}
-  alias Sanbase.Pricing.Plan.AccessSeed
+  alias Sanbase.Pricing.Plan.AccessChecker
   alias Sanbase.Auth.User
   alias Sanbase.Repo
   alias Sanbase.StripeApi
@@ -239,13 +239,13 @@ defmodule Sanbase.Pricing.Subscription do
   A query can be restricted but still accessible by not-paid users or users with
   lower plans. In this case historical and/or realtime data access can be cut off
   """
-  defdelegate is_restricted?(query), to: AccessSeed
+  defdelegate is_restricted?(query), to: AccessChecker
 
   @doc ~s"""
   Check if a query access is given only to users with an advanced plan
   (pro or higher). No access is given to users with lower plans
   """
-  defdelegate needs_advanced_plan?(query), to: AccessSeed
+  defdelegate needs_advanced_plan?(query), to: AccessChecker
 
   def plan_name(subscription) do
     subscription.plan.name
@@ -340,7 +340,7 @@ defmodule Sanbase.Pricing.Subscription do
   defp subscription_access?(nil, _query), do: false
 
   defp subscription_access?(%__MODULE__{plan: plan}, query) do
-    AccessSeed.plan_has_access?(Plan.plan_atom_name(plan), query)
+    AccessChecker.plan_has_access?(Plan.plan_atom_name(plan), query)
   end
 
   defp user_subscriptions_query(user) do

--- a/lib/sanbase/pricing/subscription.ex
+++ b/lib/sanbase/pricing/subscription.ex
@@ -230,22 +230,21 @@ defmodule Sanbase.Pricing.Subscription do
     subscription.plan.access["historical_data_in_days"]
   end
 
+  def realtime_data_cut_off_in_days(subscription) do
+    subscription.plan.access["realtime_data_cut_off_in_days"]
+  end
+
   @doc """
   Checks whether a query is in any plan.
   """
   def is_restricted?(query) do
-    query in AccessSeed.all_restricted_metrics()
+    AccessSeed.is_restricted?(query)
   end
 
   @doc """
   Query is in advanced subscription plans only
   """
-  def needs_advanced_plan?(query) do
-    advanced_metrics = AccessSeed.advanced_metrics()
-    standart_metrics = AccessSeed.standart_metrics()
-
-    query in advanced_metrics and query not in standart_metrics
-  end
+  defdelegate needs_advanced_plan?(query), to: AccessSeed
 
   def plan_name(subscription) do
     subscription.plan.name
@@ -339,8 +338,8 @@ defmodule Sanbase.Pricing.Subscription do
 
   defp subscription_access?(nil, _query), do: false
 
-  defp subscription_access?(subscription, query) do
-    query in subscription.plan.access["metrics"]
+  defp subscription_access?(%__MODULE__{plan: plan}, query) do
+    AccessSeed.plan_has_access?(Plan.plan_atom_name(plan), query)
   end
 
   defp user_subscriptions_query(user) do

--- a/lib/sanbase/pricing/subscription.ex
+++ b/lib/sanbase/pricing/subscription.ex
@@ -19,7 +19,10 @@ defmodule Sanbase.Pricing.Subscription do
 
   @percent_discount_1000_san 20
   @percent_discount_200_san 4
-  @generic_error_message "Current subscription attempt failed. Please, contact administrator of the site for more information."
+  @generic_error_message """
+  Current subscription attempt failed.
+  Please, contact administrator of the site for more information.
+  """
 
   # After `current_period_end` timestamp passes there is some time until `invoice.payment_succeeded` event is generated
   # to update the field with new timestamp value. So we add 1 day gratis in which we should receive payment before

--- a/lib/sanbase/pricing/subscription.ex
+++ b/lib/sanbase/pricing/subscription.ex
@@ -51,6 +51,10 @@ defmodule Sanbase.Pricing.Subscription do
     ])
   end
 
+  def free_subscription() do
+    %__MODULE__{plan: Plan.free_plan()}
+  end
+
   @doc """
   Subscribe user with card_token to a plan.
 

--- a/lib/sanbase/social_data/social_dominance.ex
+++ b/lib/sanbase/social_data/social_dominance.ex
@@ -8,9 +8,9 @@ defmodule Sanbase.SocialData.SocialDominance do
   defp http_client, do: Mockery.Macro.mockable(HTTPoison)
 
   require Sanbase.Utils.Config, as: Config
+  require SanbaseWeb.Graphql.Schema
 
   @recv_timeout 15_000
-
   @sources Absinthe.Schema.lookup_type(SanbaseWeb.Graphql.Schema, :social_dominance_sources).values
            |> Map.keys()
            |> List.delete(:all)

--- a/lib/sanbase_web/graphql/context_plug.ex
+++ b/lib/sanbase_web/graphql/context_plug.ex
@@ -15,8 +15,9 @@ defmodule SanbaseWeb.Graphql.ContextPlug do
   import Plug.Conn
   require Sanbase.Utils.Config, as: Config
 
-  alias SanbaseWeb.Graphql.ContextPlug
   alias Sanbase.Auth.User
+  alias Sanbase.Pricing.Subscription
+  alias SanbaseWeb.Graphql.ContextPlug
 
   require Logger
 
@@ -26,6 +27,8 @@ defmodule SanbaseWeb.Graphql.ContextPlug do
     &ContextPlug.basic_authentication/1,
     &ContextPlug.apikey_authentication/1
   ]
+
+  @api_product_id 1
 
   def init(opts), do: opts
 
@@ -106,7 +109,8 @@ defmodule SanbaseWeb.Graphql.ContextPlug do
           auth: %{
             auth_method: :user_token,
             current_user: current_user,
-            san_balance: san_balance(current_user)
+            san_balance: san_balance(current_user),
+            subscription: Subscription.current_subscription(current_user, @api_product_id)
           }
         }
 
@@ -126,7 +130,8 @@ defmodule SanbaseWeb.Graphql.ContextPlug do
         auth: %{
           auth_method: :user_token,
           current_user: current_user,
-          san_balance: san_balance(current_user)
+          san_balance: san_balance(current_user),
+          subscription: Subscription.current_subscription(current_user, @api_product_id)
         }
       }
     else
@@ -144,7 +149,8 @@ defmodule SanbaseWeb.Graphql.ContextPlug do
         auth: %{
           auth_method: :basic,
           current_user: current_user,
-          san_balance: 0
+          san_balance: 0,
+          subscription: nil
         }
       }
     else
@@ -164,7 +170,8 @@ defmodule SanbaseWeb.Graphql.ContextPlug do
           auth_method: :apikey,
           current_user: current_user,
           token: token,
-          san_balance: san_balance(current_user)
+          san_balance: san_balance(current_user),
+          subscription: Subscription.current_subscription(current_user, @api_product_id)
         }
       }
     else

--- a/lib/sanbase_web/graphql/middlewares/access_control.ex
+++ b/lib/sanbase_web/graphql/middlewares/access_control.ex
@@ -7,14 +7,14 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
   """
   @behaviour Absinthe.Middleware
 
-  require SanbaseWeb.Graphql.Schema
-  @mutation_type Absinthe.Schema.lookup_type(SanbaseWeb.Graphql.Schema, :mutation)
-  @mutations_mapset MapSet.new(@mutation_type.fields |> Map.keys())
-
   alias Absinthe.Resolution
+  alias Sanbase.Pricing.Plan.AccessChecker
   alias Sanbase.Pricing.{Subscription, Plan}
 
   require Logger
+
+  # define as module attribute to avoid function calls at runtime
+  @mutations_mapset AccessChecker.mutations_mapset()
 
   def call(
         %Resolution{

--- a/lib/sanbase_web/graphql/middlewares/timeframe_restriction.ex
+++ b/lib/sanbase_web/graphql/middlewares/timeframe_restriction.ex
@@ -217,7 +217,10 @@ defmodule SanbaseWeb.Graphql.Middlewares.TimeframeRestriction do
         resolution
         |> Resolution.put_result(
           {:error,
-           "Both `from` and `to` parameters are outside the allowed intervals you are allowed to query with your current subscription plan."}
+           """
+           Both `from` and `to` parameters are outside the allowed interval
+           you can query with your current subscription plan.
+           """}
         )
     end
   end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -80,7 +80,7 @@ defmodule SanbaseWeb.Graphql.Schema do
 
     case object.identifier do
       :query ->
-        [ApiUsage, AccessControl | prometeheus_middlewares]
+        prometeheus_middlewares ++ [ApiUsage, AccessControl]
 
       _ ->
         prometeheus_middlewares

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -1,4 +1,19 @@
 defmodule SanbaseWeb.Graphql.Schema do
+  @moduledoc ~s"""
+  The definition of the GraphQL Schema.
+
+  There are no fields explicitlty defined here. Queries, mutations and types
+  are defined in modules separated by concern. Then they are imported
+  via import_types/1 or import_fields/1
+
+  When defining a query there must be defined also a meta key 'subscription'.
+  These subscriptions have the following values:
+    > free
+    > basic
+    > pro
+    > premium
+    > enterprise
+  """
   use Absinthe.Schema
   use Absinthe.Ecto, repo: Sanbase.Repo
 

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -74,13 +74,13 @@ defmodule SanbaseWeb.Graphql.Schema do
 
   def middleware(middlewares, field, object) do
     prometeheus_middlewares =
-      middlewares
+      [AccessControl | middlewares]
       |> Prometheus.HistogramInstrumenter.instrument(field, object)
       |> Prometheus.CounterInstrumenter.instrument(field, object)
 
     case object.identifier do
       :query ->
-        prometeheus_middlewares ++ [ApiUsage, AccessControl]
+        [ApiUsage | prometeheus_middlewares]
 
       _ ->
         prometeheus_middlewares

--- a/lib/sanbase_web/graphql/schema/queries/blockchain_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/blockchain_queries.ex
@@ -34,6 +34,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     Grouping by interval works by summing all burn rate records in the interval.
     """
     field :burn_rate, list_of(:burn_rate_data) do
+      meta(subscription: :basic)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -46,6 +48,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     end
 
     field :token_age_consumed, list_of(:token_age_consumed_data) do
+      meta(subscription: :basic)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -66,6 +70,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     Grouping by interval works by summing all transaction volume records in the interval.
     """
     field :transaction_volume, list_of(:transaction_volume) do
+      meta(subscription: :basic)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -85,6 +91,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     This metric includes only on-chain transaction volume, not volume in exchanges.
     """
     field :average_token_age_consumed_in_days, list_of(:token_age) do
+      meta(subscription: :basic)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -101,6 +109,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     Projects are referred to by a unique identifier (slug).
     """
     field :token_circulation, list_of(:token_circulation) do
+      meta(subscription: :basic)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -118,6 +128,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     Projects are referred to by a unique identifier (slug).
     """
     field :token_velocity, list_of(:token_velocity) do
+      meta(subscription: :basic)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -142,6 +154,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     the exact number of unique addresses for each day.
     """
     field :daily_active_addresses, list_of(:active_addresses) do
+      meta(subscription: :basic)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -158,6 +172,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     This query returns the difference IN-OUT calculated for each interval.
     """
     field :exchange_funds_flow, list_of(:exchange_funds_flow) do
+      meta(subscription: :basic)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -173,18 +189,22 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     Calculates the exchange inflow and outflow volume in usd for a given exchange in a time interval.
     """
     field :exchange_volume, list_of(:exchange_volume) do
+      meta(subscription: :basic)
+
       arg(:exchange, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
 
       complexity(&Complexity.from_to_interval/3)
       middleware(AccessControl)
-      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
+      middleware(TimeframeRestriction)
       cache_resolve(&ExchangeResolver.exchange_volume/3)
     end
 
     @desc "Network growth returns the newly created addresses for a project in a given timeframe"
     field :network_growth, list_of(:network_growth) do
+      meta(subscription: :basic)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -198,6 +218,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
 
     @desc "Returns what percent of token supply is on exchanges"
     field :percent_of_token_supply_on_exchanges, list_of(:percent_of_token_supply_on_exchanges) do
+      meta(subscription: :basic)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -215,6 +237,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     you must pay for that computation. That payment is calculated in Gas.
     """
     field :gas_used, list_of(:gas_used) do
+      meta(subscription: :basic)
+
       arg(:slug, :string, default_value: "ethereum")
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -236,6 +260,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     * to - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
     """
     field :top_holders_percent_of_total_supply, list_of(:top_holders_percent_of_total_supply) do
+      meta(subscription: :basic)
+
       arg(:slug, non_null(:string))
       arg(:number_of_holders, non_null(:integer))
       arg(:from, non_null(:datetime))
@@ -254,6 +280,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     The realized value across the whole network is computed by summing the realized values
     of all wallets holding tokens at the moment."
     field :realized_value, list_of(:realized_value) do
+      meta(subscription: :pro)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -267,6 +295,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
 
     @desc "Returns MVRV(Market-Value-to-Realized-Value)"
     field :mvrv_ratio, list_of(:mvrv_ratio) do
+      meta(subscription: :pro)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -290,6 +320,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     a blockchain’s daily transaction throughput.
     """
     field :nvt_ratio, list_of(:nvt_ratio) do
+      meta(subscription: :pro)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -306,6 +338,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     Projects are referred to by a unique identifier (slug).
     """
     field :daily_active_deposits, list_of(:active_deposits) do
+      meta(subscription: :pro)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -322,6 +356,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     Fetch share of deposits from Daily Active Addresses.
     """
     field :share_of_deposits, list_of(:share_of_deposits) do
+      meta(subscription: :pro)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -334,6 +370,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
 
     @desc "Fetch a list of all exchange wallets. This query requires basic authentication."
     field :exchange_wallets, list_of(:wallet) do
+      meta(subscription: :restricted)
+
       arg(:slug, :string, default_value: "ethereum")
 
       middleware(BasicAuth)
@@ -344,6 +382,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     Return a list of assets that a wallet currently holds.
     """
     field :assets_held_by_address, list_of(:slug_balance) do
+      meta(subscription: :free)
+
       arg(:address, non_null(:string))
 
       cache_resolve(&ClickhouseResolver.assets_held_by_address/3)
@@ -354,18 +394,23 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     Returns the historical balance for a given address in the given interval.
     """
     field :historical_balance, list_of(:historical_balance) do
+      meta(subscription: :free)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:address, non_null(:string))
       arg(:interval, non_null(:string), default_value: "1d")
 
+      complexity(&Complexity.from_to_interval/3)
       middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
       cache_resolve(&ClickhouseResolver.historical_balance/3)
     end
 
     @desc "List all exchanges"
     field :all_exchanges, list_of(:string) do
+      meta(subscription: :free)
+
       arg(:slug, :string, default_value: "ethereum")
 
       cache_resolve(&ExchangeResolver.all_exchanges/3)
@@ -377,6 +422,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     Currently only ETH is supported.
     """
     field :mining_pools_distribution, list_of(:mining_pools_distribution) do
+      meta(subscription: :basic)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -392,6 +439,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     Currently only ETH is supported.
     """
     field :miners_balance, list_of(:miners_balance) do
+      meta(subscription: :basic)
+
       arg(:slug, :string, default_value: "ethereum")
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))

--- a/lib/sanbase_web/graphql/schema/queries/blockchain_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/blockchain_queries.ex
@@ -147,7 +147,7 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     the exact number of unique addresses for each day.
     """
     field :daily_active_addresses, list_of(:active_addresses) do
-      meta(subscription: :basic)
+      meta(subscription: :free)
 
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
@@ -155,7 +155,7 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
+      middleware(TimeframeRestriction)
       cache_resolve(&ClickhouseResolver.daily_active_addresses/3)
     end
 
@@ -385,7 +385,7 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, non_null(:string), default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
+      middleware(TimeframeRestriction)
       cache_resolve(&ClickhouseResolver.historical_balance/3)
     end
 

--- a/lib/sanbase_web/graphql/schema/queries/blockchain_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/blockchain_queries.ex
@@ -13,8 +13,7 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
 
   alias SanbaseWeb.Graphql.Middlewares.{
     TimeframeRestriction,
-    BasicAuth,
-    AccessControl
+    BasicAuth
   }
 
   import_types(SanbaseWeb.Graphql.EtherbiTypes)
@@ -42,7 +41,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
       middleware(TimeframeRestriction)
       cache_resolve(&EtherbiResolver.token_age_consumed/3)
     end
@@ -56,7 +54,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
       middleware(TimeframeRestriction)
       cache_resolve(&EtherbiResolver.token_age_consumed/3)
     end
@@ -78,7 +75,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
       middleware(TimeframeRestriction)
       cache_resolve(&EtherbiResolver.transaction_volume/3)
     end
@@ -99,7 +95,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
       middleware(TimeframeRestriction)
       cache_resolve(&EtherbiResolver.average_token_age_consumed_in_days/3)
     end
@@ -118,7 +113,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
       middleware(TimeframeRestriction)
       cache_resolve(&ClickhouseResolver.token_circulation/3)
     end
@@ -137,7 +131,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
       middleware(TimeframeRestriction)
       cache_resolve(&ClickhouseResolver.token_velocity/3)
     end
@@ -162,7 +155,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
       middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
       cache_resolve(&ClickhouseResolver.daily_active_addresses/3)
     end
@@ -180,7 +172,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
       middleware(TimeframeRestriction)
       cache_resolve(&EtherbiResolver.exchange_funds_flow/3)
     end
@@ -196,7 +187,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:to, non_null(:datetime))
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
       middleware(TimeframeRestriction)
       cache_resolve(&ExchangeResolver.exchange_volume/3)
     end
@@ -211,7 +201,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, non_null(:string), default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
       middleware(TimeframeRestriction)
       cache_resolve(&ClickhouseResolver.network_growth/3)
     end
@@ -226,7 +215,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
       middleware(TimeframeRestriction)
       cache_resolve(&ClickhouseResolver.percent_of_token_supply_on_exchanges/3)
     end
@@ -245,7 +233,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
       middleware(TimeframeRestriction)
       cache_resolve(&ClickhouseResolver.gas_used/3)
     end
@@ -269,7 +256,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
       middleware(TimeframeRestriction)
       cache_resolve(&ClickhouseResolver.top_holders_percent_of_total_supply/3)
     end
@@ -288,7 +274,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
       middleware(TimeframeRestriction)
       cache_resolve(&ClickhouseResolver.realized_value/3)
     end
@@ -303,7 +288,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, non_null(:string), default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
       middleware(TimeframeRestriction)
       cache_resolve(&ClickhouseResolver.mvrv_ratio/3)
     end
@@ -328,7 +312,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
       middleware(TimeframeRestriction)
       cache_resolve(&ClickhouseResolver.nvt_ratio/3)
     end
@@ -346,7 +329,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
       middleware(TimeframeRestriction)
       cache_resolve(&ClickhouseResolver.daily_active_deposits/3)
     end

--- a/lib/sanbase_web/graphql/schema/queries/featured_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/featured_queries.ex
@@ -10,14 +10,17 @@ defmodule SanbaseWeb.Graphql.Schema.FeaturedQueries do
 
   object :featured_queries do
     field :featured_insights, list_of(:post) do
+      meta(subscription: :free)
       cache_resolve(&FeaturedItemResolver.insights/3)
     end
 
     field :featured_watchlists, list_of(:user_list) do
+      meta(subscription: :free)
       cache_resolve(&FeaturedItemResolver.watchlists/3)
     end
 
     field :featured_user_triggers, list_of(:user_trigger) do
+      meta(subscription: :free)
       cache_resolve(&FeaturedItemResolver.user_triggers/3)
     end
   end

--- a/lib/sanbase_web/graphql/schema/queries/github_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/github_queries.ex
@@ -12,6 +12,7 @@ defmodule SanbaseWeb.Graphql.Schema.GithubQueries do
   object :github_queries do
     @desc "Returns a list of slugs of the projects that have a github link"
     field :github_availables_repos, list_of(:string) do
+      meta(subscription: :free)
       cache_resolve(&GithubResolver.available_repos/3)
     end
 
@@ -28,6 +29,8 @@ defmodule SanbaseWeb.Graphql.Schema.GithubQueries do
         It is used to calculate the moving avarage interval.
     """
     field :github_activity, list_of(:activity_point) do
+      meta(subscription: :free)
+
       arg(:slug, :string)
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -36,7 +39,7 @@ defmodule SanbaseWeb.Graphql.Schema.GithubQueries do
       arg(:moving_average_interval_base, :integer, default_value: 7)
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(TimeframeRestriction, %{allow_historical_data: true})
+      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
       cache_resolve(&GithubResolver.github_activity/3)
     end
 
@@ -45,6 +48,8 @@ defmodule SanbaseWeb.Graphql.Schema.GithubQueries do
     excluding Comments, Issues and PR Comments
     """
     field :dev_activity, list_of(:activity_point) do
+      meta(subscription: :free)
+
       arg(:slug, :string)
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -53,7 +58,7 @@ defmodule SanbaseWeb.Graphql.Schema.GithubQueries do
       arg(:moving_average_interval_base, :integer, default_value: 7)
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(TimeframeRestriction, %{allow_historical_data: true})
+      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
       cache_resolve(&GithubResolver.dev_activity/3, ttl: 600, max_ttl_offset: 600)
     end
   end

--- a/lib/sanbase_web/graphql/schema/queries/github_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/github_queries.ex
@@ -39,7 +39,7 @@ defmodule SanbaseWeb.Graphql.Schema.GithubQueries do
       arg(:moving_average_interval_base, :integer, default_value: 7)
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
+      middleware(TimeframeRestriction)
       cache_resolve(&GithubResolver.github_activity/3)
     end
 
@@ -58,7 +58,7 @@ defmodule SanbaseWeb.Graphql.Schema.GithubQueries do
       arg(:moving_average_interval_base, :integer, default_value: 7)
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
+      middleware(TimeframeRestriction)
       cache_resolve(&GithubResolver.dev_activity/3, ttl: 600, max_ttl_offset: 600)
     end
   end

--- a/lib/sanbase_web/graphql/schema/queries/insight_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/insight_queries.ex
@@ -17,6 +17,8 @@ defmodule SanbaseWeb.Graphql.Schema.InsightQueries do
   object :insight_queries do
     @desc "Fetch the currently running poll."
     field :current_poll, :poll do
+      meta(subscription: :free)
+
       cache_resolve(&InsightResolver.current_poll/3)
     end
 
@@ -25,6 +27,8 @@ defmodule SanbaseWeb.Graphql.Schema.InsightQueries do
     The user must be logged in to access all fields for the post/insight.
     """
     field :post, :post do
+      meta(subscription: :free)
+
       deprecate("Use `insight` instead")
       arg(:id, non_null(:integer))
 
@@ -36,6 +40,8 @@ defmodule SanbaseWeb.Graphql.Schema.InsightQueries do
     The user must be logged in to access all fields for the post/insight.
     """
     field :insight, :post do
+      meta(subscription: :free)
+
       arg(:id, non_null(:integer))
 
       resolve(&PostResolver.post/3)
@@ -47,6 +53,8 @@ defmodule SanbaseWeb.Graphql.Schema.InsightQueries do
     It supports paginations with `page` and `page_size` args.
     """
     field :all_insights, list_of(:post) do
+      meta(subscription: :free)
+
       arg(:page, :integer, default_value: 1)
       arg(:page_size, :integer, default_value: 20)
       arg(:tags, list_of(:string))
@@ -56,6 +64,8 @@ defmodule SanbaseWeb.Graphql.Schema.InsightQueries do
 
     @desc "Fetch a list of all posts for given user ID."
     field :all_insights_for_user, list_of(:post) do
+      meta(subscription: :free)
+
       arg(:user_id, non_null(:integer))
 
       resolve(&PostResolver.all_insights_for_user/3)
@@ -63,6 +73,8 @@ defmodule SanbaseWeb.Graphql.Schema.InsightQueries do
 
     @desc "Fetch a list of all posts for which a user has voted."
     field :all_insights_user_voted, list_of(:post) do
+      meta(subscription: :free)
+
       arg(:user_id, non_null(:integer))
 
       resolve(&PostResolver.all_insights_user_voted_for/3)
@@ -73,6 +85,8 @@ defmodule SanbaseWeb.Graphql.Schema.InsightQueries do
     The user must be logged in to access all fields for the post/insight.
     """
     field :all_insights_by_tag, list_of(:post) do
+      meta(subscriptionc: :free)
+
       arg(:tag, non_null(:string))
 
       resolve(&PostResolver.all_insights_by_tag/3)
@@ -80,6 +94,8 @@ defmodule SanbaseWeb.Graphql.Schema.InsightQueries do
 
     @desc "Fetch a list of all tags used for posts/insights. This query also returns tags that are not yet in use."
     field :all_tags, list_of(:tag) do
+      meta(subscription: :free)
+
       cache_resolve(&PostResolver.all_tags/3)
     end
   end

--- a/lib/sanbase_web/graphql/schema/queries/insight_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/insight_queries.ex
@@ -85,7 +85,7 @@ defmodule SanbaseWeb.Graphql.Schema.InsightQueries do
     The user must be logged in to access all fields for the post/insight.
     """
     field :all_insights_by_tag, list_of(:post) do
-      meta(subscriptionc: :free)
+      meta(subscription: :free)
 
       arg(:tag, non_null(:string))
 

--- a/lib/sanbase_web/graphql/schema/queries/price_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/price_queries.ex
@@ -21,7 +21,7 @@ defmodule SanbaseWeb.Graphql.Schema.PriceQueries do
       arg(:interval, :string, default_value: "")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
+      middleware(TimeframeRestriction)
       cache_resolve(&PriceResolver.history_price/3)
     end
 
@@ -38,7 +38,7 @@ defmodule SanbaseWeb.Graphql.Schema.PriceQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
+      middleware(TimeframeRestriction)
       cache_resolve(&PriceResolver.ohlc/3)
     end
   end

--- a/lib/sanbase_web/graphql/schema/queries/price_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/price_queries.ex
@@ -12,6 +12,8 @@ defmodule SanbaseWeb.Graphql.Schema.PriceQueries do
   object :price_queries do
     @desc "Fetch price history for a given slug and time interval."
     field :history_price, list_of(:price_point) do
+      meta(subscription: :free)
+
       arg(:slug, :string)
       arg(:ticker, :string, deprecate: "Use slug instead of ticker")
       arg(:from, non_null(:datetime))
@@ -28,6 +30,8 @@ defmodule SanbaseWeb.Graphql.Schema.PriceQueries do
     """
 
     field :ohlc, list_of(:ohlc) do
+      meta(subscription: :free)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))

--- a/lib/sanbase_web/graphql/schema/queries/pricing_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/pricing_queries.ex
@@ -14,6 +14,8 @@ defmodule SanbaseWeb.Graphql.Schema.PricingQueries do
     List available products with corresponding subscription plans.
     """
     field :products_with_plans, list_of(:product) do
+      meta(subscription: :free)
+
       resolve(&PricingResolver.products_with_plans/3)
     end
 
@@ -21,6 +23,8 @@ defmodule SanbaseWeb.Graphql.Schema.PricingQueries do
     List all user invoice payments.
     """
     field :payments, list_of(:payments) do
+      meta(subscription: :free)
+
       middleware(JWTAuth)
 
       resolve(&PricingResolver.payments/3)

--- a/lib/sanbase_web/graphql/schema/queries/project_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/project_queries.ex
@@ -99,7 +99,7 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
       arg(:to, non_null(:datetime))
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
+      middleware(TimeframeRestriction)
       cache_resolve(&PriceResolver.multiple_projects_stats/3)
     end
 
@@ -124,7 +124,7 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
       arg(:interval, non_null(:string), default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
+      middleware(TimeframeRestriction)
       cache_resolve(&ProjectResolver.combined_history_stats/3)
     end
 
@@ -156,7 +156,7 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
       arg(:to, non_null(:datetime))
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
+      middleware(TimeframeRestriction)
 
       cache_resolve(&ProjectTransactionsResolver.eth_spent_by_all_projects/3,
         ttl: 600,
@@ -172,7 +172,7 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
       arg(:to, non_null(:datetime))
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
+      middleware(TimeframeRestriction)
 
       cache_resolve(&ProjectTransactionsResolver.eth_spent_by_erc20_projects/3,
         ttl: 600,
@@ -192,7 +192,7 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
+      middleware(TimeframeRestriction)
 
       cache_resolve(&ProjectTransactionsResolver.eth_spent_over_time_by_erc20_projects/3,
         ttl: 600,
@@ -212,7 +212,7 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
+      middleware(TimeframeRestriction)
 
       cache_resolve(&ProjectTransactionsResolver.eth_spent_over_time_by_all_projects/3,
         ttl: 600,

--- a/lib/sanbase_web/graphql/schema/queries/project_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/project_queries.ex
@@ -18,6 +18,8 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
   object :project_queries do
     @desc "Fetch all projects that have price data."
     field :all_projects, list_of(:project) do
+      meta(subscription: :free)
+
       arg(:page, :integer)
       arg(:page_size, :integer)
       arg(:min_volume, :integer)
@@ -28,36 +30,41 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
 
     @desc "Fetch all ERC20 projects."
     field :all_erc20_projects, list_of(:project) do
+      meta(subscription: :free)
+
       arg(:page, :integer)
       arg(:page_size, :integer)
       arg(:min_volume, :integer)
 
       middleware(ProjectPermissions)
-
       cache_resolve(&ProjectResolver.all_erc20_projects/3)
     end
 
     @desc "Fetch all currency projects. A currency project is a project that has price data but is not classified as ERC20."
     field :all_currency_projects, list_of(:project) do
+      meta(subscription: :free)
+
       arg(:page, :integer)
       arg(:page_size, :integer)
       arg(:min_volume, :integer)
 
       middleware(ProjectPermissions)
-
       cache_resolve(&ProjectResolver.all_currency_projects/3)
     end
 
     field :all_projects_by_function, list_of(:project) do
+      meta(subscription: :free)
+
       arg(:function, :json)
 
       middleware(ProjectPermissions)
-
       cache_resolve(&ProjectResolver.all_projects_by_function/3)
     end
 
     @desc "Fetch all project transparency projects. This query requires basic authentication."
     field :all_projects_project_transparency, list_of(:project) do
+      meta(subscription: :free)
+
       middleware(BasicAuth)
       resolve(&ProjectResolver.all_projects_project_transparency/3)
     end
@@ -66,13 +73,18 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
 
     @desc "Fetch a project by its ID."
     field :project, :project do
+      meta(subscription: :free)
+
       arg(:id, non_null(:id))
       resolve(&ProjectResolver.project/3)
     end
 
     @desc "Fetch a project by a unique identifier."
     field :project_by_slug, :project do
+      meta(subscription: :free)
+
       arg(:slug, non_null(:string))
+
       cache_resolve(&ProjectResolver.project_by_slug/3)
     end
 
@@ -80,6 +92,8 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
     Fetch data for each of the projects in the slugs lists
     """
     field :projects_list_stats, list_of(:project_stats) do
+      meta(subscription: :free)
+
       arg(:slugs, non_null(list_of(:string)))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -91,6 +105,8 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
 
     @desc "Returns the number of erc20 projects, currency projects and all projects"
     field :projects_count, :projects_count do
+      meta(subscription: :free)
+
       arg(:min_volume, :integer)
       cache_resolve(&ProjectResolver.projects_count/3)
     end
@@ -100,6 +116,8 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
     of the marketcaps and volumes of all projects for that given time interval
     """
     field :projects_list_history_stats, list_of(:combined_projects_stats) do
+      meta(subscription: :free)
+
       arg(:slugs, non_null(list_of(:string)))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -112,16 +130,19 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
 
     @desc "Fetch all market segments."
     field :all_market_segments, list_of(:market_segment) do
+      meta(subscription: :free)
       cache_resolve(&MarketSegmentResolver.all_market_segments/3)
     end
 
     @desc "Fetch ERC20 projects' market segments."
     field :erc20_market_segments, list_of(:market_segment) do
+      meta(subscription: :free)
       cache_resolve(&MarketSegmentResolver.erc20_market_segments/3)
     end
 
     @desc "Fetch currency projects' market segments."
     field :currencies_market_segments, list_of(:market_segment) do
+      meta(subscription: :free)
       cache_resolve(&MarketSegmentResolver.currencies_market_segments/3)
     end
   end
@@ -129,6 +150,8 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
   object :project_eth_spent_queries do
     @desc "Fetch the ETH spent by all projects within a given time period."
     field :eth_spent_by_all_projects, :float do
+      meta(subscription: :free)
+
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
 
@@ -143,6 +166,8 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
 
     @desc "Fetch the ETH spent by all ERC20 projects within a given time period."
     field :eth_spent_by_erc20_projects, :float do
+      meta(subscription: :free)
+
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
 
@@ -160,6 +185,8 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
     This query returns a list of values where each value is of length `interval`.
     """
     field :eth_spent_over_time_by_erc20_projects, list_of(:eth_spent_data) do
+      meta(subscription: :free)
+
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:interval, :string, default_value: "1d")
@@ -178,6 +205,8 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
     This query returns a list of values where each value is of length `interval`.
     """
     field :eth_spent_over_time_by_all_projects, list_of(:eth_spent_data) do
+      meta(subscription: :free)
+
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:interval, :string, default_value: "1d")

--- a/lib/sanbase_web/graphql/schema/queries/project_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/project_queries.ex
@@ -63,7 +63,7 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
 
     @desc "Fetch all project transparency projects. This query requires basic authentication."
     field :all_projects_project_transparency, list_of(:project) do
-      meta(subscription: :free)
+      meta(subscription: :restricted)
 
       middleware(BasicAuth)
       resolve(&ProjectResolver.all_projects_project_transparency/3)

--- a/lib/sanbase_web/graphql/schema/queries/signal_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/signal_queries.ex
@@ -16,6 +16,8 @@ defmodule SanbaseWeb.Graphql.Schema.SignalQueries do
   object :signal_queries do
     @desc "Get signal trigger by its id"
     field :get_trigger_by_id, :user_trigger do
+      meta(subscription: :free)
+
       arg(:id, non_null(:integer))
 
       middleware(JWTAuth)
@@ -24,6 +26,8 @@ defmodule SanbaseWeb.Graphql.Schema.SignalQueries do
 
     @desc "Get public signal triggers by user_id"
     field :public_triggers_for_user, list_of(:user_trigger) do
+      meta(subscription: :free)
+
       arg(:user_id, non_null(:id))
 
       resolve(&UserTriggerResolver.public_triggers_for_user/3)
@@ -31,11 +35,15 @@ defmodule SanbaseWeb.Graphql.Schema.SignalQueries do
 
     @desc "Get all public signal triggers"
     field :all_public_triggers, list_of(:user_trigger) do
+      meta(subscription: :free)
+
       resolve(&UserTriggerResolver.all_public_triggers/3)
     end
 
     @desc "Get historical trigger points"
     field :historical_trigger_points, list_of(:json) do
+      meta(subscription: :free)
+
       arg(:cooldown, :string)
       arg(:settings, non_null(:json))
 
@@ -50,6 +58,8 @@ defmodule SanbaseWeb.Graphql.Schema.SignalQueries do
     * `limit` argument defines the size of the page. Default value is 25
     """
     field :signals_historical_activity, :signal_historical_activity_paginated do
+      meta(subscription: :free)
+
       arg(:cursor, :cursor_input)
       arg(:limit, :integer, default_value: 25)
 

--- a/lib/sanbase_web/graphql/schema/queries/social_data_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/social_data_queries.ex
@@ -43,7 +43,7 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
       arg(:interval, :string, default_value: "1d")
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
+      middleware(TimeframeRestriction)
       cache_resolve(&TwitterResolver.history_twitter_data/3)
     end
 
@@ -140,7 +140,7 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
       arg(:result_size_tail, :integer, default_value: 0)
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
+      middleware(TimeframeRestriction)
       cache_resolve(&SocialDataResolver.twitter_mention_count/3)
     end
 
@@ -159,7 +159,7 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
 
       middleware(MultipleAuth, [{JWTAuth, san_tokens: 1000}, {ApikeyAuth, san_tokens: 1000}])
       complexity(&Complexity.from_to_interval/3)
-      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
+      middleware(TimeframeRestriction)
       cache_resolve(&SocialDataResolver.emojis_sentiment/3)
     end
 
@@ -287,7 +287,7 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
 
-      middleware(TimeframeRestriction, %{allow_historical_data: true, allow_realtime_data: true})
+      middleware(TimeframeRestriction)
       cache_resolve(&ElasticsearchResolver.stats/3)
     end
 

--- a/lib/sanbase_web/graphql/schema/queries/social_data_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/social_data_queries.ex
@@ -24,6 +24,8 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
   object :social_data_queries do
     @desc "Fetch the current data for a Twitter account (currently includes only Twitter followers)."
     field :twitter_data, :twitter_data do
+      meta(subscription: :free)
+
       arg(:ticker, :string, deprecate: "Use slug instead of ticker")
       arg(:slug, :string)
 
@@ -32,6 +34,8 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
 
     @desc "Fetch historical data for a Twitter account (currently includes only Twitter followers)."
     field :history_twitter_data, list_of(:twitter_data) do
+      meta(subscription: :free)
+
       arg(:ticker, :string, deprecate: "Use slug instead of ticker")
       arg(:slug, :string)
       arg(:from, non_null(:datetime))
@@ -58,6 +62,8 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
       * to - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
     """
     field :trending_words, list_of(:trending_words) do
+      meta(subscription: :basic)
+
       arg(:source, non_null(:trending_words_sources))
       arg(:size, non_null(:integer))
       arg(:hour, non_null(:integer))
@@ -83,6 +89,8 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
       * to - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
     """
     field :word_trend_score, list_of(:word_trend_score) do
+      meta(subscription: :basic)
+
       arg(:word, non_null(:string))
       arg(:source, non_null(:trending_words_sources))
       arg(:from, non_null(:datetime))
@@ -108,6 +116,8 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
       * to - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
     """
     field :word_context, list_of(:word_context) do
+      meta(subscription: :basic)
+
       arg(:word, non_null(:string))
       arg(:source, non_null(:trending_words_sources))
       arg(:size, non_null(:integer))
@@ -121,6 +131,8 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
 
     @desc "Fetch the Twitter mention count for a given ticker and time period."
     field :twitter_mention_count, list_of(:twitter_mention_count) do
+      meta(subscription: :free)
+
       arg(:ticker, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -132,11 +144,14 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
       cache_resolve(&SocialDataResolver.twitter_mention_count/3)
     end
 
+    # TODO: Rework when removing staking
     @desc ~s"""
     Fetch the emoji sentiment for a given ticker and time period.
     This metric is a basic sentiment analysis, based on emojis used in social media.
     """
     field :emojis_sentiment, list_of(:emojis_sentiment) do
+      meta(subscription: :free)
+
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:interval, :string, default_value: "1d")
@@ -163,6 +178,8 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
         4. "DISCORD_DISCUSSION_OVERVIEW" - shows how many times the given project has been mentioned in the discord channels
     """
     field :social_volume, list_of(:social_volume) do
+      meta(subscription: :basic)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -178,6 +195,8 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
     Returns a list of slugs for which there is social volume data.
     """
     field :social_volume_projects, list_of(:string) do
+      meta(subscription: :free)
+
       cache_resolve(&SocialDataResolver.social_volume_projects/3)
     end
 
@@ -196,6 +215,8 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
       * to - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
     """
     field :topic_search, :topic_search do
+      meta(subscription: :basic)
+
       arg(:source, non_null(:topic_search_sources))
       arg(:search_text, non_null(:string))
       arg(:from, non_null(:datetime))
@@ -223,6 +244,8 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
         5. ALL - shows the average value of the social dominance across all sources
     """
     field :social_dominance, list_of(:social_dominance) do
+      meta(subscription: :basic)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -244,6 +267,8 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
       * size - size limit of the returned results
     """
     field :news, list_of(:news) do
+      meta(subscription: :free)
+
       arg(:tag, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -257,6 +282,8 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
 
     @desc "Returns statistics for the data stored in elasticsearch"
     field :elasticsearch_stats, :elasticsearch_stats do
+      meta(subscription: :free)
+
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
 
@@ -274,6 +301,8 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
     * `time_window` - the `change` time window in days. Should be between `2d` and `30d`.
     """
     field :top_social_gainers_losers, list_of(:top_social_gainers_losers) do
+      meta(subscription: :basic)
+
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:status, non_null(:social_gainers_losers_status_enum))
@@ -295,6 +324,8 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
     * `time_window` - the `change` time window in days. Should be between `2d` and `30d`.
     """
     field :social_gainers_losers_status, list_of(:social_gainers_losers_status) do
+      meta(subscription: :basic)
+
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))

--- a/lib/sanbase_web/graphql/schema/queries/tech_indicators_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/tech_indicators_queries.ex
@@ -20,6 +20,8 @@ defmodule SanbaseWeb.Graphql.Schema.TechIndicatorsQueries do
     specifically when price goes up as volume goes down.
     """
     field :price_volume_diff, list_of(:price_volume_diff) do
+      meta(subscription: :free)
+
       arg(:slug, non_null(:string))
       @desc "Currently supported currencies: USD, BTC"
       arg(:currency, non_null(:string))
@@ -45,6 +47,8 @@ defmodule SanbaseWeb.Graphql.Schema.TechIndicatorsQueries do
     * interval - an integer followed by one of: `m`, `h`, `d`, `w`
     """
     field :metric_anomaly, list_of(:anomaly_value) do
+      meta(subscription: :basic)
+
       arg(:metric, non_null(:anomalies_metrics_enum))
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))

--- a/lib/sanbase_web/graphql/schema/queries/tech_indicators_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/tech_indicators_queries.ex
@@ -47,7 +47,7 @@ defmodule SanbaseWeb.Graphql.Schema.TechIndicatorsQueries do
     * interval - an integer followed by one of: `m`, `h`, `d`, `w`
     """
     field :metric_anomaly, list_of(:anomaly_value) do
-      meta(subscription: :basic)
+      meta(subscription: :free)
 
       arg(:metric, non_null(:anomalies_metrics_enum))
       arg(:slug, non_null(:string))

--- a/lib/sanbase_web/graphql/schema/queries/timeline_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/timeline_queries.ex
@@ -9,11 +9,12 @@ defmodule SanbaseWeb.Graphql.Schema.TimelineQueries do
 
   object :timeline_queries do
     field :timeline_events, list_of(:timeline_events_paginated) do
+      meta(subscription: :free)
+
       arg(:cursor, :cursor_input)
       arg(:limit, :integer, default_value: 25)
 
       middleware(JWTAuth)
-
       resolve(&TimelineEventResolver.timeline_events/3)
     end
   end

--- a/lib/sanbase_web/graphql/schema/queries/user_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/user_queries.ex
@@ -20,6 +20,8 @@ defmodule SanbaseWeb.Graphql.Schema.UserQueries do
   object :user_queries do
     @desc "Returns the user currently logged in."
     field :current_user, :user do
+      meta(subscription: :free)
+
       resolve(&AccountResolver.current_user/3)
     end
 
@@ -30,6 +32,8 @@ defmodule SanbaseWeb.Graphql.Schema.UserQueries do
     and sanbase accounts are linked and the user can receive sanbase signals in telegram.
     """
     field :get_telegram_deep_link, :string do
+      meta(subscription: :free)
+
       middleware(JWTAuth)
       resolve(&TelegramResolver.get_telegram_deep_link/3)
     end

--- a/lib/sanbase_web/graphql/schema/queries/watchlist_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/watchlist_queries.ex
@@ -14,34 +14,46 @@ defmodule SanbaseWeb.Graphql.Schema.WatchlistQueries do
   object :user_list_queries do
     @desc "Fetch all favourites lists for current_user."
     field :fetch_user_lists, list_of(:user_list) do
+      meta(subscription: :free)
+
       deprecate("Use `fetchWatchlists` instead")
       resolve(&UserListResolver.fetch_user_lists/3)
     end
 
     @desc "Fetch all watchlists for the current user"
     field :fetch_watchlists, list_of(:user_list) do
+      meta(subscription: :free)
+
       resolve(&UserListResolver.fetch_user_lists/3)
     end
 
     @desc "Fetch all public favourites lists for current_user."
     field :fetch_public_user_lists, list_of(:user_list) do
+      meta(subscription: :free)
+
       deprecate("Use `fetchPublicWatchlists` instead")
       resolve(&UserListResolver.fetch_public_user_lists/3)
     end
 
     @desc "Fetch all public watchlists for current_user."
     field :fetch_public_watchlists, list_of(:user_list) do
+      meta(subscription: :free)
+
       resolve(&UserListResolver.fetch_public_user_lists/3)
     end
 
     @desc "Fetch all public favourites lists"
     field :fetch_all_public_user_lists, list_of(:user_list) do
+      meta(subscription: :free)
+
       deprecate("Use `fetchAllPublicWatchlists` instead")
       resolve(&UserListResolver.fetch_all_public_user_lists/3)
     end
 
     @desc "Fetch all public watchlists"
     field :fetch_all_public_watchlists, list_of(:user_list) do
+      meta(subscription: :free)
+
       resolve(&UserListResolver.fetch_all_public_user_lists/3)
     end
 
@@ -51,6 +63,8 @@ defmodule SanbaseWeb.Graphql.Schema.WatchlistQueries do
     This query returns either a single user list item or null.
     """
     field :user_list, :user_list do
+      meta(subscription: :free)
+
       deprecate("Use `watchlist` with argument `id` instead")
       arg(:user_list_id, non_null(:id))
 
@@ -58,6 +72,8 @@ defmodule SanbaseWeb.Graphql.Schema.WatchlistQueries do
     end
 
     field :watchlist, :user_list do
+      meta(subscription: :free)
+
       arg(:id, non_null(:id))
       resolve(&UserListResolver.watchlist/3)
     end

--- a/priv/repo/migrations/20190510080002_create_plans_table.exs
+++ b/priv/repo/migrations/20190510080002_create_plans_table.exs
@@ -1,7 +1,7 @@
 defmodule Sanbase.Repo.Migrations.CreatePlansTable do
   use Ecto.Migration
 
-  alias Sanbase.Pricing.Plan.AccessSeed
+  alias Sanbase.Pricing.Plan.AccessChecker
 
   @table :plans
   def up do
@@ -17,11 +17,11 @@ defmodule Sanbase.Repo.Migrations.CreatePlansTable do
 
     execute("""
     INSERT INTO plans (id, name, product_id, amount, currency, interval, access) VALUES
-      (1, 'FREE', 1, 0, 'USD', 'month', '#{AccessSeed.free() |> Jason.encode!()}'),
-      (2, 'ESSENTIAL', 1, 11900, 'USD', 'month', '#{AccessSeed.essential() |> Jason.encode!()}'),
-      (3, 'PRO', 1, 35900, 'USD', 'month', '#{AccessSeed.pro() |> Jason.encode!()}'),
-      (4, 'PREMIUM', 1, 71900, 'USD', 'month', '#{AccessSeed.premium() |> Jason.encode!()}'),
-      (5, 'CUSTOM', 1, 0, 'USD', 'month', '#{AccessSeed.premium() |> Jason.encode!()}')
+      (1, 'FREE', 1, 0, 'USD', 'month', '#{AccessChecker.free() |> Jason.encode!()}'),
+      (2, 'ESSENTIAL', 1, 11900, 'USD', 'month', '#{AccessChecker.essential() |> Jason.encode!()}'),
+      (3, 'PRO', 1, 35900, 'USD', 'month', '#{AccessChecker.pro() |> Jason.encode!()}'),
+      (4, 'PREMIUM', 1, 71900, 'USD', 'month', '#{AccessChecker.premium() |> Jason.encode!()}'),
+      (5, 'CUSTOM', 1, 0, 'USD', 'month', '#{AccessChecker.premium() |> Jason.encode!()}')
     """)
   end
 

--- a/priv/repo/migrations/20190621125354_create_yearly_plans.exs
+++ b/priv/repo/migrations/20190621125354_create_yearly_plans.exs
@@ -1,21 +1,21 @@
 defmodule Sanbase.Repo.Migrations.CreateYearlyPlans do
   use Ecto.Migration
 
-  alias Sanbase.Pricing.Plan.AccessSeed
+  alias Sanbase.Pricing.Plan.AccessChecker
 
   def up do
     execute("""
     INSERT INTO plans (id, name, product_id, amount, currency, interval, access) VALUES
       (6, 'ESSENTIAL', 1, #{calc_yearly_price(11900)}, 'USD', 'year', '#{
-      AccessSeed.essential() |> Jason.encode!()
+      AccessChecker.essential() |> Jason.encode!()
     }'),
       (7, 'PRO', 1, #{calc_yearly_price(35900)}, 'USD', 'year', '#{
-      AccessSeed.pro() |> Jason.encode!()
+      AccessChecker.pro() |> Jason.encode!()
     }'),
       (8, 'PREMIUM', 1, #{calc_yearly_price(71900)}, 'USD', 'year', '#{
-      AccessSeed.premium() |> Jason.encode!()
+      AccessChecker.premium() |> Jason.encode!()
     }'),
-      (9, 'CUSTOM', 1, 0, 'USD', 'year', '#{AccessSeed.premium() |> Jason.encode!()}')
+      (9, 'CUSTOM', 1, 0, 'USD', 'year', '#{AccessChecker.premium() |> Jason.encode!()}')
     """)
   end
 

--- a/test/sanbase/pricing/access_test.exs
+++ b/test/sanbase/pricing/access_test.exs
@@ -30,6 +30,10 @@ defmodule Sanbase.Pricing.AccessTest do
     [user: user, conn_staking: conn_staking, conn: conn, project: project]
   end
 
+  test "there are no queries without defined subscription" do
+    assert Sanbase.Pricing.Plan.AccessChecker.Helper.queries_without_subsciption_plan() == []
+  end
+
   # TODO: Remove once staking is disabled
   describe "No subscription, staking tokens user" do
     test "can access FREE metrics for all time", context do

--- a/test/sanbase/pricing/access_test.exs
+++ b/test/sanbase/pricing/access_test.exs
@@ -30,10 +30,6 @@ defmodule Sanbase.Pricing.AccessTest do
     [user: user, conn_staking: conn_staking, conn: conn, project: project]
   end
 
-  test "there are no queries without defined subscription" do
-    assert Sanbase.Pricing.Plan.AccessChecker.Helper.queries_without_subsciption_plan() == []
-  end
-
   # TODO: Remove once staking is disabled
   describe "No subscription, staking tokens user" do
     test "can access FREE metrics for all time", context do

--- a/test/sanbase/pricing/access_test.exs
+++ b/test/sanbase/pricing/access_test.exs
@@ -38,7 +38,7 @@ defmodule Sanbase.Pricing.AccessTest do
       query = history_price_query(context.project, from, to)
       result = execute_query(context.conn_staking, query, "historyPrice")
 
-      assert_called(Sanbase.Prices.Store.fetch_prices_with_resolution(:_, from, to, "1d"))
+      assert_called(Sanbase.Prices.Store.fetch_prices_with_resolution(:_, from, to, :_))
       assert result != nil
     end
 
@@ -70,12 +70,12 @@ defmodule Sanbase.Pricing.AccessTest do
       query = history_price_query(context.project, from, to)
       result = execute_query(context.conn, query, "historyPrice")
 
-      assert_called(Sanbase.Prices.Store.fetch_prices_with_resolution(:_, from, to, "1d"))
+      assert_called(Sanbase.Prices.Store.fetch_prices_with_resolution(:_, from, to, :_))
       assert result != nil
     end
 
     test "cannot access BASIC metrics for over 3 months", context do
-      from = Timex.shift(Timex.now(), days: -100)
+      from = Timex.shift(Timex.now(), days: -91)
       to = Timex.shift(Timex.now(), days: -10)
       query = network_growth_query(from, to)
       result = execute_query(context.conn, query, "networkGrowth")
@@ -95,7 +95,7 @@ defmodule Sanbase.Pricing.AccessTest do
     end
 
     test "can access BASIC metrics within 90 days and 1 day interval", context do
-      from = Timex.shift(Timex.now(), days: -85)
+      from = Timex.shift(Timex.now(), days: -89)
       to = Timex.shift(Timex.now(), days: -2)
       query = network_growth_query(from, to)
       result = execute_query(context.conn, query, "networkGrowth")
@@ -105,7 +105,7 @@ defmodule Sanbase.Pricing.AccessTest do
     end
 
     test "cannot access PRO metrics for over 3 months", context do
-      from = Timex.shift(Timex.now(), days: -100)
+      from = Timex.shift(Timex.now(), days: -91)
       to = Timex.shift(Timex.now(), days: -10)
       query = mvrv_query(from, to)
       result = execute_query(context.conn, query, "mvrvRatio")
@@ -124,8 +124,8 @@ defmodule Sanbase.Pricing.AccessTest do
       assert result != nil
     end
 
-    test "can access ADVANCED withing 90 days and 1 day interval", context do
-      from = Timex.shift(Timex.now(), days: -85)
+    test "can access PRO withing 90 days and 1 day interval", context do
+      from = Timex.shift(Timex.now(), days: -89)
       to = Timex.shift(Timex.now(), days: -2)
       query = mvrv_query(from, to)
       result = execute_query(context.conn, query, "mvrvRatio")
@@ -144,7 +144,7 @@ defmodule Sanbase.Pricing.AccessTest do
       query = history_price_query(context.project, from, to)
       result = execute_query(context.conn, query, "historyPrice")
 
-      assert_called(Sanbase.Prices.Store.fetch_prices_with_resolution(:_, from, to, "1d"))
+      assert_called(Sanbase.Prices.Store.fetch_prices_with_resolution(:_, from, to, :_))
       assert result != nil
     end
 
@@ -187,7 +187,7 @@ defmodule Sanbase.Pricing.AccessTest do
     test "cannot access PRO metrics", context do
       insert(:subscription_essential, user: context.user)
 
-      from = Timex.shift(Timex.now(), days: -100)
+      from = Timex.shift(Timex.now(), days: -91)
       to = Timex.now()
       query = mvrv_query(from, to)
 
@@ -211,7 +211,7 @@ defmodule Sanbase.Pricing.AccessTest do
       query = history_price_query(context.project, from, to)
       result = execute_query(context.conn, query, "historyPrice")
 
-      assert_called(Sanbase.Prices.Store.fetch_prices_with_resolution(:_, from, to, "1d"))
+      assert_called(Sanbase.Prices.Store.fetch_prices_with_resolution(:_, from, to, :_))
       assert result != nil
     end
 
@@ -273,7 +273,7 @@ defmodule Sanbase.Pricing.AccessTest do
       query = history_price_query(context.project, from, to)
       result = execute_query(context.conn, query, "historyPrice")
 
-      assert_called(Sanbase.Prices.Store.fetch_prices_with_resolution(:_, from, to, "1d"))
+      assert_called(Sanbase.Prices.Store.fetch_prices_with_resolution(:_, from, to, :_))
       assert result != nil
     end
 

--- a/test/sanbase/pricing/access_test.exs
+++ b/test/sanbase/pricing/access_test.exs
@@ -42,6 +42,7 @@ defmodule Sanbase.Pricing.AccessTest do
       from = Timex.shift(Timex.now(), days: -(100 + 1))
       to = Timex.now()
       query = mvrv_query(from, to)
+
       result = execute_query(context.conn_apikey, query, "mvrvRatio")
 
       assert_called(Sanbase.Clickhouse.MVRV.mvrv_ratio(:_, from, to, :_))
@@ -95,9 +96,9 @@ defmodule Sanbase.Pricing.AccessTest do
 
       refute called(Sanbase.Clickhouse.MVRV.mvrv_ratio(:_, from, to, :_))
 
-      assert error_msg == """
+      assert error_msg =~ """
              Requested metric mvrv_ratio is not provided by the current subscription plan ESSENTIAL.
-             Please upgrade to PRO or PREMIUM or CUSTOM to get access to mvrv_ratio
+             Please upgrade to Pro or higher to get access to mvrv_ratio
              """
     end
   end

--- a/test/sanbase/pricing/access_test.exs
+++ b/test/sanbase/pricing/access_test.exs
@@ -10,89 +10,188 @@ defmodule Sanbase.Pricing.AccessTest do
   alias Sanbase.Pricing.TestSeed
 
   setup_with_mocks([
+    {Sanbase.Prices.Store, [], [fetch_prices_with_resolution: fn _, _, _, _ -> price_resp() end]},
     {Sanbase.Clickhouse.MVRV, [], [mvrv_ratio: fn _, _, _, _ -> mvrv_resp() end]},
     {Sanbase.Clickhouse.NetworkGrowth, [],
      [network_growth: fn _, _, _, _ -> network_growth_resp() end]}
   ]) do
-    free_user = insert(:user)
-    user = insert(:staked_user)
+    user = insert(:user)
+    staking_user = insert(:staked_user)
+    project = insert(:random_project)
 
     TestSeed.seed_products_and_plans()
 
+    {:ok, apikey} = Apikey.generate_apikey(staking_user)
+    conn_staking = setup_apikey_auth(build_conn(), apikey)
+
     {:ok, apikey} = Apikey.generate_apikey(user)
-    conn_apikey = setup_apikey_auth(build_conn(), apikey)
+    conn = setup_apikey_auth(build_conn(), apikey)
 
-    {:ok, apikey_free} = Apikey.generate_apikey(free_user)
-    conn_apikey_free = setup_apikey_auth(build_conn(), apikey_free)
-
-    {:ok, user: user, conn_apikey: conn_apikey, conn_apikey_free: conn_apikey_free}
+    [user: user, conn_staking: conn_staking, conn: conn, project: project]
   end
 
-  describe "Free user, staked" do
-    test "can access STANDART metrics for all time", context do
-      from = Timex.shift(Timex.now(), days: -(100 + 1))
+  # TODO: Remove once staking is disabled
+  describe "No subscription, staking tokens user" do
+    test "can access FREE metrics for all time", context do
+      from = Timex.shift(Timex.now(), days: -900)
+      to = Timex.now()
+      query = history_price_query(context.project, from, to)
+      result = execute_query(context.conn_staking, query, "historyPrice")
+
+      assert_called(Sanbase.Prices.Store.fetch_prices_with_resolution(:_, from, to, "1d"))
+      assert result != nil
+    end
+
+    test "can access BASIC metrics for all time", context do
+      from = Timex.shift(Timex.now(), days: -900)
       to = Timex.now()
       query = network_growth_query(from, to)
-      result = execute_query(context.conn_apikey, query, "networkGrowth")
+      result = execute_query(context.conn_staking, query, "networkGrowth")
       assert_called(Sanbase.Clickhouse.NetworkGrowth.network_growth(:_, from, to, :_))
       assert result != nil
     end
 
-    test "can access ADVANCED metrics for all time", context do
-      from = Timex.shift(Timex.now(), days: -(100 + 1))
+    test "can access PRO metrics for all time", context do
+      from = Timex.shift(Timex.now(), days: -900)
       to = Timex.now()
       query = mvrv_query(from, to)
 
-      result = execute_query(context.conn_apikey, query, "mvrvRatio")
+      result = execute_query(context.conn_staking, query, "mvrvRatio")
 
       assert_called(Sanbase.Clickhouse.MVRV.mvrv_ratio(:_, from, to, :_))
       assert result != nil
     end
   end
 
-  describe "Free user, not staked" do
-    test "can access STANDART metrics for 3 months", context do
-      from = Timex.shift(Timex.now(), days: -(100 + 1))
+  describe "No subscription, not staking user" do
+    test "can access FREE metrics for all time", context do
+      from = Timex.shift(Timex.now(), days: -900)
       to = Timex.now()
+      query = history_price_query(context.project, from, to)
+      result = execute_query(context.conn, query, "historyPrice")
+
+      assert_called(Sanbase.Prices.Store.fetch_prices_with_resolution(:_, from, to, "1d"))
+      assert result != nil
+    end
+
+    test "cannot access BASIC metrics for over 3 months", context do
+      from = Timex.shift(Timex.now(), days: -100)
+      to = Timex.shift(Timex.now(), days: -10)
       query = network_growth_query(from, to)
-      result = execute_query(context.conn_apikey_free, query, "networkGrowth")
+      result = execute_query(context.conn, query, "networkGrowth")
 
       refute called(Sanbase.Clickhouse.NetworkGrowth.network_growth(:_, from, to, :_))
       assert result != nil
     end
 
-    test "can access ADVANCED metrics for 3 months", context do
-      from = Timex.shift(Timex.now(), days: -(100 + 1))
+    test "cannot access BASIC metrics realtime", context do
+      from = Timex.shift(Timex.now(), days: -10)
       to = Timex.now()
+      query = network_growth_query(from, to)
+      result = execute_query(context.conn, query, "networkGrowth")
+
+      refute called(Sanbase.Clickhouse.NetworkGrowth.network_growth(:_, from, to, :_))
+      assert result != nil
+    end
+
+    test "can access BASIC metrics within 90 days and 1 day interval", context do
+      from = Timex.shift(Timex.now(), days: -85)
+      to = Timex.shift(Timex.now(), days: -2)
+      query = network_growth_query(from, to)
+      result = execute_query(context.conn, query, "networkGrowth")
+
+      assert_called(Sanbase.Clickhouse.NetworkGrowth.network_growth(:_, from, to, :_))
+      assert result != nil
+    end
+
+    test "cannot access PRO metrics for over 3 months", context do
+      from = Timex.shift(Timex.now(), days: -100)
+      to = Timex.shift(Timex.now(), days: -10)
       query = mvrv_query(from, to)
-      result = execute_query(context.conn_apikey_free, query, "mvrvRatio")
+      result = execute_query(context.conn, query, "mvrvRatio")
 
       refute called(Sanbase.Clickhouse.MVRV.mvrv_ratio(:_, from, to, :_))
       assert result != nil
     end
+
+    test "cannot access PRO metrics realtime", context do
+      from = Timex.shift(Timex.now(), days: -10)
+      to = Timex.now()
+      query = mvrv_query(from, to)
+      result = execute_query(context.conn, query, "mvrvRatio")
+
+      refute called(Sanbase.Clickhouse.MVRV.mvrv_ratio(:_, from, to, :_))
+      assert result != nil
+    end
+
+    test "can access ADVANCED withing 90 days and 1 day interval", context do
+      from = Timex.shift(Timex.now(), days: -85)
+      to = Timex.shift(Timex.now(), days: -2)
+      query = mvrv_query(from, to)
+      result = execute_query(context.conn, query, "mvrvRatio")
+
+      assert_called(Sanbase.Clickhouse.MVRV.mvrv_ratio(:_, from, to, :_))
+      assert result != nil
+    end
   end
 
-  describe "user with ESSENTIAL (STANDART metrics) plan" do
-    test "can access STANDART metrics for 180 days", context do
+  describe "user with BASIC plan" do
+    test "can access FREE metrics for all time", context do
       insert(:subscription_essential, user: context.user)
 
-      from = Timex.shift(Timex.now(), days: -(100 + 1))
+      from = Timex.shift(Timex.now(), days: -900)
       to = Timex.now()
+      query = history_price_query(context.project, from, to)
+      result = execute_query(context.conn, query, "historyPrice")
+
+      assert_called(Sanbase.Prices.Store.fetch_prices_with_resolution(:_, from, to, "1d"))
+      assert result != nil
+    end
+
+    test "cannot access BASIC metrics for more than 180 days", context do
+      insert(:subscription_essential, user: context.user)
+
+      from = Timex.shift(Timex.now(), days: -181)
+      to = Timex.shift(Timex.now(), days: -3)
       query = network_growth_query(from, to)
-      result = execute_query(context.conn_apikey_free, query, "networkGrowth")
+      result = execute_query(context.conn, query, "networkGrowth")
 
       refute called(Sanbase.Clickhouse.NetworkGrowth.network_growth(:_, from, to, :_))
       assert result != nil
     end
 
-    test "can't access ADVANCED metrics", context do
+    test "can access BASIC metrics for less than 180 days", context do
       insert(:subscription_essential, user: context.user)
 
-      from = Timex.shift(Timex.now(), days: -(100 + 1))
+      from = Timex.shift(Timex.now(), days: -179)
+      to = Timex.shift(Timex.now(), days: -3)
+      query = network_growth_query(from, to)
+      result = execute_query(context.conn, query, "networkGrowth")
+
+      assert_called(Sanbase.Clickhouse.NetworkGrowth.network_growth(:_, from, to, :_))
+      assert result != nil
+    end
+
+    test "can access BASIC metrics realtime", context do
+      insert(:subscription_essential, user: context.user)
+
+      from = Timex.shift(Timex.now(), days: -10)
+      to = Timex.now()
+      query = network_growth_query(from, to)
+      result = execute_query(context.conn, query, "networkGrowth")
+
+      assert_called(Sanbase.Clickhouse.NetworkGrowth.network_growth(:_, from, to, :_))
+      assert result != nil
+    end
+
+    test "cannot access PRO metrics", context do
+      insert(:subscription_essential, user: context.user)
+
+      from = Timex.shift(Timex.now(), days: -100)
       to = Timex.now()
       query = mvrv_query(from, to)
 
-      error_msg = execute_query_with_error(context.conn_apikey, query, "mvrvRatio")
+      error_msg = execute_query_with_error(context.conn, query, "mvrvRatio")
 
       refute called(Sanbase.Clickhouse.MVRV.mvrv_ratio(:_, from, to, :_))
 
@@ -103,28 +202,102 @@ defmodule Sanbase.Pricing.AccessTest do
     end
   end
 
-  describe "user with PRO (ADVANCED metrics) plan" do
-    test "can access STANDART metrics for #{18 * 30} days", context do
+  describe "user with PRO plan" do
+    test "can access FREE metrics for all time", context do
+      insert(:subscription_pro, user: context.user)
+
+      from = Timex.shift(Timex.now(), days: -900)
+      to = Timex.now()
+      query = history_price_query(context.project, from, to)
+      result = execute_query(context.conn, query, "historyPrice")
+
+      assert_called(Sanbase.Prices.Store.fetch_prices_with_resolution(:_, from, to, "1d"))
+      assert result != nil
+    end
+
+    test "cannot access BASIC metrics for more than 18 months", context do
       insert(:subscription_pro, user: context.user)
 
       from = Timex.shift(Timex.now(), days: -(18 * 30 + 1))
       to = Timex.now()
       query = network_growth_query(from, to)
-      result = execute_query(context.conn_apikey_free, query, "networkGrowth")
+      result = execute_query(context.conn, query, "networkGrowth")
 
       refute called(Sanbase.Clickhouse.NetworkGrowth.network_growth(:_, from, to, :_))
       assert result != nil
     end
 
-    test "can access ADVANCED metrics for #{18 * 30} days", context do
+    test "can access BASIC metrics for less than 18 months", context do
+      insert(:subscription_pro, user: context.user)
+
+      from = Timex.shift(Timex.now(), days: -(18 * 30 - 1))
+      to = Timex.now()
+      query = network_growth_query(from, to)
+      result = execute_query(context.conn, query, "networkGrowth")
+
+      assert_called(Sanbase.Clickhouse.NetworkGrowth.network_growth(:_, from, to, :_))
+      assert result != nil
+    end
+
+    test "cannot access PRO metrics for more than 18 months", context do
       insert(:subscription_pro, user: context.user)
 
       from = Timex.shift(Timex.now(), days: -(18 * 30 + 1))
       to = Timex.now()
       query = mvrv_query(from, to)
-      result = execute_query(context.conn_apikey_free, query, "mvrvRatio")
+      result = execute_query(context.conn, query, "mvrvRatio")
 
       refute called(Sanbase.Clickhouse.MVRV.mvrv_ratio(:_, from, to, :_))
+      assert result != nil
+    end
+
+    test "can access PRO metrics for more less than 18 months", context do
+      insert(:subscription_pro, user: context.user)
+
+      from = Timex.shift(Timex.now(), days: -(18 * 30 - 1))
+      to = Timex.now()
+      query = mvrv_query(from, to)
+      result = execute_query(context.conn, query, "mvrvRatio")
+
+      assert_called(Sanbase.Clickhouse.MVRV.mvrv_ratio(:_, from, to, :_))
+      assert result != nil
+    end
+  end
+
+  describe "user with PREMIUM plan" do
+    test "can access FREE metrics for all time", context do
+      insert(:subscription_premium, user: context.user)
+
+      from = Timex.shift(Timex.now(), days: -900)
+      to = Timex.now()
+      query = history_price_query(context.project, from, to)
+      result = execute_query(context.conn, query, "historyPrice")
+
+      assert_called(Sanbase.Prices.Store.fetch_prices_with_resolution(:_, from, to, "1d"))
+      assert result != nil
+    end
+
+    test "can access BASIC metrics for all time", context do
+      insert(:subscription_premium, user: context.user)
+
+      from = Timex.shift(Timex.now(), days: -900)
+      to = Timex.now()
+      query = network_growth_query(from, to)
+      result = execute_query(context.conn, query, "networkGrowth")
+
+      assert_called(Sanbase.Clickhouse.NetworkGrowth.network_growth(:_, from, to, :_))
+      assert result != nil
+    end
+
+    test "can access PRO metrics for all time", context do
+      insert(:subscription_premium, user: context.user)
+
+      from = Timex.shift(Timex.now(), days: -900)
+      to = Timex.now()
+      query = mvrv_query(from, to)
+      result = execute_query(context.conn, query, "mvrvRatio")
+
+      assert_called(Sanbase.Clickhouse.MVRV.mvrv_ratio(:_, from, to, :_))
       assert result != nil
     end
   end
@@ -133,7 +306,7 @@ defmodule Sanbase.Pricing.AccessTest do
     """
       {
         mvrvRatio(slug: "ethereum", from: "#{from}", to: "#{to}", interval: "1d"){
-          datetime,
+          datetime
           ratio
         }
       }
@@ -144,8 +317,19 @@ defmodule Sanbase.Pricing.AccessTest do
     """
       {
         networkGrowth(slug: "ethereum", from: "#{from}", to: "#{to}", interval: "1d"){
-          datetime,
+          datetime
           newAddresses
+        }
+      }
+    """
+  end
+
+  defp history_price_query(project, from, to) do
+    """
+      {
+        historyPrice(slug: "#{project.coinmarketcap_id}", from: "#{from}", to: "#{to}", interval: "1d"){
+          datetime
+          priceUsd
         }
       }
     """
@@ -156,6 +340,14 @@ defmodule Sanbase.Pricing.AccessTest do
      [
        %{ratio: 0.1, datetime: from_iso8601!("2019-01-01T00:00:00Z")},
        %{ratio: 0.2, datetime: from_iso8601!("2019-01-02T00:00:00Z")}
+     ]}
+  end
+
+  defp price_resp() do
+    {:ok,
+     [
+       [from_iso8601!("2019-01-01T00:00:00Z"), 10, 0.1, 10000, 500],
+       [from_iso8601!("2019-01-01T00:00:00Z"), 20, 0.2, 20000, 1500]
      ]}
   end
 

--- a/test/sanbase/pricing/plan_test.exs
+++ b/test/sanbase/pricing/plan_test.exs
@@ -20,17 +20,11 @@ defmodule Sanbase.Pricing.PlanTest do
 
   describe "#plans_with_metric" do
     test "with standart query - returns all plans" do
-      assert Plan.plans_with_metric("network_growth") == [
-               "FREE",
-               "ESSENTIAL",
-               "PRO",
-               "PREMIUM",
-               "CUSTOM"
-             ]
+      assert Plan.lowest_plan_with_metric(:network_growth) == :basic
     end
 
     test "with advanced query - returns only plans with advanced queries" do
-      assert Plan.plans_with_metric("mvrv_ratio") == ["PRO", "PREMIUM", "CUSTOM"]
+      assert Plan.lowest_plan_with_metric(:mvrv_ratio) == :pro
     end
   end
 

--- a/test/sanbase/pricing/subscription_meta_field_test.exs
+++ b/test/sanbase/pricing/subscription_meta_field_test.exs
@@ -1,0 +1,154 @@
+defmodule Sanbase.Pricing.SubscriptionMetaFieldTest do
+  use ExUnit.Case, async: true
+
+  # Assert that a query's subscription plan does not change incidentally
+  describe "subscription meta" do
+    test "there are no queries without defined subscription" do
+      assert Sanbase.Pricing.Plan.AccessChecker.Helper.queries_without_subsciption_plan() == []
+    end
+
+    test "free queries" do
+      free_queries =
+        Sanbase.Pricing.Plan.AccessChecker.Helper.get_metrics_with_subscription_plan(:free)
+        |> Enum.sort()
+
+      expected_free_queries =
+        [
+          :get_trigger_by_id,
+          :payments,
+          :current_user,
+          :news,
+          :project,
+          :historical_balance,
+          :elasticsearch_stats,
+          :historical_trigger_points,
+          :price_volume_diff,
+          :assets_held_by_address,
+          :social_volume_projects,
+          :all_market_segments,
+          :get_telegram_deep_link,
+          :products_with_plans,
+          :projects_count,
+          :ohlc,
+          :all_insights_for_user,
+          :history_twitter_data,
+          :all_insights_user_voted,
+          :all_exchanges,
+          :eth_spent_over_time_by_erc20_projects,
+          :history_price,
+          :metric_anomaly,
+          :fetch_all_public_watchlists,
+          :public_triggers_for_user,
+          :post,
+          :projects_list_stats,
+          :all_public_triggers,
+          :currencies_market_segments,
+          :twitter_mention_count,
+          :all_currency_projects,
+          :featured_user_triggers,
+          :timeline_events,
+          :all_insights,
+          :featured_watchlists,
+          :signals_historical_activity,
+          :erc20_market_segments,
+          :github_activity,
+          :fetch_public_user_lists,
+          :project_by_slug,
+          :fetch_public_watchlists,
+          :all_tags,
+          :emojis_sentiment,
+          :fetch_all_public_user_lists,
+          :projects_list_history_stats,
+          :daily_active_addresses,
+          :twitter_data,
+          :github_availables_repos,
+          :eth_spent_by_erc20_projects,
+          :featured_insights,
+          :insight,
+          :current_poll,
+          :all_projects_by_function,
+          :eth_spent_by_all_projects,
+          :fetch_user_lists,
+          :all_erc20_projects,
+          :fetch_watchlists,
+          :all_projects,
+          :eth_spent_over_time_by_all_projects,
+          :all_insights_by_tag,
+          :user_list,
+          :dev_activity,
+          :watchlist
+        ]
+        |> Enum.sort()
+
+      assert free_queries == expected_free_queries
+    end
+
+    test "basic queries" do
+      basic_queries =
+        Sanbase.Pricing.Plan.AccessChecker.Helper.get_metrics_with_subscription_plan(:basic)
+        |> Enum.sort()
+
+      expected_basic_queries =
+        [
+          :average_token_age_consumed_in_days,
+          :burn_rate,
+          :exchange_funds_flow,
+          :exchange_volume,
+          :gas_used,
+          :miners_balance,
+          :mining_pools_distribution,
+          :network_growth,
+          :percent_of_token_supply_on_exchanges,
+          :social_dominance,
+          :social_gainers_losers_status,
+          :social_volume,
+          :token_age_consumed,
+          :token_circulation,
+          :token_velocity,
+          :top_holders_percent_of_total_supply,
+          :top_social_gainers_losers,
+          :topic_search,
+          :transaction_volume,
+          :trending_words,
+          :word_context,
+          :word_trend_score
+        ]
+        |> Enum.sort()
+
+      assert basic_queries == expected_basic_queries
+    end
+
+    test "pro queries" do
+      pro_queries =
+        Sanbase.Pricing.Plan.AccessChecker.Helper.get_metrics_with_subscription_plan(:pro)
+        |> Enum.sort()
+
+      expected_pro_queries =
+        [:daily_active_deposits, :mvrv_ratio, :nvt_ratio, :realized_value, :share_of_deposits]
+        |> Enum.sort()
+
+      assert pro_queries == expected_pro_queries
+    end
+
+    test "premium queries" do
+      premium_queries =
+        Sanbase.Pricing.Plan.AccessChecker.Helper.get_metrics_with_subscription_plan(:premium)
+        |> Enum.sort()
+
+      expected_premium_queries = []
+
+      assert premium_queries == expected_premium_queries
+    end
+
+    test "restricted queries" do
+      restricted_queries =
+        Sanbase.Pricing.Plan.AccessChecker.Helper.get_metrics_with_subscription_plan(:restricted)
+        |> Enum.sort()
+
+      expected_restricted_queries =
+        [:all_projects_project_transparency, :exchange_wallets] |> Enum.sort()
+
+      assert restricted_queries == expected_restricted_queries
+    end
+  end
+end

--- a/test/sanbase/pricing/subscription_test.exs
+++ b/test/sanbase/pricing/subscription_test.exs
@@ -36,25 +36,25 @@ defmodule Sanbase.Pricing.SubscriptionTest do
 
   describe "#is_restricted?" do
     test "network_growth and mvrv_ratio are restricted" do
-      assert Subscription.is_restricted?("network_growth")
-      assert Subscription.is_restricted?("mvrv_ratio")
+      assert Subscription.is_restricted?(:network_growth)
+      assert Subscription.is_restricted?(:mvrv_ratio)
     end
 
     test "all_projects and history_price are not restricted" do
-      refute Subscription.is_restricted?("all_projects")
-      refute Subscription.is_restricted?("history_price")
+      refute Subscription.is_restricted?(:all_projects)
+      refute Subscription.is_restricted?(:history_price)
     end
   end
 
   describe "#needs_advanced_plan?" do
     test "mvrv_ratio needs advanced plan subscription" do
-      assert Subscription.needs_advanced_plan?("mvrv_ratio")
+      assert Subscription.needs_advanced_plan?(:mvrv_ratio)
     end
 
     test "network_growth, all_projects and history_price does not need advanced plan subscription" do
-      refute Subscription.needs_advanced_plan?("network_growth")
-      refute Subscription.needs_advanced_plan?("all_projects")
-      refute Subscription.needs_advanced_plan?("history_price")
+      refute Subscription.needs_advanced_plan?(:network_growth)
+      refute Subscription.needs_advanced_plan?(:all_projects)
+      refute Subscription.needs_advanced_plan?(:history_price)
     end
   end
 
@@ -62,32 +62,32 @@ defmodule Sanbase.Pricing.SubscriptionTest do
     test "subscription to ESSENTIAL plan has access to STANDART metrics", context do
       subscription = insert(:subscription_essential, user: context.user) |> Repo.preload(:plan)
 
-      assert Subscription.has_access?(subscription, "network_growth")
+      assert Subscription.has_access?(subscription, :network_growth)
     end
 
     test "subscription to ESSENTIAL plan does not have access to ADVANCED metrics", context do
       subscription = insert(:subscription_essential, user: context.user) |> Repo.preload(:plan)
 
-      refute Subscription.has_access?(subscription, "mvrv_ratio")
+      refute Subscription.has_access?(subscription, :mvrv_ratio)
     end
 
     test "subscription to ESSENTIAL plan has access to not restricted metrics", context do
       subscription = insert(:subscription_essential, user: context.user) |> Repo.preload(:plan)
 
-      assert Subscription.has_access?(subscription, "history_price")
+      assert Subscription.has_access?(subscription, :history_price)
     end
 
     test "subscription to PRO plan have access to both STANDART and ADVANCED metrics", context do
       subscription = insert(:subscription_pro, user: context.user) |> Repo.preload(:plan)
 
-      assert Subscription.has_access?(subscription, "network_growth")
-      assert Subscription.has_access?(subscription, "mvrv_ratio")
+      assert Subscription.has_access?(subscription, :network_growth)
+      assert Subscription.has_access?(subscription, :mvrv_ratio)
     end
 
     test "subscription to PRO plan has access to not restricted metrics", context do
       subscription = insert(:subscription_pro, user: context.user) |> Repo.preload(:plan)
 
-      assert Subscription.has_access?(subscription, "history_price")
+      assert Subscription.has_access?(subscription, :history_price)
     end
   end
 

--- a/test/sanbase_web/graphql/context_plug_test.exs
+++ b/test/sanbase_web/graphql/context_plug_test.exs
@@ -24,7 +24,8 @@ defmodule SanbaseWeb.Graphql.ContextPlugTest do
     assert conn_context.auth == %{
              auth_method: :user_token,
              current_user: user,
-             san_balance: 500_000.0
+             san_balance: 500_000.0,
+             subscription: nil
            }
 
     assert conn_context.remote_ip == {127, 0, 0, 1}

--- a/test/support/sanbase_factory.ex
+++ b/test/support/sanbase_factory.ex
@@ -21,7 +21,7 @@ defmodule Sanbase.Factory do
 
   alias Sanbase.Signal.{UserTrigger, HistoricalActivity}
   alias Sanbase.Pricing.{Product, Plan, Subscription}
-  alias Sanbase.Pricing.Plan.AccessSeed
+  alias Sanbase.Pricing.Plan.AccessChecker
   alias Sanbase.Timeline.TimelineEvent
 
   def user_factory() do
@@ -227,7 +227,7 @@ defmodule Sanbase.Factory do
       amount: 0,
       currency: "USD",
       interval: "month",
-      access: AccessSeed.free()
+      access: AccessChecker.free()
     }
   end
 
@@ -238,7 +238,7 @@ defmodule Sanbase.Factory do
       amount: 15900,
       currency: "USD",
       interval: "month",
-      access: AccessSeed.essential()
+      access: AccessChecker.essential()
     }
   end
 
@@ -249,7 +249,7 @@ defmodule Sanbase.Factory do
       amount: 35900,
       currency: "USD",
       interval: "month",
-      access: AccessSeed.pro(),
+      access: AccessChecker.pro(),
       stripe_id: plan_stripe_id()
     }
   end
@@ -261,7 +261,7 @@ defmodule Sanbase.Factory do
       amount: 75900,
       currency: "USD",
       interval: "month",
-      access: AccessSeed.premium()
+      access: AccessChecker.premium()
     }
   end
 
@@ -272,7 +272,7 @@ defmodule Sanbase.Factory do
       amount: 0,
       currency: "USD",
       interval: "month",
-      access: AccessSeed.custom()
+      access: AccessChecker.custom()
     }
   end
 
@@ -283,7 +283,7 @@ defmodule Sanbase.Factory do
       amount: 128_520,
       currency: "USD",
       interval: "year",
-      access: AccessSeed.pro()
+      access: AccessChecker.pro()
     }
   end
 
@@ -294,7 +294,7 @@ defmodule Sanbase.Factory do
       amount: 387_720,
       currency: "USD",
       interval: "year",
-      access: AccessSeed.pro()
+      access: AccessChecker.pro()
     }
   end
 
@@ -305,7 +305,7 @@ defmodule Sanbase.Factory do
       amount: 819_720,
       currency: "USD",
       interval: "year",
-      access: AccessSeed.premium()
+      access: AccessChecker.premium()
     }
   end
 
@@ -316,7 +316,7 @@ defmodule Sanbase.Factory do
       amount: 0,
       currency: "USD",
       interval: "year",
-      access: AccessSeed.custom()
+      access: AccessChecker.custom()
     }
   end
 

--- a/test/support/sanbase_factory.ex
+++ b/test/support/sanbase_factory.ex
@@ -334,6 +334,13 @@ defmodule Sanbase.Factory do
     }
   end
 
+  def subscription_premium_factory() do
+    %Subscription{
+      plan_id: 4,
+      current_period_end: Timex.shift(Timex.now(), days: 1)
+    }
+  end
+
   def timeline_event_factory() do
     %TimelineEvent{}
   end


### PR DESCRIPTION
#### Summary
This PR includes:
- Complete rewrite of TimeframeRestriction middleware. Now it is simplified (no nested with-case-if expressions) and there are more functions, each of them doing less things
- Complete rewrite of how the subscription plan of a given query is determined. We introduce the usage of the `meta` information in every query. As the GraphQL Schema is build compile-time, the `AcecssSeed` module automatically determines all queries and all access restrictions. It builds different sets and provides functions to check the data.
- Rewrite of how the subscription is accessed - it is now determined in the `ContextPlug` because previously it could make 2 DB queries during the execution.
- Rewrite the logic in such a way that communication with the DB is not needed to determine query access. The database data for the metrics in each plan is now not used and could be deprecated in the future.

Additional smaller changes part of this PR:
- Add missing Complexity middleware in some places
- Allow realtime access to GitHub data

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
