### PR TITLE
Rename metric functions

### DIFF
--- a/lib/sanbase/chart/chart.ex
+++ b/lib/sanbase/chart/chart.ex
@@ -154,7 +154,7 @@ defmodule Sanbase.Chart do
     from = Timex.shift(to, days: -size + 1)
 
     with {:ok, metric_name} <- Sanbase.Metric.human_readable_name(metric),
-         {:ok, data} <- Sanbase.Metric.get(metric, slug, from, to, "1d"),
+         {:ok, data} <- Sanbase.Metric.timeseries_data(metric, slug, from, to, "1d"),
          [_ | _] = values <- data |> Enum.map(& &1.value) |> Enum.reject(&is_nil/1),
          {min, max} <- Math.min_max(values) do
       %{

--- a/lib/sanbase/clickhouse/daily_active_addresses.ex
+++ b/lib/sanbase/clickhouse/daily_active_addresses.ex
@@ -41,7 +41,7 @@ defmodule Sanbase.Clickhouse.DailyActiveAddresses do
 
   def average_active_addresses(btc, from, to, interval)
       when is_binary(btc) and btc in @bitcoin do
-    Metric.get("daily_active_addresses", "bitcoin", from, to, interval)
+    Metric.timeseries_data("daily_active_addresses", "bitcoin", from, to, interval)
   end
 
   def average_active_addresses(eth, from, to, interval)
@@ -86,7 +86,7 @@ defmodule Sanbase.Clickhouse.DailyActiveAddresses do
   defp do_btc_average_active_addresses([], _, _), do: {:ok, []}
 
   defp do_btc_average_active_addresses([_ | _], from, to) do
-    case Metric.get_aggregated("daily_active_addresses", "bitcoin", from, to) do
+    case Metric.aggregated_data("daily_active_addresses", "bitcoin", from, to) do
       {:ok, result} -> {:ok, [{"BTC", result}]}
       {:error, error} -> handle_error("Bitcoin", error)
     end

--- a/lib/sanbase/clickhouse/github/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/github/metric_adapter.ex
@@ -21,7 +21,8 @@ defmodule Sanbase.Clickhouse.Github.MetricAdapter do
   @restricted_metrics []
 
   @impl Sanbase.Metric.Behaviour
-  def get(metric, slug, from, to, interval, _aggregation) when metric in @metrics do
+  def timeseries_data(metric, slug, from, to, interval, _aggregation)
+      when metric in @metrics do
     case Project.github_organizations(slug) do
       {:ok, organizations} ->
         apply(
@@ -44,7 +45,7 @@ defmodule Sanbase.Clickhouse.Github.MetricAdapter do
   end
 
   @impl Sanbase.Metric.Behaviour
-  def get_aggregated(metric, organizations, from, to, _aggregation)
+  def aggregated_data(metric, organizations, from, to, _aggregation)
       when is_binary(organizations) or is_list(organizations) do
     apply(
       Github,

--- a/lib/sanbase/metric/behaviour.ex
+++ b/lib/sanbase/metric/behaviour.ex
@@ -15,21 +15,21 @@ defmodule Sanbase.Metric.Behaviour do
           available_aggregations: list()
         }
 
-  @type metric_result :: %{datetime: Datetime.t(), value: float()}
+  @type timeseries_data_point :: %{datetime: Datetime.t(), value: float()}
   @type aggregation :: nil | :any | :sum | :avg | :min | :max | :last | :first | :median
 
-  @callback get(
-              metric,
+  @callback timeseries_data(
+              metric :: metric,
               selector :: any(),
               from :: DatetTime.t(),
               to :: DateTime.t(),
               interval :: interval,
               opts :: Keyword.t()
             ) ::
-              {:ok, list(metric_result)} | {:error, String.t()}
+              {:ok, list(timeseries_data_point)} | {:error, String.t()}
 
-  @callback get_aggregated(
-              metric,
+  @callback aggregated_data(
+              metric :: metric,
               selector :: any(),
               from :: DatetTime.t(),
               to :: DateTime.t(),

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -48,9 +48,10 @@ defmodule Sanbase.Metric do
   aggregations are #{inspect(@available_aggregations)}. If no aggregation is provided,
   a default one (based on the metric) will be used.
   """
-  def get(metric, identifier, from, to, interval, aggregation \\ nil)
+  def timeseries_data(metric, identifier, from, to, interval, aggregation \\ nil)
 
-  def get(_, _, _, _, _, aggregation) when aggregation not in @aggregation_arg_supported do
+  def timeseries_data(_, _, _, _, _, aggregation)
+      when aggregation not in @aggregation_arg_supported do
     {:error, "The aggregation '#{inspect(aggregation)}' is not supported"}
   end
 
@@ -60,7 +61,7 @@ defmodule Sanbase.Metric do
   The available aggregations are #{inspect(@available_aggregations)}. If no aggregation is
   provided, a default one (based on the metric) will be used.
   """
-  def get_aggregated(metric, identifier, from, to, aggregation \\ nil)
+  def aggregated_data(metric, identifier, from, to, aggregation \\ nil)
 
   @doc ~s"""
   Get the human readable name representation of a given metric
@@ -88,8 +89,8 @@ defmodule Sanbase.Metric do
   def available_slugs(metric)
 
   for %{metric: metric, module: module} <- @metrics_module_mapping do
-    def get(unquote(metric), identifier, from, to, interval, aggregation) do
-      unquote(module).get(
+    def timeseries_data(unquote(metric), identifier, from, to, interval, aggregation) do
+      unquote(module).timeseries_data(
         unquote(metric),
         identifier,
         from,
@@ -99,8 +100,8 @@ defmodule Sanbase.Metric do
       )
     end
 
-    def get_aggregated(unquote(metric), identifier, from, to, aggregation) do
-      unquote(module).get_aggregated(
+    def aggregated_data(unquote(metric), identifier, from, to, aggregation) do
+      unquote(module).aggregated_data(
         unquote(metric),
         identifier,
         from,
@@ -126,7 +127,7 @@ defmodule Sanbase.Metric do
     end
   end
 
-  def get(metric, _, _, _, _, _), do: metric_not_available_error(metric)
+  def timeseries_data(metric, _, _, _, _, _), do: metric_not_available_error(metric)
   def metadata(metric), do: metric_not_available_error(metric)
   def first_datetime(metric, _), do: metric_not_available_error(metric)
 

--- a/lib/sanbase/notifications/discord/daa_signal.ex
+++ b/lib/sanbase/notifications/discord/daa_signal.ex
@@ -190,7 +190,13 @@ defmodule Sanbase.Notifications.Discord.DaaSignal do
       |> Enum.map(& &1.slug)
       |> Enum.reject(&is_nil/1)
 
-    Metric.get_aggregated("daily_active_addresses", slugs, timeframe_from(), timeframe_to(), :avg)
+    Metric.aggregated_data(
+      "daily_active_addresses",
+      slugs,
+      timeframe_from(),
+      timeframe_to(),
+      :avg
+    )
     |> handle_result()
   end
 

--- a/lib/sanbase/notifications/discord/exchange_inflow.ex
+++ b/lib/sanbase/notifications/discord/exchange_inflow.ex
@@ -29,7 +29,7 @@ defmodule Sanbase.Notifications.Discord.ExchangeInflow do
 
     slugs = Enum.map(projects, & &1.slug) |> Enum.reject(&is_nil/1)
 
-    Metric.get_aggregated("exchange_inflow", slugs, from, to, :sum)
+    Metric.aggregated_data("exchange_inflow", slugs, from, to, :sum)
     |> case do
       {:ok, list} ->
         notification_type = Type.get_or_create("exchange_inflow")
@@ -115,7 +115,7 @@ defmodule Sanbase.Notifications.Discord.ExchangeInflow do
   defp build_payload(%Project{} = project, from, inflow) do
     %Project{slug: slug} = project
 
-    case Metric.get_aggregated("exchange_inflow", slug, from, Timex.now(), :sum) do
+    case Metric.aggregated_data("exchange_inflow", slug, from, Timex.now(), :sum) do
       {:ok, [%{slug: ^slug, value: new_inflow}]} ->
         new_percent_of_total_supply = percent_of_total_supply(project, new_inflow)
 

--- a/lib/sanbase/signals/history/daily_active_addresses_history.ex
+++ b/lib/sanbase/signals/history/daily_active_addresses_history.ex
@@ -55,7 +55,7 @@ defmodule Sanbase.Signal.History.DailyActiveAddressesHistory do
       to = Timex.now()
       shift = @historical_days_from + str_to_days(time_window) - 1
 
-      Sanbase.Metric.get(
+      Sanbase.Metric.timeseries_data(
         "daily_active_addresses",
         slug,
         Timex.shift(to, days: -shift),

--- a/lib/sanbase/signals/history/metric_history.ex
+++ b/lib/sanbase/signals/history/metric_history.ex
@@ -43,7 +43,7 @@ defmodule Sanbase.Signal.History.MetricHistory do
       to = Timex.now()
       shift = @historical_days_from + str_to_days(time_window) - 1
 
-      Sanbase.Metric.get(
+      Sanbase.Metric.timeseries_data(
         metric,
         slug,
         Timex.shift(to, days: -shift),

--- a/lib/sanbase/signals/trigger/settings/metric_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/metric_trigger_settings.ex
@@ -82,7 +82,7 @@ defmodule Sanbase.Signal.Trigger.MetricTriggerSettings do
       |> :erlang.phash2()
 
     Cache.get_or_store(cache_key, fn ->
-      case Metric.get(metric, slug, from, to, interval) do
+      case Metric.timeseries_data(metric, slug, from, to, interval) do
         {:ok, [_ | _] = result} -> result
         _ -> nil
       end

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -35,7 +35,8 @@ defmodule Sanbase.SocialData.MetricAdapter do
   @access_map Enum.reduce(@metrics, %{}, fn metric, acc -> Map.put(acc, metric, :restricted) end)
 
   @impl Sanbase.Metric.Behaviour
-  def get(metric, slug, from, to, interval, _aggregation) when metric in @social_volume_metrics do
+  def timeseries_data(metric, slug, from, to, interval, _aggregation)
+      when metric in @social_volume_metrics do
     [source, _] = String.split(metric, "_", parts: 2)
 
     Sanbase.TechIndicators.social_volume(
@@ -48,7 +49,7 @@ defmodule Sanbase.SocialData.MetricAdapter do
     |> transform_to_value_pairs(:mentions_count)
   end
 
-  def get(metric, slug, from, to, interval, _aggregation)
+  def timeseries_data(metric, slug, from, to, interval, _aggregation)
       when metric in @social_dominance_metrics do
     [source, _] = String.split(metric, "_", parts: 2)
 
@@ -63,7 +64,7 @@ defmodule Sanbase.SocialData.MetricAdapter do
   end
 
   @impl Sanbase.Metric.Behaviour
-  def get_aggregated(metric, slug, from, to, _aggregation)
+  def aggregated_data(metric, slug, from, to, _aggregation)
       when is_binary(slug) and metric in @social_volume_metrics do
     [source, _] = String.split(metric, "_", parts: 2)
 
@@ -84,7 +85,7 @@ defmodule Sanbase.SocialData.MetricAdapter do
     end
   end
 
-  def get_aggregated(metric, slug, from, to, _aggregation)
+  def aggregated_data(metric, slug, from, to, _aggregation)
       when metric in @social_dominance_metrics do
     [source, _] = String.split(metric, "_", parts: 2)
 

--- a/lib/sanbase_web/graphql/dataloader/clickhouse_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/clickhouse_dataloader.ex
@@ -60,7 +60,7 @@ defmodule SanbaseWeb.Graphql.ClickhouseDataloader do
       |> Enum.map(fn %{project: project} -> project.slug end)
       |> Enum.reject(&is_nil/1)
 
-    Sanbase.Metric.get_aggregated("daily_active_addresses", slugs, from, to, :avg)
+    Sanbase.Metric.aggregated_data("daily_active_addresses", slugs, from, to, :avg)
     |> case do
       {:ok, result} ->
         result
@@ -83,7 +83,7 @@ defmodule SanbaseWeb.Graphql.ClickhouseDataloader do
         organizations
       end)
 
-    Sanbase.Metric.get_aggregated("dev_activity", organizations, from, to)
+    Sanbase.Metric.aggregated_data("dev_activity", organizations, from, to)
     |> case do
       {:ok, result} ->
         result

--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -123,7 +123,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
   end
 
   def mvrv_ratio(_root, %{slug: _, from: _, to: _, interval: _} = args, _resolution) do
-    SanbaseWeb.Graphql.Resolvers.MetricResolver.get_timeseries_data(
+    SanbaseWeb.Graphql.Resolvers.MetricResolver.timeseries_data(
       %{},
       args,
       %{source: %{metric: "mvrv_usd"}}
@@ -136,7 +136,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
         %{slug: _, from: _, to: _, interval: _} = args,
         _resolution
       ) do
-    SanbaseWeb.Graphql.Resolvers.MetricResolver.get_timeseries_data(
+    SanbaseWeb.Graphql.Resolvers.MetricResolver.timeseries_data(
       %{},
       args,
       %{source: %{metric: "circulation_1d"}}
@@ -149,7 +149,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
         %{slug: _, from: _, to: _, interval: _} = args,
         _resolution
       ) do
-    SanbaseWeb.Graphql.Resolvers.MetricResolver.get_timeseries_data(
+    SanbaseWeb.Graphql.Resolvers.MetricResolver.timeseries_data(
       %{},
       args,
       %{source: %{metric: "velocity"}}
@@ -162,7 +162,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
         %{slug: _, from: _, to: _, interval: _} = args,
         _resolution
       ) do
-    SanbaseWeb.Graphql.Resolvers.MetricResolver.get_timeseries_data(
+    SanbaseWeb.Graphql.Resolvers.MetricResolver.timeseries_data(
       %{},
       args,
       %{source: %{metric: "daily_active_addresses"}}
@@ -264,13 +264,13 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
         _resolution
       ) do
     with {:ok, nvt_circulation} <-
-           SanbaseWeb.Graphql.Resolvers.MetricResolver.get_timeseries_data(
+           SanbaseWeb.Graphql.Resolvers.MetricResolver.timeseries_data(
              %{},
              args,
              %{source: %{metric: "nvt"}}
            ),
          {:ok, nvt_transaction_volume} <-
-           SanbaseWeb.Graphql.Resolvers.MetricResolver.get_timeseries_data(
+           SanbaseWeb.Graphql.Resolvers.MetricResolver.timeseries_data(
              %{},
              args,
              %{source: %{metric: "nvt_transaction_volume"}}

--- a/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
@@ -11,7 +11,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
         %{slug: _slug, from: _from, to: _to, interval: _interval} = args,
         _resolution
       ) do
-    SanbaseWeb.Graphql.Resolvers.MetricResolver.get_timeseries_data(
+    SanbaseWeb.Graphql.Resolvers.MetricResolver.timeseries_data(
       %{},
       args,
       %{source: %{metric: "age_destroyed"}}
@@ -49,7 +49,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
         %{slug: _slug, from: _from, to: _to, interval: _interval} = args,
         _resolution
       ) do
-    SanbaseWeb.Graphql.Resolvers.MetricResolver.get_timeseries_data(
+    SanbaseWeb.Graphql.Resolvers.MetricResolver.timeseries_data(
       %{},
       args,
       %{source: %{metric: "transaction_volume"}}
@@ -66,7 +66,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
         %{slug: _slug, from: _from, to: _to, interval: _interval} = args,
         _resolution
       ) do
-    SanbaseWeb.Graphql.Resolvers.MetricResolver.get_timeseries_data(
+    SanbaseWeb.Graphql.Resolvers.MetricResolver.timeseries_data(
       %{},
       args,
       %{source: %{metric: "exchange_balance"}}
@@ -79,7 +79,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
         %{slug: _slug, from: _from, to: _to, interval: _interval} = args,
         _resolution
       ) do
-    SanbaseWeb.Graphql.Resolvers.MetricResolver.get_timeseries_data(
+    SanbaseWeb.Graphql.Resolvers.MetricResolver.timeseries_data(
       %{},
       args,
       %{source: %{metric: "velocity"}}

--- a/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
@@ -19,7 +19,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   def available_since(_root, %{slug: slug}, %{source: %{metric: metric}}),
     do: Metric.first_datetime(metric, slug)
 
-  def get_timeseries_data(
+  def timeseries_data(
         _root,
         %{slug: slug, from: from, to: to, interval: interval} = args,
         %{source: %{metric: metric}}
@@ -27,7 +27,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     with {:ok, from, to, interval} <-
            calibrate_interval(Metric, metric, slug, from, to, interval, 86_400, @datapoints),
          {:ok, result} <-
-           Metric.get(metric, slug, from, to, interval, args[:aggregation]) do
+           Metric.timeseries_data(metric, slug, from, to, interval, args[:aggregation]) do
       {:ok, result |> Enum.reject(&is_nil/1)}
     else
       {:error, error} ->

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -67,7 +67,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       complexity(&Complexity.from_to_interval/3)
       middleware(AccessControl)
 
-      cache_resolve(&MetricResolver.get_timeseries_data/3)
+      cache_resolve(&MetricResolver.timeseries_data/3)
     end
 
     field :available_since, :datetime do

--- a/test/sanbase/metric/metric_test.exs
+++ b/test/sanbase/metric/metric_test.exs
@@ -17,9 +17,11 @@ defmodule Sanbase.MetricTest do
   setup_with_mocks([
     {Sanbase.TechIndicators, [:passthrough],
      social_volume_projects: fn -> {:ok, ["bitcoin", "santiment"]} end},
-    {Sanbase.Clickhouse.Metric, [], get: fn _, _, _, _, _, _ -> {:ok, @resp} end},
-    {Sanbase.Clickhouse.Github.MetricAdapter, [], get: fn _, _, _, _, _, _ -> {:ok, @resp} end},
-    {Sanbase.SocialData.MetricAdapter, [], get: fn _, _, _, _, _, _ -> {:ok, @resp} end}
+    {Sanbase.Clickhouse.Metric, [], timeseries_data: fn _, _, _, _, _, _ -> {:ok, @resp} end},
+    {Sanbase.Clickhouse.Github.MetricAdapter, [],
+     timeseries_data: fn _, _, _, _, _, _ -> {:ok, @resp} end},
+    {Sanbase.SocialData.MetricAdapter, [],
+     timeseries_data: fn _, _, _, _, _, _ -> {:ok, @resp} end}
   ]) do
     []
   end
@@ -29,7 +31,7 @@ defmodule Sanbase.MetricTest do
 
     results =
       for metric <- metrics do
-        Metric.get(metric, "santiment", @from, @to, "1d", :avg)
+        Metric.timeseries_data(metric, "santiment", @from, @to, "1d", :avg)
       end
 
     assert Enum.all?(results, &match?({:ok, _}, &1))
@@ -42,7 +44,7 @@ defmodule Sanbase.MetricTest do
 
     results =
       for metric <- rand_metrics do
-        Metric.get(metric, "santiment", @from, @to, "1d", :avg)
+        Metric.timeseries_data(metric, "santiment", @from, @to, "1d", :avg)
       end
 
     assert Enum.all?(results, &match?({:error, _}, &1))
@@ -54,7 +56,7 @@ defmodule Sanbase.MetricTest do
 
     results =
       for aggregation <- aggregations do
-        Metric.get(metric, "santiment", @from, @to, "1d", aggregation)
+        Metric.timeseries_data(metric, "santiment", @from, @to, "1d", aggregation)
       end
 
     assert Enum.all?(results, &match?({:ok, _}, &1))
@@ -69,7 +71,7 @@ defmodule Sanbase.MetricTest do
 
     results =
       for aggregation <- rand_aggregations do
-        Metric.get(metric, "santiment", @from, @to, "1d", aggregation)
+        Metric.timeseries_data(metric, "santiment", @from, @to, "1d", aggregation)
       end
 
     assert Enum.all?(results, &match?({:error, _}, &1))
@@ -78,7 +80,7 @@ defmodule Sanbase.MetricTest do
   test "fetch a single metric" do
     [metric | _] = Metric.available_metrics()
 
-    result = Metric.get(metric, "santiment", @from, @to, "1d", :avg)
+    result = Metric.timeseries_data(metric, "santiment", @from, @to, "1d", :avg)
 
     assert result == {:ok, @resp}
   end

--- a/test/sanbase/signals/history/trigger_daily_active_addresses_history_test.exs
+++ b/test/sanbase/signals/history/trigger_daily_active_addresses_history_test.exs
@@ -8,7 +8,7 @@ defmodule Sanbase.Signal.TriggerDailyActiveAddressesHistoryTest do
 
   setup_with_mocks([
     {Sanbase.Metric, [:passthrough],
-     [get: fn "daily_active_addresses", _, _, _, _, _ -> {:ok, daa_resp()} end]}
+     [timeseries_data: fn "daily_active_addresses", _, _, _, _, _ -> {:ok, daa_resp()} end]}
   ]) do
     :ok
   end

--- a/test/sanbase/signals/history/trigger_metric_signal_history_test.exs
+++ b/test/sanbase/signals/history/trigger_metric_signal_history_test.exs
@@ -7,7 +7,7 @@ defmodule Sanbase.Signal.TriggerMetricHistoryTest do
   alias Sanbase.Signal.UserTrigger
 
   setup_with_mocks([
-    {Sanbase.Metric, [:passthrough], [get: fn _, _, _, _, _ -> {:ok, resp()} end]}
+    {Sanbase.Metric, [:passthrough], [timeseries_data: fn _, _, _, _, _ -> {:ok, resp()} end]}
   ]) do
     :ok
   end

--- a/test/sanbase/signals/metric/trigger_metric_test.exs
+++ b/test/sanbase/signals/metric/trigger_metric_test.exs
@@ -25,7 +25,7 @@ defmodule Sanbase.Signal.TriggerMetricTest do
     {
       Metric,
       [:passthrough],
-      get: fn _, _, _, _, _ -> {:ok, []} end
+      timeseries_data: fn _, _, _, _, _ -> {:ok, []} end
     }
   ]) do
     # Clean children on exit, otherwise DB calls from async tasks can be attempted
@@ -70,7 +70,7 @@ defmodule Sanbase.Signal.TriggerMetricTest do
       Enum.zip(datetimes, [100, 100, 100, 100, 100, 100, 5000])
       |> Enum.map(&%{datetime: elem(&1, 0), value: elem(&1, 1)})
 
-    with_mock Metric, [:passthrough], get: fn _, _, _, _, _ -> {:ok, data} end do
+    with_mock Metric, [:passthrough], timeseries_data: fn _, _, _, _, _ -> {:ok, data} end do
       [triggered] =
         MetricTriggerSettings.type()
         |> UserTrigger.get_active_triggers_by_type()
@@ -103,7 +103,7 @@ defmodule Sanbase.Signal.TriggerMetricTest do
       Enum.zip(datetimes, [100, 100, 100, 100, 100, 100, 500])
       |> Enum.map(&%{datetime: elem(&1, 0), value: elem(&1, 1)})
 
-    with_mock Metric, [:passthrough], get: fn _, _, _, _, _ -> {:ok, data} end do
+    with_mock Metric, [:passthrough], timeseries_data: fn _, _, _, _, _ -> {:ok, data} end do
       [triggered] =
         MetricTriggerSettings.type()
         |> UserTrigger.get_active_triggers_by_type()

--- a/test/sanbase_web/graphql/billing/api_product_access_test.exs
+++ b/test/sanbase_web/graphql/billing/api_product_access_test.exs
@@ -16,7 +16,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
      [active_deposits: fn _, _, _, _ -> daily_active_deposits_resp() end]},
     {Sanbase.Clickhouse.NetworkGrowth, [],
      [network_growth: fn _, _, _, _ -> network_growth_resp() end]},
-    {Metric, [:passthrough], [get: fn _, _, _, _, _, _ -> metric_resp() end]}
+    {Metric, [:passthrough], [timeseries_data: fn _, _, _, _, _, _ -> metric_resp() end]}
   ]) do
     :ok
   end
@@ -37,7 +37,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       metric = v2_free_metric()
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
-      assert_called(Metric.get(metric, :_, from, to, :_, :_))
+      assert_called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 
@@ -47,8 +47,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
-      assert_called(Metric.get(metric, :_, :_, :_, :_, :_))
-      refute called(Metric.get(metric, :_, from, to, :_, :_))
+      assert_called(Metric.timeseries_data(metric, :_, :_, :_, :_, :_))
+      refute called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 
@@ -129,7 +129,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       metric = v2_free_metric()
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
-      assert called(Metric.get(metric, :_, from, to, :_, :_))
+      assert called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 
@@ -139,7 +139,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
-      assert called(Metric.get(metric, :_, from, to, :_, :_))
+      assert called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 
@@ -149,8 +149,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
-      assert_called(Metric.get(metric, :_, :_, :_, :_, :_))
-      refute called(Metric.get(metric, :_, from, to, :_, :_))
+      assert_called(Metric.timeseries_data(metric, :_, :_, :_, :_, :_))
+      refute called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 
@@ -160,7 +160,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
-      assert called(Metric.get(metric, :_, from, to, :_, :_))
+      assert called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 
@@ -220,7 +220,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       metric = v2_free_metric()
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
-      assert called(Metric.get(metric, :_, from, to, :_, :_))
+      assert called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 
@@ -230,7 +230,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
-      assert called(Metric.get(metric, :_, from, to, :_, :_))
+      assert called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 
@@ -240,8 +240,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
-      assert_called(Metric.get(metric, :_, :_, :_, :_, :_))
-      refute called(Metric.get(metric, :_, from, to, :_, :_))
+      assert_called(Metric.timeseries_data(metric, :_, :_, :_, :_, :_))
+      refute called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 
@@ -251,7 +251,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
-      assert called(Metric.get(metric, :_, from, to, :_, :_))
+      assert called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 
@@ -312,7 +312,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       metric = v2_free_metric()
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
-      assert_called(Metric.get(metric, :_, from, to, :_, :_))
+      assert_called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 
@@ -321,7 +321,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       metric = v2_restricted_metric()
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
-      assert_called(Metric.get(metric, :_, from, to, :_, :_))
+      assert_called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 

--- a/test/sanbase_web/graphql/billing/sanbase_product_access_test.exs
+++ b/test/sanbase_web/graphql/billing/sanbase_product_access_test.exs
@@ -19,7 +19,7 @@ defmodule Sanbase.Billing.SanbaseProductAccessTest do
      [active_deposits: fn _, _, _, _ -> daily_active_deposits_resp() end]},
     {Sanbase.Clickhouse.NetworkGrowth, [],
      [network_growth: fn _, _, _, _ -> network_growth_resp() end]},
-    {Metric, [:passthrough], [get: fn _, _, _, _, _, _ -> metric_resp() end]},
+    {Metric, [:passthrough], [timeseries_data: fn _, _, _, _, _, _ -> metric_resp() end]},
     {UserTrigger, [:passthrough], [triggers_count_for: fn _ -> @triggers_limit_count end]}
   ]) do
     :ok
@@ -40,7 +40,7 @@ defmodule Sanbase.Billing.SanbaseProductAccessTest do
       metric = v2_free_metric()
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
-      assert_called(Metric.get(metric, :_, from, to, :_, :_))
+      assert_called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 
@@ -50,8 +50,8 @@ defmodule Sanbase.Billing.SanbaseProductAccessTest do
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
-      assert_called(Metric.get(metric, :_, :_, :_, :_, :_))
-      refute called(Metric.get(metric, :_, from, to, :_, :_))
+      assert_called(Metric.timeseries_data(metric, :_, :_, :_, :_, :_))
+      refute called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 
@@ -61,7 +61,7 @@ defmodule Sanbase.Billing.SanbaseProductAccessTest do
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
-      refute called(Metric.get(metric, :_, from, to, :_, :_))
+      refute called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 
@@ -144,7 +144,7 @@ defmodule Sanbase.Billing.SanbaseProductAccessTest do
       metric = v2_free_metric()
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
-      assert_called(Metric.get(metric, :_, from, to, :_, :_))
+      assert_called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 
@@ -153,7 +153,7 @@ defmodule Sanbase.Billing.SanbaseProductAccessTest do
       metric = v2_restricted_metric()
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
-      assert_called(Metric.get(metric, :_, from, to, :_, :_))
+      assert_called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 
@@ -223,7 +223,7 @@ defmodule Sanbase.Billing.SanbaseProductAccessTest do
       metric = v2_free_metric()
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
-      assert_called(Metric.get(metric, :_, from, to, :_, :_))
+      assert_called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 
@@ -232,7 +232,7 @@ defmodule Sanbase.Billing.SanbaseProductAccessTest do
       metric = v2_restricted_metric()
       query = metric_query(metric, from, to)
       result = execute_query(context.conn, query, "getMetric")
-      assert_called(Metric.get(metric, :_, from, to, :_, :_))
+      assert_called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
     end
 

--- a/test/sanbase_web/graphql/blockchain/etherbi_average_token_age_consumed_in_days_test.exs
+++ b/test/sanbase_web/graphql/blockchain/etherbi_average_token_age_consumed_in_days_test.exs
@@ -30,7 +30,7 @@ defmodule Sanbase.Etherbi.AverageTokenAgeConsumedInDaysApiTest do
     with_mocks([
       {Sanbase.Metric, [:passthrough],
        [
-         get: fn
+         timeseries_data: fn
            "age_destroyed", _, _, _, _, _ ->
              {:ok,
               [

--- a/test/sanbase_web/graphql/blockchain/etherbi_token_age_consumed_api_test.exs
+++ b/test/sanbase_web/graphql/blockchain/etherbi_token_age_consumed_api_test.exs
@@ -30,7 +30,7 @@ defmodule Sanbase.Etherbi.TokenAgeConsumedApiTest do
       {Sanbase.Metric, [:passthrough],
        [
          first_datetime: fn _, _ -> {:ok, context.from} end,
-         get: fn _, _, _, _, _, _ ->
+         timeseries_data: fn _, _, _, _, _, _ ->
            {:ok,
             [
               %{datetime: Enum.at(datetimes, 0), value: 100},
@@ -74,7 +74,7 @@ defmodule Sanbase.Etherbi.TokenAgeConsumedApiTest do
     with_mocks([
       {Sanbase.Metric, [:passthrough],
        [
-         get: fn _, _, _, _, _, _ ->
+         timeseries_data: fn _, _, _, _, _, _ ->
            {:ok,
             [
               %{datetime: Enum.at(datetimes, 0), value: 100},

--- a/test/sanbase_web/graphql/blockchain/etherbi_trx_volume_api_test.exs
+++ b/test/sanbase_web/graphql/blockchain/etherbi_trx_volume_api_test.exs
@@ -28,7 +28,7 @@ defmodule Sanbase.Etherbi.TransactionVolumeApiTest do
       {Sanbase.Metric, [:passthrough],
        [
          first_datetime: fn _, _ -> {:ok, context.from} end,
-         get: fn _, _, _, _, _, _ ->
+         timeseries_data: fn _, _, _, _, _, _ ->
            {:ok,
             [
               %{datetime: Enum.at(datetimes, 0), value: 100},
@@ -72,7 +72,7 @@ defmodule Sanbase.Etherbi.TransactionVolumeApiTest do
     with_mocks([
       {Sanbase.Metric, [:passthrough],
        [
-         get: fn _, _, _, _, _, _ ->
+         timeseries_data: fn _, _, _, _, _, _ ->
            {:ok,
             [
               %{datetime: Enum.at(datetimes, 0), value: 100},

--- a/test/sanbase_web/graphql/clickhouse/daily_active_addresses_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/daily_active_addresses_test.exs
@@ -31,7 +31,7 @@ defmodule SanbaseWeb.Graphql.DailyActiveAddressesApiTest do
       {Sanbase.Metric, [:passthrough],
        [
          first_datetime: fn _, _ -> {:ok, context.from} end,
-         get: fn _, _, _, _, _, _ ->
+         timeseries_data: fn _, _, _, _, _, _ ->
            {:ok,
             [
               %{datetime: Enum.at(datetimes, 0), value: 100},
@@ -75,7 +75,7 @@ defmodule SanbaseWeb.Graphql.DailyActiveAddressesApiTest do
     with_mocks([
       {Sanbase.Metric, [:passthrough],
        [
-         get: fn _, _, _, _, _, _ ->
+         timeseries_data: fn _, _, _, _, _, _ ->
            {:ok,
             [
               %{datetime: Enum.at(datetimes, 0), value: 100},

--- a/test/sanbase_web/graphql/clickhouse/metric/api_metric_timeseries_data_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/metric/api_metric_timeseries_data_test.exs
@@ -28,7 +28,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ApiMetricTimeseriesDataTest do
     [metric | _] = Metric.available_metrics()
 
     with_mock Metric, [],
-      get: fn _, _, _, _, _, _ ->
+      timeseries_data: fn _, _, _, _, _, _ ->
         {:ok,
          [
            %{value: 100.0, datetime: from_iso8601!("2019-01-01T00:00:00Z")},
@@ -50,7 +50,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ApiMetricTimeseriesDataTest do
                }
              ]
 
-      assert_called(Metric.get(metric, slug, from, to, interval, aggregation))
+      assert_called(Metric.timeseries_data(metric, slug, from, to, interval, aggregation))
     end
   end
 
@@ -60,7 +60,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ApiMetricTimeseriesDataTest do
     metrics = Metric.available_metrics()
 
     with_mock Metric, [],
-      get: fn _, _, _, _, _, _ ->
+      timeseries_data: fn _, _, _, _, _, _ ->
         {:ok,
          [
            %{value: 100.0, datetime: from_iso8601!("2019-01-01T00:00:00Z")},
@@ -86,7 +86,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ApiMetricTimeseriesDataTest do
     [metric | _] = Metric.available_metrics()
 
     with_mock Metric, [],
-      get: fn _, _, _, _, _, _ ->
+      timeseries_data: fn _, _, _, _, _, _ ->
         {:ok,
          [
            %{value: 100.0, datetime: from_iso8601!("2019-01-01T00:00:00Z")},

--- a/test/sanbase_web/graphql/clickhouse/mvrv_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/mvrv_test.exs
@@ -28,7 +28,7 @@ defmodule SanbaseWeb.Graphql.MVRVApiTest do
       {Sanbase.Metric, [:passthrough],
        [
          first_datetime: fn _, _ -> {:ok, context.from} end,
-         get: fn _, _, _, _, _, _ ->
+         timeseries_data: fn _, _, _, _, _, _ ->
            {:ok,
             [
               %{datetime: Enum.at(datetimes, 0), value: 100},
@@ -72,7 +72,7 @@ defmodule SanbaseWeb.Graphql.MVRVApiTest do
     with_mocks([
       {Sanbase.Metric, [:passthrough],
        [
-         get: fn _, _, _, _, _, _ ->
+         timeseries_data: fn _, _, _, _, _, _ ->
            {:ok,
             [
               %{datetime: Enum.at(datetimes, 0), value: 100},

--- a/test/sanbase_web/graphql/clickhouse/nvt_api_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/nvt_api_test.exs
@@ -31,7 +31,7 @@ defmodule SanbaseWeb.Graphql.NVTApiTest do
       {Sanbase.Metric, [:passthrough],
        [
          first_datetime: fn _, _ -> {:ok, context.from} end,
-         get: fn
+         timeseries_data: fn
            "nvt_transaction_volume", _, _, _, _, _ ->
              {:ok,
               [
@@ -79,7 +79,7 @@ defmodule SanbaseWeb.Graphql.NVTApiTest do
       {Sanbase.Metric, [:passthrough],
        [
          first_datetime: fn _, _ -> {:ok, context.from} end,
-         get: fn _, _, _, _, _, _ -> {:ok, []} end
+         timeseries_data: fn _, _, _, _, _, _ -> {:ok, []} end
        ]}
     ]) do
       response = execute_query(context)
@@ -93,7 +93,7 @@ defmodule SanbaseWeb.Graphql.NVTApiTest do
     error = "Some error description here"
 
     with_mock Sanbase.Metric,
-      get: fn _, _, _, _, _, _ -> {:error, error} end do
+      timeseries_data: fn _, _, _, _, _, _ -> {:error, error} end do
       log =
         capture_log(fn ->
           response = execute_query(context)
@@ -107,7 +107,7 @@ defmodule SanbaseWeb.Graphql.NVTApiTest do
   end
 
   test "uses 1d as default interval", context do
-    with_mock Sanbase.Metric, get: fn _, _, _, _, _, _ -> {:ok, []} end do
+    with_mock Sanbase.Metric, timeseries_data: fn _, _, _, _, _, _ -> {:ok, []} end do
       query = """
         {
           nvtRatio(slug: "#{context.slug}", from: "#{context.from}", to: "#{context.to}"){
@@ -121,7 +121,7 @@ defmodule SanbaseWeb.Graphql.NVTApiTest do
       context.conn
       |> post("/graphql", query_skeleton(query, "nvtRatio"))
 
-      assert_called(Sanbase.Metric.get(:_, :_, context.from, context.to, "1d", :_))
+      assert_called(Sanbase.Metric.timeseries_data(:_, :_, context.from, context.to, "1d", :_))
     end
   end
 

--- a/test/sanbase_web/graphql/clickhouse/token_circulation_api_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/token_circulation_api_test.exs
@@ -28,7 +28,7 @@ defmodule SanbaseWeb.Graphql.TokenCirculationApiTest do
       {Sanbase.Metric, [:passthrough],
        [
          first_datetime: fn _, _ -> {:ok, context.from} end,
-         get: fn _, _, _, _, _, _ ->
+         timeseries_data: fn _, _, _, _, _, _ ->
            {:ok,
             [
               %{datetime: Enum.at(datetimes, 0), value: 100},
@@ -72,7 +72,7 @@ defmodule SanbaseWeb.Graphql.TokenCirculationApiTest do
     with_mocks([
       {Sanbase.Metric, [:passthrough],
        [
-         get: fn _, _, _, _, _, _ ->
+         timeseries_data: fn _, _, _, _, _, _ ->
            {:ok,
             [
               %{datetime: Enum.at(datetimes, 0), value: 100},


### PR DESCRIPTION
#### Summary
Rename get to timeseries_data
Rename get_aggregated to aggregated_data

These two renamings are done to better integrate with the upcoming
histogram_data function
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
