### PR TITLE
Improve error messages for queries available only for ethereum

### DIFF
--- a/lib/sanbase/utils/error_handling.ex
+++ b/lib/sanbase/utils/error_handling.ex
@@ -28,6 +28,10 @@ defmodule Sanbase.Utils.ErrorHandling do
     "[#{Ecto.UUID.generate()}] Can't fetch #{metric_name} for #{description}: #{identifier}"
   end
 
+  def graphql_error_msg_eth(metric_name, identifier) do
+    "[#{Ecto.UUID.generate()}] Can't fetch #{metric_name} for project with slug #{identifier}, because the only slug, that can be used, is ethereum."
+  end
+
   def log_graphql_error(message, error) do
     Logger.warn("#{message}" <> ", Reason: #{inspect(error)}")
   end

--- a/lib/sanbase/utils/error_handling.ex
+++ b/lib/sanbase/utils/error_handling.ex
@@ -28,10 +28,6 @@ defmodule Sanbase.Utils.ErrorHandling do
     "[#{Ecto.UUID.generate()}] Can't fetch #{metric_name} for #{description}: #{identifier}"
   end
 
-  def graphql_error_msg_eth(metric_name, identifier) do
-    "[#{Ecto.UUID.generate()}] Can't fetch #{metric_name} for project with slug #{identifier}, because the only slug, that can be used, is ethereum."
-  end
-
   def log_graphql_error(message, error) do
     Logger.warn("#{message}" <> ", Reason: #{inspect(error)}")
   end

--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -116,7 +116,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
 
   def mining_pools_distribution(
         _root,
-        %{slug: slug, from: from, to: to, interval: interval},
+        %{slug: slug = "ethereum", from: from, to: to, interval: interval},
         _resolution
       ) do
     case MiningPoolsDistribution.distribution(slug, from, to, interval) do
@@ -130,9 +130,23 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
     end
   end
 
+  def mining_pools_distribution(
+        _root,
+        %{slug: slug, from: _from, to: _to, interval: _interval},
+        _resolution
+      ) do
+    log_graphql_error(
+      "Can't fetch Mining Pools Distribution for project with slug: #{slug}",
+      "Currently only ethereum is supported."
+    )
+
+    {:error,
+     "Can't fetch Mining Pools Distribution for project with slug: #{slug}. Currently only ethereum is supported."}
+  end
+
   def miners_balance(
         _root,
-        %{slug: slug, from: from, to: to, interval: interval},
+        %{slug: slug = "ethereum", from: from, to: to, interval: interval},
         _resolution
       ) do
     with {:ok, from, to, interval} <-
@@ -154,6 +168,20 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
         log_graphql_error(error_msg, error)
         {:error, error_msg}
     end
+  end
+
+  def miners_balance(
+        _root,
+        %{slug: slug, from: _from, to: _to, interval: _interval},
+        _resolution
+      ) do
+    log_graphql_error(
+      "Can't fetch Miners Balance for project with slug: #{slug}",
+      "Currently only ethereum is supported."
+    )
+
+    {:error,
+     "Can't fetch Miners Balance for project with slug: #{slug}. Currently only ethereum is supported."}
   end
 
   def mvrv_ratio(_root, %{slug: "bitcoin", from: from, to: to, interval: interval}, _resolution) do

--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -9,7 +9,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
   alias SanbaseWeb.Graphql.SanbaseDataloader
 
   import Sanbase.Utils.ErrorHandling,
-    only: [log_graphql_error: 2, graphql_error_msg: 1, graphql_error_msg: 2, graphql_error_msg: 3]
+    only: [log_graphql_error: 2, graphql_error_msg: 1, graphql_error_msg: 2, graphql_error_msg: 3, "graphql_error_msg_eth": 2]
 
   alias Sanbase.Clickhouse.HistoricalBalance.MinersBalance
 
@@ -76,7 +76,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
         {:ok, gas_used}
 
       {:error, error} ->
-        error_msg = graphql_error_msg("Gas Used", slug)
+        case slug do
+          "ethereum" ->
+            error_msg = graphql_error_msg("Gas Used", slug)
+          _ ->
+            error_msg = graphql_error_msg_eth("Gas Used", slug)
+        end
         log_graphql_error(error_msg, error)
         {:error, error_msg}
     end

--- a/test/sanbase_web/graphql/clickhouse/gas_used_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/gas_used_test.exs
@@ -98,7 +98,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.GasUsedTest do
   end
 
   test "works only for ethereum", context do
-    error = "Currently only ethereum is supported!"
+    error = "Currently only ethereum is supported."
 
     with_mock GasUsed,
       gas_used: fn _, _, _, _ -> {:error, error} end do

--- a/test/sanbase_web/graphql/clickhouse/historical_balance/miners_balance_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/historical_balance/miners_balance_test.exs
@@ -104,6 +104,20 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalance.MinersBalanceTest do
     end
   end
 
+  test "returns error when something except ethereum is requested", context do
+    error = "Currently only ethereum is supported."
+
+    with_mock MinersBalance,
+      historical_balance: fn _, _, _, _ -> {:error, error} end do
+      assert capture_log(fn ->
+               response = execute_query("unsupported", context)
+               result = parse_response(response)
+               assert result == nil
+             end) =~
+               graphql_error_msg("Miners Balance", "unsupported", error)
+    end
+  end
+
   defp parse_response(response) do
     json_response(response, 200)["data"]["minersBalance"]
   end

--- a/test/sanbase_web/graphql/clickhouse/mining_pools_distribution_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/mining_pools_distribution_test.exs
@@ -23,7 +23,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.MiningPoolsDistributionTest do
   end
 
   test "works only for ethereum", context do
-    error = "Currently only ethereum is supported!"
+    error = "Currently only ethereum is supported."
 
     with_mock MiningPoolsDistribution,
       distribution: fn _, _, _, _ -> {:error, error} end do
@@ -32,7 +32,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.MiningPoolsDistributionTest do
                result = parse_response(response)
                assert result == nil
              end) =~
-               graphql_error_msg("Mining Pools Distribution", error)
+               graphql_error_msg("Mining Pools Distribution", "unsupported", error)
     end
   end
 


### PR DESCRIPTION
With this PR I add proper messages to errors given, when we use any slug instead of ethereum with miner metrics