### PR TITLE
Add coupon support subscriptions

### DIFF
--- a/lib/sanbase/billing/subscription.ex
+++ b/lib/sanbase/billing/subscription.ex
@@ -24,6 +24,7 @@ defmodule Sanbase.Billing.Subscription do
   Please, contact administrator of the site for more information.
   """
   @free_trial_days_for_coupons 14
+  @percent_off_for_free_trial 100
 
   schema "subscriptions" do
     field(:stripe_id, :string)
@@ -363,7 +364,7 @@ defmodule Sanbase.Billing.Subscription do
          percent_off: percent_off,
          id: id
        })
-       when percent_off == 100 do
+       when percent_off == @percent_off_for_free_trial do
     subscription
     |> Map.put(:trial_period_days, @free_trial_days_for_coupons)
     |> Map.put(:metadata, %{coupon_id: id})

--- a/lib/sanbase/stripe_api.ex
+++ b/lib/sanbase/stripe_api.ex
@@ -85,6 +85,10 @@ defmodule Sanbase.StripeApi do
     Stripe.Coupon.create(%{percent_off: percent_off, duration: duration})
   end
 
+  def retrieve_coupon(coupon_id) do
+    Stripe.Coupon.retrieve(coupon_id)
+  end
+
   def list_payments(%User{stripe_customer_id: stripe_customer_id})
       when is_binary(stripe_customer_id) do
     Stripe.Charge.list(%{customer: stripe_customer_id})

--- a/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
@@ -11,11 +11,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
     Plan.product_with_plans()
   end
 
-  def subscribe(_root, %{card_token: card_token, plan_id: plan_id, coupon: coupon}, %{
+  def subscribe(_root, %{card_token: card_token, plan_id: plan_id} = args, %{
         context: %{auth: %{current_user: current_user}}
       }) do
+    coupon = Map.get(args, :coupon)
+
     with {:plan?, %Plan{} = plan} <- {:plan?, Repo.get(Plan, plan_id)},
-         {:ok, subscription} <- Subscription.subscribe(current_user, card_token, plan) do
+         {:ok, subscription} <-
+           Subscription.subscribe(current_user, card_token, plan, coupon) do
       {:ok, subscription}
     else
       result ->

--- a/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
@@ -11,7 +11,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
     Plan.product_with_plans()
   end
 
-  def subscribe(_root, %{card_token: card_token, plan_id: plan_id}, %{
+  def subscribe(_root, %{card_token: card_token, plan_id: plan_id, coupon: coupon}, %{
         context: %{auth: %{current_user: current_user}}
       }) do
     with {:plan?, %Plan{} = plan} <- {:plan?, Repo.get(Plan, plan_id)},

--- a/lib/sanbase_web/graphql/schema/queries/billing_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/billing_queries.ex
@@ -39,6 +39,7 @@ defmodule SanbaseWeb.Graphql.Schema.BillingQueries do
     field :subscribe, :subscription_plan do
       arg(:card_token, non_null(:string))
       arg(:plan_id, non_null(:integer))
+      arg(:coupon, :string, default_value: nil)
 
       middleware(JWTAuth)
 


### PR DESCRIPTION
Added optional arg `coupon` to the subscription mutation.

example:
```graphql
    mutation {
      subscribe(card_token: "card_token", plan_id: 5, coupon: "COUPON_CODE") {
        id,
        status
        plan {
          id
          name
          interval
          amount
          product {
            name
          }
        }
      }
    }
```