### PR TITLE
Optimize influx tests

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -21,4 +21,4 @@ RUN mix deps.compile
 COPY . /app
 RUN mix format --check-formatted
 
-CMD mix test_all --trace
+CMD mix test_all --trace --slowest 20

--- a/lib/sanbase/influxdb/store.ex
+++ b/lib/sanbase/influxdb/store.ex
@@ -106,6 +106,12 @@ defmodule Sanbase.Influxdb.Store do
         |> post()
       end
 
+      def drop_db() do
+        Sanbase.Utils.Config.get(:database)
+        |> Instream.Admin.Database.drop()
+        |> post()
+      end
+
       def last_record(measurement) do
         ~s/SELECT * FROM "#{measurement}" ORDER BY time DESC LIMIT 1/
         |> get()

--- a/test/sanbase/external_services/coinmarketcap/graph_data_test.exs
+++ b/test/sanbase/external_services/coinmarketcap/graph_data_test.exs
@@ -5,6 +5,8 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphDataTest do
   alias Sanbase.ExternalServices.Coinmarketcap.PricePoint2, as: PricePoint
   alias Sanbase.Prices.Store
 
+  import Sanbase.InfluxdbHelpers
+
   @total_market_measurement "TOTAL_MARKET_total-market"
 
   test "fetching the first price datetime of a token" do
@@ -87,9 +89,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.GraphDataTest do
       }
     end)
 
-    Store.create_db()
-    measurement_name = "TOTAL_MARKET_total-market"
-    Store.drop_measurement(measurement_name)
+    setup_prices_influxdb()
 
     # The HTTP GET request is mocked, this interval here does not play a role.
     # Put one day before now so we will have only one day range and won't make many HTTP queries

--- a/test/sanbase/external_services/coinmarketcap/ticker_fetcher_test.exs
+++ b/test/sanbase/external_services/coinmarketcap/ticker_fetcher_test.exs
@@ -1,29 +1,22 @@
 defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcherTest do
   use ExUnit.Case
-  use Sanbase.DataCase, async: true
+  use Sanbase.DataCase, async: false
 
   # TODO: Change after old cmc scraper is removed
   alias Sanbase.ExternalServices.Coinmarketcap.TickerFetcher2, as: TickerFetcher
   alias Sanbase.Prices.Store
 
+  import Sanbase.InfluxdbHelpers
+
   @btc_measurement "BTC_bitcoin"
   @eth_measurement "ETH_ethereum"
-  @xrp_measurement "XRP_ripple"
-  @bch_measurement "BCH_bitcoin-cash"
-  @eos_measurement "EOS_eos"
 
-  test "parsing the project page", _context do
-    Store.create_db()
+  test "parsing the project page" do
+    setup_prices_influxdb()
 
     Tesla.Mock.mock(fn %{method: :get} ->
       %Tesla.Env{status: 200, body: File.read!(Path.join(__DIR__, "pro_cmc_api_2.json"))}
     end)
-
-    Store.drop_measurement(@btc_measurement)
-    Store.drop_measurement(@eth_measurement)
-    Store.drop_measurement(@xrp_measurement)
-    Store.drop_measurement(@bch_measurement)
-    Store.drop_measurement(@eos_measurement)
 
     TickerFetcher.work()
 

--- a/test/sanbase/notifications/price_volume_diff_test.exs
+++ b/test/sanbase/notifications/price_volume_diff_test.exs
@@ -7,10 +7,12 @@ defmodule Sanbase.Notifications.PriceVolumeDiffTest do
   alias Sanbase.Prices.Store
   alias Sanbase.Influxdb.Measurement
 
+  import Sanbase.InfluxdbHelpers
+
   @moduletag capture_log: true
 
   setup do
-    Store.create_db()
+    setup_prices_influxdb()
 
     # TODO: Make projects with cmc_id and import correctly!!!
 
@@ -35,10 +37,6 @@ defmodule Sanbase.Notifications.PriceVolumeDiffTest do
       |> Sanbase.Repo.insert!()
 
     ticker_cmc_id1 = ticker1 <> "_" <> slug1
-    ticker_cmc_id2 = ticker2 <> "_" <> slug2
-
-    Store.drop_measurement(ticker_cmc_id1)
-    Store.drop_measurement(ticker_cmc_id2)
 
     datetime =
       DateTime.utc_now()

--- a/test/sanbase/signals/price/trigger_price_absolute_change_test.exs
+++ b/test/sanbase/signals/price/trigger_price_absolute_change_test.exs
@@ -4,6 +4,7 @@ defmodule Sanbase.Signal.TriggerPriceAbsoluteChangeTest do
   import Mock
   import Sanbase.Factory
   import ExUnit.CaptureLog
+  import Sanbase.InfluxdbHelpers
 
   alias Sanbase.Prices.Store
   alias Sanbase.Influxdb.Measurement
