### PR TITLE
Improve the API

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric.ex
+++ b/lib/sanbase/clickhouse/metric/metric.ex
@@ -112,6 +112,9 @@ defmodule Sanbase.Clickhouse.Metric do
   @spec available_aggregations() :: {:ok, list(atom())}
   def available_aggregations(), do: {:ok, @aggregations}
 
+  @spec available_aggregations!() :: list(atom())
+  def available_aggregations!(), do: @aggregations
+
   def first_datetime(metric, slug) do
     case metric in @metrics_mapset do
       false ->

--- a/lib/sanbase_web/graphql/middlewares/project_permissions.ex
+++ b/lib/sanbase_web/graphql/middlewares/project_permissions.ex
@@ -30,7 +30,8 @@ defmodule SanbaseWeb.Graphql.Middlewares.ProjectPermissions do
       "fundsRaisedEthIcoEndPrice",
       "fundsRaisedUsdIcoEndPrice",
       "fundsRaisedBtcIcoEndPrice",
-      "availableMetrics"
+      "availableMetrics",
+      "availableQueries"
     ]
 
     requested_fields = Utils.requested_fields(resolution)

--- a/lib/sanbase_web/graphql/schema/queries/metric_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/metric_queries.ex
@@ -23,7 +23,7 @@ defmodule SanbaseWeb.Graphql.Schema.MetricQueries do
 
     field :get_available_slugs, list_of(:string) do
       meta(access: :free)
-      resolve(&MetricResolver.get_available_slugs/3)
+      cache_resolve(&MetricResolver.get_available_slugs/3, ttl: 600)
     end
   end
 end

--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -28,6 +28,10 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       cache_resolve(&ProjectResolver.available_metrics/3, ttl: 1800)
     end
 
+    field :available_queries, list_of(:string) do
+      cache_resolve(&ProjectResolver.available_metrics/3, ttl: 1800)
+    end
+
     field(:id, non_null(:id))
     field(:name, non_null(:string))
     field(:slug, :string)


### PR DESCRIPTION
- Introduce `availableSlugs` in the `getMetric` metadata
- Add `availableQueries` in the GQL project type with the same meaning as `availableMetrics`. After the frontend changes to this new field, `availableMetrics` will mean metrics available via the `getMetric` query

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
