### PR TITLE
Add alias to the V2 metric mvrv_usd_long_short_diff

### DIFF
--- a/lib/sanbase/clickhouse/metric/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/available_v2_metrics.json
@@ -150,6 +150,7 @@
 
   {
     "metric": "mvrv_usd_long_short_diff",
+    "alias": "mvrv_long_short_diff_usd",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -195,7 +195,8 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
         "realized_value_usd_1d",
         "velocity",
         "age_destroyed",
-        "age_destroyed_5min"
+        "age_destroyed_5min",
+        "mvrv_long_short_diff_usd"
       ]
 
       queries = [


### PR DESCRIPTION
The name mvrv_usd_long_short_diff is too inconsistent and makes it harder to generate a function in SanSheets automatically, -> mvrv_long_short_diff_usd