### PR TITLE
Rework historical balance API

### DIFF
--- a/lib/sanbase/clickhouse/historical_balance/behaviour.ex
+++ b/lib/sanbase/clickhouse/historical_balance/behaviour.ex
@@ -30,13 +30,24 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Behaviour do
         }
 
   @type historical_balance :: %{
-          datetime: non_neg_integer(),
+          datetime: datetime(),
           balance: float()
         }
 
+  @type historical_balance_result :: {:ok, list(historical_balance)} | {:error, String.t()}
+
   @type balance_change ::
           {address, {balance_before :: number, balance_after :: number, balance_change :: number}}
-          | {:error, String.t()}
+
+  @type balance_change_result :: {:ok, list(balance_change)} | {:error, String.t()}
+
+  @type historical_balance_change :: %{
+          datetime: datetime(),
+          balance_change: number()
+        }
+
+  @type historical_balance_change_result ::
+          {:ok, list(historical_balance_change)} | {:error, String.t()}
 
   @doc ~s"""
   Return a list of all assets that the address holds or has held in the past and
@@ -56,8 +67,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Behaviour do
               from :: datetime,
               to :: datetime,
               interval
-            ) ::
-              {:ok, list(historical_balance)} | {:error, String.t()}
+            ) :: historical_balance_result()
 
   @doc ~s"""
   For a given address or list of addresses returns the balance change for the
@@ -70,8 +80,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Behaviour do
               decimals,
               from :: datetime,
               to :: datetime
-            ) ::
-              {:ok, list(balance_change)} | {:error, String.t()}
+            ) :: balance_change_result()
 
   @doc ~s"""
   For a given address or list of addresses returns the balance change for each bucket
@@ -84,8 +93,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Behaviour do
               from :: datetime,
               to :: datetime,
               interval
-            ) ::
-              {:ok, list(balance_change)} | {:error, String.t()}
+            ) :: historical_balance_change_result()
 
   @callback last_balance_before(
               address,

--- a/lib/sanbase/clickhouse/historical_balance/eth_spent.ex
+++ b/lib/sanbase/clickhouse/historical_balance/eth_spent.ex
@@ -1,6 +1,6 @@
 defmodule Sanbase.Clickhouse.HistoricalBalance.EthSpent do
   @moduledoc ~s"""
-  Module providing functions for fetching etheruem spent
+  Module providing functions for fetching ethereum spent
   """
 
   alias Sanbase.Clickhouse.HistoricalBalance

--- a/lib/sanbase/clickhouse/historical_balance/eth_spent.ex
+++ b/lib/sanbase/clickhouse/historical_balance/eth_spent.ex
@@ -1,15 +1,14 @@
 defmodule Sanbase.Clickhouse.HistoricalBalance.EthSpent do
   @moduledoc ~s"""
-  Module providing functions for historical balances, balance changes, ethereum/token
-  spent. This module dispatches to underlaying modules and serves as common interface
-  for many different database tables and schemas.
+  Module providing functions for fetching etheruem spent
   """
 
+  alias Sanbase.Clickhouse.HistoricalBalance
   alias Sanbase.Clickhouse.HistoricalBalance.EthBalance
 
   @type slug :: String.t()
 
-  @type address :: String.t()
+  @type address :: String.t() | list(String.t())
 
   @typedoc ~s"""
   An interval represented as string. It has the format of number followed by one of:
@@ -17,13 +16,12 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EthSpent do
   """
   @type interval :: String.t()
 
-  @typedoc ~s"""
-  The type returned by the historical_balance/5 function
-  """
-  @type historical_balance_return ::
-          {:ok, []}
-          | {:ok, list(%{datetime: DateTime.t(), balance: number()})}
-          | {:error, String.t()}
+  @type eth_spent_over_time :: %{
+          datetime: DateTime.t(),
+          eth_spent: number()
+        }
+
+  @type eth_spent_over_time_result :: {:ok, list(eth_spent_over_time)} | {:error, String.t()}
 
   @doc ~s"""
   For a given address or list of addresses returns the ethereum balance change for the
@@ -33,10 +31,8 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EthSpent do
   This is special case of balance_change/4 but as ethereum is used a lot for calculating
   ethereum spent this case avoids a call to the database to obtain the contract
   """
-  @spec eth_balance_change(address | list(address), DateTime.t(), DateTime.t()) ::
-          {:ok, list({address, {balance_before, balance_after, balance_change}})}
-          | {:error, String.t()}
-        when balance_before: number(), balance_after: number(), balance_change: number()
+  @spec eth_balance_change(address, from :: DateTime.t(), to :: DateTime.t()) ::
+          HistoricalBalance.Behaviour.balance_change_result()
   def eth_balance_change(addresses, from, to) do
     EthBalance.balance_change(addresses, "ETH", 18, from, to)
   end
@@ -45,9 +41,8 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EthSpent do
   For a given address or list of addresses returns the ethereum  balance change for each bucket
   of size `interval` in the from-to time period
   """
-  @spec eth_balance_change(address | list(address), DateTime.t(), DateTime.t(), interval) ::
-          {:ok, list({address, %{datetime: DateTime.t(), balance_change: number()}})}
-          | {:error, String.t()}
+  @spec eth_balance_change(address, from :: DateTime.t(), to :: DateTime.t(), interval) ::
+          HistoricalBalance.Behaviour.historical_balance_change_result()
   def eth_balance_change(addresses, from, to, interval) do
     EthBalance.historical_balance_change(addresses, "ETH", 18, from, to, interval)
   end
