### PR TITLE
Add include_incomplete_data bool flag to the getMetric API

### DIFF
--- a/lib/sanbase/clickhouse/github/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/github/metric_adapter.ex
@@ -24,6 +24,9 @@ defmodule Sanbase.Clickhouse.Github.MetricAdapter do
   @restricted_metrics []
 
   @impl Sanbase.Metric.Behaviour
+  def has_incomplete_data?(_), do: false
+
+  @impl Sanbase.Metric.Behaviour
   def timeseries_data(metric, slug, from, to, interval, _aggregation) do
     case Project.github_organizations(slug) do
       {:ok, organizations} ->

--- a/lib/sanbase/clickhouse/metric/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/available_v2_metrics.json
@@ -8,6 +8,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -19,6 +20,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -30,6 +32,7 @@
     "aggregation": "last",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -41,6 +44,7 @@
     "aggregation": "last",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -52,6 +56,7 @@
     "aggregation": "max",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -63,6 +68,7 @@
     "aggregation": "min",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -74,6 +80,7 @@
     "aggregation": "first",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -85,6 +92,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -96,6 +104,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -107,6 +116,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -118,6 +128,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -129,6 +140,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -140,6 +152,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -151,6 +164,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -162,6 +176,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -173,6 +188,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -184,6 +200,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -195,6 +212,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -206,6 +224,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -217,6 +236,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -228,6 +248,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
 
@@ -240,6 +261,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
 
@@ -252,6 +274,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -263,6 +286,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -274,6 +298,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -285,6 +310,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -296,6 +322,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -307,6 +334,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -318,6 +346,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -329,6 +358,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -340,6 +370,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -351,6 +382,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -362,6 +394,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -373,6 +406,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
 
@@ -385,6 +419,7 @@
     "aggregation": "sum",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -396,6 +431,7 @@
     "aggregation": "sum",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -407,6 +443,7 @@
     "aggregation": "sum",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -418,6 +455,7 @@
     "aggregation": "sum",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -429,6 +467,7 @@
     "aggregation": "sum",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -440,6 +479,7 @@
     "aggregation": "sum",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -451,6 +491,7 @@
     "aggregation": "sum",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -462,6 +503,7 @@
     "aggregation": "sum",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -473,6 +515,7 @@
     "aggregation": "sum",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -484,6 +527,7 @@
     "aggregation": "sum",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -495,6 +539,7 @@
     "aggregation": "sum",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -506,6 +551,7 @@
     "aggregation": "sum",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
 
@@ -518,6 +564,7 @@
     "aggregation": "last",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries",
     "unit": "days"
   },
@@ -531,6 +578,7 @@
     "aggregation": "last",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries",
     "unit": "days"
   },
@@ -544,6 +592,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -555,6 +604,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
 
@@ -567,6 +617,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -578,6 +629,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -589,6 +641,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -600,6 +653,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -611,6 +665,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -622,6 +677,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -633,6 +689,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -644,6 +701,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -655,6 +713,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -666,6 +725,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
 
@@ -678,6 +738,7 @@
     "aggregation": "last",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
 
@@ -690,6 +751,7 @@
     "aggregation": "sum",
     "min_interval": "5m",
     "table": "intraday_metrics",
+    "has_incomplete_data": false,
     "data_type": "timeseries"
   },
 
@@ -702,6 +764,7 @@
     "aggregation": "sum",
     "min_interval": "5m",
     "table": "intraday_metrics",
+    "has_incomplete_data": false,
     "data_type": "timeseries"
   },
   {
@@ -713,6 +776,7 @@
     "aggregation": "sum",
     "min_interval": "5m",
     "table": "intraday_metrics",
+    "has_incomplete_data": false,
     "data_type": "timeseries"
   },
   {
@@ -724,6 +788,7 @@
     "aggregation": "sum",
     "min_interval": "5m",
     "table": "intraday_metrics",
+    "has_incomplete_data": false,
     "data_type": "timeseries"
   },
 
@@ -736,6 +801,7 @@
     "aggregation": "sum",
     "min_interval": "5m",
     "table": "intraday_metrics",
+    "has_incomplete_data": false,
     "data_type": "timeseries"
   },
 
@@ -748,6 +814,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
 
@@ -760,6 +827,7 @@
     "aggregation": "avg",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": false,
     "data_type": "timeseries"
   },
 
@@ -772,6 +840,7 @@
     "aggregation": "sum",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -784,6 +853,7 @@
     "min_interval": "5m",
     "label": "The amount of tokens last moved between ${1} and ${2}",
     "table": "distribution_deltas_5min",
+    "has_incomplete_data": false,
     "data_type": "histogram"
   }
 ]

