### PR TITLE
Fix watchlist settings issues

### DIFF
--- a/lib/sanbase/user_lists/settings.ex
+++ b/lib/sanbase/user_lists/settings.ex
@@ -74,7 +74,7 @@ defmodule Sanbase.UserList.Settings do
     belongs_to(:user, User, foreign_key: :user_id, primary_key: true)
     belongs_to(:watchlist, UserList, foreign_key: :watchlist_id, primary_key: true)
 
-    embeds_one(:settings, WatchlistSettings)
+    embeds_one(:settings, WatchlistSettings, on_replace: :update)
   end
 
   def changeset(%__MODULE__{} = settings, attrs \\ %{}) do

--- a/lib/sanbase/user_lists/settings.ex
+++ b/lib/sanbase/user_lists/settings.ex
@@ -104,7 +104,11 @@ defmodule Sanbase.UserList.Settings do
   end
 
   def settings_for(%UserList{} = ul, _) do
-    get_settings(ul.id, ul.user_id)
+    settings =
+      get_settings(ul.id, ul.user_id) ||
+        WatchlistSettings.default_settings()
+
+    {:ok, settings}
   end
 
   @doc ~s"""


### PR DESCRIPTION
Two issues fixed:
- The first update_or_create is creating the settings and the second is
updating them. The update was broken and not tested. Fixed and added
tests
- Fetching settings was returning only value instead of {:ok, value} in some cases
#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
