### PR TITLE
Rework metric signal

### DIFF
--- a/config/scheduler_config.exs
+++ b/config/scheduler_config.exs
@@ -46,7 +46,7 @@ config :sanbase, Sanbase.Signals.Scheduler,
       task: {Sanbase.Signal.Scheduler, :run_signal, [Trigger.TrendingWordsTriggerSettings]}
     ],
     metric_signal: [
-      schedule: "0 3 * * *",
+      schedule: "5-59/5 * * * *",
       task: {Sanbase.Signal.Scheduler, :run_signal, [Trigger.MetricTriggerSettings]}
     ]
   ]

--- a/docs/user-triggers-api.md
+++ b/docs/user-triggers-api.md
@@ -514,19 +514,39 @@ these are the tickers of the projects. Supported currencies are: `XRP`, `BTC`, `
 
 #### Example settings structure for `metric_signal`
 
+Supported metrics are all metrics obtainable by the getMetric API that have
+a min interval at most 5 minutes. These metrics are:
+
+##### Price data
+
+- "price_usd", "price_btc", "volume_usd", "marketcap_usd"
+
+##### Social data
+
+"telegram_social_dominance", "reddit_social_dominance", "discord_social_dominance", "telegram_social_volume", "discord_social_volume"
+
+##### On-chain data
+
+- "transaction_volume", "exchange_balance", "exchange_inflow", "exchange_outflow", "age_destroyed"
+
+##### Github data
+
+- "dev_activity", "github_activity"
+
 ```json
-// The MVRV of Santiment's project is above 2
+// The transaction volume of Santiment's project is above 1,000,000
 {
   "type": "metric_signal",
-  "metric": "mvrv_usd",
+  "metric": "transaction_volume",
+  "time_window": "1d",
   "channel": "telegram",
   "target": { "slug": "santiment" },
-  "operation": { "above": 2 }
+  "operation": { "above": 1000000 }
 }
 ```
 
 ```json
-// The Circulation of Santiment's tokens increased by 10% compared to 1 day ago
+// The price of Santiment's tokens increased by 10% compared to 1 day ago
 {
   "type": "metric_signal",
   "metric": "circulation_1d",

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -218,7 +218,27 @@ defmodule Sanbase.Metric do
   @doc ~s"""
   Get all available metrics
   """
-  def available_metrics(), do: @metrics
+  def available_metrics(opts \\ [])
+
+  def available_metrics(opts) do
+    case Keyword.get(opts, :min_interval_less_or_equal) do
+      nil ->
+        @metrics
+
+      interval ->
+        interval_to_sec = Sanbase.DateTimeUtils.str_to_sec(interval)
+
+        @metrics
+        |> Enum.filter(fn metric ->
+          {:ok, %{min_interval: min_interval}} = metadata(metric)
+
+          case Sanbase.DateTimeUtils.str_to_sec(min_interval) do
+            seconds when seconds <= interval_to_sec -> true
+            _ -> false
+          end
+        end)
+    end
+  end
 
   def available_timeseries_metrics(), do: @timeseries_metrics
 

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -216,7 +216,11 @@ defmodule Sanbase.Metric do
   def available_aggregations(), do: @available_aggregations
 
   @doc ~s"""
-  Get all available metrics
+  Get all available metrics.
+
+  Available options:
+  - min_interval_less_or_equal - return all metrics with min interval that is
+  less or equal than a given amount (expessed as a string - 5m, 1h, etc.)
   """
   def available_metrics(opts \\ [])
 

--- a/lib/sanbase/signals/trigger/settings/metric_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/metric_trigger_settings.ex
@@ -30,6 +30,7 @@ defmodule Sanbase.Signal.Trigger.MetricTriggerSettings do
             filtered_target: %{list: []}
 
   validates(:metric, &valid_metric?/1)
+  validates(:metric, &valid_5m_min_interval_metric?/1)
   validates(:target, &valid_target?/1)
   validates(:channel, &valid_notification_channel?/1)
   validates(:time_window, &valid_time_window?/1)

--- a/lib/sanbase/utils/validation.ex
+++ b/lib/sanbase/utils/validation.ex
@@ -92,4 +92,16 @@ defmodule Sanbase.Validation do
         {:error, "#{inspect(metric)} is not a valid metric."}
     end
   end
+
+  def valid_5m_min_interval_metric?(metric) do
+    with {:ok, %{min_interval: min_interval}} <- Sanbase.Metric.metadata(metric),
+         interval_sec when is_number(interval_sec) and interval_sec <= 300 <-
+           Sanbase.DateTimeUtils.str_to_sec(min_interval) do
+      :ok
+    else
+      _ ->
+        {:error,
+         "The metric #{inspect(metric)} is not supported or is mistyped or does not have min interval equal or less than to 5 minutes."}
+    end
+  end
 end


### PR DESCRIPTION
It now works only with metrics with min_intervall less or equal to 5 minutes.
It will also execute every 5 minutes instead of once per 24 hours

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
