### PR TITLE
Add custom implementation of the datetime scalar in GraphQL

### DIFF
--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -23,7 +23,6 @@ defmodule SanbaseWeb.Graphql.Schema do
   alias SanbaseWeb.Graphql.Middlewares.{ApiUsage, AccessControl}
 
   import_types(Absinthe.Plug.Types)
-  import_types(Absinthe.Type.Custom)
   import_types(Graphql.TagTypes)
   import_types(Graphql.CustomTypes)
   import_types(Graphql.AccountTypes)

--- a/lib/sanbase_web/graphql/schema/types/custom_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/custom_types.ex
@@ -1,32 +1,65 @@
 defmodule SanbaseWeb.Graphql.CustomTypes do
   use Absinthe.Schema.Notation
 
-  scalar :ecto_datetime, name: "EctoDateTime" do
-    serialize(&Ecto.DateTime.to_iso8601/1)
-    parse(&parse_ecto_datetime/1)
-  end
-
   scalar :ecto_date, name: "EctoDate" do
     serialize(&Ecto.Date.to_iso8601/1)
     parse(&parse_ecto_date/1)
   end
 
-  @spec parse_ecto_datetime(Absinthe.Blueprint.Input.String.t()) ::
-          {:ok, Ecto.DateTime.type()} | :error
-  @spec parse_ecto_datetime(Absinthe.Blueprint.Input.Null.t()) :: {:ok, nil}
-  defp parse_ecto_datetime(%Absinthe.Blueprint.Input.String{value: value}) do
-    case Ecto.DateTime.cast(value) do
-      {:ok, ecto_datetime} -> {:ok, ecto_datetime}
-      _error -> :error
+  scalar :datetime, name: "DateTime" do
+    description("""
+    The `DateTime` scalar type represents a date and time in the UTC
+    timezone. The DateTime appears in a JSON response as an ISO8601 formatted
+    string, including UTC timezone ("Z"). The parsed date and time string will
+    be converted to UTC and any UTC offset other than 0 will be rejected.
+    """)
+
+    serialize(fn dt -> DateTime.truncate(dt, :second) |> DateTime.to_iso8601() end)
+    parse(&parse_datetime/1)
+  end
+
+  scalar :naive_datetime, name: "NaiveDateTime" do
+    description("""
+    The `Naive DateTime` scalar type represents a naive date and time without
+    timezone. The DateTime appears in a JSON response as an ISO8601 formatted
+    string.
+    """)
+
+    serialize(&NaiveDateTime.to_iso8601/1)
+    parse(&parse_naive_datetime/1)
+  end
+
+  scalar :date do
+    description("""
+    The `Date` scalar type represents a date. The Date appears in a JSON
+    response as an ISO8601 formatted string, without a time component.
+    """)
+
+    serialize(&Date.to_iso8601/1)
+    parse(&parse_date/1)
+  end
+
+  scalar :time do
+    description("""
+    The `Time` scalar type represents a time. The Time appears in a JSON
+    response as an ISO8601 formatted string, without a date component.
+    """)
+
+    serialize(&Time.to_iso8601/1)
+    parse(&parse_time/1)
+  end
+
+  if Code.ensure_loaded?(Decimal) do
+    scalar :decimal do
+      description("""
+      The `Decimal` scalar type represents signed double-precision fractional
+      values parsed by the `Decimal` library.  The Decimal appears in a JSON
+      response as a string to preserve precision.
+      """)
+
+      serialize(&Absinthe.Type.Custom.Decimal.serialize/1)
+      parse(&Absinthe.Type.Custom.Decimal.parse/1)
     end
-  end
-
-  defp parse_ecto_datetime(%Absinthe.Blueprint.Input.Null{}) do
-    {:ok, nil}
-  end
-
-  defp parse_ecto_datetime(_) do
-    :error
   end
 
   @spec parse_ecto_date(Absinthe.Blueprint.Input.String.t()) :: {:ok, Ecto.Date.type()} | :error
@@ -43,6 +76,76 @@ defmodule SanbaseWeb.Graphql.CustomTypes do
   end
 
   defp parse_ecto_date(_) do