@@ -90,8 +85,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EthSpent do
     time bucket, the ethereum spent is equal to 0
   """
   @spec eth_spent_over_time(address | list(address), DateTime.t(), DateTime.t(), interval) ::
-          {:ok, list(%{datetime: DateTime.t(), eth_spent: number})}
-          | {:error, String.t()}
+          eth_spent_over_time_result()
   def eth_spent_over_time(addresses, from, to, interval)
       when is_binary(addresses) or is_list(addresses) do
     case eth_balance_change(addresses, from, to, interval) do

--- a/lib/sanbase/clickhouse/historical_balance/fetchers/bnb_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/fetchers/bnb_balance.ex
@@ -53,7 +53,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.BnbBalance do
 
     ClickhouseRepo.query_transform(query, args, fn [dt, value, has_changed] ->
       %{
-        datetime: Sanbase.DateTimeUtils.from_erl!(dt),
+        datetime: DateTime.from_unix!(dt),
         balance: value,
         has_changed: has_changed
       }
@@ -128,14 +128,14 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.BnbBalance do
     SELECT time, SUM(value), toUInt8(SUM(has_changed))
       FROM (
         SELECT
-          toDateTime(intDiv(toUInt32(?5 + number * ?1), ?1) * ?1) AS time,
+          toUnixTimestamp(intDiv(toUInt32(?5 + number * ?1), ?1) * ?1) AS time,
           toFloat64(0) AS value,
           toUInt8(0) AS has_changed
         FROM numbers(?2)
 
     UNION ALL
 
-    SELECT toDateTime(intDiv(toUInt32(dt), ?1) * ?1) AS time, argMax(value, dt), toUInt8(1) AS has_changed
+    SELECT toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time, argMax(value, dt), toUInt8(1) AS has_changed
       FROM #{@table}
       PREWHERE
         address = ?3 AND

--- a/lib/sanbase/clickhouse/historical_balance/fetchers/eos_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/fetchers/eos_balance.ex
@@ -53,7 +53,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EosBalance do
 
     ClickhouseRepo.query_transform(query, args, fn [dt, value, has_changed] ->
       %{
-        datetime: Sanbase.DateTimeUtils.from_erl!(dt),
+        datetime: DateTime.from_unix!(dt),
         balance: value,
         has_changed: has_changed
       }
@@ -128,14 +128,14 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EosBalance do
     SELECT time, SUM(value), toUInt8(SUM(has_changed))
       FROM (
         SELECT
-          toDateTime(intDiv(toUInt32(?5 + number * ?1), ?1) * ?1) AS time,
+          toUnixTimestamp(intDiv(toUInt32(?5 + number * ?1), ?1) * ?1) AS time,
           toFloat64(0) AS value,
           toUInt8(0) AS has_changed
         FROM numbers(?2)
 
     UNION ALL
 
-    SELECT toDateTime(intDiv(toUInt32(dt), ?1) * ?1) AS time, argMax(value, dt), toUInt8(1) AS has_changed
+    SELECT toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time, argMax(value, dt), toUInt8(1) AS has_changed
       FROM #{@table}
       PREWHERE
         address = ?3 AND

--- a/lib/sanbase/clickhouse/historical_balance/fetchers/erc20_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/fetchers/erc20_balance.ex
@@ -78,7 +78,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20Balance do
 
     ClickhouseRepo.query_transform(query, args, fn [dt, value, has_changed] ->
       %{
-        datetime: Sanbase.DateTimeUtils.from_erl!(dt),
+        datetime: DateTime.from_unix!(dt),
         balance: value / pow_decimals,
         has_changed: has_changed
       }
@@ -152,14 +152,14 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20Balance do
     SELECT time, SUM(value), toUInt8(SUM(has_changed))
       FROM (
         SELECT
-          toDateTime(intDiv(toUInt32(?5 + number * ?1), ?1) * ?1) AS time,
+          toUnixTimetamp(intDiv(toUInt32(?5 + number * ?1), ?1) * ?1) AS time,
           toFloat64(0) AS value,
           toUInt8(0) AS has_changed
         FROM numbers(?2)
 
     UNION ALL
 
-    SELECT toDateTime(intDiv(toUInt32(dt), ?1) * ?1) AS time, argMax(value, dt), toUInt8(1) AS has_changed
+    SELECT toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time, argMax(value, dt), toUInt8(1) AS has_changed
       FROM #{@table}
       PREWHERE
         address = ?3 AND

--- a/lib/sanbase/clickhouse/historical_balance/fetchers/eth_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/fetchers/eth_balance.ex
@@ -54,13 +54,12 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EthBalance do
     address = String.downcase(address)
     {query, args} = historical_balance_query(address, from, to, interval)
 
-    ClickhouseRepo.query_transform(query, args, fn
-      [dt, value, has_changed] ->
-        %{
-          datetime: DateTime.from_unix!(dt),
-          balance: value / @eth_decimals,
-          has_changed: has_changed
-        }
+    ClickhouseRepo.query_transform(query, args, fn [dt, value, has_changed] ->
+      %{
+        datetime: DateTime.from_unix!(dt),
+        balance: value / @eth_decimals,
+        has_changed: has_changed
+      }
     end)
     |> maybe_update_first_balance(fn -> last_balance_before(address, "ETH", 18, from) end)
     |> maybe_fill_gaps_last_seen_balance()

--- a/lib/sanbase/clickhouse/historical_balance/fetchers/eth_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/fetchers/eth_balance.ex
@@ -54,12 +54,13 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EthBalance do
     address = String.downcase(address)
     {query, args} = historical_balance_query(address, from, to, interval)
 
-    ClickhouseRepo.query_transform(query, args, fn [dt, value, has_changed] ->
-      %{
-        datetime: DateTime.from_unix!(dt),
-        balance: value / @eth_decimals,
-        has_changed: has_changed
-      }
+    ClickhouseRepo.query_transform(query, args, fn
+      [dt, value, has_changed] ->
+        %{
+          datetime: DateTime.from_unix!(dt),
+          balance: value / @eth_decimals,
+          has_changed: has_changed
+        }
     end)
     |> maybe_update_first_balance(fn -> last_balance_before(address, "ETH", 18, from) end)
     |> maybe_fill_gaps_last_seen_balance()

--- a/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
@@ -73,11 +73,11 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
              do: EthBalance.balance_change(address, contract, decimals, from, to)
 
       {"ETH", _} ->
-        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug),
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug || "ethereum"),
              do: Erc20Balance.balance_change(address, contract, decimals, from, to)
 
       {"XRP", _} ->
-        currency = Map.fetch!(selector, :currency)
+        currency = Map.get(selector, :currency, "XRP")
         XrpBalance.balance_change(address, currency, 0, from, to)
 
       {"BTC", _} ->
@@ -93,11 +93,11 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
              do: LtcBalance.balance_change(address, contract, decimals, from, to)
 
       {"EOS", _} ->
-        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug),
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug || "eos"),
              do: EosBalance.balance_change(address, contract, decimals, from, to)
 
       {"BNB", _} ->
-        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug),
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug || "binance-coin"),
              do: BnbBalance.balance_change(address, contract, decimals, from, to)
     end
   end
@@ -117,11 +117,11 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
              do: EthBalance.historical_balance(address, contract, decimals, from, to, interval)
 
       {"ETH", _} ->
-        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug),
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug || "ethereum"),
              do: Erc20Balance.historical_balance(address, contract, decimals, from, to, interval)
 
       {"XRP", _} ->
-        currency = Map.fetch!(selector, :currency)
+        currency = Map.get(selector, :currency, "XRP")
         XrpBalance.historical_balance(address, currency, 0, from, to, interval)
 
       {"BTC", _} ->
@@ -137,11 +137,11 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
              do: LtcBalance.historical_balance(address, contract, decimals, from, to, interval)
 
       {"EOS", _} ->
-        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug),
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug || "eos"),
              do: EosBalance.historical_balance(address, contract, decimals, from, to, interval)
 
       {"BNB", _} ->
-        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug),
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug || "binance-coin"),
              do: BnbBalance.historical_balance(address, contract, decimals, from, to, interval)
     end
   end

--- a/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
@@ -64,7 +64,6 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
   """
   def balance_change(selector, address, from, to) do
     infrastructure = Map.fetch!(selector, :infrastructure)
