### PR TITLE
Fix dev activity bug

### DIFF
--- a/lib/sanbase/clickhouse/github.ex
+++ b/lib/sanbase/clickhouse/github.ex
@@ -77,9 +77,9 @@ defmodule Sanbase.Clickhouse.Github do
           {:ok, list({String.t(), non_neg_integer()})} | {:error, String.t()}
   def total_dev_activity([], _from, _to), do: {:ok, []}
 
-  def total_dev_activity(organizations, from, to) when length(organizations) > 10 do
+  def total_dev_activity(organizations, from, to) when length(organizations) > 20 do
     total_dev_activity =
-      Enum.chunk_every(organizations, 10)
+      Enum.chunk_every(organizations, 20)
       |> Sanbase.Parallel.map(&total_dev_activity(&1, from, to),
         timeout: 25_000,
         max_concurrency: 8,


### PR DESCRIPTION
#### Summary
Dataloader related fields only:
The issue occurs when we try to fetch the same field with different arguments using aliases. In this case, the batch contains records for all parameters but only one of them is fetched (the first one in the list). The correct behavior is to group the batches into the appropriate groups
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
