### PR TITLE
Rename alias to name. Introduce a name for all metrics

### DIFF
--- a/lib/sanbase/billing/plan/access_checker.ex
+++ b/lib/sanbase/billing/plan/access_checker.ex
@@ -41,7 +41,7 @@ defmodule Sanbase.Billing.Plan.AccessChecker do
   alias Sanbase.Billing.GraphqlSchema
 
   # Raise an error if there is any query without subscription plan
-  case GraphqlSchema.get_metrics_without_access_level() do
+  case GraphqlSchema.get_all_without_access_level() do
     [] ->
       :ok
 
@@ -56,14 +56,14 @@ defmodule Sanbase.Billing.Plan.AccessChecker do
       """)
   end
 
-  @extension_metrics GraphqlSchema.get_metrics_with_access_level(:extension)
+  @extension_metrics GraphqlSchema.get_all_with_access_level(:extension)
   def extension_metrics(), do: @extension_metrics
 
-  @free_metrics GraphqlSchema.get_metrics_with_access_level(:free)
+  @free_metrics GraphqlSchema.get_all_with_access_level(:free)
   @free_metrics_mapset MapSet.new(@free_metrics)
   def free_metrics_mapset(), do: @free_metrics_mapset
 
-  @restricted_metrics GraphqlSchema.get_metrics_with_access_level(:restricted)
+  @restricted_metrics GraphqlSchema.get_all_with_access_level(:restricted)
   @restricted_metrics_mapset MapSet.new(@restricted_metrics)
   def restricted_metrics_mapset(), do: @restricted_metrics_mapset
 

--- a/lib/sanbase/clickhouse/metric/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/available_v2_metrics.json
@@ -1,8 +1,9 @@
 [
   {
+    "human_readable_name": "Daily Average USD Marketcap",
+    "name": "daily_avg_marketcap_usd",
     "metric": "daily_avg_marketcap_usd",
     "version": "2019-01-01",
-    "human_readable_name": "Daily Average USD Marketcap",
     "access": "free",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -10,9 +11,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Daily Average USD Price",
+    "name": "daily_avg_price_usd",
     "metric": "daily_avg_price_usd",
     "version": "2019-01-01",
-    "human_readable_name": "Daily Average USD Price",
     "access": "free",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -20,9 +22,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Daily Closing USD Marketcap",
+    "name": "daily_closing_marketcap_usd",
     "metric": "daily_closing_marketcap_usd",
     "version": "2019-01-01",
-    "human_readable_name": "Daily Closing USD Marketcap",
     "access": "free",
     "aggregation": "last",
     "min_interval": "1d",
@@ -30,9 +33,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Daily Closing USD Price",
+    "name": "daily_closing_price_usd",
     "metric": "daily_closing_price_usd",
     "version": "2019-01-01",
-    "human_readable_name": "Daily Closing USD Price",
     "access": "free",
     "aggregation": "last",
     "min_interval": "1d",
@@ -40,9 +44,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Daily High USD Price",
+    "name": "daily_high_price_usd",
     "metric": "daily_high_price_usd",
     "version": "2019-01-01",
-    "human_readable_name": "Daily High USD Price",
     "access": "free",
     "aggregation": "max",
     "min_interval": "1d",
@@ -50,9 +55,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Daily Low USD Price",
+    "name": "daily_low_price_usd",
     "metric": "daily_low_price_usd",
     "version": "2019-01-01",
-    "human_readable_name": "Daily Low USD Price",
     "access": "free",
     "aggregation": "min",
     "min_interval": "1d",
@@ -60,9 +66,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Daily Opening USD Price",
+    "name": "daily_opening_price_usd",
     "metric": "daily_opening_price_usd",
     "version": "2019-01-01",
-    "human_readable_name": "Daily Opening USD Price",
     "access": "free",
     "aggregation": "first",
     "min_interval": "1d",
@@ -70,9 +77,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Daily Trading USD Volume",
+    "name": "daily_trading_volume_usd",
     "metric": "daily_trading_volume_usd",
     "version": "2019-01-01",
-    "human_readable_name": "Daily Trading USD Volume",
     "access": "free",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -80,9 +88,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Daily Active Addresses",
+    "name": "daily_active_addresses",
     "metric": "daily_active_addresses",
     "version": "2019-01-01",
-    "human_readable_name": "Daily Active Addresses",
     "access": "free",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -90,10 +99,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Mean Realized USD Price",
+    "name": "mean_realized_price_usd",
     "metric": "mean_realized_price_usd_20y",
     "version": "2019-01-01",
-    "human_readable_name": "Mean Realized USD Price",
-    "alias": "mean_realized_price_usd",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -101,9 +110,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 10 years",
+    "name": "mean_realized_price_usd_10y",
     "metric": "mean_realized_price_usd_10y",
     "version": "2019-01-01",
-    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 10 years",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -111,9 +121,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 5 years",
+    "name": "mean_realized_price_usd_5y",
     "metric": "mean_realized_price_usd_5y",
     "version": "2019-01-01",
-    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 5 years",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -121,9 +132,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 3 years",
+    "name": "mean_realized_price_usd_3y",
     "metric": "mean_realized_price_usd_3y",
     "version": "2019-01-01",
-    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 3 years",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -131,9 +143,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 2 years",
+    "name": "mean_realized_price_usd_2y",
     "metric": "mean_realized_price_usd_2y",
     "version": "2019-01-01",
-    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 2 years",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -141,9 +154,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 1 year",
+    "name": "mean_realized_price_usd_365d",
     "metric": "mean_realized_price_usd_365d",
     "version": "2019-01-01",
-    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 1 year",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -151,9 +165,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 180 days",
+    "name": "mean_realized_price_usd_180d",
     "metric": "mean_realized_price_usd_180d",
     "version": "2019-01-01",
-    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 180 days",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -161,9 +176,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 90 days",
+    "name": "mean_realized_price_usd_90d",
     "metric": "mean_realized_price_usd_90d",
     "version": "2019-01-01",
-    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 90 days",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -171,9 +187,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 60 days",
+    "name": "mean_realized_price_usd_60d",
     "metric": "mean_realized_price_usd_60d",
     "version": "2019-01-01",
-    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 60 days",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -181,9 +198,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 30 days",
+    "name": "mean_realized_price_usd_30d",
     "metric": "mean_realized_price_usd_30d",
     "version": "2019-01-01",
-    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 30 days",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -191,9 +209,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 7 days",
+    "name": "mean_realized_price_usd_7d",
     "metric": "mean_realized_price_usd_7d",
     "version": "2019-01-01",
-    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 7 days",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -201,9 +220,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 1 day",
+    "name": "mean_realized_price_usd_1d",
     "metric": "mean_realized_price_usd_1d",
     "version": "2019-01-01",
-    "human_readable_name": "Mean Realized USD Price for coins that moved in the past 1 day",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -212,10 +232,10 @@
   },
 
   {
+    "human_readable_name": "MVRV Long/Short Difference",
+    "name": "mvrv_usd_long_short_diff",
     "metric": "mvrv_usd_long_short_diff",
     "version": "2019-01-01",
-    "human_readable_name": "MVRV Long/Short Difference",
-    "alias": "mvrv_long_short_diff_usd",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -224,10 +244,10 @@
   },
 
   {
+    "human_readable_name": "MVRV",
+    "name": "mvrv_usd",
     "metric": "mvrv_usd_20y",
     "version": "2019-01-01",
-    "human_readable_name": "MVRV",
-    "alias": "mvrv_usd",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -235,9 +255,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "MVRV for coins that moved in the past 10 years",
+    "name": "mvrv_usd_10y",
     "metric": "mvrv_usd_10y",
     "version": "2019-01-01",
-    "human_readable_name": "MVRV for coins that moved in the past 10 years",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -245,9 +266,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "MVRV for coins that moved in the past 5 years",
+    "name": "mvrv_usd_5y",
     "metric": "mvrv_usd_5y",
     "version": "2019-01-01",
-    "human_readable_name": "MVRV for coins that moved in the past 5 years",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -255,9 +277,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "MVRV for coins that moved in the past 3 years",
+    "name": "mvrv_usd_3y",
     "metric": "mvrv_usd_3y",
     "version": "2019-01-01",
-    "human_readable_name": "MVRV for coins that moved in the past 3 years",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -265,9 +288,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "MVRV for coins that moved in the past 2 years",
+    "name": "mvrv_usd_2y",
     "metric": "mvrv_usd_2y",
     "version": "2019-01-01",
-    "human_readable_name": "MVRV for coins that moved in the past 2 years",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -275,9 +299,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "MVRV for coins that moved in the past 1 year",
+    "name": "mvrv_usd_365d",
     "metric": "mvrv_usd_365d",
     "version": "2019-01-01",
-    "human_readable_name": "MVRV for coins that moved in the past 1 year",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -285,9 +310,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "MVRV for coins that moved in the past 180 days",
+    "name": "mvrv_usd_180d",
     "metric": "mvrv_usd_180d",
     "version": "2019-01-01",
-    "human_readable_name": "MVRV for coins that moved in the past 180 days",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -295,9 +321,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "MVRV for coins that moved in the past 90 days",
+    "name": "mvrv_usd_90d",
     "metric": "mvrv_usd_90d",
     "version": "2019-01-01",
-    "human_readable_name": "MVRV for coins that moved in the past 90 days",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -305,9 +332,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "MVRV for coins that moved in the past 60 days",
+    "name": "mvrv_usd_60d",
     "metric": "mvrv_usd_60d",
     "version": "2019-01-01",
-    "human_readable_name": "MVRV for coins that moved in the past 60 days",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -315,9 +343,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "MVRV for coins that moved in the past 30 days",
+    "name": "mvrv_usd_30d",
     "metric": "mvrv_usd_30d",
     "version": "2019-01-01",
-    "human_readable_name": "MVRV for coins that moved in the past 30 days",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -325,9 +354,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "MVRV for coins that moved in the past 7 days",
+    "name": "mvrv_usd_7d",
     "metric": "mvrv_usd_7d",
     "version": "2019-01-01",
-    "human_readable_name": "MVRV for coins that moved in the past 7 days",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -335,9 +365,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "MVRV for coins that moved in the past 1 day",
+    "name": "mvrv_usd_1d",
     "metric": "mvrv_usd_1d",
     "version": "2019-01-01",
-    "human_readable_name": "MVRV for coins that moved in the past 1 day",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -346,10 +377,10 @@
   },
 
   {
+    "human_readable_name": "Circulation",
+    "name": "circulation",
     "metric": "stack_circulation_20y",
     "version": "2019-01-01",
-    "human_readable_name": "Circulation",
-    "alias": "circulation",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "1d",
@@ -357,10 +388,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Circulation for coins that moved in the past 10 years",
+    "name": "circulation_10y",
     "metric": "stack_circulation_10y",
     "version": "2019-01-01",
-    "human_readable_name": "Circulation for coins that moved in the past 10 years",
-    "alias": "circulation_10y",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "1d",
@@ -368,10 +399,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Circulation for coins that moved in the past 5 years",
+    "name": "circulation_5y",
     "metric": "stack_circulation_5y",
     "version": "2019-01-01",
-    "human_readable_name": "Circulation for coins that moved in the past 5 years",
-    "alias": "circulation_5y",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "1d",
@@ -379,10 +410,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Circulation for coins that moved in the past 3 years",
+    "name": "circulation_3y",
     "metric": "stack_circulation_3y",
     "version": "2019-01-01",
-    "human_readable_name": "Circulation for coins that moved in the past 3 years",
-    "alias": "circulation_3y",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "1d",
@@ -390,10 +421,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Circulation for coins that moved in the past 2 years",
+    "name": "circulation_2y",
     "metric": "stack_circulation_2y",
     "version": "2019-01-01",
-    "human_readable_name": "Circulation for coins that moved in the past 2 years",
-    "alias": "circulation_2y",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "1d",
@@ -401,10 +432,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Circulation for coins that moved in the past 1 year",
+    "name": "circulation_365d",
     "metric": "stack_circulation_365d",
     "version": "2019-01-01",
-    "human_readable_name": "Circulation for coins that moved in the past 1 year",
-    "alias": "circulation_365d",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "1d",
@@ -412,10 +443,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Circulation for coins that moved in the past 180 days",
+    "name": "circulation_180d",
     "metric": "stack_circulation_180d",
     "version": "2019-01-01",
-    "human_readable_name": "Circulation for coins that moved in the past 180 days",
-    "alias": "circulation_180d",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "1d",
@@ -423,10 +454,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Circulation for coins that moved in the past 90 days",
+    "name": "circulation_90d",
     "metric": "stack_circulation_90d",
     "version": "2019-01-01",
-    "human_readable_name": "Circulation for coins that moved in the past 90 days",
-    "alias": "circulation_90d",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "1d",
@@ -434,10 +465,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Circulation for coins that moved in the past 60 days",
+    "name": "circulation_60d",
     "metric": "stack_circulation_60d",
     "version": "2019-01-01",
-    "human_readable_name": "Circulation for coins that moved in the past 60 days",
-    "alias": "circulation_60d",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "1d",
@@ -445,10 +476,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Circulation for coins that moved in the past 30 days",
+    "name": "circulation_30d",
     "metric": "stack_circulation_30d",
     "version": "2019-01-01",
-    "human_readable_name": "Circulation for coins that moved in the past 30 days",
-    "alias": "circulation_30d",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "1d",
@@ -456,10 +487,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Circulation for coins that moved in the past 7 days",
+    "name": "circulation_7d",
     "metric": "stack_circulation_7d",
     "version": "2019-01-01",
-    "human_readable_name": "Circulation for coins that moved in the past 7 days",
-    "alias": "circulation_7d",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "1d",
@@ -467,10 +498,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Circulation for coins that moved in the past 1 day",
+    "name": "circulation_1d",
     "metric": "stack_circulation_1d",
     "version": "2019-01-01",
-    "human_readable_name": "Circulation for coins that moved in the past 1 day",
-    "alias": "circulation_1d",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "1d",
@@ -479,10 +510,10 @@
   },
 
   {
+    "human_readable_name": "Mean Age in days",
+    "name": "mean_age",
     "metric": "stack_mean_age_days",
     "version": "2019-01-01",
-    "human_readable_name": "Mean Age in days",
-    "alias": "mean_age",
     "access": "restricted",
     "aggregation": "last",
     "min_interval": "1d",
@@ -492,10 +523,10 @@
   },
 
   {
+    "human_readable_name": "Mean Dollar Invested Age in days for coins that moved",
+    "name": "mean_dollar_invested_age",
     "metric": "stack_mean_age_dollar_days",
     "version": "2019-01-01",
-    "human_readable_name": "Mean Dollar Invested Age in days for coins that moved",
-    "alias": "mean_dollar_invested_age",
     "access": "restricted",
     "aggregation": "last",
     "min_interval": "1d",
@@ -505,10 +536,10 @@
   },
 
   {
+    "human_readable_name": "Realized Value",
+    "name": "realized_value_usd",
     "metric": "stack_realized_cap_usd_20y",
     "version": "2019-01-01",
-    "human_readable_name": "Realized Value",
-    "alias": "realized_value_usd",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -516,10 +547,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Realized Value for coins that moved in the past 10 years",
+    "name": "realized_value_usd_10y",
     "metric": "stack_realized_cap_usd_10y",
     "version": "2019-01-01",
-    "human_readable_name": "Realized Value for coins that moved in the past 10 years",
-    "alias": "realized_value_usd_10y",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -528,10 +559,10 @@
   },
 
   {
+    "human_readable_name": "Realized Value for coins that moved in the past 5 years",
+    "name": "realized_value_usd_5y",
     "metric": "stack_realized_cap_usd_5y",
     "version": "2019-01-01",
-    "human_readable_name": "Realized Value for coins that moved in the past 5 years",
-    "alias": "realized_value_usd_5y",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -539,10 +570,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Realized Value for coins that moved in the past 3 years",
+    "name": "realized_value_usd_3y",
     "metric": "stack_realized_cap_usd_3y",
     "version": "2019-01-01",
-    "human_readable_name": "Realized Value for coins that moved in the past 3 years",
-    "alias": "realized_value_usd_3y",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -550,10 +581,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Realized Value for coins that moved in the past 2 years",
+    "name": "realized_value_usd_2y",
     "metric": "stack_realized_cap_usd_2y",
     "version": "2019-01-01",
-    "human_readable_name": "Realized Value for coins that moved in the past 2 years",
-    "alias": "realized_value_usd_2y",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -561,10 +592,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Realized Value for coins that moved in the past 1 year",
+    "name": "realized_value_usd_365d",
     "metric": "stack_realized_cap_usd_365d",
     "version": "2019-01-01",
-    "human_readable_name": "Realized Value for coins that moved in the past 1 year",
-    "alias": "realized_value_usd_365d",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -572,10 +603,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Realized Value for coins that moved in the past 180 days",
+    "name": "realized_value_usd_180d",
     "metric": "stack_realized_cap_usd_180d",
     "version": "2019-01-01",
-    "human_readable_name": "Realized Value for coins that moved in the past 180 days",
-    "alias": "realized_value_usd_180d",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -583,10 +614,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Realized Value for coins that moved in the past 90 days",
+    "name": "realized_value_usd_90d",
     "metric": "stack_realized_cap_usd_90d",
     "version": "2019-01-01",
-    "human_readable_name": "Realized Value for coins that moved in the past 90 days",
-    "alias": "realized_value_usd_90d",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -594,10 +625,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Realized Value for coins that moved in the past 60 days",
+    "name": "realized_value_usd_60d",
     "metric": "stack_realized_cap_usd_60d",
     "version": "2019-01-01",
-    "human_readable_name": "Realized Value for coins that moved in the past 60 days",
-    "alias": "realized_value_usd_60d",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -605,10 +636,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Realized Value for coins that moved in the past 30 days",
+    "name": "realized_value_usd_30d",
     "metric": "stack_realized_cap_usd_30d",
     "version": "2019-01-01",
-    "human_readable_name": "Realized Value for coins that moved in the past 30 days",
-    "alias": "realized_value_usd_30d",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -616,10 +647,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Realized Value for coins that moved in the past 7 days",
+    "name": "realized_value_usd_7d",
     "metric": "stack_realized_cap_usd_7d",
     "version": "2019-01-01",
-    "human_readable_name": "Realized Value for coins that moved in the past 7 days",
-    "alias": "realized_value_usd_7d",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -627,10 +658,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Realized Value for coins that moved in the past 1 day",
+    "name": "realized_value_usd_1d",
     "metric": "stack_realized_cap_usd_1d",
     "version": "2019-01-01",
-    "human_readable_name": "Realized Value for coins that moved in the past 1 day",
-    "alias": "realized_value_usd_1d",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -639,10 +670,10 @@
   },
 
   {
+    "human_readable_name": "Velocity",
+    "name": "velocity",
     "metric": "token_velocity",
     "version": "2019-01-01",
-    "human_readable_name": "Velocity",
-    "alias": "velocity",
     "access": "restricted",
     "aggregation": "last",
     "min_interval": "1d",
@@ -651,10 +682,10 @@
   },
 
   {
+    "human_readable_name": "On-Chain Transaction Volume",
+    "name": "transaction_volume",
     "metric": "transaction_volume_5min",
     "version": "2019-01-01",
-    "human_readable_name": "On-Chain Transaction Volume",
-    "alias": "transaction_volume",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "5m",
@@ -663,9 +694,10 @@
   },
 
   {
+    "human_readable_name": "Exchange Inflow",
+    "name": "exchange_inflow",
     "metric": "exchange_inflow",
     "version": "2019-01-01",
-    "human_readable_name": "Exchange Inflow",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "5m",
@@ -673,9 +705,10 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Exchange Inflow",
+    "name": "exchange_outflow",
     "metric": "exchange_outflow",
     "version": "2019-01-01",
-    "human_readable_name": "Exchange Inflow",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "5m",
@@ -683,9 +716,10 @@
     "data_type": "timeseries"
   },
   {
+    "name": "exchange_balance",
+    "human_readable_name": "Exchange Balance (Inflow - Outflow)",
     "metric": "exchange_balance",
     "version": "2019-01-01",
-    "human_readable_name": "Exchange Balance (Inflow - Outflow)",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "5m",
@@ -694,10 +728,10 @@
   },
 
   {
+    "human_readable_name": "Age Destroyed",
+    "name": "age_destroyed",
     "metric": "stack_age_consumed_5min",
     "version": "2019-01-01",
-    "human_readable_name": "Age Destroyed",
-    "alias": "age_destroyed",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "5m",
@@ -706,9 +740,10 @@
   },
 
   {
+    "human_readable_name": "NVT (Using Circulation)",
+    "name": "nvt",
     "metric": "nvt",
     "version": "2019-01-01",
-    "human_readable_name": "NVT (Using Circulation)",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -717,9 +752,10 @@
   },
 
   {
+    "human_readable_name": "NVT (Using Transaction Volume)",
+    "name": "nvt_transaction_volume",
     "metric": "nvt_transaction_volume",
     "version": "2019-01-01",
-    "human_readable_name": "NVT (Using Transaction Volume)",
     "access": "restricted",
     "aggregation": "avg",
     "min_interval": "1d",
@@ -728,9 +764,10 @@
   },
 
   {
+    "human_readable_name": "Network Growth",
+    "name": "network_growth",
     "metric": "network_growth",
     "version": "2019-01-01",
-    "human_readable_name": "Network Growth",
     "access": "restricted",
     "aggregation": "sum",
     "min_interval": "1d",
@@ -739,13 +776,13 @@
   },
   {
     "human_readable_name": "Age Distribution Histogram",
-    "alias": "age_distribution",
+    "name": "age_distribution",
     "metric": "age_distribution_5min_delta",
     "version": "2019-01-01",
-    "label": "The amount of tokens last moved between ${1} and ${2}",
     "access": "restricted",
     "aggregation": "last",
     "min_interval": "5m",
+    "label": "The amount of tokens last moved between ${1} and ${2}",
     "table": "distribution_deltas_5min",
     "data_type": "histogram"
   }

--- a/lib/sanbase/clickhouse/metric/file_handler.ex
+++ b/lib/sanbase/clickhouse/metric/file_handler.ex
@@ -7,7 +7,11 @@ defmodule Sanbase.Clickhouse.Metric.FileHandler do
       |> Enum.map(fn
         %{"name" => name, ^field => value} ->
           {name, transform_fn.(value)}
+
+        _ ->
+          nil
       end)
+      |> Enum.reject(&is_nil/1)
       |> Map.new()
     end
   end
@@ -36,6 +40,7 @@ defmodule Sanbase.Clickhouse.Metric.FileHandler do
   @metrics_file "available_v2_metrics.json"
   @external_resource available_metrics_file = Path.join(__DIR__, @metrics_file)
   @metrics_json File.read!(available_metrics_file) |> Jason.decode!()
+  @aggregations [:any, :sum, :avg, :min, :max, :last, :first, :median]
 
   @metrics_data_type_map Helper.name_to_field_map(@metrics_json, "data_type", &String.to_atom/1)
   @name_to_column_map Helper.name_to_field_map(@metrics_json, "metric")
@@ -45,6 +50,7 @@ defmodule Sanbase.Clickhouse.Metric.FileHandler do
   @min_interval_map Helper.name_to_field_map(@metrics_json, "min_interval")
   @human_readable_name_map Helper.name_to_field_map(@metrics_json, "human_readable_name")
   @metric_version_map Helper.name_to_field_map(@metrics_json, "version")
+  @metrics_label_map Helper.name_to_field_map(@metrics_json, "label")
 
   @metrics_list @metrics_json |> Enum.map(fn %{"name" => name} -> name end)
   @metrics_mapset MapSet.new(@metrics_list)

--- a/lib/sanbase/clickhouse/metric/metric.ex
+++ b/lib/sanbase/clickhouse/metric/metric.ex
@@ -24,8 +24,8 @@ defmodule Sanbase.Clickhouse.Metric do
 
   @plain_aggregations FileHandler.aggregations()
   @aggregations [nil] ++ @plain_aggregations
-  @timeseries_metrics_public_name_list FileHandler.metrics_with_data_type(:timeseries)
-  @histogram_metrics_public_name_list FileHandler.metrics_with_data_type(:histogram)
+  @timeseries_metrics_name_list FileHandler.metrics_with_data_type(:timeseries)
+  @histogram_metrics_name_list FileHandler.metrics_with_data_type(:histogram)
   @access_map FileHandler.access_map()
   @min_interval_map FileHandler.min_interval_map()
   @free_metrics FileHandler.metrics_with_access(:free)
@@ -34,9 +34,9 @@ defmodule Sanbase.Clickhouse.Metric do
   @human_readable_name_map FileHandler.human_readable_name_map()
   @metrics_data_type_map FileHandler.metrics_data_type_map()
   @metrics_label_map FileHandler.metrics_label_map()
-  @metrics_public_name_list (@histogram_metrics_public_name_list ++
-                               @timeseries_metrics_public_name_list)
-                            |> Enum.uniq()
+  @metrics_name_list (@histogram_metrics_name_list ++
+                        @timeseries_metrics_name_list)
+                     |> Enum.uniq()
 
   @type slug :: String.t()
   @type metric :: String.t()
@@ -145,21 +145,16 @@ defmodule Sanbase.Clickhouse.Metric do
 
   @doc ~s"""
   Return a list of available metrics.
