### PR TITLE
Fix not existing atom issue

### DIFF
--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -125,7 +125,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       resolve(&ProjectResolver.volume_usd/3)
     end
 
-    field :volume_change_24h, :float, name: "volume_change24h" do
+    field :volume_change24h, :float do
       cache_resolve(&ProjectResolver.volume_change_24h/3)
     end
 
@@ -168,15 +168,15 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       resolve(&ProjectResolver.total_supply/3)
     end
 
-    field :percent_change_1h, :decimal, name: "percent_change1h" do
+    field :percent_change1h, :decimal do
       resolve(&ProjectResolver.percent_change_1h/3)
     end
 
-    field :percent_change_24h, :decimal, name: "percent_change24h" do
+    field :percent_change24h, :decimal do
       resolve(&ProjectResolver.percent_change_24h/3)
     end
 
-    field :percent_change_7d, :decimal, name: "percent_change7d" do
+    field :percent_change7d, :decimal do
       resolve(&ProjectResolver.percent_change_7d/3)
     end
 


### PR DESCRIPTION
#### Summary
The query name was given by a string and it did not correspond to the atom name. That's why the String.to_existing_atom/1 failed
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