@@ -143,9 +144,9 @@ defmodule Sanbase.Signal.TriggerPriceAbsoluteChangeTest do
   end
 
   defp populate_influxdb() do
-    ticker_cmc_id = "#{@ticker}_#{@cmc_id}"
+    setup_prices_influxdb()
 
-    Store.drop_measurement(ticker_cmc_id)
+    ticker_cmc_id = "#{@ticker}_#{@cmc_id}"
 
     datetime1 = Timex.shift(Timex.now(), hours: -9)
     datetime2 = Timex.shift(Timex.now(), hours: -8)

--- a/test/sanbase/signals/price/trigger_price_percent_change_test.exs
+++ b/test/sanbase/signals/price/trigger_price_percent_change_test.exs
@@ -3,6 +3,7 @@ defmodule Sanbase.Signal.TriggerPricePercentChangeTest do
 
   import Mock
   import Sanbase.Factory
+  import Sanbase.InfluxdbHelpers
 
   alias Sanbase.Prices.Store
   alias Sanbase.Influxdb.Measurement
@@ -91,9 +92,9 @@ defmodule Sanbase.Signal.TriggerPricePercentChangeTest do
   end
 
   defp populate_influxdb() do
-    ticker_cmc_id = "#{@ticker}_#{@cmc_id}"
+    setup_prices_influxdb()
 
-    Store.drop_measurement(ticker_cmc_id)
+    ticker_cmc_id = "#{@ticker}_#{@cmc_id}"
 
     datetime1 = Timex.shift(Timex.now(), hours: -9)
     datetime2 = Timex.shift(Timex.now(), hours: -8)

--- a/test/sanbase_web/graphql/prices_api_test.exs
+++ b/test/sanbase_web/graphql/prices_api_test.exs
@@ -3,13 +3,14 @@ defmodule SanbaseWeb.Graphql.PricesApiTest do
 
   import Plug.Conn
   import SanbaseWeb.Graphql.TestHelpers
+  import Sanbase.InfluxdbHelpers
   import Sanbase.Factory
 
   alias Sanbase.Prices.Store
   alias Sanbase.Influxdb.Measurement
 
   setup do
-    Store.create_db()
+    setup_prices_influxdb()
 
     slug1 = "test122"
     ticker1 = "TEST"

--- a/test/sanbase_web/graphql/projects/project_api_combined_stats_test.exs
+++ b/test/sanbase_web/graphql/projects/project_api_combined_stats_test.exs
@@ -3,20 +3,19 @@ defmodule SanbaseWeb.Graphql.ProjectApiCombinedStatsTest do
 
   import Sanbase.Factory
   import SanbaseWeb.Graphql.TestHelpers
+  import Sanbase.InfluxdbHelpers
 
   alias Sanbase.Prices.Store
   alias Sanbase.Influxdb.Measurement
 
   setup do
+    setup_prices_influxdb()
+
     p1 = insert(:random_erc20_project)
     p2 = insert(:random_erc20_project)
 
     measurement1 = Measurement.name_from(p1)
     measurement2 = Measurement.name_from(p2)
-
-    Store.create_db()
-    Store.drop_measurement(measurement1)
-    Store.drop_measurement(measurement2)
 
     datetime1 = DateTime.from_naive!(~N[2017-05-13 21:45:00], "Etc/UTC")
     datetime2 = DateTime.from_naive!(~N[2017-05-14 21:45:00], "Etc/UTC")

--- a/test/sanbase_web/graphql/projects/project_api_funds_raised_test.exs
+++ b/test/sanbase_web/graphql/projects/project_api_funds_raised_test.exs
@@ -3,6 +3,7 @@ defmodule SanbaseWeb.Graphql.ProjectApiFundsRaisedTest do
 
   import Sanbase.Utils.Config, only: [parse_config_value: 1]
   import Sanbase.Factory
+  import Sanbase.InfluxdbHelpers
 
   alias Sanbase.Prices.Store
   alias Sanbase.Influxdb.Measurement
@@ -11,7 +12,7 @@ defmodule SanbaseWeb.Graphql.ProjectApiFundsRaisedTest do
   import SanbaseWeb.Graphql.TestHelpers
 
   setup do
-    Store.create_db()
+    setup_prices_influxdb()
 
     # Add the Projects to the Postgres
     insert(:project, %{name: "Test project", coinmarketcap_id: "test", ticker: "TEST"})
@@ -22,10 +23,6 @@ defmodule SanbaseWeb.Graphql.ProjectApiFundsRaisedTest do
     test_ticker_cmc_id = "TEST_test"
     btc_ticker_cmc_id = "BTC_bitcoin"
     eth_ticker_cmc_id = "ETH_ethereum"
-
-    Store.drop_measurement(test_ticker_cmc_id)
-    Store.drop_measurement(btc_ticker_cmc_id)
-    Store.drop_measurement(eth_ticker_cmc_id)
 
     date1 = "2017-08-19"
     {:ok, dt1} = Timex.parse!(date1, "{YYYY}-{0M}-{D}") |> DateTime.from_naive("Etc/UTC")