-
-  If a metric has an alias only the alias is added to the list. But when a metric
-  is queries, the alias **and** the original metric name is accepted. This is
-  done so we do not pollute the public API with too much metric names and we
-  expose only the user-friendly ones.
   """
 
   @impl Sanbase.Metric.Behaviour
-  def available_histogram_metrics(), do: @histogram_metrics_public_name_list
+  def available_histogram_metrics(), do: @histogram_metrics_name_list
 
   @impl Sanbase.Metric.Behaviour
-  def available_timeseries_metrics(), do: @timeseries_metrics_public_name_list
+  def available_timeseries_metrics(), do: @timeseries_metrics_name_list
 
   @impl Sanbase.Metric.Behaviour
-  def available_metrics(), do: @metrics_public_name_list
+  def available_metrics(), do: @metrics_name_list
 
   @impl Sanbase.Metric.Behaviour
   def available_slugs(), do: get_available_slugs()

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -144,7 +144,7 @@ defmodule Sanbase.Metric do
   @doc ~s"""
   Get the human readable name representation of a given metric
   """
-  def human_reanable_name(metric)
+  def human_readable_name(metric)
 
   for %{metric: metric, module: module} <- @metric_module_mapping do
     def human_readable_name(unquote(metric)) do

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -144,6 +144,8 @@ defmodule Sanbase.Metric do
   @doc ~s"""
   Get the human readable name representation of a given metric
   """
+  def human_reanable_name(metric)
+
   for %{metric: metric, module: module} <- @metric_module_mapping do
     def human_readable_name(unquote(metric)) do
       unquote(module).human_readable_name(unquote(metric))
@@ -160,6 +162,7 @@ defmodule Sanbase.Metric do
   - The available aggregations for the metric
   - The available slugs for the metric
   """