-
     slug = Map.get(selector, :slug)
 
     case {infrastructure, slug} do

--- a/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
@@ -112,11 +112,11 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
     slug = Map.get(selector, :slug)
 
     case {infrastructure, slug} do
-      {"ETH", ethereum} when ethereum in [nil, ethereum] ->
+      {"ETH", ethereum} when ethereum in [nil, "ethereum"] ->
         with {:ok, contract, decimals} <- Project.contract_info_by_slug("ethereum"),
              do: EthBalance.historical_balance(address, contract, decimals, from, to, interval)
 
-      {"ETH", <<"0x", _rest::binary>>} ->
+      {"ETH", _} ->
         with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug),
              do: Erc20Balance.historical_balance(address, contract, decimals, from, to, interval)
 

--- a/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
@@ -21,6 +21,14 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
     XrpBalance
   }
 
+  @typedoc ~s"""
+  """
+  @type selector :: %{
+          required(:infrastructure) => String.t(),
+          optional(:currency) => String.t(),
+          optional(:slug) => String.t()
+        }
+
   @type slug :: String.t()
 
   @type address :: String.t()
@@ -62,6 +70,8 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
   from-to period. The returned lists indicates the address, before balance, after balance
   and the balance change
   """
+  @spec balance_change(selector, address, from :: DateTime.t(), to :: DateTime.t()) ::
+          __MODULE__.Behaviour.balance_change_result()
   def balance_change(selector, address, from, to) do
     infrastructure = Map.fetch!(selector, :infrastructure)
     slug = Map.get(selector, :slug)
@@ -105,7 +115,8 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
   For a given address or list of addresses returns the combined `slug` balance for each bucket
   of size `interval` in the from-to time period
   """
-
+  @spec historical_balance(selector, address, from :: DateTime.t(), to :: DateTime.t(), interval) ::
+          __MODULE__.Behaviour.historical_balance_result()
   def historical_balance(selector, address, from, to, interval) do
     infrastructure = Map.fetch!(selector, :infrastructure)
     slug = Map.get(selector, :slug)

--- a/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
@@ -62,41 +62,43 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
   from-to period. The returned lists indicates the address, before balance, after balance
   and the balance change
   """
-  @spec balance_change(address | list(address), slug, DateTime.t(), DateTime.t()) ::
-          {:ok, list({address, {balance_before, balance_after, balance_change}})}
-          | {:error, String.t()}
-        when balance_before: number(), balance_after: number(), balance_change: number()
-  def balance_change(address, slug, from, to) do
-    case Project.contract_info_by_slug(slug) do
-      {:ok, contract, decimals} ->
-        case contract do
-          "ETH" ->
-            EthBalance.balance_change(address, contract, decimals, from, to)
+  def balance_change(selector, address, from, to) do
+    infrastructure = Map.fetch!(selector, :infrastructure)
 
-          "XRP" ->
-            XrpBalance.balance_change(address, contract, decimals, from, to)
+    slug = Map.get(selector, :slug)
 
-          "BTC" ->
-            BtcBalance.balance_change(address, contract, decimals, from, to)
+    case {infrastructure, slug} do
+      {"ETH", "ethereum"} ->
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug("ethereum"),
+             do: EthBalance.balance_change(address, contract, decimals, from, to)
 
-          "BCH" ->
-            BchBalance.balance_change(address, contract, decimals, from, to)
+      {"ETH", _} ->
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug),
+             do: Erc20Balance.balance_change(address, contract, decimals, from, to)
 
-          "LTC" ->
-            LtcBalance.balance_change(address, contract, decimals, from, to)
+      {"XRP", _} ->
+        currency = Map.fetch!(selector, :currency)
+        XrpBalance.balance_change(address, currency, 0, from, to)
 
-          "eosio.token/EOS" ->
-            EosBalance.balance_change(address, contract, decimals, from, to)
+      {"BTC", _} ->
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug("bitcoin"),
+             do: BtcBalance.balance_change(address, contract, decimals, from, to)
 
-          "BNB" ->
-            BnbBalance.balance_change(address, contract, decimals, from, to)
+      {"BCH", _} ->
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug("bitcoin-cash"),
+             do: BchBalance.balance_change(address, contract, decimals, from, to)
 
-          <<"0x", _rest::binary>> = contract ->
-            Erc20Balance.balance_change(address, contract, decimals, from, to)
-        end
+      {"LTC", _} ->
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug("litecoin"),
+             do: LtcBalance.balance_change(address, contract, decimals, from, to)
 
-      {:error, error} ->
-        {:error, inspect(error)}
+      {"EOS", _} ->
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug),
+             do: EosBalance.balance_change(address, contract, decimals, from, to)
+
+      {"BNB", _} ->
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug),
+             do: BnbBalance.balance_change(address, contract, decimals, from, to)
     end
   end
 
@@ -104,39 +106,43 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
   For a given address or list of addresses returns the combined `slug` balance for each bucket
   of size `interval` in the from-to time period
   """
