### PR TITLE
Docker will use diff DBs for postgres and timescale

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -10,10 +10,5 @@ test_command="mix $tests_to_execute"
 
 echo "Will execute: $test_command"
 
-docker-compose build && \
-  docker-compose run \
-    -e DATABASE_URL=postgres://postgres:postgres@postgres:5432/sanbase_test \
-    -e TIMESCALE_DATABASE_URL=postgres://postgres:postgres@postgres:5432/sanbase_timescale_test \
-    -e INFLUXDB_HOST=influxdb \
-    -e MIX_ENV=test \
-    sanbase sh -c "$test_command"
+
+docker-compose run -e MIX_ENV=test sanbase sh -c "$test_command"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
 
     environment:
       DATABASE_URL: postgres://postgres:postgres@postgres:5432/santiment
-      TIMESCALE_DATABASE_URL: postgres://postgres:postgres@postgres:5432/santiment
+      TIMESCALE_DATABASE_URL: postgres://postgres:postgres@postgres:5432/santiment_timescale
       ADMIN_BASIC_AUTH_USERNAME: admin
       ADMIN_BASIC_AUTH_PASSWORD: admin
       INFLUXDB_HOST: influxdb


### PR DESCRIPTION
#### Summary
Running migrations was causing timescale tables to go into
postgres' structure.sql


[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
