### PR TITLE
Implement configurable table for the v2 metics

### DIFF
--- a/lib/sanbase/clickhouse/metric/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/available_v2_metrics.json
@@ -2,307 +2,464 @@
   {
     "metric": "daily_active_addresses",
     "access": "free",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "daily_avg_marketcap_usd",
     "access": "free",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "daily_avg_price_usd",
     "access": "free",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "daily_closing_marketcap_usd",
     "access": "free",
-    "aggregation": "last"
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "daily_closing_price_usd",
     "access": "free",
-    "aggregation": "last"
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "daily_high_price_usd",
     "access": "free",
-    "aggregation": "max"
+    "aggregation": "max",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "daily_low_price_usd",
     "access": "free",
-    "aggregation": "min"
+    "aggregation": "min",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "daily_opening_price_usd",
     "access": "free",
-    "aggregation": "first"
+    "aggregation": "first",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
 
   {
     "metric": "daily_trading_volume_usd",
     "access": "free",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mean_realized_price_usd_10y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mean_realized_price_usd_180d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mean_realized_price_usd_1d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mean_realized_price_usd_20y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mean_realized_price_usd_2y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mean_realized_price_usd_30d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mean_realized_price_usd_365d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mean_realized_price_usd_3y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mean_realized_price_usd_5y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mean_realized_price_usd_60d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mean_realized_price_usd_7d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mean_realized_price_usd_90d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mvrv_usd_10y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mvrv_usd_180d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mvrv_usd_1d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mvrv_usd_20y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mvrv_usd_2y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mvrv_usd_30d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mvrv_usd_365d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mvrv_usd_3y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mvrv_usd_5y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mvrv_usd_60d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mvrv_usd_7d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "mvrv_usd_90d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_age_consumed",
     "access": "restricted",
-    "aggregation": "sum"
+    "aggregation": "sum",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_circulation_10y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_circulation_180d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_circulation_1d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_circulation_20y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_circulation_2y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_circulation_30d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_circulation_365d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_circulation_3y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_circulation_5y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_circulation_60d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_circulation_7d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_circulation_90d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_mean_age_days",
     "access": "restricted",
-    "aggregation": "last"
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_realized_cap_usd_10y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_realized_cap_usd_180d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_realized_cap_usd_1d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_realized_cap_usd_20y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_realized_cap_usd_2y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_realized_cap_usd_30d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_realized_cap_usd_365d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_realized_cap_usd_3y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_realized_cap_usd_5y",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_realized_cap_usd_60d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_realized_cap_usd_7d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "stack_realized_cap_usd_90d",
     "access": "restricted",
-    "aggregation": "avg"
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "token_velocity",
     "access": "restricted",
-    "aggregation": "last"
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
   },
   {
     "metric": "transaction_volume",
     "access": "restricted",
-    "aggregation": "sum"
+    "aggregation": "sum",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2"
+  },
+  {
+    "metric": "exchange_inflow",
+    "access": "restricted",
+    "aggregation": "sum",
+    "min_interval": "5m",
+    "table": "exchange_flow_metrics"
+  },
+  {
+    "metric": "exchange_outflow",
+    "access": "restricted",
+    "aggregation": "sum",
+    "min_interval": "5m",
+    "table": "exchange_flow_metrics"
+  },
+  {
+    "metric": "exchange_balance",
+    "access": "restricted",
+    "aggregation": "sum",
+    "min_interval": "5m",
+    "table": "exchange_flow_metrics"
+  },
+  {
+    "metric": "transaction_volume_5min",
+    "access": "restricted",
+    "aggregation": "sum",
+    "min_interval": "5m",
+    "table": "transaction_volume_metrics"
+  },
+  {
+    "metric": "stack_age_consumed_5min",
+    "access": "restricted",
+    "aggregation": "sum",
+    "min_interval": "5m",
+    "table": "token_age_consumed_metrics"
   }
 ]