--- a/lib/sanbase/clickhouse/metric/file_handler.ex
+++ b/lib/sanbase/clickhouse/metric/file_handler.ex
@@ -51,6 +51,7 @@ defmodule Sanbase.Clickhouse.Metric.FileHandler do
   @human_readable_name_map Helper.name_to_field_map(@metrics_json, "human_readable_name")
   @metric_version_map Helper.name_to_field_map(@metrics_json, "version")
   @metrics_label_map Helper.name_to_field_map(@metrics_json, "label")
+  @incomplete_data_map Helper.name_to_field_map(@metrics_json, "has_incomplete_data")
 
   @metrics_list @metrics_json |> Enum.map(fn %{"name" => name} -> name end)
   @metrics_mapset MapSet.new(@metrics_list)
@@ -78,6 +79,7 @@ defmodule Sanbase.Clickhouse.Metric.FileHandler do
   def human_readable_name_map(), do: @human_readable_name_map
   def metric_version_map(), do: @metric_version_map
   def metrics_data_type_map(), do: @metrics_data_type_map
+  def incomplete_data_map(), do: @incomplete_data_map
 
   def metrics_label_map(), do: @metrics_label_map
 

--- a/lib/sanbase/clickhouse/metric/metric.ex
+++ b/lib/sanbase/clickhouse/metric/metric.ex
@@ -37,6 +37,7 @@ defmodule Sanbase.Clickhouse.Metric do
   @metrics_name_list (@histogram_metrics_name_list ++
                         @timeseries_metrics_name_list)
                      |> Enum.uniq()
+  @incomplete_data_map FileHandler.incomplete_data_map()
 
   @type slug :: String.t()
   @type metric :: String.t()
@@ -58,6 +59,9 @@ defmodule Sanbase.Clickhouse.Metric do
 
   @impl Sanbase.Metric.Behaviour
   def access_map(), do: @access_map
+
+  @impl Sanbase.Metric.Behaviour
+  def has_incomplete_data?(metric), do: Map.get(@incomplete_data_map, metric)
 
   @doc ~s"""
   Get a given metric for a slug and time range. The metric's aggregation

--- a/lib/sanbase/metric/behaviour.ex
+++ b/lib/sanbase/metric/behaviour.ex
@@ -56,6 +56,8 @@ defmodule Sanbase.Metric.Behaviour do
               opts :: options
             ) :: {:ok, list()} | {:error, String.t()}
 
+  @callback has_incomplete_data?(metric :: metric) :: true | false
+
   @callback first_datetime(metric, slug) ::
               {:ok, DateTime.t()} | {:error, String.t()}
 

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -50,6 +50,11 @@ defmodule Sanbase.Metric do
   @metric_module_mapping (@histogram_metric_module_mapping ++ @timeseries_metric_module_mapping)
                          |> Enum.uniq()
 
+  @metric_to_module_map @metric_module_mapping
+                        |> Enum.into(%{}, fn %{metric: metric, module: module} ->
+                          {metric, module}
+                        end)
+
   @access_map Enum.reduce(@access_map_acc, %{}, fn map, acc -> Map.merge(map, acc) end)
   @aggregation_arg_supported [nil] ++ @available_aggregations
 
@@ -66,6 +71,12 @@ defmodule Sanbase.Metric do
       true -> true
       false -> metric_not_available_error(metric)
     end
+  end
+
+  def has_incomplete_data?(metric) do
+    module = Map.get(@metric_to_module_map, metric)
+
+    module.has_incomplete_data?(metric)
   end
 
   @doc ~s"""

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -36,6 +36,9 @@ defmodule Sanbase.SocialData.MetricAdapter do
   @access_map Enum.reduce(@metrics, %{}, fn metric, acc -> Map.put(acc, metric, :restricted) end)
 
   @impl Sanbase.Metric.Behaviour
+  def has_incomplete_data?(_), do: false
+
+  @impl Sanbase.Metric.Behaviour
   def timeseries_data(metric, slug, from, to, interval, _aggregation)
       when metric in @social_volume_timeseries_metrics do
     [source, _] = String.split(metric, "_", parts: 2)

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -95,6 +95,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       arg(:to, non_null(:datetime))
       arg(:interval, :interval, default_value: "1d")
       arg(:aggregation, :aggregation, default_value: nil)
