### PR TITLE
Fix the public name of mvrv_usd_long_short_diff as it is used in a sansheets already

### DIFF
--- a/lib/sanbase/clickhouse/metric/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/available_v2_metrics.json
@@ -233,7 +233,7 @@
 
   {
     "human_readable_name": "MVRV Long/Short Difference",
-    "name": "mvrv_usd_long_short_diff",
+    "name": "mvrv_long_short_diff_usd",
     "metric": "mvrv_usd_long_short_diff",
     "version": "2019-01-01",
     "access": "restricted",

--- a/test/sanbase/billing/access_level_test.exs
+++ b/test/sanbase/billing/access_level_test.exs
@@ -173,7 +173,7 @@ defmodule Sanbase.Billing.AccessLevelTest do
       "mean_realized_price_usd_30d",
       "mean_realized_price_usd_7d",
       "mean_realized_price_usd_1d",
-      "mvrv_usd_long_short_diff",
+      "mvrv_long_short_diff_usd",
       "mvrv_usd",
       "mvrv_usd_10y",
       "mvrv_usd_5y",

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -184,7 +184,7 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
         "mean_realized_price_usd_30d",
         "mean_realized_price_usd_7d",
         "mean_realized_price_usd_1d",
-        "mvrv_usd_long_short_diff",
+        "mvrv_long_short_diff_usd",
         "mvrv_usd",
         "mvrv_usd_10y",
         "mvrv_usd_5y",


### PR DESCRIPTION
#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
