### PR TITLE
Fix the last_triggered field update order

### DIFF
--- a/lib/sanbase/signals/evaluator/scheduler.ex
+++ b/lib/sanbase/signals/evaluator/scheduler.ex
@@ -119,7 +119,9 @@ defmodule Sanbase.Signal.Scheduler do
         # because we're checking every item in the list separately if it was
         # triggered or not.
         {list, :ok}, acc when is_list(list) ->
-          Enum.map(list, fn elem -> {elem, now} end) |> Map.new() |> Map.merge(acc)
+          Enum.reduce(list, acc, fn elem, inner_acc ->
+            Map.put(inner_acc, elem, now)
+          end)
 
         {slug, :ok}, acc ->
           Map.put(acc, slug, now)


### PR DESCRIPTION
#### Summary
Fix an error where the way we use `Map.merge/2` lead to older value having precedence over new value - the newer `last_triggered` was not properly recorded 

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
