### PR TITLE
Fix memory leaks

### DIFF
--- a/lib/sanbase_web/graphql/cache/con_cache_provider.ex
+++ b/lib/sanbase_web/graphql/cache/con_cache_provider.ex
@@ -45,51 +45,64 @@ defmodule SanbaseWeb.Graphql.ConCacheProvider do
 
   @impl true
   def get_or_store(cache, key, func, cache_modify_middleware) do
-    {result, error_if_any} =
-      case ConCache.get(cache, key) do
-        {:stored, value} ->
-          {value, nil}
+    case ConCache.get(cache, key) do
+      {:stored, value} ->
+        {value, nil}
 
-        _ ->
-          ConCache.isolated(cache, key, fn ->
-            case ConCache.get(cache, key) do
-              {:stored, value} ->
-                {value, nil}
+      _ ->
+        ConCache.isolated(cache, key, fn ->
+          case ConCache.get(cache, key) do
+            {:stored, value} ->
+              {value, nil}
 
-              _ ->
-                case func.() do
-                  {:error, _} = error ->
-                    {nil, error}
+            _ ->
+              case func.() do
+                {:error, _} = error ->
+                  {nil, error}
 
-                  {:middleware, _, _} = tuple ->
-                    # Decides on its behalf whether or not to put the value in the cache
-                    {cache_modify_middleware.(cache, key, tuple), nil}
+                {:middleware, _, _} = tuple ->
+                  # Decides on its behalf whether or not to put the value in the cache
+                  {cache_modify_middleware.(cache, key, tuple), nil}
 
-                  {:nocache, {:ok, _result} = value} ->
-                    Process.put(:do_not_cache_query, true)
-                    {value, nil}
+                {:nocache, {:ok, _result} = value} ->
+                  Process.put(:do_not_cache_query, true)
+                  {value, nil}
 
-                  value ->
-                    cache_item(cache, key, {:stored, value})
-                    {value, nil}
-                end
-            end
-          end)
-      end
-
-    if error_if_any != nil do
-      # Logger.warn("Somethting went wrong...")
-      error_if_any
-    else
-      result
+                value ->
+                  cache_item(cache, key, {:stored, value})
+                  {value, nil}
+              end
+          end
+        end)
+    end
+    |> case do
+      {result, nil} -> result
+      {_result, error} -> error
     end
   end
 
-  defp cache_item(cache, {_, ttl} = key, value) when is_integer(ttl) and ttl <= @max_cache_ttl do
-    ConCache.put(cache, key, %ConCache.Item{value: value, ttl: :timer.seconds(ttl)})
+  defp cache_item(cache, key, {:stored, value}) when is_binary(value) do
+    do_cache_item(cache, key, {:stored, :binary.copy(value)})
   end
 
   defp cache_item(cache, key, value) do
+    do_cache_item(cache, key, value)
+  end
+
+  defp do_cache_item(cache, key, value) when is_binary(key) do
+    ConCache.put(cache, :binary.copy(key), value)
+  end
+
+  defp do_cache_item(cache, {_, ttl} = key, value)
+       when is_integer(ttl) and ttl <= @max_cache_ttl do
+    ConCache.put(
+      cache,
+      key,
+      %ConCache.Item{value: value, ttl: :timer.seconds(ttl)}
+    )
+  end
+
+  defp do_cache_item(cache, key, value) do
     ConCache.put(cache, key, value)
   end
 end


### PR DESCRIPTION
#### Summary
Absinthe uses `Jason.decode` and from its docs we read:
```
 • :strings - controls how strings (including keys) are decoded. Possible
    values are:
    • :reference (default) - when possible tries to create a sub-binary
      into the original
    • :copy - always copies the strings. This option is especially useful
      when parts of the decoded data will be stored for a long time (in ets or
      some process) to avoid keeping the reference to the original data.
```
I am not entirely sure, but it could happen that we're hitting this issue somewhere with our ETS caching
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
