### PR TITLE
Fix error evaluating DAA signals

### DIFF
--- a/lib/sanbase/signals/trigger/settings/daily_active_addresses_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/daily_active_addresses_settings.ex
@@ -80,13 +80,9 @@ defmodule Sanbase.Signal.Trigger.DailyActiveAddressesSettings do
           result
 
         _ ->
-          {:error, :nodata}
+          []
       end
     end)
-    |> case do
-      {:error, _} -> 0
-      result -> result
-    end
   end
 
   defimpl Sanbase.Signal.Settings, for: DailyActiveAddressesSettings do

--- a/test/sanbase/api_call_data_exporter/api_call_data_exporter_test.exs
+++ b/test/sanbase/api_call_data_exporter/api_call_data_exporter_test.exs
@@ -99,7 +99,7 @@ defmodule ApiCallDataExporterTest do
     for _ <- 1..10_000,
         do: :ok = Sanbase.ApiCallDataExporter.persist(exporter_pid, api_call_data())
 
-    Process.sleep(100)
+    Process.sleep(300)
     state = Sanbase.InMemoryKafka.Producer.get_state()
     topic_data = Map.get(state, topic)
     assert length(topic_data) == 10_000


### PR DESCRIPTION
When the fetching of DAA fails return list instead of number so the
Enum.map/2 does not fail with error

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
