### PR TITLE
Fix sending of email

### DIFF
--- a/lib/sanbase/signals/signal.ex
+++ b/lib/sanbase/signals/signal.ex
@@ -46,14 +46,14 @@ defimpl Sanbase.Signal, for: Any do
           settings: %{triggered?: true, payload: payload_map}
         }
       })
-      when is_map(payload_map) do
+      when is_binary(email) and is_map(payload_map) do
     payload_map
     |> Enum.map(fn {identifier, payload} ->
       {identifier, do_send_email(email, payload, id)}
     end)
   end
 
-  def send_email(_), do: :ok
+  def send_email(_), do: []
 
   def send_telegram(%{
         user: %Sanbase.Auth.User{


### PR DESCRIPTION
#### Summary
If we return just `:ok` it can break the counting in the scheduler where it expects a 2-element tuple
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