-  @spec historical_balance(address | list(address), slug, DateTime.t(), DateTime.t(), interval) ::
-          historical_balance_return
-  def historical_balance(address, slug, from, to, interval) do
-    case Project.contract_info_by_slug(slug) do
-      {:ok, contract, decimals} ->
-        case contract do
-          "ETH" ->
-            EthBalance.historical_balance(address, contract, decimals, from, to, interval)
 
-          "XRP" ->
-            XrpBalance.historical_balance(address, contract, decimals, from, to, interval)
+  def historical_balance(selector, address, from, to, interval) do
+    infrastructure = Map.fetch!(selector, :infrastructure)
+    slug = Map.get(selector, :slug)
 
-          "BTC" ->
-            BtcBalance.historical_balance(address, contract, decimals, from, to, interval)
+    case {infrastructure, slug} do
+      {"ETH", "ethereum"} ->
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug("ethereum"),
+             do: EthBalance.historical_balance(address, contract, decimals, from, to, interval)
 
-          "BCH" ->
-            BchBalance.historical_balance(address, contract, decimals, from, to, interval)
+      {"ETH", _} ->
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug),
+             do: Erc20Balance.historical_balance(address, contract, decimals, from, to, interval)
 
-          "LTC" ->
-            LtcBalance.historical_balance(address, contract, decimals, from, to, interval)
+      {"XRP", _} ->
+        currency = Map.fetch!(selector, :currency)
+        XrpBalance.historical_balance(address, currency, 0, from, to, interval)
 
-          "eosio.token/EOS" ->
-            EosBalance.historical_balance(address, contract, decimals, from, to, interval)
+      {"BTC", _} ->
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug("bitcoin"),
+             do: BtcBalance.historical_balance(address, contract, decimals, from, to, interval)
 
-          "BNB" ->
-            BnbBalance.historical_balance(address, contract, decimals, from, to, interval)
+      {"BCH", _} ->
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug("bitcoin-cash"),
+             do: BchBalance.historical_balance(address, contract, decimals, from, to, interval)
 
-          <<"0x", _rest::binary>> = contract ->
-            Erc20Balance.historical_balance(address, contract, decimals, from, to, interval)
-        end
+      {"LTC", _} ->
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug("litecoin"),
+             do: LtcBalance.historical_balance(address, contract, decimals, from, to, interval)
 
-      {:error, error} ->
-        {:error, inspect(error)}
+      {"EOS", _} ->
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug),
+             do: EosBalance.historical_balance(address, contract, decimals, from, to, interval)
+
+      {"BNB", _} ->
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug),
+             do: BnbBalance.historical_balance(address, contract, decimals, from, to, interval)
     end
   end
 end

--- a/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
@@ -112,12 +112,12 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
     slug = Map.get(selector, :slug)
 
     case {infrastructure, slug} do
-      {"ETH", "ethereum"} ->
+      {"ETH", ethereum} when ethereum in [nil, ethereum] ->
         with {:ok, contract, decimals} <- Project.contract_info_by_slug("ethereum"),
              do: EthBalance.historical_balance(address, contract, decimals, from, to, interval)
 
-      {"ETH", _} ->
-        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug || "ethereum"),
+      {"ETH", <<"0x", _rest::binary>>} ->
+        with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug),
              do: Erc20Balance.historical_balance(address, contract, decimals, from, to, interval)
 
       {"XRP", _} ->

--- a/lib/sanbase/clickhouse/historical_balance/utils.ex
+++ b/lib/sanbase/clickhouse/historical_balance/utils.ex
@@ -1,4 +1,8 @@
 defmodule Sanbase.Clickhouse.HistoricalBalance.Utils do
