### PR TITLE
Change signals count function

### DIFF
--- a/lib/sanbase/signals/user_trigger.ex
+++ b/lib/sanbase/signals/user_trigger.ex
@@ -81,7 +81,8 @@ defmodule Sanbase.Signal.UserTrigger do
 
   @spec triggers_count_for(%User{}) :: integer()
   def triggers_count_for(user) do
-    triggers_for(user)
+    from(ut in UserTrigger, where: ut.user_id == ^user.id)
+    |> Repo.all()
     |> Enum.count()
   end
 

--- a/lib/sanbase/signals/user_trigger.ex
+++ b/lib/sanbase/signals/user_trigger.ex
@@ -81,9 +81,8 @@ defmodule Sanbase.Signal.UserTrigger do
 
   @spec triggers_count_for(%User{}) :: integer()
   def triggers_count_for(user) do
-    from(ut in UserTrigger, where: ut.user_id == ^user.id)
-    |> Repo.all()
-    |> Enum.count()
+    from(ut in UserTrigger, where: ut.user_id == ^user.id, select: fragment("count(*)"))
+    |> Repo.one()
   end
 
   @doc ~s"""


### PR DESCRIPTION
Remove using `triggers_for` -> which is calling `atomize_keys` for all user triggers. This is not needed for simple count.
