### PR TITLE
Renamed logo fetcher urls

### DIFF
--- a/lib/sanbase/model/project/project.ex
+++ b/lib/sanbase/model/project/project.ex
@@ -24,8 +24,6 @@ defmodule Sanbase.Model.Project do
     field(:name, :string)
     field(:ticker, :string)
     field(:logo_url, :string)
-    field(:logo32_url, :string)
-    field(:logo64_url, :string)
     field(:website_link, :string)
     field(:email, :string)
     field(:btt_link, :string)
@@ -75,8 +73,6 @@ defmodule Sanbase.Model.Project do
       :name,
       :ticker,
       :logo_url,
-      :logo32_url,
-      :logo64_url,
       :coinmarketcap_id,
       :website_link,
       :email,

--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -37,8 +37,6 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     end
 
     field(:logo_url, :string)
-    field(:logo32_url, :string)
-    field(:logo64_url, :string)
     field(:website_link, :string)
     field(:email, :string)
     field(:btt_link, :string)

--- a/priv/repo/migrations/20190828092907_remove_logo_url.exs
+++ b/priv/repo/migrations/20190828092907_remove_logo_url.exs
@@ -1,9 +1,15 @@
 defmodule Sanbase.Repo.Migrations.RemoveLogoUrl do
   use Ecto.Migration
 
-  def change do
+  def up do
     alter table("project") do
       remove(:logo_url)
+    end
+  end
+
+  def down do
+    alter table("project") do
+      add(:logo_url, :string)
     end
   end
 end

--- a/priv/repo/migrations/20190828092907_remove_logo_url.exs
+++ b/priv/repo/migrations/20190828092907_remove_logo_url.exs
@@ -1,0 +1,9 @@
+defmodule Sanbase.Repo.Migrations.RemoveLogoUrl do
+  use Ecto.Migration
+
+  def change do
+    alter table("project") do
+      remove(:logo_url)
+    end
+  end
+end

--- a/priv/repo/migrations/20190828104846_rename_logo_64_url_to_logo_url.exs
+++ b/priv/repo/migrations/20190828104846_rename_logo_64_url_to_logo_url.exs
@@ -1,0 +1,7 @@
+defmodule Sanbase.Repo.Migrations.RenameLogo64UrlToLogoUrl do
+  use Ecto.Migration
+
+  def change do
+    rename(table("project"), :logo64_url, to: :logo_url)
+  end
+end

--- a/priv/repo/migrations/20190828104909_remove_logo_32_url.exs
+++ b/priv/repo/migrations/20190828104909_remove_logo_32_url.exs
@@ -1,0 +1,9 @@
+defmodule Sanbase.Repo.Migrations.RemoveLogo32Url do
+  use Ecto.Migration
+
+  def change do
+    alter table("project") do
+      remove(:logo32_url)
+    end
+  end
+end

--- a/priv/repo/migrations/20190828104909_remove_logo_32_url.exs
+++ b/priv/repo/migrations/20190828104909_remove_logo_32_url.exs
@@ -1,9 +1,15 @@
 defmodule Sanbase.Repo.Migrations.RemoveLogo32Url do
   use Ecto.Migration
 
-  def change do
+  def up do
     alter table("project") do
       remove(:logo32_url)
+    end
+  end
+
+  def down do
+    alter table("project") do
+      add(:logo32_url, :string)
     end
   end
 end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -870,9 +870,7 @@ CREATE TABLE public.project (
     description text,
     email character varying(255),
     main_contract_address character varying(255),
-    long_description text,
-    logo32_url character varying(255),
-    logo64_url character varying(255)
+    long_description text
 );
 
 

--- a/test/sanbase/external_services/coinmarketcap2/logo_fetcher_test.exs
+++ b/test/sanbase/external_services/coinmarketcap2/logo_fetcher_test.exs
@@ -42,11 +42,8 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.LogoFetcherTest do
 
       file_store_path = "/tmp/sanbase/filestore-test"
 
-      assert Repo.get(Project, context.bitcoin.id).logo32_url =~
-               "#{file_store_path}/logo32_#{context.bitcoin.coinmarketcap_id}.png"
-
-      assert Repo.get(Project, context.ethereum.id).logo64_url =~
-               "#{file_store_path}/logo64_#{context.ethereum.coinmarketcap_id}.png"
+      assert Repo.get(Project, context.ethereum.id).logo_url =~
+               "#{file_store_path}/logo_#{context.ethereum.coinmarketcap_id}.png"
     end
 
     test "saves logo hash", context do

--- a/test/sanbase_web/graphql/projects/project_api_test.exs
+++ b/test/sanbase_web/graphql/projects/project_api_test.exs
@@ -98,9 +98,7 @@ defmodule SanbaseWeb.Graphql.ProjectApiTest do
       insert(
         :random_project,
         %{
-          logo_url: "logo_url.png",
-          logo64_url: "logo64_url.png",
-          logo32_url: "logo32_url.png"
+          logo_url: "logo_url.png"
         }
       )
 
@@ -108,8 +106,6 @@ defmodule SanbaseWeb.Graphql.ProjectApiTest do
     {
       projectBySlug(slug: "#{project.coinmarketcap_id}") {
         logoUrl
-        logo64Url
-        logo32Url
       }
     }
     """
@@ -120,8 +116,6 @@ defmodule SanbaseWeb.Graphql.ProjectApiTest do
       |> json_response(200)
 
     assert result["data"]["projectBySlug"]["logoUrl"] == "logo_url.png"
-    assert result["data"]["projectBySlug"]["logo64Url"] == "logo64_url.png"
-    assert result["data"]["projectBySlug"]["logo32Url"] == "logo32_url.png"
   end
 
   test "Fetch project's github links", context do


### PR DESCRIPTION
#### Summary
 * Added a migration to rename the logo64_url to just logo_url, thus removing logo_url beforehand, combined with logo32_url's removal