+  @moduledoc ~s"""
+  Helper functions used when working with the historical balances
+  """
+
   @type in_type :: %{
           sign: non_neg_integer(),
           balance: float(),

--- a/lib/sanbase/signals/history/eth_wallet_trigger_history.ex
+++ b/lib/sanbase/signals/history/eth_wallet_trigger_history.ex
@@ -31,8 +31,15 @@ defmodule Sanbase.Signal.History.EthWalletTriggerHistory do
       addresses ->
         result =
           addresses
-          |> Enum.map(fn addr ->
-            {:ok, result} = HistoricalBalance.historical_balance(addr, asset, from, to, interval)
+          |> Enum.map(fn address ->
+            {:ok, result} =
+              HistoricalBalance.historical_balance(
+                %{infrastructure: "ETH", slug: asset},
+                address,
+                from,
+                to,
+                interval
+              )
 
             result
           end)

--- a/lib/sanbase/signals/trigger/settings/eth_wallet_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/eth_wallet_trigger_settings.ex
@@ -105,7 +105,12 @@ defmodule Sanbase.Signal.Trigger.EthWalletTriggerSettings do
     Cache.get_or_store(
       cache_key,
       fn ->
-        HistoricalBalance.balance_change(addresses, slug, from, to)
+        HistoricalBalance.balance_change(
+          %{infrastructure: "ETH", slug: slug},
+          addresses,
+          from,
+          to
+        )
         |> case do
           {:ok, result} -> result
           _ -> []

--- a/lib/sanbase/utils/error_handling.ex
+++ b/lib/sanbase/utils/error_handling.ex
@@ -31,6 +31,13 @@ defmodule Sanbase.Utils.ErrorHandling do
     end
   end
 
+  def maybe_handle_graphql_error({:ok, result}, _), do: {:ok, result}
+
+  def maybe_handle_graphql_error({:error, error}, error_handler)
+      when is_function(error_handler, 1) do
+    {:error, error_handler.(error)}
+  end
+
   # Private functions
   defp format_error({msg, opts}) do
     Enum.reduce(opts, msg, fn {key, value}, acc ->

--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -9,16 +9,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
 
   alias SanbaseWeb.Graphql.SanbaseDataloader
 
-  import Sanbase.Utils.ErrorHandling,
-    only: [handle_graphql_error: 3, handle_graphql_error: 4]
-
-  alias Sanbase.Clickhouse.HistoricalBalance.MinersBalance
+  import Sanbase.Utils.ErrorHandling, only: [handle_graphql_error: 3]
 
   alias Sanbase.Clickhouse.{
     RealizedValue,
     DailyActiveDeposits,
     GasUsed,
-    HistoricalBalance,
     MiningPoolsDistribution,
     NetworkGrowth,
     PercentOfTokenSupplyOnExchanges,
@@ -27,7 +23,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
   }
 
   # Return this number of datapoints is the provided interval is an empty string
-  @datapoints 50
+  @datapoints 300
 
   @one_hour_in_seconds 3_600
 
@@ -95,30 +91,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
 
       {:error, error} ->
         {:error, handle_graphql_error("Mining Pools Distribution", slug, error)}
-    end
-  end
-
-  def miners_balance(
-        _root,
-        %{slug: slug, from: from, to: to, interval: interval},
-        _resolution
-      ) do
-    with {:ok, from, to, interval} <-
-           calibrate_interval(
-             MinersBalance,
-             slug,
-             from,
-             to,
-             interval,
-             86_400,
-             @datapoints
-           ),
-         {:ok, balance} <-
-           MinersBalance.historical_balance(slug, from, to, interval) do
-      {:ok, balance}
-    else
-      {:error, error} ->
-        {:error, handle_graphql_error("Miners Balance", slug, error)}
     end
   end
 
@@ -287,41 +259,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
         end)
 
       {:ok, result}
-    end
-  end
-
-  def assets_held_by_address(_root, %{address: address}, _resolution) do
-    HistoricalBalance.assets_held_by_address(address)
-    |> case do
-      {:ok, result} ->
-        # We do this, because many contracts emit a transfer
-        # event when minting new tokens by setting 0x00...000
-        # as the from address, hence 0x00...000 is "sending"
-        # tokens it does not have which leads to "negative" balance
-
-        result =
-          result
-          |> Enum.reject(fn %{balance: balance} -> balance < 0 end)
-
-        {:ok, result}
-
-      {:error, error} ->
-        {:error,
-         handle_graphql_error("Assets held by address", address, error, description: "address")}
-    end
-  end
-
-  def historical_balance(
-        _root,
-        %{slug: slug, from: from, to: to, interval: interval, address: address},
-        _resolution
-      ) do
-    case HistoricalBalance.historical_balance(address, slug, from, to, interval) do
-      {:ok, result} ->
-        {:ok, result}
-
-      {:error, error} ->
-        {:error, handle_graphql_error("Historical Balances", slug, error)}
     end
   end
 

--- a/lib/sanbase_web/graphql/resolvers/historical_balance_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/historical_balance_resolver.ex
@@ -1,0 +1,96 @@
+defmodule SanbaseWeb.Graphql.Resolvers.HistoricalBalanceResolver do
+  import Sanbase.Utils.ErrorHandling,
+    only: [handle_graphql_error: 3, handle_graphql_error: 4]
+
+  import SanbaseWeb.Graphql.Helpers.Utils, only: [calibrate_interval: 7]
+
+  alias Sanbase.Clickhouse.HistoricalBalance
+
+  # Return this number of datapoints is the provided interval is an empty string
+  @datapoints 300
+
+  def assets_held_by_address(_root, %{address: address}, _resolution) do
+    HistoricalBalance.assets_held_by_address(address)
+    |> case do
+      {:ok, result} ->
+        # We do this, because many contracts emit a transfer
+        # event when minting new tokens by setting 0x00...000
+        # as the from address, hence 0x00...000 is "sending"
+        # tokens it does not have which leads to "negative" balance
+
+        result =
+          result
+          |> Enum.reject(fn %{balance: balance} -> balance < 0 end)
+
+        {:ok, result}
+
+      {:error, error} ->
+        {:error,
+         handle_graphql_error("Assets held by address", address, error, description: "address")}
+    end
+  end
+
+  def historical_balance(
+        _root,
+        %{selector: selector, from: from, to: to, interval: interval, address: address},
+        _resolution
+      ) do
+    case HistoricalBalance.historical_balance(
+           selector,
+           address,
+           from,
+           to,
+           interval
+         ) do
+      {:ok, result} ->
+        {:ok, result}
+
+      {:error, error} ->
+        {:error, handle_graphql_error("Historical Balances", selector, error)}
+    end
+  end
+
+  def historical_balance(
+        _root,
+        %{slug: slug, from: from, to: to, interval: interval, address: address},
+        _resolution
+      ) do
+    case HistoricalBalance.historical_balance(
+           %{infrastructure: "ETH", slug: slug},
+           address,
+           from,
+           to,
+           interval
+         ) do
+      {:ok, result} ->
+        {:ok, result}
+
+      {:error, error} ->
+        {:error, handle_graphql_error("Historical Balances", slug, error)}
+    end
+  end
+
+  def miners_balance(
+        _root,
+        %{slug: slug, from: from, to: to, interval: interval},
+        _resolution
+      ) do
+    with {:ok, from, to, interval} <-
+           calibrate_interval(
+             HistoricalBalance.MinersBalance,
+             slug,
+             from,
+             to,
+             interval,
+             86_400,
+             @datapoints
+           ),
+         {:ok, balance} <-
+           HistoricalBalance.MinersBalance.historical_balance(slug, from, to, interval) do
+      {:ok, balance}
+    else
+      {:error, error} ->
+        {:error, handle_graphql_error("Miners Balance", slug, error)}
+    end
+  end
+end

--- a/lib/sanbase_web/graphql/resolvers/historical_balance_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/historical_balance_resolver.ex
@@ -46,7 +46,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.HistoricalBalanceResolver do
         {:ok, result}
 
       {:error, error} ->
-        {:error, handle_graphql_error("Historical Balances", selector, error)}
+        {:error,
+         handle_graphql_error("Historical Balances", inspect(selector), error,
+           description: "selector"
+         )}
     end
   end
 

--- a/lib/sanbase_web/graphql/resolvers/historical_balance_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/historical_balance_resolver.ex
@@ -1,6 +1,6 @@
 defmodule SanbaseWeb.Graphql.Resolvers.HistoricalBalanceResolver do
   import Sanbase.Utils.ErrorHandling,
-    only: [handle_graphql_error: 3, handle_graphql_error: 4]
+    only: [maybe_handle_graphql_error: 2, handle_graphql_error: 3, handle_graphql_error: 4]
 
   import SanbaseWeb.Graphql.Helpers.Utils, only: [calibrate_interval: 7]
 
@@ -35,22 +35,21 @@ defmodule SanbaseWeb.Graphql.Resolvers.HistoricalBalanceResolver do
         %{selector: selector, from: from, to: to, interval: interval, address: address},
         _resolution
       ) do
-    case HistoricalBalance.historical_balance(
-           selector,
-           address,
-           from,
-           to,
-           interval
-         ) do
-      {:ok, result} ->
-        {:ok, result}
-
-      {:error, error} ->
-        {:error,
-         handle_graphql_error("Historical Balances", inspect(selector), error,
-           description: "selector"
-         )}
-    end
+    HistoricalBalance.historical_balance(
+      selector,
+      address,
+      from,
+      to,
+      interval
+    )
+    |> maybe_handle_graphql_error(fn error ->
+      handle_graphql_error(
+        "Historical Balances",
+        inspect(selector),
+        error,
+        description: "selector"
+      )
+    end)
   end
 
   def historical_balance(
@@ -58,19 +57,16 @@ defmodule SanbaseWeb.Graphql.Resolvers.HistoricalBalanceResolver do
         %{slug: slug, from: from, to: to, interval: interval, address: address},
         _resolution
       ) do
-    case HistoricalBalance.historical_balance(
-           %{infrastructure: "ETH", slug: slug},
-           address,
-           from,
-           to,
-           interval
-         ) do
-      {:ok, result} ->
-        {:ok, result}
-
-      {:error, error} ->
-        {:error, handle_graphql_error("Historical Balances", slug, error)}
-    end
+    HistoricalBalance.historical_balance(
+      %{infrastructure: "ETH", slug: slug},
+      address,
+      from,
+      to,
+      interval
+    )
+    |> maybe_handle_graphql_error(fn error ->
+      handle_graphql_error("Historical Balances", slug, error)
+    end)
   end
 
   def miners_balance(

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -22,6 +22,7 @@ defmodule SanbaseWeb.Graphql.Schema do
   alias SanbaseWeb.Graphql.{SanbaseRepo, SanbaseDataloader}
   alias SanbaseWeb.Graphql.Middlewares.ApiUsage
 
+  # Types
   import_types(Graphql.CustomTypes.Decimal)
   import_types(Graphql.CustomTypes.DateTime)
   import_types(Graphql.CustomTypes.JSON)
@@ -41,7 +42,9 @@ defmodule SanbaseWeb.Graphql.Schema do
   import_types(Graphql.InsightTypes)
   import_types(Graphql.TwitterTypes)
   import_types(Graphql.MetricTypes)
+  import_types(Graphql.HistoricalBalanceTypes)
 
+  # Queries and mutations
   import_types(Graphql.Schema.MetricQueries)
   import_types(Graphql.Schema.SocialDataQueries)
   import_types(Graphql.Schema.WatchlistQueries)
@@ -57,6 +60,7 @@ defmodule SanbaseWeb.Graphql.Schema do
   import_types(Graphql.Schema.TimelineQueries)
   import_types(Graphql.Schema.BillingQueries)
   import_types(Graphql.Schema.Subscriptions.KafkaSubscriptions)
+  import_types(Graphql.Schema.HistoricalBalanceQueries)
 
   def dataloader() do
     Dataloader.new(timeout: :timer.seconds(20))
@@ -108,6 +112,7 @@ defmodule SanbaseWeb.Graphql.Schema do
     import_fields(:user_queries)
     import_fields(:timeline_queries)
     import_fields(:billing_queries)
+    import_fields(:historical_balance_queries)
   end
 
   mutation do

--- a/lib/sanbase_web/graphql/schema/queries/blockchain_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/blockchain_queries.ex
@@ -3,11 +3,7 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
 
   import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1]
 
-  alias SanbaseWeb.Graphql.Resolvers.{
-    EtherbiResolver,
-    ClickhouseResolver,
-    ExchangeResolver
-  }
+  alias SanbaseWeb.Graphql.Resolvers.{EtherbiResolver, ClickhouseResolver, ExchangeResolver}
 
   alias SanbaseWeb.Graphql.Complexity
   alias Sanbase.Billing.Product
@@ -385,36 +381,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       cache_resolve(&EtherbiResolver.exchange_wallets/3)
     end
 
-    @desc ~s"""
-    Return a list of assets that a wallet currently holds.
-    """
-    field :assets_held_by_address, list_of(:slug_balance) do
-      meta(access: :free)
-
-      arg(:address, non_null(:string))
-
-      cache_resolve(&ClickhouseResolver.assets_held_by_address/3)
-    end
-
-    @desc ~s"""
-    Historical balance for erc20 token or eth address.
-    Returns the historical balance for a given address in the given interval.
-    """
-    field :historical_balance, list_of(:historical_balance) do
-      meta(access: :free)
-
-      arg(:slug, :string)
-      arg(:selector, :historical_balance_selector)
-      arg(:from, non_null(:datetime))
-      arg(:to, non_null(:datetime))
-      arg(:address, non_null(:string))
-      arg(:interval, non_null(:interval), default_value: "1d")
-
-      complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
-      cache_resolve(&ClickhouseResolver.historical_balance/3)
-    end
-
     @desc "List all exchanges"
     field :all_exchanges, list_of(:string) do
       meta(access: :free)
@@ -440,23 +406,6 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
       complexity(&Complexity.from_to_interval/3)
       middleware(AccessControl)
       cache_resolve(&ClickhouseResolver.mining_pools_distribution/3)
-    end
-
-    @desc """
-    Returns miner balances over time.
-    Currently only ETH is supported.
-    """
-    field :miners_balance, list_of(:miners_balance) do
-      meta(access: :restricted)
-
-      arg(:slug, :string, default_value: "ethereum")
-      arg(:from, non_null(:datetime))
-      arg(:to, non_null(:datetime))
-      arg(:interval, :interval, default_value: "1d")
-
-      complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
-      cache_resolve(&ClickhouseResolver.miners_balance/3)
     end
   end
 end

--- a/lib/sanbase_web/graphql/schema/queries/blockchain_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/blockchain_queries.ex
@@ -403,7 +403,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainQueries do
     field :historical_balance, list_of(:historical_balance) do
       meta(access: :free)
 
-      arg(:slug, non_null(:string))
+      arg(:slug, :string)
+      arg(:selector, :historical_balance_selector)
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:address, non_null(:string))

--- a/lib/sanbase_web/graphql/schema/queries/historical_balance_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/historical_balance_queries.ex
@@ -1,0 +1,59 @@
+defmodule SanbaseWeb.Graphql.Schema.HistoricalBalanceQueries do
+  use Absinthe.Schema.Notation
+
+  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1]
+
+  alias SanbaseWeb.Graphql.Resolvers.HistoricalBalanceResolver
+
+  alias SanbaseWeb.Graphql.Complexity
+  alias SanbaseWeb.Graphql.Middlewares.AccessControl
+
+  object :historical_balance_queries do
+    @desc ~s"""
+    Return a list of assets that a wallet currently holds.
+    """
+    field :assets_held_by_address, list_of(:slug_balance) do
+      meta(access: :free)
+
+      arg(:address, non_null(:string))
+
+      cache_resolve(&HistoricalBalanceResolver.assets_held_by_address/3)
+    end
+
+    @desc ~s"""
+    Historical balance for erc20 token or eth address.
+    Returns the historical balance for a given address in the given interval.
+    """
+    field :historical_balance, list_of(:historical_balance) do
+      meta(access: :free)
+
+      arg(:slug, :string)
+      arg(:selector, :historical_balance_selector)
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+      arg(:address, non_null(:string))
+      arg(:interval, non_null(:interval), default_value: "1d")
+
+      complexity(&Complexity.from_to_interval/3)
+      middleware(AccessControl)
+      cache_resolve(&HistoricalBalanceResolver.historical_balance/3)
+    end
+
+    @desc """
+    Returns miner balances over time.
+    Currently only ETH is supported.
+    """
+    field :miners_balance, list_of(:miners_balance) do
+      meta(access: :restricted)
+
+      arg(:slug, :string, default_value: "ethereum")
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+      arg(:interval, :interval, default_value: "1d")
+
+      complexity(&Complexity.from_to_interval/3)
+      middleware(AccessControl)
+      cache_resolve(&HistoricalBalanceResolver.miners_balance/3)
+    end
+  end
+end

