### PR TITLE
Add version to metrics

### DIFF
--- a/lib/sanbase/clickhouse/metric/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/available_v2_metrics.json
@@ -1,6 +1,7 @@
 [
   {
     "metric": "daily_avg_marketcap_usd",
+    "version": "2019-01-01",
     "human_readable_name": "Daily Average USD Marketcap",
     "access": "free",
     "aggregation": "avg",
@@ -9,6 +10,7 @@
   },
   {
     "metric": "daily_avg_price_usd",
+    "version": "2019-01-01",
     "human_readable_name": "Daily Average USD Price",
     "access": "free",
     "aggregation": "avg",
@@ -17,6 +19,7 @@
   },
   {
     "metric": "daily_closing_marketcap_usd",
+    "version": "2019-01-01",
     "human_readable_name": "Daily Closing USD Marketcap",
     "access": "free",
     "aggregation": "last",
@@ -25,6 +28,7 @@
   },
   {
     "metric": "daily_closing_price_usd",
+    "version": "2019-01-01",
     "human_readable_name": "Daily Closing USD Price",
     "access": "free",
     "aggregation": "last",
@@ -33,6 +37,7 @@
   },
   {
     "metric": "daily_high_price_usd",
+    "version": "2019-01-01",
     "human_readable_name": "Daily High USD Price",
     "access": "free",
     "aggregation": "max",
@@ -41,6 +46,7 @@
   },
   {
     "metric": "daily_low_price_usd",
+    "version": "2019-01-01",
     "human_readable_name": "Daily Low USD Price",
     "access": "free",
     "aggregation": "min",
@@ -49,6 +55,7 @@
   },
   {
     "metric": "daily_opening_price_usd",
+    "version": "2019-01-01",
     "human_readable_name": "Daily Opening USD Price",
     "access": "free",
     "aggregation": "first",
@@ -57,6 +64,7 @@
   },
   {
     "metric": "daily_trading_volume_usd",
+    "version": "2019-01-01",
     "human_readable_name": "Daily Trading USD Volume",
     "access": "free",
     "aggregation": "avg",
@@ -65,6 +73,7 @@
   },
   {
     "metric": "daily_active_addresses",
+    "version": "2019-01-01",
     "human_readable_name": "Daily Active Addresses",
     "access": "free",
     "aggregation": "avg",
@@ -73,6 +82,7 @@
   },
   {
     "metric": "mean_realized_price_usd_20y",
+    "version": "2019-01-01",
     "human_readable_name": "Mean Realized USD Price",
     "alias": "mean_realized_price_usd",
     "access": "restricted",
@@ -82,6 +92,7 @@
   },
   {
     "metric": "mean_realized_price_usd_10y",
+    "version": "2019-01-01",
     "human_readable_name": "Mean Realized USD Price for coins that moved in the past 10 years",
     "access": "restricted",
     "aggregation": "avg",
@@ -90,6 +101,7 @@
   },
   {
     "metric": "mean_realized_price_usd_5y",
+    "version": "2019-01-01",
     "human_readable_name": "Mean Realized USD Price for coins that moved in the past 5 years",
     "access": "restricted",
     "aggregation": "avg",
@@ -98,6 +110,7 @@
   },
   {
     "metric": "mean_realized_price_usd_3y",
+    "version": "2019-01-01",
     "human_readable_name": "Mean Realized USD Price for coins that moved in the past 3 years",
     "access": "restricted",
     "aggregation": "avg",
@@ -106,6 +119,7 @@
   },
   {
     "metric": "mean_realized_price_usd_2y",
+    "version": "2019-01-01",
     "human_readable_name": "Mean Realized USD Price for coins that moved in the past 2 years",
     "access": "restricted",
     "aggregation": "avg",
@@ -114,6 +128,7 @@
   },
   {
     "metric": "mean_realized_price_usd_365d",
+    "version": "2019-01-01",
     "human_readable_name": "Mean Realized USD Price for coins that moved in the past 1 year",
     "access": "restricted",
     "aggregation": "avg",
@@ -122,6 +137,7 @@
   },
   {
     "metric": "mean_realized_price_usd_180d",
+    "version": "2019-01-01",
     "human_readable_name": "Mean Realized USD Price for coins that moved in the past 180 days",
     "access": "restricted",
     "aggregation": "avg",
@@ -130,6 +146,7 @@
   },
   {
     "metric": "mean_realized_price_usd_90d",
+    "version": "2019-01-01",
     "human_readable_name": "Mean Realized USD Price for coins that moved in the past 90 days",
     "access": "restricted",
     "aggregation": "avg",
@@ -138,6 +155,7 @@
   },
   {
     "metric": "mean_realized_price_usd_60d",
+    "version": "2019-01-01",
     "human_readable_name": "Mean Realized USD Price for coins that moved in the past 60 days",
     "access": "restricted",
     "aggregation": "avg",
@@ -146,6 +164,7 @@
   },
   {
     "metric": "mean_realized_price_usd_30d",
+    "version": "2019-01-01",
     "human_readable_name": "Mean Realized USD Price for coins that moved in the past 30 days",
     "access": "restricted",
     "aggregation": "avg",
@@ -154,6 +173,7 @@
   },
   {
     "metric": "mean_realized_price_usd_7d",
+    "version": "2019-01-01",
     "human_readable_name": "Mean Realized USD Price for coins that moved in the past 7 days",
     "access": "restricted",
     "aggregation": "avg",
@@ -162,6 +182,7 @@
   },
   {
     "metric": "mean_realized_price_usd_1d",
+    "version": "2019-01-01",
     "human_readable_name": "Mean Realized USD Price for coins that moved in the past 1 day",
     "access": "restricted",
     "aggregation": "avg",
@@ -171,6 +192,7 @@
 
   {
     "metric": "mvrv_usd_long_short_diff",
+    "version": "2019-01-01",
     "human_readable_name": "MVRV Long/Short Difference",
     "alias": "mvrv_long_short_diff_usd",
     "access": "restricted",
@@ -181,6 +203,7 @@
 
   {
     "metric": "mvrv_usd_20y",
+    "version": "2019-01-01",
     "human_readable_name": "MVRV",
     "alias": "mvrv_usd",
     "access": "restricted",
@@ -190,6 +213,7 @@
   },
   {
     "metric": "mvrv_usd_10y",
+    "version": "2019-01-01",
     "human_readable_name": "MVRV for coins that moved in the past 10 years",
     "access": "restricted",
     "aggregation": "avg",
@@ -198,6 +222,7 @@
   },
   {
     "metric": "mvrv_usd_5y",
+    "version": "2019-01-01",
     "human_readable_name": "MVRV for coins that moved in the past 5 years",
     "access": "restricted",
     "aggregation": "avg",
@@ -206,6 +231,7 @@
   },
   {
     "metric": "mvrv_usd_3y",
+    "version": "2019-01-01",
     "human_readable_name": "MVRV for coins that moved in the past 3 years",
     "access": "restricted",
     "aggregation": "avg",
@@ -214,6 +240,7 @@
   },
   {
     "metric": "mvrv_usd_2y",
+    "version": "2019-01-01",
     "human_readable_name": "MVRV for coins that moved in the past 2 years",
     "access": "restricted",
     "aggregation": "avg",
@@ -222,6 +249,7 @@
   },
   {
     "metric": "mvrv_usd_365d",
+    "version": "2019-01-01",
     "human_readable_name": "MVRV for coins that moved in the past 1 year",
     "access": "restricted",
     "aggregation": "avg",
@@ -230,6 +258,7 @@
   },
   {
     "metric": "mvrv_usd_180d",
+    "version": "2019-01-01",
     "human_readable_name": "MVRV for coins that moved in the past 180 days",
     "access": "restricted",
     "aggregation": "avg",
@@ -238,6 +267,7 @@
   },
   {
     "metric": "mvrv_usd_90d",
+    "version": "2019-01-01",
     "human_readable_name": "MVRV for coins that moved in the past 90 days",
     "access": "restricted",
     "aggregation": "avg",
@@ -246,6 +276,7 @@
   },
   {
     "metric": "mvrv_usd_60d",
+    "version": "2019-01-01",
     "human_readable_name": "MVRV for coins that moved in the past 60 days",
     "access": "restricted",
     "aggregation": "avg",
@@ -254,6 +285,7 @@
   },
   {
     "metric": "mvrv_usd_30d",
+    "version": "2019-01-01",
     "human_readable_name": "MVRV for coins that moved in the past 30 days",
     "access": "restricted",
     "aggregation": "avg",
@@ -262,6 +294,7 @@
   },
   {
     "metric": "mvrv_usd_7d",
+    "version": "2019-01-01",
     "human_readable_name": "MVRV for coins that moved in the past 7 days",
     "access": "restricted",
     "aggregation": "avg",
@@ -270,6 +303,7 @@
   },
   {
     "metric": "mvrv_usd_1d",
+    "version": "2019-01-01",
     "human_readable_name": "MVRV for coins that moved in the past 1 day",
     "access": "restricted",
     "aggregation": "avg",
@@ -279,6 +313,7 @@
 
   {
     "metric": "stack_circulation_20y",
+    "version": "2019-01-01",
     "human_readable_name": "Circulation",
     "alias": "circulation",
     "access": "restricted",
@@ -288,6 +323,7 @@
   },
   {
     "metric": "stack_circulation_10y",
+    "version": "2019-01-01",
     "human_readable_name": "Circulation for coins that moved in the past 10 years",
     "alias": "circulation_10y",
     "access": "restricted",
@@ -297,6 +333,7 @@
   },
   {
     "metric": "stack_circulation_5y",
+    "version": "2019-01-01",
     "human_readable_name": "Circulation for coins that moved in the past 5 years",
     "alias": "circulation_5y",
     "access": "restricted",
@@ -306,6 +343,7 @@
   },
   {
     "metric": "stack_circulation_3y",
+    "version": "2019-01-01",
     "human_readable_name": "Circulation for coins that moved in the past 3 years",
     "alias": "circulation_3y",
     "access": "restricted",
@@ -315,6 +353,7 @@
   },
   {
     "metric": "stack_circulation_2y",
+    "version": "2019-01-01",
     "human_readable_name": "Circulation for coins that moved in the past 2 years",
     "alias": "circulation_2y",
     "access": "restricted",
@@ -324,6 +363,7 @@
   },
   {
     "metric": "stack_circulation_365d",
+    "version": "2019-01-01",
     "human_readable_name": "Circulation for coins that moved in the past 1 year",
     "alias": "circulation_365d",
     "access": "restricted",
@@ -333,6 +373,7 @@
   },
   {
     "metric": "stack_circulation_180d",
+    "version": "2019-01-01",
     "human_readable_name": "Circulation for coins that moved in the past 180 days",
     "alias": "circulation_180d",
     "access": "restricted",
@@ -342,6 +383,7 @@
   },
   {
     "metric": "stack_circulation_90d",
+    "version": "2019-01-01",
     "human_readable_name": "Circulation for coins that moved in the past 90 days",
     "alias": "circulation_90d",
     "access": "restricted",
@@ -351,6 +393,7 @@
   },
   {
     "metric": "stack_circulation_60d",
+    "version": "2019-01-01",
     "human_readable_name": "Circulation for coins that moved in the past 60 days",
     "alias": "circulation_60d",
     "access": "restricted",
@@ -360,6 +403,7 @@
   },
   {
     "metric": "stack_circulation_30d",
+    "version": "2019-01-01",
     "human_readable_name": "Circulation for coins that moved in the past 30 days",
     "alias": "circulation_30d",
     "access": "restricted",
@@ -369,6 +413,7 @@
   },
   {
     "metric": "stack_circulation_7d",
+    "version": "2019-01-01",
     "human_readable_name": "Circulation for coins that moved in the past 7 days",
     "alias": "circulation_7d",
     "access": "restricted",
@@ -378,6 +423,7 @@
   },
   {
     "metric": "stack_circulation_1d",
+    "version": "2019-01-01",
     "human_readable_name": "Circulation for coins that moved in the past 1 day",
     "alias": "circulation_1d",
     "access": "restricted",
@@ -388,6 +434,7 @@
 
   {
     "metric": "stack_mean_age_days",
+    "version": "2019-01-01",
     "human_readable_name": "Mean Age in days",
     "alias": "mean_age",
     "access": "restricted",
@@ -399,6 +446,7 @@
 
   {
     "metric": "stack_mean_age_dollar_days",
+    "version": "2019-01-01",
     "human_readable_name": "Mean Dollar Invested Age in days for coins that moved",
     "alias": "mean_dollar_invested_age",
     "access": "restricted",
@@ -410,6 +458,7 @@
 
   {
     "metric": "stack_realized_cap_usd_20y",
+    "version": "2019-01-01",
     "human_readable_name": "Realized Value",
     "alias": "realized_value_usd",
     "access": "restricted",
@@ -419,6 +468,7 @@
   },
   {
     "metric": "stack_realized_cap_usd_10y",
+    "version": "2019-01-01",
     "human_readable_name": "Realized Value for coins that moved in the past 10 years",
     "alias": "realized_value_usd_10y",
     "access": "restricted",
@@ -429,6 +479,7 @@
 
   {
     "metric": "stack_realized_cap_usd_5y",
+    "version": "2019-01-01",
     "human_readable_name": "Realized Value for coins that moved in the past 5 years",
     "alias": "realized_value_usd_5y",
     "access": "restricted",
@@ -438,6 +489,7 @@
   },
   {
     "metric": "stack_realized_cap_usd_3y",
+    "version": "2019-01-01",
     "human_readable_name": "Realized Value for coins that moved in the past 3 years",
     "alias": "realized_value_usd_3y",
     "access": "restricted",
@@ -447,6 +499,7 @@
   },
   {
     "metric": "stack_realized_cap_usd_2y",
+    "version": "2019-01-01",
     "human_readable_name": "Realized Value for coins that moved in the past 2 years",
     "alias": "realized_value_usd_2y",
     "access": "restricted",
@@ -456,6 +509,7 @@
   },
   {
     "metric": "stack_realized_cap_usd_365d",
+    "version": "2019-01-01",
     "human_readable_name": "Realized Value for coins that moved in the past 1 year",
     "alias": "realized_value_usd_365d",
     "access": "restricted",
@@ -465,6 +519,7 @@
   },
   {
     "metric": "stack_realized_cap_usd_180d",
+    "version": "2019-01-01",
     "human_readable_name": "Realized Value for coins that moved in the past 180 days",
     "alias": "realized_value_usd_180d",
     "access": "restricted",
@@ -474,6 +529,7 @@
   },
   {
     "metric": "stack_realized_cap_usd_90d",
+    "version": "2019-01-01",
     "human_readable_name": "Realized Value for coins that moved in the past 90 days",
     "alias": "realized_value_usd_90d",
     "access": "restricted",
@@ -483,6 +539,7 @@
   },
   {
     "metric": "stack_realized_cap_usd_60d",
+    "version": "2019-01-01",
     "human_readable_name": "Realized Value for coins that moved in the past 60 days",
     "alias": "realized_value_usd_60d",
     "access": "restricted",
@@ -492,6 +549,7 @@
   },
   {
     "metric": "stack_realized_cap_usd_30d",
+    "version": "2019-01-01",
     "human_readable_name": "Realized Value for coins that moved in the past 30 days",
     "alias": "realized_value_usd_30d",
     "access": "restricted",
@@ -501,6 +559,7 @@
   },
   {
     "metric": "stack_realized_cap_usd_7d",
+    "version": "2019-01-01",
     "human_readable_name": "Realized Value for coins that moved in the past 7 days",
     "alias": "realized_value_usd_7d",
     "access": "restricted",
@@ -510,6 +569,7 @@
   },
   {
     "metric": "stack_realized_cap_usd_1d",
+    "version": "2019-01-01",
     "human_readable_name": "Realized Value for coins that moved in the past 1 day",
     "alias": "realized_value_usd_1d",
     "access": "restricted",
@@ -520,6 +580,7 @@
 
   {
     "metric": "token_velocity",
+    "version": "2019-01-01",
     "human_readable_name": "Velocity",
     "alias": "velocity",
     "access": "restricted",
@@ -530,6 +591,7 @@
 
   {
     "metric": "transaction_volume_5min",
+    "version": "2019-01-01",
     "human_readable_name": "On-Chain Transaction Volume",
     "alias": "transaction_volume",
     "access": "restricted",
@@ -540,6 +602,7 @@
 
   {
     "metric": "exchange_inflow",
+    "version": "2019-01-01",
     "human_readable_name": "Exchange Inflow",
     "access": "restricted",
     "aggregation": "sum",
@@ -548,6 +611,7 @@
   },
   {
     "metric": "exchange_outflow",
+    "version": "2019-01-01",
     "human_readable_name": "Exchange Inflow",
     "access": "restricted",
     "aggregation": "sum",
@@ -556,6 +620,7 @@
   },
   {
     "metric": "exchange_balance",
+    "version": "2019-01-01",
     "human_readable_name": "Exchange Balance (Inflow - Outflow)",
     "access": "restricted",
     "aggregation": "sum",
@@ -565,6 +630,7 @@
 
   {
     "metric": "stack_age_consumed_5min",
+    "version": "2019-01-01",
     "human_readable_name": "Age Destroyed",
     "alias": "age_destroyed",
     "access": "restricted",
@@ -575,6 +641,7 @@
 
   {
     "metric": "nvt",
+    "version": "2019-01-01",
     "human_readable_name": "NVT (Using Circulation)",
     "access": "restricted",
     "aggregation": "avg",
@@ -584,6 +651,7 @@
 
   {
     "metric": "nvt_transaction_volume",
+    "version": "2019-01-01",
     "human_readable_name": "NVT (Using Transaction Volume)",
     "access": "restricted",
     "aggregation": "avg",
@@ -593,6 +661,7 @@
 
   {
     "metric": "network_growth",
+    "version": "2019-01-01",
     "human_readable_name": "Network Growth",
     "access": "restricted",
     "aggregation": "sum",

--- a/lib/sanbase/clickhouse/metric/file_handler.ex
+++ b/lib/sanbase/clickhouse/metric/file_handler.ex
@@ -116,6 +116,19 @@ defmodule Sanbase.Clickhouse.Metric.FileHandler do
                            end)
                            |> Map.new()
 
+  @metric_version_map @metrics_json
+                      |> Enum.flat_map(fn
+                        %{"alias" => metric_alias, "metric" => metric, "version" => version} ->
+                          [
+                            {metric_alias, version},
+                            {metric, version}
+                          ]
+
+                        %{"metric" => metric, "version" => version} ->
+                          [{metric, version}]
+                      end)
+                      |> Map.new()
+
   def access_map(), do: @access_map
   def table_map(), do: @table_map
   def metrics_mapset(), do: @metrics_mapset
@@ -124,6 +137,8 @@ defmodule Sanbase.Clickhouse.Metric.FileHandler do
   def min_interval_map(), do: @min_interval_map
   def name_to_column_map(), do: @name_to_column_map
   def human_readable_name_map(), do: @human_readable_name_map
+
+  def metric_version_map(), do: @metric_version_map
 
   def metrics_with_access(level) when level in [:free, :restricted] do
     @access_map

--- a/test/sanbase/clickhouse/metric/clickhouse_metric_helper_test.exs
+++ b/test/sanbase/clickhouse/metric/clickhouse_metric_helper_test.exs
@@ -1,0 +1,22 @@
+defmodule Sanbase.Clickhouse.Metric.HelperTest do
+  use Sanbase.DataCase
+
+  import Mock
+
+  test "metric id to name map correctly uses the version" do
+    with_mock Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:ok,
+         %{
+           rows: [
+             [1, "daily_active_addresses", "2019-01-01"],
+             [2, "daily_active_addresses", "2019-11-03"]
+           ]
+         }}
+      end do
+      {:ok, version_map} = Sanbase.Clickhouse.Metric.Helper.metric_name_id_map()
+      assert {"daily_active_addresses", 1} in version_map
+      refute {"daily_active_addresses", 2} in version_map
+    end
+  end
+end

--- a/test/sanbase_web/graphql/insight/insight_api_test.exs
+++ b/test/sanbase_web/graphql/insight/insight_api_test.exs
@@ -54,22 +54,29 @@ defmodule SanbaseWeb.Graphql.InsightApiTest do
     }
     """
 
-    result = conn |> post("/graphql", query_skeleton(query, "currentUser"))
+    result =
+      conn
+      |> post("/graphql", query_skeleton(query, "currentUser"))
+      |> json_response(200)
 
-    assert json_response(result, 200)["data"]["currentUser"] == %{
-             "insights" => [
-               %{
-                 "id" => "#{published.id}",
-                 "readyState" => "#{published.ready_state}",
-                 "text" => "#{published.text}"
-               },
-               %{
-                 "id" => "#{draft.id}",
-                 "readyState" => "#{draft.ready_state}",
-                 "text" => "#{draft.text}"
-               }
-             ]
-           }
+    expected_insights =
+      [
+        %{
+          "id" => "#{published.id}",
+          "readyState" => "#{published.ready_state}",
+          "text" => "#{published.text}"
+        },
+        %{
+          "id" => "#{draft.id}",
+          "readyState" => "#{draft.ready_state}",
+          "text" => "#{draft.text}"
+        }
+      ]
+      |> Enum.sort_by(& &1["id"])
+
+    insights = result["data"]["currentUser"]["insights"] |> Enum.sort_by(& &1["id"])
+
+    assert insights == expected_insights
   end
 
   test "get an insight by id", %{conn: conn, user: user, poll: poll} do


### PR DESCRIPTION
#### Summary
In order to smoothly update metrics without dropping first the data we are going to start using the `version` field. So instead of only the name (which will no longer identify a row in the metric_metadata table) we are using the (metric, version) pair

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
