### PR TITLE
Add email channel signals

### DIFF
--- a/config/notifications_config.exs
+++ b/config/notifications_config.exs
@@ -46,3 +46,6 @@ config :sanbase, Sanbase.Telegram,
   bot_username: {:system, "TELEGRAM_NOTIFICATAIONS_BOT_USERNAME", "SanbaseSignalsStageBot"},
   telegram_endpoint: {:system, "TELEGRAM_ENDPOINT_RANDOM_STRING", "some_random_string"},
   token: {:system, "TELEGRAM_SIGNALS_BOT_TOKEN"}
+
+config :sanbase, Sanbase.Signal,
+  email_channel_enabled: {:system, "EMAIL_CHANNEL_ENABLED", "false"}

--- a/config/test.exs
+++ b/config/test.exs
@@ -75,6 +75,8 @@ config :sanbase, Sanbase.Elasticsearch, indices: "index1,index2,index3,index4"
 
 config :sanbase, SanbaseWeb.Plug.VerifyStripeWebhook, webhook_secret: "stripe_webhook_secret"
 
+config :sanbase, Sanbase.Signal, email_channel_enabled: {:system, "EMAIL_CHANNEL_ENABLED", "true"}
+
 # So the router can read it compile time
 System.put_env("TELEGRAM_ENDPOINT_RANDOM_STRING", "random_string")
 

--- a/lib/sanbase/signals/signal.ex
+++ b/lib/sanbase/signals/signal.ex
@@ -81,7 +81,7 @@ defimpl Sanbase.Signal, for: Any do
 
   defp do_send_email(email, payload, trigger_id) do
     Sanbase.MandrillApi.send("signals", email, %{
-      PAYLOAD: extend_payload(payload, trigger_id)
+      payload: extend_payload(payload, trigger_id)
     })
     |> case do
       {:ok, _} -> :ok


### PR DESCRIPTION
Template in Mailchimp is called `signals` and var is `payload`
**Note**: Blocked until we have proper templates for signals emails.