### PR TITLE
Remove check for valid notfication channels when getting active triggers

### DIFF
--- a/lib/sanbase/signals/user_trigger.ex
+++ b/lib/sanbase/signals/user_trigger.ex
@@ -136,26 +136,7 @@ defmodule Sanbase.Signal.UserTrigger do
     )
     |> Repo.all()
     |> Enum.map(&trigger_in_struct/1)
-    |> Enum.filter(&has_valid_notification_channel?/1)
   end
-
-  defp has_valid_notification_channel?(%{
-         user: %{
-           user_settings: %{settings: %{telegram_chat_id: chat_id}}
-         },
-         trigger: %{settings: %{channel: "telegram"}}
-       })
-       when is_integer(chat_id) and chat_id > 0,
-       do: true
-
-  defp has_valid_notification_channel?(%{
-         user: %{email: email},
-         trigger: %{settings: %{channel: "email"}}
-       })
-       when is_binary(email),
-       do: true
-
-  defp has_valid_notification_channel?(_), do: false
 
   @doc ~s"""
   Create a new user trigger that is used to fire signals.


### PR DESCRIPTION
#### Summary
We need to remove this because even if there's no valid notification
channel the user can see the historical activity in his activity feed.
Furthermore, the check was stopping running triggers with a list of notification
channels

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