+      arg(:include_incomplete_data, :boolean, default_value: false)
 
       complexity(&Complexity.from_to_interval/3)
       middleware(AccessControl)

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -88,6 +88,24 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     @desc ~s"""
     Return a list of 'datetime' and 'value' for a given metric, slug
     and time period.
+
+    The 'includeIncompleteData' flag has a default value 'false'.
+
+    Some metrics may have incomplete data for the last data point (usually today)
+    as they are computed since the beginning of the day. An example is daily
+    active addresses for today - at 12:00pm it will contain the data only
+    for the last 12 hours, not for a whole day. This incomplete data can be
+    confusing so it is excluded by default. If this incomplete data is needed,
+    the flag includeIncompleteData should be set to 'true'.
+
+    Incomplete data can still be useful. Here are two examples:
+    Daily Active Addresses: The number is only going to increase during the day,
+    so if the intention is to see when they reach over a threhsold the incomplete
+    data gives more timely signal.
+
+    NVT: Due to the way it is computed, the value is only going to decrease
+    during the day, so if the intention is to see when it falls below a threhsold,
+    the incomplete gives more timely signal.
     """
     field :timeseries_data, list_of(:metric_data) do
       arg(:slug, non_null(:string))

--- a/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_include_incomplete_data_flag_test.exs
+++ b/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_include_incomplete_data_flag_test.exs
@@ -1,0 +1,106 @@
+defmodule Sanbase.Billing.ApiIncludeIncompleteDataFlagTest do
+  use SanbaseWeb.ConnCase
+
+  import Mock
+  import Sanbase.Factory
+  import SanbaseWeb.Graphql.TestHelpers
+
+  alias Sanbase.Auth.Apikey
+  alias Sanbase.Metric
+
+  @moduletag capture_log: true
+
+  setup_with_mocks([
+    {Metric, [:passthrough], [timeseries_data: fn _, _, _, _, _, _ -> metric_resp() end]}
+  ]) do
+    user = insert(:user)
+    insert(:subscription_premium, user: user)
+
+    project = insert(:random_erc20_project)
+
+    {:ok, apikey} = Apikey.generate_apikey(user)
+    conn = setup_apikey_auth(build_conn(), apikey)
+
+    [user: user, conn: conn, project: project]
+  end
+
+  test "incomplete data is not included when flag is false", context do
+    %{conn: conn, project: project} = context
+    to = Timex.now()
+    from = Timex.shift(to, days: -30)
+    beginning_of_day = Timex.beginning_of_day(to)
+    metric = "nvt"
+    interval = "1d"
+
+    query = metric_query(metric, project.slug, from, to, interval, false)
+    execute_query(conn, query, "getMetric")
+
+    refute called(Metric.timeseries_data(metric, project.slug, from, to, interval, :_))
+
+    assert called(
+             Metric.timeseries_data(metric, project.slug, from, beginning_of_day, interval, :_)
+           )
+  end
+
+  test "incomplete data is included when flag is true", context do
+    %{conn: conn, project: project} = context
+    to = Timex.now()
+    from = Timex.shift(to, days: -30)
+    beginning_of_day = Timex.beginning_of_day(to)
+    metric = "nvt"
+    interval = "1d"
+
+    query = metric_query(metric, project.slug, from, to, interval, true)
+    execute_query(conn, query, "getMetric")
+
+    assert called(Metric.timeseries_data(metric, project.slug, from, to, interval, :_))
+
+    refute called(
+             Metric.timeseries_data(metric, project.slug, from, beginning_of_day, interval, :_)
+           )
+  end
+
+  test "returns error if both from and to are today", context do
+    %{conn: conn, project: project} = context
+    beginning_of_day = Timex.beginning_of_day(Timex.now())
+    from = Timex.shift(beginning_of_day, hours: 5)
+    to = Timex.shift(beginning_of_day, hours: 10)
+    metric = "nvt"
+    interval = "1h"
+
+    query = metric_query(metric, project.slug, from, to, interval, false)
+
+    error_message = execute_query_with_error(conn, query, "getMetric")
+    assert error_message =~ "Can't fetch nvt"
+    assert error_message =~ "could have incomplete data"
+    assert error_message =~ "you can pass the flag `includeIncompleteData: true` "
+  end
+
+  # Private functions
+
+  defp metric_query(metric, slug, from, to, interval, include_incomplete_data) do
+    """
+      {
+        getMetric(metric: "#{metric}") {
+          timeseriesData(
+            slug: "#{slug}"
+            from: "#{from}"
+            to: "#{to}"
+            interval: "#{interval}"
+            includeIncompleteData: #{include_incomplete_data}){
+              datetime
+              value
+          }
+        }
+      }
+    """
+  end
+
+  defp metric_resp() do
+    {:ok,
+     [
+       %{value: 10.0, datetime: ~U[2019-01-01 00:00:00Z]},
+       %{value: 20.0, datetime: ~U[2019-01-02 00:00:00Z]}
+     ]}
+  end
+end