+  def metadata(metric)
 
   for %{metric: metric, module: module} <- @metric_module_mapping do
     def metadata(unquote(metric)) do
@@ -172,6 +175,7 @@ defmodule Sanbase.Metric do
   @doc ~s"""
   Get the first datetime for which a given metric is available for a given slug
   """
+  def first_datetime(metric, slug)
 
   for %{metric: metric, module: module} <- @metric_module_mapping do
     def first_datetime(unquote(metric), slug) do
@@ -184,6 +188,8 @@ defmodule Sanbase.Metric do
   @doc ~s"""
   Get all available slugs for a given metric
   """
+  def available_slugs(metric)
+
   for %{metric: metric, module: module} <- @metric_module_mapping do
     def available_slugs(unquote(metric)) do
       unquote(module).available_slugs(unquote(metric))

--- a/lib/sanbase_web/graphql/middlewares/access_control.ex
+++ b/lib/sanbase_web/graphql/middlewares/access_control.ex
@@ -123,7 +123,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
 
   defp get_query(:timeseries_data, %{metric: metric}), do: {:metric, metric}
   defp get_query(:histogram_data, %{metric: metric}), do: {:metric, metric}
-  defp get_query(query, _), do: query
+  defp get_query(query, _), do: {:query, query}
 
   defp restricted_query(
          %Resolution{arguments: %{from: from, to: to}, context: context} = resolution,

--- a/lib/sanbase_web/plug/session_plug.ex
+++ b/lib/sanbase_web/plug/session_plug.ex
@@ -7,7 +7,10 @@ defmodule SanbaseWeb.Plug.SessionPlug do
 
   require Sanbase.Utils.Config, as: Config
 
-  def init(opts), do: opts
+  def init(opts) do
+    IO.inspect(" I AM BEING CALLED")
+    opts
+  end
 
   def call(conn, opts) do
     runtime_opts =

--- a/lib/sanbase_web/plug/session_plug.ex
+++ b/lib/sanbase_web/plug/session_plug.ex
@@ -7,10 +7,7 @@ defmodule SanbaseWeb.Plug.SessionPlug do
 
   require Sanbase.Utils.Config, as: Config
 
-  def init(opts) do
-    IO.inspect(" I AM BEING CALLED")
-    opts
-  end
+  def init(opts), do: opts
 
   def call(conn, opts) do
     runtime_opts =

--- a/test/sanbase/billing/access_level_test.exs
+++ b/test/sanbase/billing/access_level_test.exs
@@ -1,0 +1,296 @@
+defmodule Sanbase.Billing.AccessLevelTest do
+  use ExUnit.Case, async: true
+
+  # Assert that a query's access level does not change incidentally
+  test "there are no queries without defined subscription" do
+    assert Sanbase.Billing.GraphqlSchema.get_all_without_access_level() == []
+  end
+
+  test "free queries defined in the schema" do
+    free_queries =
+      Sanbase.Billing.GraphqlSchema.get_queries_with_access_level(:free)
+      |> Enum.sort()
+
+    expected_free_queries =
+      [
+        :get_coupon,
+        :get_trigger_by_id,
+        :payments,
+        :current_user,
+        :news,
+        :project,
+        :historical_balance,
+        :elasticsearch_stats,
+        :historical_trigger_points,
+        :price_volume_diff,
+        :assets_held_by_address,
+        :social_volume_projects,
+        :all_market_segments,
+        :get_telegram_deep_link,
+        :products_with_plans,
+        :projects_count,
+        :ohlc,
+        :all_insights_for_user,
+        :history_twitter_data,
+        :all_insights_user_voted,
+        :all_exchanges,
+        :eth_spent_over_time_by_erc20_projects,
+        :history_price,
+        :metric_anomaly,
+        :fetch_all_public_watchlists,
+        :public_triggers_for_user,
+        :post,
+        :projects_list_stats,
+        :all_public_triggers,
+        :currencies_market_segments,
+        :twitter_mention_count,
+        :all_currency_projects,
+        :featured_user_triggers,
+        :timeline_events,
+        :all_insights,
+        :featured_watchlists,
+        :signals_historical_activity,
+        :erc20_market_segments,
+        :github_activity,
+        :fetch_public_user_lists,
+        :project_by_slug,
+        :fetch_public_watchlists,
+        :all_tags,
+        :fetch_all_public_user_lists,
+        :projects_list_history_stats,
+        :daily_active_addresses,
+        :twitter_data,
+        :github_availables_repos,
+        :eth_spent_by_erc20_projects,
+        :featured_insights,
+        :insight,
+        :current_poll,
+        :all_projects_by_function,
+        :eth_spent_by_all_projects,
+        :fetch_user_lists,
+        :all_erc20_projects,
+        :fetch_watchlists,
+        :all_projects,
+        :eth_spent_over_time_by_all_projects,
+        :all_insights_by_tag,
+        :user_list,
+        :dev_activity,
+        :watchlist,
+        :watchlist_by_slug,
+        :get_available_metrics,
+        :get_available_slugs,
+        :get_metric,
+        :get_user
+      ]
+      |> Enum.sort()
+
+    assert free_queries == expected_free_queries
+  end
+
+  test "free metrics" do
+    free_queries =
+      Sanbase.Billing.GraphqlSchema.get_metrics_with_access_level(:free)
+      |> Enum.sort()
+
+    expected_free_queries =
+      [
+        "daily_active_addresses",
+        "daily_avg_marketcap_usd",
+        "daily_avg_price_usd",
+        "daily_closing_marketcap_usd",
+        "daily_closing_price_usd",
+        "daily_high_price_usd",
+        "daily_low_price_usd",
+        "daily_opening_price_usd",
+        "daily_trading_volume_usd",
+        "dev_activity",
+        "github_activity"
+      ]
+      |> Enum.sort()
+
+    assert free_queries == expected_free_queries
+  end
+
+  test "restricted queries defined in the schema" do
+    basic_queries =
+      Sanbase.Billing.GraphqlSchema.get_queries_with_access_level(:restricted)
+      |> Enum.sort()
+
+    expected_basic_queries =
+      [
+        :average_token_age_consumed_in_days,
+        :burn_rate,
+        :daily_active_deposits,
+        :emojis_sentiment,
+        :exchange_funds_flow,
+        :exchange_volume,
+        :gas_used,
+        :get_project_trending_history,
+        :get_word_trending_history,
+        :get_trending_words,
+        :miners_balance,
+        :mining_pools_distribution,
+        :mvrv_ratio,
+        :network_growth,
+        :nvt_ratio,
+        :percent_of_token_supply_on_exchanges,
+        :realized_value,
+        :share_of_deposits,
+        :social_dominance,
+        :social_gainers_losers_status,
+        :social_volume,
+        :token_age_consumed,
+        :token_circulation,
+        :token_velocity,
+        :top_holders_percent_of_total_supply,
+        :top_social_gainers_losers,
+        :topic_search,
+        :transaction_volume,
+        :trending_words,
+        :word_context,
+        :word_trend_score
+      ]
+      |> Enum.sort()
+
+    assert basic_queries == expected_basic_queries
+  end
+
+  test "restricted metrics" do
+    restricted_metrics =
+      Sanbase.Billing.GraphqlSchema.get_metrics_with_access_level(:restricted)
+      |> Enum.sort()
+
+    metrics = [
+      "mean_realized_price_usd",
+      "mean_realized_price_usd_10y",
+      "mean_realized_price_usd_5y",
+      "mean_realized_price_usd_3y",
+      "mean_realized_price_usd_2y",
+      "mean_realized_price_usd_365d",
+      "mean_realized_price_usd_180d",
+      "mean_realized_price_usd_90d",
+      "mean_realized_price_usd_60d",
+      "mean_realized_price_usd_30d",
+      "mean_realized_price_usd_7d",
+      "mean_realized_price_usd_1d",
+      "mvrv_usd_long_short_diff",
+      "mvrv_usd",
+      "mvrv_usd_10y",
+      "mvrv_usd_5y",
+      "mvrv_usd_3y",
+      "mvrv_usd_2y",
+      "mvrv_usd_365d",
+      "mvrv_usd_180d",
+      "mvrv_usd_90d",
+      "mvrv_usd_60d",
+      "mvrv_usd_30d",
+      "mvrv_usd_7d",
+      "mvrv_usd_1d",
+      "circulation",
+      "circulation_10y",
+      "circulation_5y",
+      "circulation_3y",
+      "circulation_2y",
+      "circulation_365d",
+      "circulation_180d",
+      "circulation_90d",
+      "circulation_60d",
+      "circulation_30d",
+      "circulation_7d",
+      "circulation_1d",
+      "mean_age",
+      "mean_dollar_invested_age",
+      "realized_value_usd",
+      "realized_value_usd_10y",
+      "realized_value_usd_5y",
+      "realized_value_usd_3y",
+      "realized_value_usd_2y",
+      "realized_value_usd_365d",
+      "realized_value_usd_180d",
+      "realized_value_usd_90d",
+      "realized_value_usd_60d",
+      "realized_value_usd_30d",
+      "realized_value_usd_7d",
+      "realized_value_usd_1d",
+      "velocity",
+      "transaction_volume",
+      "exchange_inflow",
+      "exchange_outflow",
+      "exchange_balance",
+      "age_destroyed",
+      "nvt",
+      "nvt_transaction_volume",
+      "network_growth",
+      "age_distribution",
+      "discord_social_dominance",
+      "discord_social_volume",
+      "reddit_social_dominance",
+      "reddit_social_volume",
+      "telegram_social_dominance",
+      "telegram_social_volume",
+      "twitter_social_dominance",
+      "twitter_social_volume"
+    ]
+
+    expected_result = metrics |> Enum.sort()
+
+    # The diff algorithm fails to nicely print that a single metric is
+    # missing but instead shows some not-understandable result when comparing
+    # the lists directly
+
+    # not present in expected
+    assert MapSet.difference(MapSet.new(restricted_metrics), MapSet.new(expected_result))
+           |> Enum.to_list() == []
+
+    # not present in the metrics list
+    assert MapSet.difference(MapSet.new(expected_result), MapSet.new(restricted_metrics))
+           |> Enum.to_list() == []
+  end
+
+  test "extension needed queries" do
+    # Forbidden queries are acessible only by basic authorization
+    extension_queries =
+      Sanbase.Billing.GraphqlSchema.get_queries_with_access_level(:extension)
+      |> Enum.sort()
+
+    expected_extension_queries =
+      [:exchange_wallets, :all_exchange_wallets]
+      |> Enum.sort()
+
+    assert extension_queries == expected_extension_queries
+  end
+
+  test "extension needed metrics" do
+    # Forbidden queries are acessible only by basic authorization
+    extension_metrics =
+      Sanbase.Billing.GraphqlSchema.get_metrics_with_access_level(:extension)
+      |> Enum.sort()
+
+    assert extension_metrics == []
+  end
+
+  test "forbidden queries" do
+    # Forbidden queries are acessible only by basic authorization
+    forbiden_queries =
+      Sanbase.Billing.GraphqlSchema.get_queries_with_access_level(:forbidden)
+      |> Enum.sort()
+
+    expected_forbiden_queries =
+      [:all_projects_project_transparency]
+      |> Enum.sort()
+
+    assert forbiden_queries == expected_forbiden_queries
+  end
+
+  test "forbidden metrics" do
+    forbidden_metrics =
+      Sanbase.Billing.GraphqlSchema.get_metrics_with_access_level(:forbidden)
+      |> Enum.sort()
+
+    expected_forbidden_metrics =
+      []
+      |> Enum.sort()
+
+    assert forbidden_metrics == expected_forbidden_metrics
+  end
+end

--- a/test/sanbase/billing/access_level_test.exs
+++ b/test/sanbase/billing/access_level_test.exs
@@ -64,7 +64,6 @@ defmodule Sanbase.Billing.AccessLevelTest do
         :eth_spent_by_erc20_projects,
         :featured_insights,
         :insight,
-        :current_poll,
         :all_projects_by_function,
         :eth_spent_by_all_projects,
         :fetch_user_lists,
@@ -80,7 +79,8 @@ defmodule Sanbase.Billing.AccessLevelTest do
         :get_available_metrics,
         :get_available_slugs,
         :get_metric,
-        :get_user
+        :get_user,
+        :all_projects_by_ticker
       ]
       |> Enum.sort()
 

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -4,14 +4,13 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
   # Assert that a query's access level does not change incidentally
   describe "subscription meta" do
     test "there are no queries without defined subscription" do
