### PR TITLE
Add docs links to access-plans article

### DIFF
--- a/lib/sanbase/clickhouse/metric/helper.ex
+++ b/lib/sanbase/clickhouse/metric/helper.ex
@@ -10,18 +10,18 @@ defmodule Sanbase.Clickhouse.Metric.Helper do
   end
 
   @doc documentation_ref: """
-  DOCS access-plans/index.md
-  """
+       DOCS access-plans/index.md
+       """
   def mvrv_metrics(), do: metric_with_name_containing("mvrv") |> wrap()
 
   @doc documentation_ref: """
-  DOCS access-plans/index.md
-  """
+       DOCS access-plans/index.md
+       """
   def realized_value_metrics(), do: metric_with_name_containing("realized") |> wrap()
 
   @doc documentation_ref: """
-  DOCS access-plans/index.md
-  """
+       DOCS access-plans/index.md
+       """
   def token_age_consumed_metrics(), do: metric_with_name_containing("age_consumed") |> wrap()
 
   defp wrap(list) do

--- a/lib/sanbase/clickhouse/metric/helper.ex
+++ b/lib/sanbase/clickhouse/metric/helper.ex
@@ -9,19 +9,13 @@ defmodule Sanbase.Clickhouse.Metric.Helper do
     Enum.filter(metrics, fn metric -> String.contains?(metric, str) end)
   end
 
-  @doc documentation_ref: """
-       DOCS access-plans/index.md
-       """
+  @doc documentation_ref: "DOCS access-plans/index.md"
   def mvrv_metrics(), do: metric_with_name_containing("mvrv") |> wrap()
 
-  @doc documentation_ref: """
-       DOCS access-plans/index.md
-       """
+  @doc documentation_ref: "DOCS access-plans/index.md"
   def realized_value_metrics(), do: metric_with_name_containing("realized") |> wrap()
 
-  @doc documentation_ref: """
-       DOCS access-plans/index.md
-       """
+  @doc documentation_ref: "DOCS access-plans/index.md"
   def token_age_consumed_metrics(), do: metric_with_name_containing("age_consumed") |> wrap()
 
   defp wrap(list) do

--- a/lib/sanbase/clickhouse/metric/helper.ex
+++ b/lib/sanbase/clickhouse/metric/helper.ex
@@ -9,8 +9,19 @@ defmodule Sanbase.Clickhouse.Metric.Helper do
     Enum.filter(metrics, fn metric -> String.contains?(metric, str) end)
   end
 
+  @doc documentation_ref: """
+  DOCS access-plans/index.md
+  """
   def mvrv_metrics(), do: metric_with_name_containing("mvrv") |> wrap()
+
+  @doc documentation_ref: """
+  DOCS access-plans/index.md
+  """
   def realized_value_metrics(), do: metric_with_name_containing("realized") |> wrap()
+
+  @doc documentation_ref: """
+  DOCS access-plans/index.md
+  """
   def token_age_consumed_metrics(), do: metric_with_name_containing("age_consumed") |> wrap()
 
   defp wrap(list) do


### PR DESCRIPTION
#### Summary
Add documentation links to access plans article. 

[//]: # (#### Related PRs)
https://github.com/santiment/articles/pull/3