--- a/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_product_access_test.exs
+++ b/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_product_access_test.exs
@@ -372,9 +372,14 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
     """
       {
         getMetric(metric: "#{metric}") {
-          timeseriesData(slug: "#{slug}", from: "#{from}", to: "#{to}", interval: "30d"){
-            datetime
-            value
+          timeseriesData(
+            slug: "#{slug}"
+            from: "#{from}"
+            to: "#{to}"
+            interval: "30d"
+            includeIncompleteData: true){
+              datetime
+              value
           }
         }
       }

--- a/test/sanbase_web/graphql/billing/timeframe_access_restrictions/sanbase_product_access_test.exs
+++ b/test/sanbase_web/graphql/billing/timeframe_access_restrictions/sanbase_product_access_test.exs
@@ -360,9 +360,14 @@ defmodule Sanbase.Billing.SanbaseProductAccessTest do
     """
       {
         getMetric(metric: "#{metric}") {
-          timeseriesData(slug: "#{slug}", from: "#{from}", to: "#{to}", interval: "30d"){
-            datetime
-            value
+          timeseriesData(
+            slug: "#{slug}"
+            from: "#{from}"
+            to: "#{to}"
+            interval: "30d"
+            includeIncompleteData: true){
+              datetime
+              value
           }
         }
       }

--- a/test/sanbase_web/graphql/clickhouse/nvt_api_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/nvt_api_test.exs
@@ -92,7 +92,7 @@ defmodule SanbaseWeb.Graphql.NVTApiTest do
   test "returns error to the user when calculation errors", context do
     error = "Some error description here"
 
-    with_mock Sanbase.Metric,
+    with_mock Sanbase.Metric, [:passthrough],
       timeseries_data: fn _, _, _, _, _, _ -> {:error, error} end do
       log =
         capture_log(fn ->
@@ -107,7 +107,8 @@ defmodule SanbaseWeb.Graphql.NVTApiTest do
   end
 
   test "uses 1d as default interval", context do
-    with_mock Sanbase.Metric, timeseries_data: fn _, _, _, _, _, _ -> {:ok, []} end do
+    with_mock Sanbase.Metric, [:passthrough],
+      timeseries_data: fn _, _, _, _, _, _ -> {:ok, []} end do
       query = """
         {
           nvtRatio(slug: "#{context.slug}", from: "#{context.from}", to: "#{context.to}"){


### PR DESCRIPTION
#### Summary
Some of our metrics are computed every 6 hours but are computing the data since the beginning of the day. This means that metrics like `daily_active_addresses` can have a misleading value for today as the day is not completed. In this case the addresses count could seem lower than expected.

We're introducing a flag in the `timeseriesData` field of `getMetric` called `includeIncompleteData` which has a default value of `false`. This flag is used to determine whether or not to include data for the last day.

**NOTE**: This changes the default behaviour. The flag has a default value of `false` whereas the previous behaviour was such as if the flag was set to `true` (which was causing issues to some users that closesly follow the last value)

### Example:
If both `from` and `to` are today and the flag is `false` - return error:

Request:
```graphql
{
  getMetric(metric: "daily_active_addresses") {
    timeseriesData(
      slug: "santiment",
      from: "2020-01-13T00:00:00Z",
      to: "2020-01-13T15:00:00Z",
      interval: "1d",
    	includeIncompleteData: false) {
        datetime
        value
    }
  }
}
```
Response:
```json
{
  "data": {
    "getMetric": {
      "timeseriesData": null
    }
  },
  "errors": [
    {
      "locations": [
        {
          "column": 5,
          "line": 3
        }
      ],
      "message": "[80ea2a49-18bb-4648-9bf6-954eac170c0d] Can't fetch daily_active_addresses for project with slug: santiment, Reason: \"The time range provided [2020-01-13 00:00:00Z - 2020-01-13 15:00:00Z] is contained in today. The metric\\nrequested could have incomplete data as it's calculated since the beginning\\nof the day and not for the last 24 hours. If you still want to see this\\ndata you can pass the flag `includeIncompleteData: true` in the\\n`timeseriesData` arguments\\n\"",
      "path": [
        "getMetric",
        "timeseriesData"
      ]
    }
  ]
}
```

### Example:
If at least `from` is before today (beginning of day) the data for today will not be returned.

### Example:
If the flag is `true` the data will be returned as is. Incomplete data can still be useful:
- Daily Active Addresses are only going to increase during the day. You can use incomplete data if you want to monitor the number of addresses going over a threhsold.
- NVT using circulation will only decrease during the day. You can use incomplete data if you want to monitor the NVT going below a given threhsold. (It is going to decrease as we're dividing by 1 day circulation which is only increasing as the day progresses)
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
