### PR TITLE
Fix fetch_average_volume error handling in dataloader

### DIFF
--- a/lib/sanbase/notifications/discord/daa_signal.ex
+++ b/lib/sanbase/notifications/discord/daa_signal.ex
@@ -99,7 +99,7 @@ defmodule Sanbase.Notifications.Discord.DaaSignal do
       current_daa = get_daa_contract(Project.contract_address(project), today_daa_for_projects)
       {last_triggered_daa, hours} = last_triggered_daa(project, notification_type)
 
-      percent_change = percent_change(avg_daa, current_daa - last_triggered_daa)
+      percent_change = Sanbase.Math.percent_change(avg_daa, current_daa - last_triggered_daa)
 
       if percent_change > trigger_percent(project) * 100 do
         {project, avg_daa, current_daa, last_triggered_daa, percent_change, hours}
@@ -239,13 +239,6 @@ defmodule Sanbase.Notifications.Discord.DaaSignal do
 
   defp notification_emoji_up() do
     ":small_red_triangle:"
-  end
-
-  defp percent_change(0, _current), do: 0
-  defp percent_change(nil, _current), do: 0
-
-  defp percent_change(previous, current) do
-    Float.round((current - previous) / previous * 100)
   end
 
   defp webhook_url() do

--- a/lib/sanbase/prices/store.ex
+++ b/lib/sanbase/prices/store.ex
@@ -88,11 +88,14 @@ defmodule Sanbase.Prices.Store do
     |> get()
     |> case do
       %{results: [%{series: series}]} ->
-        series
-        |> Enum.map(fn %{name: name, values: [[_, value]]} -> {name, value} end)
+        result =
+          series
+          |> Enum.map(fn %{name: name, values: [[_, value]]} -> {name, value} end)
 
-      _ ->
-        {:error, []}
+        {:ok, result}
+
+      error ->
+        {:error, error}
     end
   end
 

--- a/lib/sanbase/signals/history/daily_active_addresses_history.ex
+++ b/lib/sanbase/signals/history/daily_active_addresses_history.ex
@@ -33,7 +33,7 @@ defmodule Sanbase.Signal.History.DailyActiveAddressesHistory do
     end
 
     import Sanbase.DateTimeUtils, only: [str_to_days: 1]
-    import Sanbase.Signal.Utils, only: [percent_change: 2]
+    import Sanbase.Math, only: [percent_change: 2]
     import Sanbase.Signal.OperationEvaluation, only: [operation_triggered?: 2]
 
     alias Sanbase.Signal.History.DailyActiveAddressesHistory

--- a/lib/sanbase/signals/history/utils.ex
+++ b/lib/sanbase/signals/history/utils.ex
@@ -1,5 +1,6 @@
 defmodule Sanbase.Signal.History.Utils do
-  import Sanbase.Signal.{Utils, OperationEvaluation}
+  import Sanbase.Signal.OperationEvaluation, only: [operation_triggered?: 2]
+  import Sanbase.Math, only: [percent_change: 2]
 
   @type percent_change_calculations :: {float(), boolean()}
 

--- a/lib/sanbase/signals/trigger/settings/daily_active_addresses_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/daily_active_addresses_settings.ex
@@ -11,6 +11,7 @@ defmodule Sanbase.Signal.Trigger.DailyActiveAddressesSettings do
 
   import Sanbase.{Validation, Signal.Validation}
   import Sanbase.Signal.Utils
+  import Sanbase.Math, only: [percent_change: 2]
 
   alias __MODULE__
   alias Sanbase.Signal.Type

--- a/lib/sanbase/signals/trigger/settings/price_percent_change_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/price_percent_change_settings.ex
@@ -8,6 +8,7 @@ defmodule Sanbase.Signal.Trigger.PricePercentChangeSettings do
 
   import Sanbase.{Validation, Signal.Validation}
   import Sanbase.Signal.{Utils, OperationEvaluation}
+  import Sanbase.Math, only: [percent_change: 2]
 
   alias __MODULE__
   alias Sanbase.Signal.Type

--- a/lib/sanbase/signals/trigger/settings/utils.ex
+++ b/lib/sanbase/signals/trigger/settings/utils.ex
@@ -1,45 +1,6 @@
 defmodule Sanbase.Signal.Utils do
   alias Sanbase.Math
 