+    :error
+  end
+
+  @spec parse_datetime(Absinthe.Blueprint.Input.String.t()) :: {:ok, DateTime.t()} | :error
+  @spec parse_datetime(Absinthe.Blueprint.Input.Null.t()) :: {:ok, nil}
+  defp parse_datetime(%Absinthe.Blueprint.Input.String{value: value}) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, 0} -> {:ok, datetime}
+      {:ok, _datetime, _offset} -> :error
+      _error -> :error
+    end
+  end
+
+  defp parse_datetime(%Absinthe.Blueprint.Input.Null{}) do
+    {:ok, nil}
+  end
+
+  defp parse_datetime(_) do
+    :error
+  end
+
+  @spec parse_naive_datetime(Absinthe.Blueprint.Input.String.t()) ::
+          {:ok, NaiveDateTime.t()} | :error
+  @spec parse_naive_datetime(Absinthe.Blueprint.Input.Null.t()) :: {:ok, nil}
+  defp parse_naive_datetime(%Absinthe.Blueprint.Input.String{value: value}) do
+    case NaiveDateTime.from_iso8601(value) do
+      {:ok, naive_datetime} -> {:ok, naive_datetime}
+      _error -> :error
+    end
+  end
+
+  defp parse_naive_datetime(%Absinthe.Blueprint.Input.Null{}) do
+    {:ok, nil}
+  end
+
+  defp parse_naive_datetime(_) do
+    :error
+  end
+
+  @spec parse_date(Absinthe.Blueprint.Input.String.t()) :: {:ok, Date.t()} | :error
+  @spec parse_date(Absinthe.Blueprint.Input.Null.t()) :: {:ok, nil}
+  defp parse_date(%Absinthe.Blueprint.Input.String{value: value}) do
+    case Date.from_iso8601(value) do
+      {:ok, date} -> {:ok, date}
+      _error -> :error
+    end
+  end
+
+  defp parse_date(%Absinthe.Blueprint.Input.Null{}) do
+    {:ok, nil}
+  end
+
+  defp parse_date(_) do
+    :error
+  end
+
+  @spec parse_time(Absinthe.Blueprint.Input.String.t()) :: {:ok, Time.t()} | :error
+  @spec parse_time(Absinthe.Blueprint.Input.Null.t()) :: {:ok, nil}
+  defp parse_time(%Absinthe.Blueprint.Input.String{value: value}) do
+    case Time.from_iso8601(value) do
+      {:ok, time} -> {:ok, time}
+      _error -> :error
+    end
+  end
+
+  defp parse_time(%Absinthe.Blueprint.Input.Null{}) do
+    {:ok, nil}
+  end
+
+  defp parse_time(_) do
     :error
   end
 end

--- a/test/sanbase_web/graphql/billing/subscribe_api_test.exs
+++ b/test/sanbase_web/graphql/billing/subscribe_api_test.exs
@@ -304,7 +304,9 @@ defmodule SanbaseWeb.Graphql.Billing.SubscribeApiTest do
       response = execute_mutation(context.conn, query, "cancelSubscription")
 
       assert response["isScheduledForCancellation"]
-      assert response["ScheduledForCancellationAt"] == DateTime.to_iso8601(tomorrow)
+
+      assert response["scheduledForCancellationAt"] ==
+               DateTime.to_iso8601(DateTime.truncate(tomorrow, :second))
     end
 
     test "returns error if subscription is scheduled for cancellation", context do
@@ -579,7 +581,7 @@ defmodule SanbaseWeb.Graphql.Billing.SubscribeApiTest do
     mutation {
       cancelSubscription(subscriptionId: #{subscription_id}) {
         isScheduledForCancellation
-        ScheduledForCancellationAt
+        scheduledForCancellationAt
       }
     }
     """

--- a/test/sanbase_web/graphql/insight/current_poll_api_test.exs
+++ b/test/sanbase_web/graphql/insight/current_poll_api_test.exs
@@ -34,7 +34,7 @@ defmodule SanbaseWeb.Graphql.CurrentPollApiTest do
     currentPoll = json_response(result, 200)["data"]["currentPoll"]
 
     assert Timex.parse!(currentPoll["startAt"], "{ISO:Extended}") ==
-             Timex.beginning_of_week(Timex.now())
+             Timex.beginning_of_week(Timex.now()) |> DateTime.truncate(:second)
 
     assert currentPoll["posts"] == []
   end

--- a/test/sanbase_web/graphql/timeline_event_api_test.exs
+++ b/test/sanbase_web/graphql/timeline_event_api_test.exs
@@ -68,8 +68,8 @@ defmodule SanbaseWeb.Graphql.TimelineEventApiTest do
     assert result |> hd() |> Map.get("events") |> length() == 3
 
     assert result |> hd() |> Map.get("cursor") == %{
-             "after" => DateTime.to_iso8601(event3.inserted_at),
-             "before" => DateTime.to_iso8601(event1.inserted_at)
+             "after" => DateTime.to_iso8601(DateTime.truncate(event3.inserted_at, :second)),
+             "before" => DateTime.to_iso8601(DateTime.truncate(event1.inserted_at, :second))
            }
   end
 


### PR DESCRIPTION
#### Summary
Remove the dependency on the Absinthe's implementation of some of the date/datetime types.
We need to truncate the date times to seconds (we don't care for lower precision). GraphQL spec does not define `datetime` type so it's a custom provided type by Absinthe.

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->