### PR TITLE
Add on_conflict: :nothing to a migration that fills the source slug t…

### DIFF
--- a/priv/repo/migrations/20190904083753_fill_slug_source_mappings_table.exs
+++ b/priv/repo/migrations/20190904083753_fill_slug_source_mappings_table.exs
@@ -14,7 +14,7 @@ defmodule Sanbase.Repo.Migrations.FillSourceSlugMappingsTable do
         %{source: "coinmarketcap", slug: slug, project_id: project_id}
       end)
 
-    Sanbase.Repo.insert_all(Project.SourceSlugMapping, insert_data)
+    Sanbase.Repo.insert_all(Project.SourceSlugMapping, insert_data, on_conflict: :nothing)
   end
 
   def down do


### PR DESCRIPTION
…able

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