-  @epsilon 1.0e-6
-
-  @doc ~s"""
-  Calculate the % change that occured between the first and the second arguments
-
-    ## Examples
-
-      iex> Sanbase.Signal.Utils.percent_change(1.0, 2.0)
-      100.0
-
-      iex> Sanbase.Signal.Utils.percent_change(1.0, 1.05)
-      5.0
-
-      iex> Sanbase.Signal.Utils.percent_change(0, 2.0)
-      0.0
-
-      iex> Sanbase.Signal.Utils.percent_change(2.0, 1.0)
-      -50.0
-
-      iex> Sanbase.Signal.Utils.percent_change(2.0, 0.0)
-      -100.0
-
-      iex> Sanbase.Signal.Utils.percent_change(2.0, -1)
-      -150.0
-
-      iex> Sanbase.Signal.Utils.percent_change(10.0, 10.0)
-      0.0
-  """
-  def percent_change(0, _current_daa), do: 0.0
-  def percent_change(nil, _current_daa), do: 0.0
-
-  def percent_change(previous, _current_daa)
-      when is_number(previous) and previous <= @epsilon,
-      do: 0
-
-  def percent_change(previous, current) when is_number(previous) and is_number(current) do
-    Float.round((current - previous) / previous * 100, 2)
-  end
-
   def chart_url(project, type) do
     Sanbase.Chart.build_embedded_chart(
       project,

--- a/lib/sanbase/utils/math.ex
+++ b/lib/sanbase/utils/math.ex
@@ -8,25 +8,25 @@ defmodule Sanbase.Math do
 
     ## Examples
 
-      iex> Sanbase.Signal.Utils.percent_change(1.0, 2.0)
+      iex> Sanbase.Math.percent_change(1.0, 2.0)
       100.0
 
-      iex> Sanbase.Signal.Utils.percent_change(1.0, 1.05)
+      iex> Sanbase.Math.percent_change(1.0, 1.05)
       5.0
 
-      iex> Sanbase.Signal.Utils.percent_change(0, 2.0)
+      iex> Sanbase.Math.percent_change(0, 2.0)
       0.0
 
-      iex> Sanbase.Signal.Utils.percent_change(2.0, 1.0)
+      iex> Sanbase.Math.percent_change(2.0, 1.0)
       -50.0
 
-      iex> Sanbase.Signal.Utils.percent_change(2.0, 0.0)
+      iex> Sanbase.Math.percent_change(2.0, 0.0)
       -100.0
 
-      iex> Sanbase.Signal.Utils.percent_change(2.0, -1)
+      iex> Sanbase.Math.percent_change(2.0, -1)
       -150.0
 
-      iex> Sanbase.Signal.Utils.percent_change(10.0, 10.0)
+      iex> Sanbase.Math.percent_change(10.0, 10.0)
       0.0
   """
   def percent_change(0, _current_daa), do: 0.0

--- a/lib/sanbase/utils/math.ex
+++ b/lib/sanbase/utils/math.ex
@@ -1,6 +1,45 @@
 defmodule Sanbase.Math do
   require Integer
 
+  @epsilon 1.0e-6
+
+  @doc ~s"""
+  Calculate the % change that occured between the first and the second arguments
+
+    ## Examples
+
+      iex> Sanbase.Signal.Utils.percent_change(1.0, 2.0)
+      100.0
+
+      iex> Sanbase.Signal.Utils.percent_change(1.0, 1.05)
+      5.0
+
+      iex> Sanbase.Signal.Utils.percent_change(0, 2.0)
+      0.0
+
+      iex> Sanbase.Signal.Utils.percent_change(2.0, 1.0)
+      -50.0
+
+      iex> Sanbase.Signal.Utils.percent_change(2.0, 0.0)
+      -100.0
+
+      iex> Sanbase.Signal.Utils.percent_change(2.0, -1)
+      -150.0
+
+      iex> Sanbase.Signal.Utils.percent_change(10.0, 10.0)
+      0.0
+  """
+  def percent_change(0, _current_daa), do: 0.0
+  def percent_change(nil, _current_daa), do: 0.0
+
+  def percent_change(previous, _current_daa)
+      when is_number(previous) and previous <= @epsilon,
+      do: 0
+
+  def percent_change(previous, current) when is_number(previous) and is_number(current) do
+    Float.round((current - previous) / previous * 100, 2)
+  end
+
   @doc ~S"""
   Integer power function. Erlang's :math is using floating point numbers.
   Sometimes the result is needed as Integer and not as Float (ex. for using in Decimal.div/1)

--- a/lib/sanbase_web/graphql/dataloader/influxdb_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/influxdb_dataloader.ex
@@ -33,7 +33,7 @@ defmodule SanbaseWeb.Graphql.InfluxdbDataloader do
             yesterday_vol = Map.get(volumes_previous_24h_map, name, 0)
 
             if yesterday_vol > 1 do
-              {name, (today_vol - yesterday_vol) * 100 / yesterday_vol}
+              {name, Sanbase.Math.percent_change(yesterday_vol, today_vol)}
             end
           end)
         else


### PR DESCRIPTION
#### Summary
Fixing these issues:
https://sentry.production.internal.santiment.net/sentry/sanbase-backend/issues/13908/
https://sentry.production.internal.santiment.net/sentry/sanbase-backend/issues/13909/
https://sentry.production.internal.santiment.net/sentry/sanbase-backend/issues/13922/

Also it unifies the response of the `fetch_average_volume` when queries with a single measurement and list of measurements
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->