### PR TITLE
Change active subscriptions query

### DIFF
--- a/lib/sanbase/billing/subscription.ex
+++ b/lib/sanbase/billing/subscription.ex
@@ -24,12 +24,6 @@ defmodule Sanbase.Billing.Subscription do
   Please, contact administrator of the site for more information.
   """
 
-  # After `current_period_end` timestamp passes there is some time until `invoice.payment_succeeded` event is generated
-  # to update the field with new timestamp value. So we add 1 day gratis in which we should receive payment before
-  # we decide that this subscription is not active.
-  # Check for active subscription: current_period_end > Timex.now - @subscription_gratis_days
-  @subscription_gratis_days 1
-
   schema "subscriptions" do
     field(:stripe_id, :string)
     field(:current_period_end, :utc_datetime)
@@ -352,13 +346,8 @@ defmodule Sanbase.Billing.Subscription do
     )
   end
 
-  # current_period_end > Timex.now - gratis days
   defp active_subscriptions_query(query) do
-    from(s in query,
-      where:
-        s.status != "canceled" and
-          s.current_period_end > ^Timex.shift(Timex.now(), days: -@subscription_gratis_days)
-    )
+    from(s in query, where: s.status != "canceled")
   end
 
   defp last_subscription_for_product_query(query, product_id) do

--- a/test/sanbase/billing/subscription_test.exs
+++ b/test/sanbase/billing/subscription_test.exs
@@ -37,7 +37,7 @@ defmodule Sanbase.Billing.SubscriptionTest do
       insert(:subscription_essential,
         user: context.user,
         cancel_at_period_end: true,
-        current_period_end: Timex.shift(Timex.now(), days: -1)
+        status: "canceled"
       )
 
       assert Subscription.user_subscriptions(context.user) == []
@@ -61,7 +61,7 @@ defmodule Sanbase.Billing.SubscriptionTest do
       insert(:subscription_essential,
         user: context.user,
         cancel_at_period_end: true,
-        current_period_end: Timex.shift(Timex.now(), days: -1)
+        status: "canceled"
       )
 
       current_subscription = Subscription.current_subscription(context.user, context.product.id)

--- a/test/sanbase_web/graphql/billing/subscribe_api_test.exs
+++ b/test/sanbase_web/graphql/billing/subscribe_api_test.exs
@@ -76,7 +76,7 @@ defmodule SanbaseWeb.Graphql.Billing.SubscribeApiTest do
     test "when there are no active subscriptions - return []", context do
       insert(:subscription_essential,
         user: context.user,
-        current_period_end: Timex.shift(Timex.now(), days: -2)
+        status: "canceled"
       )
 
       current_user = execute_query(context.conn, current_user_query(), "currentUser")


### PR DESCRIPTION
Use Stripe status to determine if a subscription is active. It is active if it isn't cancelled.
Subscription can be cancelled in those 3 cases:

* User cancel from account. It is cancelled by Stripe when `current_period_end` is reached.
* Payment failed and Stripe retry scheme failed. It will be cancelled after max retries reached.
* Manually cancel subscription in Stripe