### PR TITLE
Add price data to the getMetric API

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -51,7 +51,8 @@ alias Sanbase.{
   DateTimeUtils,
   ApplicationUtils,
   Parallel,
-  MandrillApi
+  MandrillApi,
+  Price
 }
 
 alias Sanbase.InternalServices.{

--- a/lib/sanbase/insight/comment/comment.ex
+++ b/lib/sanbase/insight/comment/comment.ex
@@ -237,10 +237,8 @@ defmodule Sanbase.Insight.Comment do
     |> Ecto.Multi.run(
       :update_subcomments_count,
       fn %{create_new_comment: %__MODULE__{root_parent_id: root_id}} ->
-        case update_subcomments_counts(root_id) do
-          :ok -> {:ok, "Updated all subcomment counts in the tree"}
-          _ -> {:error, "Failed to update all subcomment counts in the tree"}
-        end
+        :ok = update_subcomments_counts(root_id)
+        {:ok, "Updated all subcomment counts in the tree"}
       end
     )
   end

--- a/lib/sanbase/intercom/intercom.ex
+++ b/lib/sanbase/intercom/intercom.ex
@@ -126,17 +126,13 @@ defmodule Sanbase.Intercom do
 
     Stripe.Customer.retrieve(stripe_customer_id)
     |> case do
-      {:ok, customer} ->
-        if not is_nil(customer.subscriptions) and customer.subscriptions.object == "list" do
-          customer.subscriptions.data
-          |> Enum.filter(&(&1.plan.product == sanbase_product_stripe_id))
-          |> Enum.max_by(& &1.created, fn -> nil end)
-          |> case do
-            nil -> {nil, nil}
-            subscription -> {subscription.status, format_dt(subscription.trial_start)}
-          end
-        else
-          {nil, nil}
+      {:ok, %{subscriptions: %{object: "list", data: data}}} when is_list(data) ->
+        data
+        |> Enum.filter(&(&1.plan.product == sanbase_product_stripe_id))
+        |> Enum.max_by(& &1.created, fn -> nil end)
+        |> case do
+          nil -> {nil, nil}
+          subscription -> {subscription.status, format_dt(subscription.trial_start)}
         end
 
       _ ->

--- a/lib/sanbase/metric/behaviour.ex
+++ b/lib/sanbase/metric/behaviour.ex
@@ -3,9 +3,9 @@ defmodule Sanbase.Metric.Behaviour do
   Behaviour describing a metric fetcher
   """
 
-  @type interval :: String.t()
-  @type metric :: String.t()
   @type slug :: String.t()
+  @type metric :: String.t() | Atom.t()
+  @type interval :: String.t()
   @type options :: Keyword.t()
   @type available_data_types :: :timeseries | :histogram
 

--- a/lib/sanbase/metric/behaviour.ex
+++ b/lib/sanbase/metric/behaviour.ex
@@ -4,7 +4,7 @@ defmodule Sanbase.Metric.Behaviour do
   """
 
   @type slug :: String.t()
-  @type metric :: String.t() | Atom.t()
+  @type metric :: String.t()
   @type interval :: String.t()
   @type options :: Keyword.t()
   @type available_data_types :: :timeseries | :histogram

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -12,7 +12,8 @@ defmodule Sanbase.Metric do
   @metric_modules [
     Clickhouse.Github.MetricAdapter,
     Clickhouse.Metric,
-    Sanbase.SocialData.MetricAdapter
+    Sanbase.SocialData.MetricAdapter,
+    Sanbase.Price.MetricAdapter
   ]
 
   Module.register_attribute(__MODULE__, :available_aggregations_acc, accumulate: true)

--- a/lib/sanbase/model/ico.ex
+++ b/lib/sanbase/model/ico.ex
@@ -107,7 +107,7 @@ defmodule Sanbase.Model.Ico do
   # Private functions
 
   defp funds_raised_ico_end_price_from_currencies(
-         project,
+         _project,
          %Ico{} = ico,
          target_currency,
          date

--- a/lib/sanbase/prices/metric_adapter.ex
+++ b/lib/sanbase/prices/metric_adapter.ex
@@ -4,20 +4,16 @@ defmodule Sanbase.Price.MetricAdapter do
 
   @aggregations [:any, :sum, :avg, :min, :max, :last, :first, :median]
 
-  @timeseries_metrics_argument_mapping %{
-    "price_usd" => :price_usd,
-    "price_btc" => :price_btc,
-    "volume_usd" => :volume_usd,
-    "marketcap_usd" => :marketcap_usd
-  }
-
-  @timeseries_metrics Map.keys(@timeseries_metrics_argument_mapping)
+  @timeseries_metrics ["price_usd", "price_btc", "volume_usd", "marketcap_usd"]
   @histogram_metrics []
 
   @metrics @histogram_metrics ++ @timeseries_metrics
 
-  @free_metrics @metrics
-  @restricted_metrics []
+  @access_map Enum.into(@metrics, %{}, fn metric -> {metric, :free} end)
+
+  @free_metrics Enum.filter(@access_map, fn {_, level} -> level == :free end) |> Keyword.keys()
+  @restricted_metrics Enum.filter(@access_map, fn {_, level} -> level == :restricted end)
+                      |> Keyword.keys()
 
   @impl Sanbase.Metric.Behaviour
   def has_incomplete_data?(_), do: false
@@ -90,12 +86,5 @@ defmodule Sanbase.Price.MetricAdapter do
   def restricted_metrics(), do: @restricted_metrics
 
   @impl Sanbase.Metric.Behaviour
-  def access_map() do
-    %{
-      "price_usd" => :free,
-      "price_btc" => :free,
-      "marketcap_usd" => :free,
-      "volume_usd" => :free
-    }
-  end
+  def access_map(), do: @access_map
 end

--- a/lib/sanbase/prices/metric_adapter.ex
+++ b/lib/sanbase/prices/metric_adapter.ex
@@ -1,0 +1,101 @@
+defmodule Sanbase.Price.MetricAdapter do
+  @behaviour Sanbase.Metric.Behaviour
+  alias Sanbase.Price
+
+  @aggregations [:any, :sum, :avg, :min, :max, :last, :first, :median]
+
+  @timeseries_metrics_argument_mapping %{
+    "price_usd" => :price_usd,
+    "price_btc" => :price_btc,
+    "volume_usd" => :volume_usd,
+    "marketcap_usd" => :marketcap_usd
+  }
+
+  @timeseries_metrics Map.keys(@timeseries_metrics_argument_mapping)
+  @histogram_metrics []
+
+  @metrics @histogram_metrics ++ @timeseries_metrics
+
+  @free_metrics @metrics
+  @restricted_metrics []
+
+  @impl Sanbase.Metric.Behaviour
+  def has_incomplete_data?(_), do: false
+
+  @impl Sanbase.Metric.Behaviour
+  def timeseries_data(metric, slug, from, to, interval, aggregation) do
+    Price.timeseries_metric_data(slug, metric, from, to, interval, aggregation: aggregation)
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def aggregated_timeseries_data(metric, slug, from, to, aggregation) do
+    Price.aggregated_metric_timeseries_data(slug, metric, from, to, aggregation: aggregation)
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def first_datetime(_metric, slug) do
+    Price.first_datetime(slug)
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def metadata(metric) do
+    {:ok,
+     %{
+       metric: metric,
+       min_interval: "5m",
+       default_aggregation: :last,
+       available_aggregations: @aggregations,
+       data_type: :timeseries
+     }}
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def human_readable_name(metric) do
+    case metric do
+      "price_usd" -> {:ok, "Price in USD"}
+      "price_btc" -> {:ok, "Price in BTC"}
+      "marketcap_usd" -> {:ok, "Marketcap in USD"}
+      "volume_usd" -> {:ok, "Volume in USd"}
+    end
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def available_aggregations(), do: @aggregations
+
+  @impl Sanbase.Metric.Behaviour
+  def available_timeseries_metrics(), do: @timeseries_metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def available_histogram_metrics(), do: @histogram_metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def available_metrics(), do: @metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def available_slugs() do
+    Sanbase.Cache.get_or_store({:slugs_with_prices, 1800}, fn ->
+      Price.available_slugs()
+    end)
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def available_slugs(metric) when metric in @metrics do
+    available_slugs()
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def free_metrics(), do: @free_metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def restricted_metrics(), do: @restricted_metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def access_map() do
+    %{
+      "price_usd" => :free,
+      "price_btc" => :free,
+      "marketcap_usd" => :free,
+      "volume_usd" => :free
+    }
+  end
+end

--- a/lib/sanbase/prices/price.ex
+++ b/lib/sanbase/prices/price.ex
@@ -9,9 +9,10 @@ defmodule Sanbase.Price do
 
   @default_source "coinmarketcap"
   @metrics [:price_usd, :price_btc, :marketcap_usd, :volume_usd]
+  @metrics @metrics ++ Enum.map(@metrics, &Atom.to_string/1)
   @aggregations aggregations()
-  @type metric :: :price_usd | :price_btc | :marketcap_usd | :volume_usd
 
+  @type metric :: String.t() | Atom.t()
   @type error :: String.t()
   @type slug :: String.t()
   @type slugs :: list(slug)

--- a/lib/sanbase/prices/price.ex
+++ b/lib/sanbase/prices/price.ex
@@ -31,6 +31,14 @@ defmodule Sanbase.Price do
 
   @type timeseries_data_result :: {:ok, list(timeseries_data_map())} | {:error, error()}
 
+  @type timeseries_metric_data_map :: %{
+          datetime: DateTime.t(),
+          value: float() | nil
+        }
+
+  @type timeseries_metric_data_result ::
+          {:ok, list(timeseries_metric_data_map())} | {:error, error()}
+
   @type aggregated_metric_timeseries_data_map :: %{
           String.t() => float()
         }
@@ -118,8 +126,9 @@ defmodule Sanbase.Price do
   end
 
   def timeseries_data(slug, from, to, interval, opts) when is_binary(slug) do
-    source = Keyword.get(opts, :source, @default_source)
-    {query, args} = timeseries_data_query(slug, from, to, interval, source)
+    source = Keyword.get(opts, :source) || @default_source
+    aggregation = Keyword.get(opts, :aggregation) || :last
+    {query, args} = timeseries_data_query(slug, from, to, interval, source, aggregation)
 
     ClickhouseRepo.query_transform(
       query,
@@ -139,6 +148,54 @@ defmodule Sanbase.Price do
       end
     )
     |> remove_missing_values()
+  end
+
+  @doc ~s"""
+  Return timeseries data for the given time period where every point consists
+  of price in USD, price in BTC, marketcap in USD and volume in USD
+  """
+  @spec timeseries_metric_data(slug, metric, DateTime.t(), DateTime.t(), interval, opts) ::
+          timeseries_metric_data_result
+  def timeseries_metric_data(slug, metric, from, to, interval, opts \\ [])
+
+  def timeseries_metric_data("TOTAL_ERC20", metric, from, to, interval, opts) do
+    Project.List.erc20_projects_slugs()
+    |> combined_marketcap_and_volume(from, to, interval, opts)
+    |> case do
+      {:ok, result} ->
+        metric = String.to_existing_atom(metric)
+
+        result =
+          result
+          |> Enum.map(fn %{^metric => value, datetime: datetime} ->
+            %{datetime: datetime, value: value}
+          end)
+
+        {:ok, result}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  def timeseries_metric_data(slug, metric, from, to, interval, opts) when is_binary(slug) do
+    source = Keyword.get(opts, :source) || @default_source
+    aggregation = Keyword.get(opts, :aggregation) || :last
+
+    {query, args} =
+      timeseries_metric_data_query(slug, metric, from, to, interval, source, aggregation)
+
+    ClickhouseRepo.query_transform(
+      query,
+      args,
+      fn
+        [timestamp, value] ->
+          %{
+            datetime: DateTime.from_unix!(timestamp),
+            value: value
+          }
+      end
+    )
   end
 
   @doc ~s"""
@@ -199,10 +256,12 @@ defmodule Sanbase.Price do
 
   def aggregated_metric_timeseries_data(slug_or_slugs, metric, from, to, opts)
       when metric in @metrics and (is_binary(slug_or_slugs) or is_list(slug_or_slugs)) do
-    source = Keyword.get(opts, :source, @default_source)
+    source = Keyword.get(opts, :source) || @default_source
+    aggregation = Keyword.get(opts, :aggregation) || :avg
     slugs = List.wrap(slug_or_slugs)
 
-    {query, args} = aggregated_metric_timeseries_data_query(slugs, metric, from, to, source, opts)
+    {query, args} =
+      aggregated_metric_timeseries_data_query(slugs, metric, from, to, source, aggregation)
 
     ClickhouseRepo.query_reduce(query, args, %{}, fn
       [slug, value, has_changed], acc ->
@@ -378,6 +437,23 @@ defmodule Sanbase.Price do
     )
     |> remove_missing_values()
     |> maybe_add_percent_of_total_marketcap()
+  end
+
+  def available_slugs(opts \\ [])
+
+  def available_slugs(opts) do
+    case Keyword.get(opts, :source) || @default_source do
+      "coinmarketcap" ->
+        slugs =
+          Sanbase.Model.Project.List.projects_with_source("coinmarketcap")
+          |> Enum.map(& &1.slug)
+
+        {:ok, slugs}
+
+      source ->
+        {query, args} = available_slugs_query(source)
+        ClickhouseRepo.query_transform(query, args, fn [slug] -> slug end)
+    end
   end
 
   def slugs_with_volume_over(volume, opts \\ [])

--- a/lib/sanbase/user_lists/monitor.ex
+++ b/lib/sanbase/user_lists/monitor.ex
@@ -9,7 +9,7 @@ defmodule Sanbase.UserList.Monitor do
   import Ecto.Query
 
   alias Sanbase.UserList
-  alias Sanbase.Auth.{User, UserRole, Role}
+  alias Sanbase.Auth.User
   alias Sanbase.Insight.Post
   alias Sanbase.Repo
 
@@ -205,12 +205,4 @@ defmodule Sanbase.UserList.Monitor do
   end
 
   defp week_ago(now), do: Timex.shift(now, days: -7)
-
-  defp san_family_ids() do
-    from(ur in UserRole,
-      where: ur.role_id == ^Role.san_family_role_id(),
-      select: ur.user_id
-    )
-    |> Repo.all()
-  end
 end

--- a/test/sanbase/billing/access_level_test.exs
+++ b/test/sanbase/billing/access_level_test.exs
@@ -109,7 +109,11 @@ defmodule Sanbase.Billing.AccessLevelTest do
         "daily_opening_price_usd",
         "daily_trading_volume_usd",
         "dev_activity",
-        "github_activity"
+        "github_activity",
+        "marketcap_usd",
+        "price_btc",
+        "price_usd",
+        "volume_usd"
       ]
       |> Enum.sort()
 

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -110,7 +110,11 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           "daily_opening_price_usd",
           "daily_trading_volume_usd",
           "dev_activity",
-          "github_activity"
+          "github_activity",
+          "marketcap_usd",
+          "price_btc",
+          "price_usd",
+          "volume_usd"
         ]
         |> Enum.sort()
 

--- a/test/sanbase/metric/metric_test.exs
+++ b/test/sanbase/metric/metric_test.exs
@@ -21,7 +21,8 @@ defmodule Sanbase.MetricTest do
     {Sanbase.Clickhouse.Github.MetricAdapter, [],
      timeseries_data: fn _, _, _, _, _, _ -> {:ok, @resp} end},
     {Sanbase.SocialData.MetricAdapter, [],
-     timeseries_data: fn _, _, _, _, _, _ -> {:ok, @resp} end}
+     timeseries_data: fn _, _, _, _, _, _ -> {:ok, @resp} end},
+    {Sanbase.Price.MetricAdapter, [], timeseries_data: fn _, _, _, _, _, _ -> {:ok, @resp} end}
   ]) do
     []
   end


### PR DESCRIPTION
#### Summary
Adding the following metrics to the getMetric API:
- price_usd
- price_btc
- volume_usd
- marketcap_usd

So now fetching USD price can look like:
```graphql
{
  getMetric(metric: "price_usd"){
    timeseriesData(
      slug: "santiment"
      from: "2020-01-07T00:00:00Z"
      to: "2020-01-08T00:00:00Z"
      aggregation: LAST) {
        datetime
        value
    }
  }
}
```

This API also allows you to control the way the data is aggregated. In historyPrice this aggregations was not explicit and obvious.
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