-      assert Sanbase.Billing.GraphqlSchema.get_metrics_without_access_level() == []
+      assert Sanbase.Billing.GraphqlSchema.get_all_without_access_level() == []
     end
 
     test "free queries defined in the schema" do
       free_queries =
-        Sanbase.Billing.GraphqlSchema.get_metrics_with_access_level(:free)
+        Sanbase.Billing.GraphqlSchema.get_queries_with_access_level(:free)
         |> Enum.sort()
-        |> Enum.filter(&is_atom/1)
 
       expected_free_queries =
         [
@@ -93,8 +92,6 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
       free_queries =
         Sanbase.Billing.GraphqlSchema.get_metrics_with_access_level(:free)
         |> Enum.sort()
-        |> Enum.reject(&is_atom/1)
-        |> Enum.map(&elem(&1, 1))
 
       expected_free_queries =
         [
@@ -117,8 +114,7 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
 
     test "restricted queries defined in the schema" do
       basic_queries =
-        Sanbase.Billing.GraphqlSchema.get_metrics_with_access_level(:restricted)
-        |> Enum.filter(&is_atom/1)
+        Sanbase.Billing.GraphqlSchema.get_queries_with_access_level(:restricted)
         |> Enum.sort()
 
       expected_basic_queries =
@@ -163,13 +159,45 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
     test "restricted metrics" do
       restricted_queries =
         Sanbase.Billing.GraphqlSchema.get_metrics_with_access_level(:restricted)
-        |> Enum.reject(&is_atom/1)
-        |> Enum.map(&elem(&1, 1))
         |> Enum.sort()
 
-      aliases = [
+      added_with_metric_adapter = [
+        "discord_social_dominance",
+        "discord_social_volume",
+        "reddit_social_dominance",
+        "reddit_social_volume",
+        "telegram_social_dominance",
+        "telegram_social_volume",
+        "twitter_social_dominance",
+        "twitter_social_volume"
+      ]
+
+      metrics = [
         "mean_realized_price_usd",
+        "mean_realized_price_usd_10y",
+        "mean_realized_price_usd_5y",
+        "mean_realized_price_usd_3y",
+        "mean_realized_price_usd_2y",
+        "mean_realized_price_usd_365d",
+        "mean_realized_price_usd_180d",
+        "mean_realized_price_usd_90d",
+        "mean_realized_price_usd_60d",
+        "mean_realized_price_usd_30d",
+        "mean_realized_price_usd_7d",
+        "mean_realized_price_usd_1d",
+        "mvrv_usd_long_short_diff",
         "mvrv_usd",
+        "mvrv_usd_10y",
+        "mvrv_usd_5y",
+        "mvrv_usd_3y",
+        "mvrv_usd_2y",
+        "mvrv_usd_365d",
+        "mvrv_usd_180d",
+        "mvrv_usd_90d",
+        "mvrv_usd_60d",
+        "mvrv_usd_30d",
+        "mvrv_usd_7d",
+        "mvrv_usd_1d",
         "circulation",
         "circulation_10y",
         "circulation_5y",
@@ -197,114 +225,49 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
         "realized_value_usd_7d",
         "realized_value_usd_1d",
         "velocity",
-        "age_destroyed",
-        "mvrv_long_short_diff_usd",
-        "discord_social_dominance",
-        "discord_social_volume",
-        "reddit_social_dominance",
-        "reddit_social_volume",
-        "telegram_social_dominance",
-        "telegram_social_volume",
-        "twitter_social_dominance",
-        "twitter_social_volume",
-        "age_distribution"
-      ]
-
-      queries = [
-        "mean_realized_price_usd_10y",
-        "mean_realized_price_usd_180d",
-        "mean_realized_price_usd_1d",
-        "mean_realized_price_usd_20y",
-        "mean_realized_price_usd_2y",
-        "mean_realized_price_usd_30d",
-        "mean_realized_price_usd_365d",
-        "mean_realized_price_usd_3y",
-        "mean_realized_price_usd_5y",
-        "mean_realized_price_usd_60d",
-        "mean_realized_price_usd_7d",
-        "mean_realized_price_usd_90d",
-        "mvrv_usd_20y",
-        "mvrv_usd_10y",
-        "mvrv_usd_180d",
-        "mvrv_usd_1d",
-        "mvrv_usd_2y",
-        "mvrv_usd_30d",
-        "mvrv_usd_365d",
-        "mvrv_usd_3y",
-        "mvrv_usd_5y",
-        "mvrv_usd_60d",
-        "mvrv_usd_7d",
-        "mvrv_usd_90d",
-        "stack_circulation_10y",
-        "stack_circulation_180d",
-        "stack_circulation_1d",
-        "stack_circulation_20y",
-        "stack_circulation_2y",
-        "stack_circulation_30d",
-        "stack_circulation_365d",
-        "stack_circulation_3y",
-        "stack_circulation_5y",
-        "stack_circulation_60d",
-        "stack_circulation_7d",
-        "stack_circulation_90d",
-        "stack_mean_age_days",
-        "stack_mean_age_dollar_days",
-        "stack_realized_cap_usd_10y",
-        "stack_realized_cap_usd_180d",
-        "stack_realized_cap_usd_1d",
-        "stack_realized_cap_usd_20y",
-        "stack_realized_cap_usd_2y",
-        "stack_realized_cap_usd_30d",
-        "stack_realized_cap_usd_365d",
-        "stack_realized_cap_usd_3y",
-        "stack_realized_cap_usd_5y",
-        "stack_realized_cap_usd_60d",
-        "stack_realized_cap_usd_7d",
-        "stack_realized_cap_usd_90d",
-        "token_velocity",
         "transaction_volume",
         "exchange_inflow",
         "exchange_outflow",
         "exchange_balance",
-        "transaction_volume_5min",
-        "stack_age_consumed_5min",
+        "age_destroyed",
         "nvt",
         "nvt_transaction_volume",
-        "mvrv_usd_long_short_diff",
         "network_growth",
-        "age_distribution_5min_delta"
+        "age_distribution"
       ]
 
-      expected_result = (aliases ++ queries) |> Enum.sort()
+      expected_metrics =
+        (added_with_metric_adapter ++ metrics)
+        |> Enum.uniq()
+        |> Enum.sort()
 
       # The diff algorithm fails to nicely print that a single metric is
       # missing but instead shows some not-understandable result when comparing
       # the lists directly
-
-      assert MapSet.difference(MapSet.new(restricted_queries), MapSet.new(expected_result))
+      assert MapSet.difference(MapSet.new(restricted_queries), MapSet.new(expected_metrics))
              |> Enum.to_list() == []
 
-      assert MapSet.difference(MapSet.new(expected_result), MapSet.new(restricted_queries))
+      assert MapSet.difference(MapSet.new(expected_metrics), MapSet.new(restricted_queries))
              |> Enum.to_list() == []
     end
 
     test "forbidden queries from the schema" do
       # Forbidden queries are acessible only by basic authorization
-      pro_queries =
-        Sanbase.Billing.GraphqlSchema.get_metrics_with_access_level(:forbidden)
+      forbidden_queries =
+        Sanbase.Billing.GraphqlSchema.get_queries_with_access_level(:forbidden)
         |> Enum.sort()
 
-      expected_pro_queries =
+      expected_forbidden_queries =
         [:all_projects_project_transparency]
         |> Enum.sort()
 
-      assert pro_queries == expected_pro_queries
+      assert forbidden_queries == expected_forbidden_queries
     end
 
     test "extension needed queries from the schema" do
       # Forbidden queries are acessible only by basic authorization
       pro_queries =
-        Sanbase.Billing.GraphqlSchema.get_metrics_with_access_level(:extension)
+        Sanbase.Billing.GraphqlSchema.get_queries_with_access_level(:extension)
         |> Enum.sort()
 
       expected_pro_queries =
@@ -315,17 +278,13 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
     end
 
     test "forbidden metrics" do
-      forbidden_queries =
+      forbidden_metrics =
         Sanbase.Billing.GraphqlSchema.get_metrics_with_access_level(:forbidden)
         |> Enum.sort()
-        |> Enum.reject(&is_atom/1)
-        |> Enum.map(&elem(&1, 1))
 
-      expected_forbidden_queries =
-        []
-        |> Enum.sort()
+      expected_forbidden_metrics = [] |> Enum.sort()
 
-      assert forbidden_queries == expected_forbidden_queries
+      assert forbidden_metrics == expected_forbidden_metrics
     end
   end
 end

--- a/test/sanbase/billing/subscription_test.exs
+++ b/test/sanbase/billing/subscription_test.exs
@@ -11,13 +11,13 @@ defmodule Sanbase.Billing.SubscriptionTest do
 
   describe "#is_restricted?" do
     test "network_growth and daily_active_deposits are restricted" do
-      assert Subscription.is_restricted?(:network_growth)
-      assert Subscription.is_restricted?(:daily_active_deposits)
+      assert Subscription.is_restricted?({:query, :network_growth})
+      assert Subscription.is_restricted?({:query, :daily_active_deposits})
     end
 
     test "all_projects and history_price are not restricted" do
-      refute Subscription.is_restricted?(:all_projects)
-      refute Subscription.is_restricted?(:history_price)
+      refute Subscription.is_restricted?({:query, :all_projects})
+      refute Subscription.is_restricted?({:query, :history_price})
     end
   end
 


### PR DESCRIPTION
#### Summary
Rename `alias` to simply `name`. All metric definitions should have `name` and this will be the only name acceptable/displayed.

Refactor how queries/metrics are handled internally - uniform the shape of data passed around.
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