--- a/lib/sanbase_web/graphql/schema/types/clickhouse_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/clickhouse_types.ex
@@ -34,6 +34,13 @@ defmodule SanbaseWeb.Graphql.ClickhouseTypes do
     field(:balance, :float)
   end
 
+  input_object :historical_balance_selector do
+    field(:infrastructure, non_null(:string))
+    field(:currency, :string)
+    field(:contract, :string)
+    field(:address, non_null(:string))
+  end
+
   object :mining_pools_distribution do
     field(:datetime, non_null(:datetime))
     field(:top3, :float)

--- a/lib/sanbase_web/graphql/schema/types/clickhouse_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/clickhouse_types.ex
@@ -24,33 +24,11 @@ defmodule SanbaseWeb.Graphql.ClickhouseTypes do
     field(:gas_used, :integer)
   end
 
-  object :slug_balance do
-    field(:slug, non_null(:string))
-    field(:balance, non_null(:float))
-  end
-
-  object :historical_balance do
-    field(:datetime, non_null(:datetime))
-    field(:balance, :float)
-  end
-
-  input_object :historical_balance_selector do
-    field(:infrastructure, non_null(:string))
-    field(:currency, :string)
-    field(:contract, :string)
-    field(:address, non_null(:string))
-  end
-
   object :mining_pools_distribution do
     field(:datetime, non_null(:datetime))
     field(:top3, :float)
     field(:top10, :float)
     field(:other, :float)
