### PR TITLE
Implement custom test formatter that prints the failed tests

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -22,4 +22,4 @@ RUN mix deps.compile
 COPY . /app
 RUN mix format --check-formatted
 
-CMD mix test_all --trace --slowest 20
+CMD mix test_all --formatter Sanbase.FailedTestFormatter --formatter ExUnit.CLIFormatter --slowest 20

--- a/lib/mix/failure_test_formatter.ex
+++ b/lib/mix/failure_test_formatter.ex
@@ -1,0 +1,51 @@
+defmodule Sanbase.FailedTestFormatter do
+  @moduledoc false
+  use GenServer
+
+  ## Callbacks
+
+  def init(_opts) do
+    {:ok,
+     %{
+       failed: [],
+       failure_counter: 0
+     }}
+  end
+
+  def handle_cast({:test_finished, %ExUnit.Test{state: {:failed, _}} = test}, config) do
+    %ExUnit.Test{
+      state:
+        {:failed,
+         [
+           {:error, _error,
+            [
+              {_module, _test_name, _, [file: file, line: line]}
+            ]}
+         ]}
+    } = test
+
+    config = %{
+      config
+      | failed: ["#{file}:#{line}" | config.failed],
+        failure_counter: config.failure_counter + 1
+    }
+
+    {:noreply, config}
+  end
+
+  def handle_cast({:suite_finished, _run_us, _load_us}, config) do
+    print_suite(config)
+    {:noreply, config}
+  end
+
+  def handle_cast(_, config) do
+    {:noreply, config}
+  end
+
+  defp print_suite(config) do
+    if config.failure_counter > 0 do
+      message = config.failed |> Enum.join("\n")
+      IO.puts("Failed tests:\n" <> message)
+    end
+  end
+end

--- a/test/sanbase_web/graphql/user/apikey_resolver_test.exs
+++ b/test/sanbase_web/graphql/user/apikey_resolver_test.exs
@@ -5,7 +5,6 @@ defmodule SanbaseWeb.Graphql.ApikeyResolverTest do
 
   import SanbaseWeb.Graphql.TestHelpers
   import Sanbase.Factory
-  import Mockery
 
   alias Sanbase.Repo
 


### PR DESCRIPTION
#### Summary
![image](https://user-images.githubusercontent.com/6518376/62537042-2f32c500-b858-11e9-80c6-236a9b2cf97d.png)

Here it how it looks like in the CI:
<img width="1334" alt="image" src="https://user-images.githubusercontent.com/6518376/62537383-f1826c00-b858-11e9-9e72-527293895b5e.png">

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
