### PR TITLE
Add the resolution.source to the cache key

### DIFF
--- a/lib/sanbase_web/graphql/cache/cache.ex
+++ b/lib/sanbase_web/graphql/cache/cache.ex
@@ -125,19 +125,19 @@ defmodule SanbaseWeb.Graphql.Cache do
       %{id: id} = root, args, resolution ->
         fun = fn -> resolver_fn.(root, args, resolution) end
 
-        cache_key({name, id}, args, opts)
+        cache_key({name, id, resolution.source}, args, opts)
         |> get_or_store(fun)
 
       %{word: word} = root, args, resolution ->
         fun = fn -> resolver_fn.(root, args, resolution) end
 
-        cache_key({name, word}, args, opts)
+        cache_key({name, word, resolution.source}, args, opts)
         |> get_or_store(fun)
 
       %{}, args, resolution ->
         fun = fn -> resolver_fn.(%{}, args, resolution) end
 
-        cache_key(name, args, opts)
+        cache_key({name, resolution.source}, args, opts)
         |> get_or_store(fun)
     end
   end

--- a/lib/sanbase_web/graphql/schema/queries/metric_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/metric_queries.ex
@@ -1,7 +1,7 @@
 defmodule SanbaseWeb.Graphql.Schema.MetricQueries do
   use Absinthe.Schema.Notation
 
-  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1, cache_resolve: 2]
+  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 2]
 
   alias SanbaseWeb.Graphql.Resolvers.MetricResolver
 
@@ -12,7 +12,8 @@ defmodule SanbaseWeb.Graphql.Schema.MetricQueries do
     field :get_metric, :metric do
       meta(access: :free)
       arg(:metric, non_null(:string))
-      cache_resolve(&MetricResolver.get_metric/3)
+
+      resolve(&MetricResolver.get_metric/3)
     end
 
     field :get_available_metrics, list_of(:string) do


### PR DESCRIPTION
This fixes issues where custom resolvers depend on the return value of
the top-level resolver. Example for this is the timeSeries custom
resolver for the getMetric query. It was not using the 'metric' for the
cache key and all metrics with the same datetime params were cached
under the same key

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