-  end
-
-  object :miners_balance do
-    field(:datetime, non_null(:datetime))
-    field(:balance, :float)
   end
 
   object :mvrv_ratio do

--- a/lib/sanbase_web/graphql/schema/types/historical_balance_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/historical_balance_types.ex
@@ -1,0 +1,25 @@
+defmodule SanbaseWeb.Graphql.HistoricalBalanceTypes do
+  use Absinthe.Schema.Notation
+
+  object :slug_balance do
+    field(:slug, non_null(:string))
+    field(:balance, non_null(:float))
+  end
+
+  object :historical_balance do
+    field(:datetime, non_null(:datetime))
+    field(:balance, :float)
+  end
+
+  input_object :historical_balance_selector do
+    field(:infrastructure, non_null(:string))
+    field(:address, non_null(:string))
+    field(:currency, :string)
+    field(:contract, :string)
+  end
+
+  object :miners_balance do
+    field(:datetime, non_null(:datetime))
+    field(:balance, :float)
+  end
+end

--- a/lib/sanbase_web/graphql/schema/types/historical_balance_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/historical_balance_types.ex
@@ -13,9 +13,9 @@ defmodule SanbaseWeb.Graphql.HistoricalBalanceTypes do
 
   input_object :historical_balance_selector do
     field(:infrastructure, non_null(:string))
-    field(:address, non_null(:string))
     field(:currency, :string)
     field(:contract, :string)
+    field(:slug, :string)
   end
 
   object :miners_balance do

--- a/test/sanbase_web/graphql/clickhouse/historical_balance/historical_balances_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/historical_balance/historical_balances_test.exs
@@ -250,7 +250,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
              assert error["message"] =~
                       "Can't fetch Historical Balances for project with slug: someid1"
            end) =~
-             "{:missing_contract, \\\"Can't find contract address of project with slug: someid1\\\"}"
+             "Can't find contract address of project with slug: someid1"
   end
 
   test "historical balances when clickhouse returns error", context do

--- a/test/sanbase_web/graphql/clickhouse/historical_balance/historical_balances_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/historical_balance/historical_balances_test.exs
@@ -34,6 +34,61 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
     ]
   end
 
