### PR TITLE
Fix assets held by address when contract address has capital letters

### DIFF
--- a/lib/sanbase/clickhouse/historical_balance/fetchers/erc20_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/fetchers/erc20_balance.ex
@@ -37,7 +37,9 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20Balance do
 
         result =
           Enum.map(contract_value_pairs, fn [contract, value] ->
-            case Enum.find(projects, &match?(%_{main_contract_address: ^contract}, &1)) do
+            case Enum.find(projects, fn %{main_contract_address: project_contract} ->
+                   String.downcase(project_contract) == contract
+                 end) do
               nil ->
                 nil
 

--- a/lib/sanbase/model/project/list/list.ex
+++ b/lib/sanbase/model/project/list/list.ex
@@ -349,6 +349,17 @@ defmodule Sanbase.Model.Project.List do
   """
   def by_field(values, field, opts \\ [])
 
+  # NOTE: This should be handled in more places. Ultimate solution would be to use
+  # the citext type for such fields
+  @case_insensitive_fields [:main_contract_address]
+  def by_field(values, field, opts) when is_list(values) and field in @case_insensitive_fields do
+    values = Enum.map(values, &String.downcase/1)
+
+    projects_query(opts)
+    |> where([p], fragment("LOWER(?)", field(p, ^field)) in ^values)
+    |> Repo.all()
+  end
+
   def by_field(values, field, opts) when is_list(values) do
     projects_query(opts)
     |> where([p], field(p, ^field) in ^values)


### PR DESCRIPTION
The check in by_field function does not work well when the casing of
contract addresses is different

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