--- a/lib/sanbase/clickhouse/metric/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/available_v2_metrics.json
@@ -1,10 +1,5 @@
 [
   {
-    "metric": "average_price",
-    "access": "free",
-    "aggregation": "avg"
-  },
-  {
     "metric": "daily_active_addresses",
     "access": "free",
     "aggregation": "avg"
@@ -44,11 +39,7 @@
     "access": "free",
     "aggregation": "first"
   },
-  {
-    "metric": "daily_stack_circulation",
-    "access": "restricted",
-    "aggregation": "avg"
-  },
+
   {
     "metric": "daily_trading_volume_usd",
     "access": "free",
@@ -240,24 +231,9 @@
     "aggregation": "avg"
   },
   {
-    "metric": "stack_cumulative_age_consumed",
-    "access": "restricted",
-    "aggregation": "sum"
-  },
-  {
-    "metric": "stack_liveliness",
-    "access": "restricted",
-    "aggregation": "last"
-  },
-  {
     "metric": "stack_mean_age_days",
     "access": "restricted",
     "aggregation": "last"
-  },
-  {
-    "metric": "stack_realized_cap_usd",
-    "access": "restricted",
-    "aggregation": "avg"
   },
   {
     "metric": "stack_realized_cap_usd_10y",
@@ -318,11 +294,6 @@
     "metric": "stack_realized_cap_usd_90d",
     "access": "restricted",
     "aggregation": "avg"
-  },
-  {
-    "metric": "stack_total_age",
-    "access": "restricted",
-    "aggregation": "last"
   },
   {
     "metric": "token_velocity",

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -96,7 +96,6 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
 
       expected_free_queries =
         [
-          "average_price",
           "daily_active_addresses",
           "daily_avg_marketcap_usd",
           "daily_avg_price_usd",
@@ -157,13 +156,12 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
     test "restricted clickhouse v2 queries" do
       restricted_queries =
         Sanbase.Billing.Plan.AccessChecker.Helper.get_metrics_with_access_level(:restricted)
-        |> Enum.sort()
         |> Enum.reject(&is_atom/1)
         |> Enum.map(&elem(&1, 1))
+        |> Enum.sort()
 
       expected_restricted_queries =
         [
-          "daily_stack_circulation",
           "mean_realized_price_usd_10y",
           "mean_realized_price_usd_180d",
           "mean_realized_price_usd_1d",
@@ -201,10 +199,7 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           "stack_circulation_60d",
           "stack_circulation_7d",
           "stack_circulation_90d",
-          "stack_cumulative_age_consumed",
-          "stack_liveliness",
           "stack_mean_age_days",
-          "stack_realized_cap_usd",
           "stack_realized_cap_usd_10y",
           "stack_realized_cap_usd_180d",
           "stack_realized_cap_usd_1d",
@@ -217,9 +212,13 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           "stack_realized_cap_usd_60d",
           "stack_realized_cap_usd_7d",
           "stack_realized_cap_usd_90d",
-          "stack_total_age",
           "token_velocity",
-          "transaction_volume"
+          "transaction_volume",
+          "exchange_inflow",
+          "exchange_outflow",
+          "exchange_balance",
+          "transaction_volume_5min",
+          "stack_age_consumed_5min"
         ]
         |> Enum.sort()
 

--- a/test/sanbase_web/graphql/clickhouse/metric/api_metric_metadata_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/metric/api_metric_metadata_test.exs
@@ -16,7 +16,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ApiMetricMetadataTest do
       %{"data" => %{"getMetric" => %{"metadata" => metadata}}} = fetch_metadata(conn, metric)
       assert match?(%{"defaultAggregation" => _, "minInterval" => _}, metadata)
       assert metadata["defaultAggregation"] in aggregations
-      assert metadata["minInterval"] == "1d"
+      assert metadata["minInterval"] in ["1d", "5m"]
     end
   end
 


### PR DESCRIPTION
#### Summary
We have many tables with the same structure, so we can unify the access to them. By specifying the table we can reuse one query (💍) to fetch them all.
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->