+  test "all infrastructures are supported", context do
+    selectors = [
+      %{infrastructure: "ETH"},
+      %{infrastructure: "ETH", slug: "ethereum"},
+      %{infrastructure: "ETH", slug: context.project_with_contract.slug},
+      %{infrastructure: "BTC"},
+      %{infrastructure: "LTC"},
+      %{infrastructure: "BCH"},
+      %{infrastructure: "BNB"},
+      %{infrastructure: "BNB", slug: "binance-coin"},
+      %{infrastructure: "XRP"},
+      %{infrastructure: "XRP", currency: "BTC"},
+      %{infrastructure: "EOS"},
+      %{infrastructure: "EOS", slug: "eos"}
+    ]
+
+    dt1 = ~U[2019-01-01 00:00:00Z]
+    dt2 = ~U[2019-01-02 00:00:00Z]
+    dt3 = ~U[2019-01-03 00:00:00Z]
+    dt4 = ~U[2019-01-04 00:00:00Z]
+
+    with_mock(Sanbase.ClickhouseRepo,
+      query: fn _, _ ->
+        {:ok,
+         %{
+           rows: [
+             [dt1 |> DateTime.to_unix(), :math.pow(10, 18) * 2000, 1],
+             [dt2 |> DateTime.to_unix(), 0, 0],
+             [dt3 |> DateTime.to_unix(), 0, 0],
+             [dt4 |> DateTime.to_unix(), :math.pow(10, 18) * 1800, 1]
+           ]
+         }}
+      end
+    ) do
+      from = dt1
+      to = dt4
+      selector = %{infrastructure: "ETH", slug: "ethereum"}
+
+      for selector <- selectors do
+        query = historical_balances_query(selector, context.address, from, to, "1d")
+
+        result =
+          context.conn
+          |> post("/graphql", query_skeleton(query, "historicalBalance"))
+          |> json_response(200)
+
+        refute Map.has_key?(result, "errors")
+        assert Map.has_key?(result, "data")
+
+        historical_balance = result["data"]["historicalBalance"]
+        assert length(historical_balance) == 4
+      end
+    end
+  end
+
   test "historical balances when interval is bigger than balances values interval", context do
     dt1 = DateTimeUtils.from_iso8601!("2017-05-11T00:00:00Z") |> DateTime.to_unix()
     dt2 = DateTimeUtils.from_iso8601!("2017-05-12T00:00:00Z") |> DateTime.to_unix()
@@ -194,16 +249,16 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
         {:ok,
          %{
            rows: [
-             [{{2017, 05, 11}, {0, 0, 0}}, 0, 1],
-             [{{2017, 05, 12}, {0, 0, 0}}, 0, 1],
-             [{{2017, 05, 13}, {0, 0, 0}}, :math.pow(10, 18) * 2000, 1],
-             [{{2017, 05, 14}, {0, 0, 0}}, :math.pow(10, 18) * 1800, 1],
-             [{{2017, 05, 15}, {0, 0, 0}}, 0, 0],
-             [{{2017, 05, 16}, {0, 0, 0}}, :math.pow(10, 18) * 1500, 1],
-             [{{2017, 05, 17}, {0, 0, 0}}, :math.pow(10, 18) * 1900, 1],
-             [{{2017, 05, 18}, {0, 0, 0}}, :math.pow(10, 18) * 1000, 1],
-             [{{2017, 05, 19}, {0, 0, 0}}, 0, 0],
-             [{{2017, 05, 20}, {0, 0, 0}}, 0, 0]
+             [~U[2017-05-11 00:00:00Z] |> DateTime.to_unix(), 0, 1],
+             [~U[2017-05-12 00:00:00Z] |> DateTime.to_unix(), 0, 1],
+             [~U[2017-05-13 00:00:00Z] |> DateTime.to_unix(), :math.pow(10, 18) * 2000, 1],
+             [~U[2017-05-14 00:00:00Z] |> DateTime.to_unix(), :math.pow(10, 18) * 1800, 1],
+             [~U[2017-05-15 00:00:00Z] |> DateTime.to_unix(), 0, 0],
+             [~U[2017-05-16 00:00:00Z] |> DateTime.to_unix(), :math.pow(10, 18) * 1500, 1],
+             [~U[2017-05-17 00:00:00Z] |> DateTime.to_unix(), :math.pow(10, 18) * 1900, 1],
+             [~U[2017-05-18 00:00:00Z] |> DateTime.to_unix(), :math.pow(10, 18) * 1000, 1],
+             [~U[2017-05-19 00:00:00Z] |> DateTime.to_unix(), 0, 0],
+             [~U[2017-05-20 00:00:00Z] |> DateTime.to_unix(), 0, 0]
            ]
          }}
       end do
@@ -252,21 +307,23 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
         context.interval
       )
 
-    assert capture_log(fn ->
-             result =
-               context.conn
-               |> post("/graphql", query_skeleton(query, "historicalBalance"))
-               |> json_response(200)
+    log =
+      capture_log(fn ->
+        result =
+          context.conn
+          |> post("/graphql", query_skeleton(query, "historicalBalance"))
+          |> json_response(200)
 
-             historical_balance = result["data"]["historicalBalance"]
-             assert historical_balance == nil
+        historical_balance = result["data"]["historicalBalance"]
+        assert historical_balance == nil
 
-             error = result["errors"] |> List.first()
+        error = result["errors"] |> List.first()
 
-             assert error["message"] =~
-                      "Can't fetch Historical Balances for selector: #{inspect(selector)}"
-           end) =~
-             "Can't find contract address of project with slug: someid1"
+        assert error["message"] =~
+                 "Can't fetch Historical Balances for selector: #{inspect(selector)}"
+      end)
+
+    assert log =~ "Can't find contract address of project with slug: someid1"
   end
 
   test "historical balances when clickhouse returns error", context do


### PR DESCRIPTION
#### Summary
- Drop non null requirements for `slug` in the historical balance API
- Add `selector` input object where `infrastructure` is mandatory (EOS, XRP, ETH, BTC, BCH, LTC or BNB).
-- For XRP `currency` is needed to specify what's the target. If not provided `XRP` is the default. Supported are `XRP`, `BTC`, etc.
-- For ETH, EOS, BNB `slug` is needed. It defaults to ethereum, eos and binance-coin (the native coins)
-- For BTC, BCH and LTC nothing else is needed as there are no tokens on the chain.
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

#### Screenshots
Fetching Bitcoin balance:
<img width="1057" alt="image" src="https://user-images.githubusercontent.com/6518376/69641060-2b75b900-1068-11ea-8416-745a01e93cb0.png">

Fetching Ripple needs an additional `currency` param: 
<img width="1046" alt="image" src="https://user-images.githubusercontent.com/6518376/69641212-77286280-1068-11ea-83f8-26fd9fd9fb99.png">

Fetching Eos/Ethereum needs an additional slug parameter:
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/6518376/69641266-932c0400-1068-11ea-8f25-14e4b9580c50.png">


<!-- (if appropriate) -->