--- a/test/sanbase_web/graphql/projects/project_api_roi_test.exs
+++ b/test/sanbase_web/graphql/projects/project_api_roi_test.exs
@@ -8,9 +8,10 @@ defmodule SanbaseWeb.Graphql.ProjectApiRoiTest do
 
   import Plug.Conn
   import SanbaseWeb.Graphql.TestHelpers
+  import Sanbase.InfluxdbHelpers
 
   defp setup do
-    Store.create_db()
+    setup_prices_influxdb()
 
     %Project{}
     |> Project.changeset(%{name: "Ethereum", ticker: "ETH", coinmarketcap_id: "ethereum"})

--- a/test/sanbase_web/graphql/twitter_api_test.exs
+++ b/test/sanbase_web/graphql/twitter_api_test.exs
@@ -7,12 +7,10 @@ defmodule Sanbase.Github.TwitterApiTest do
   alias Sanbase.Model.Project
 
   import SanbaseWeb.Graphql.TestHelpers
+  import Sanbase.InfluxdbHelpers
 
   setup do
-    Store.create_db()
-    Store.drop_measurement("SAN")
-    Store.drop_measurement("TEST1")
-    Store.drop_measurement("TEST2")
+    setup_twitter_influxdb()
 
     datetime1 = DateTime.from_naive!(~N[2017-05-13 18:00:00], "Etc/UTC")
     datetime2 = DateTime.from_naive!(~N[2017-05-14 18:00:00], "Etc/UTC")

--- a/test/sanbase_web/graphql/watchlist/watchlist_historical_stats_api_test.exs
+++ b/test/sanbase_web/graphql/watchlist/watchlist_historical_stats_api_test.exs
@@ -8,9 +8,12 @@ defmodule SanbaseWeb.Graphql.WatchlistHistoricalStatsApiTest do
   alias Sanbase.Prices.Store
 
   import SanbaseWeb.Graphql.TestHelpers
+  import Sanbase.InfluxdbHelpers
   import Sanbase.Factory
 
   setup do
+    setup_prices_influxdb()
+
     clean_task_supervisor_children()
 
     user = insert(:user)
@@ -122,10 +125,6 @@ defmodule SanbaseWeb.Graphql.WatchlistHistoricalStatsApiTest do
     datetime3 = DateTime.from_naive!(~N[2017-05-15 21:45:00], "Etc/UTC")
     datetime4 = DateTime.from_naive!(~N[2017-05-16 21:45:00], "Etc/UTC")
     datetime5 = DateTime.from_naive!(~N[2017-05-16 23:59:59], "Etc/UTC")
-
-    Store.create_db()
-    Store.drop_measurement(measurement1)
-    Store.drop_measurement(measurement2)
 
     Store.import([
       %Measurement{

--- a/test/support/influxdb_helpers.ex
+++ b/test/support/influxdb_helpers.ex
@@ -1,0 +1,21 @@
+defmodule Sanbase.InfluxdbHelpers do
+  defmacro setup_twitter_influxdb() do
+    quote do
+      Sanbase.ExternalServices.TwitterData.Store.create_db()
+
+      on_exit(fn ->
+        Sanbase.ExternalServices.TwitterData.Store.drop_db()
+      end)
+    end
+  end
+
+  defmacro setup_prices_influxdb() do
+    quote do
+      Sanbase.Prices.Store.create_db()
+
+      on_exit(fn ->
+        Sanbase.Prices.Store.drop_db()
+      end)
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -7,4 +7,3 @@ Ecto.Adapters.SQL.Sandbox.mode(Sanbase.Repo, :manual)
 Ecto.Adapters.SQL.Sandbox.mode(Sanbase.TimescaleRepo, :manual)
 
 ExUnit.configure(exclude: [timescaledb: true])
-Sanbase.Prices.Store.create_db()


### PR DESCRIPTION
#### Summary
There was a flaky test - `test/sanbase/external_services/coinmarketcap/ticker_fetcher_test.exs` which was failing due to timeouts. 

Dropping a single measurement is a [slow operation](https://github.com/influxdata/influxdb/issues/10306), so first I tried dropping all series but that resulted in inconsistent results - random timeouts or very slow execution of the drop.

So it seems the most performant way  is to re-create the DB on every test that uses influxdb.

Test suite execution has been reduced from 100-150s to 75s on my machine and is much more consistent.

Before
![Screenshot from 2019-07-25 11-47-32](https://user-images.githubusercontent.com/103871/61879766-615d3200-aefc-11e9-82f6-c18bfbb4df6a.png)

After
![Screenshot from 2019-07-25 11-53-21](https://user-images.githubusercontent.com/103871/61879775-64582280-aefc-11e9-9318-9ced19019e9d.png)

