### PR TITLE
Reorder the tags to match the order they were when created

### DIFF
--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -94,7 +94,7 @@ defmodule Sanbase.Insight.Post do
     |> Repo.get(post_id)
     |> case do
       nil -> {:error, "There is no insight with id #{post_id}"}
-      post -> {:ok, post}
+      post -> {:ok, post |> Tag.Preloader.order_tags()}
     end
   end
 
@@ -104,7 +104,7 @@ defmodule Sanbase.Insight.Post do
     |> Repo.insert()
     |> case do
       {:ok, post} ->
-        {:ok, post}
+        {:ok, post |> Tag.Preloader.order_tags()}
 
       {:error, changeset} ->
         {
@@ -117,10 +117,21 @@ defmodule Sanbase.Insight.Post do
   def update(post_id, %User{id: user_id}, args) do
     case Repo.get(__MODULE__, post_id) do
       %__MODULE__{user_id: ^user_id} = post ->
+        # If the tags are updated they need to be dropped from the mapping table
+        # and inserted again as the order needs to be preserved.
+        maybe_drop_post_tags(post, args)
+
         post
         |> Repo.preload([:tags, :images])
         |> update_changeset(args)
         |> Repo.update()
+        |> case do
+          {:ok, post} ->
+            {:ok, post |> Tag.Preloader.order_tags()}
+
+          {:error, error} ->
+            {:error, error}
+        end
 
       %__MODULE__{user_id: another_user_id} when user_id != another_user_id ->
         {:error, "Cannot update not owned insight: #{post_id}"}
@@ -145,7 +156,7 @@ defmodule Sanbase.Insight.Post do
         # Note: When ecto changeset middleware is implemented return just `Repo.delete(post)`
         case Repo.delete(post) do
           {:ok, post} ->
-            {:ok, post}
+            {:ok, post |> Tag.Preloader.order_tags()}
 
           {:error, changeset} ->
             {
@@ -168,7 +179,7 @@ defmodule Sanbase.Insight.Post do
          {:own_post?, %Post{user_id: ^user_id}} <- {:own_post?, post},
          {:draft?, %Post{ready_state: @draft}} <- {:draft?, post},
          {:ok, post} <- publish_post(post) do
-      {:ok, post}
+      {:ok, post |> Tag.Preloader.order_tags()}
     else
       {:nil?, nil} ->
         {:error, "Cannot publish insight with id #{post_id}"}
@@ -208,6 +219,7 @@ defmodule Sanbase.Insight.Post do
     |> by_user(user_id)
     |> Repo.all()
     |> Repo.preload(@preloads)
+    |> Tag.Preloader.order_tags()
   end
 
   @doc """
@@ -218,6 +230,7 @@ defmodule Sanbase.Insight.Post do
     |> by_user(user_id)
     |> Repo.all()
     |> Repo.preload(@preloads)
+    |> Tag.Preloader.order_tags()
   end
 
   @doc """
@@ -229,6 +242,7 @@ defmodule Sanbase.Insight.Post do
     |> page(page, page_size)
     |> Repo.all()
     |> Repo.preload(@preloads)
+    |> Tag.Preloader.order_tags()
   end
 
   @doc """
@@ -239,6 +253,7 @@ defmodule Sanbase.Insight.Post do
     |> after_datetime(datetime)
     |> order_by_published_at()
     |> Repo.all()
+    |> Tag.Preloader.order_tags()
   end
 
   @doc """
@@ -393,4 +408,10 @@ defmodule Sanbase.Insight.Post do
     extract_image_url_from_post(post)
     |> Enum.map(&Sanbase.FileStore.delete/1)
   end
+
+  defp maybe_drop_post_tags(post, %{tags: tags}) when is_list(tags) do
+    Tag.drop_tags(post)
+  end
+
+  defp maybe_drop_post_tags(_, _), do: :oka
 end

--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -413,5 +413,5 @@ defmodule Sanbase.Insight.Post do
     Tag.drop_tags(post)
   end
 
-  defp maybe_drop_post_tags(_, _), do: :oka
+  defp maybe_drop_post_tags(_, _), do: :ok
 end

--- a/lib/sanbase/tag/preloader.ex
+++ b/lib/sanbase/tag/preloader.ex
@@ -1,0 +1,46 @@
+defmodule Sanbase.Tag.Preloader do
+  import Ecto.Query
+
+  alias Sanbase.Repo
+  alias Sanbase.Insight.Post
+
+  def order_tags([]), do: []
+  def order_tags(%Post{} = post), do: order_tags([post]) |> hd()
+
+  def order_tags([%Post{} | _] = structs) do
+    structs = Repo.preload(structs, [:tags])
+
+    post_id_to_ordered_tag_ids = post_id_to_ordered_tag_ids(structs)
+
+    Enum.map(structs, fn
+      %Post{tags: []} = post ->
+        post
+
+      %Post{tags: tags} = post ->
+        tags_order = Map.get(post_id_to_ordered_tag_ids, post.id)
+        tags = Enum.map(tags_order, fn tag_id -> Enum.find(tags, &(&1.id == tag_id)) end)
+
+        %Post{post | tags: tags}
+    end)
+  end
+
+  # Get a map where the key is the post_id and the value is the list of tags in
+  # the proper order
+  defp post_id_to_ordered_tag_ids(structs) do
+    post_ids = structs |> Enum.map(& &1.id)
+
+    from(pt in "posts_tags",
+      where: pt.post_id in ^post_ids,
+      select: {pt.post_id, pt.tag_id, pt.id}
+    )
+    |> Repo.all()
+    |> Enum.reduce(%{}, fn {post_id, tag_id, id}, acc ->
+      elem = {tag_id, id}
+      Map.update(acc, post_id, [elem], fn list -> [elem | list] end)
+    end)
+    |> Enum.into(%{}, fn {post_id, tags} ->
+      tags = Enum.sort_by(tags, &elem(&1, 1)) |> Enum.map(&elem(&1, 0))
+      {post_id, tags}
+    end)
+  end
+end

--- a/lib/sanbase/tag/tag.ex
+++ b/lib/sanbase/tag/tag.ex
@@ -10,7 +10,7 @@ defmodule Sanbase.Tag do
   alias Sanbase.Signal.UserTrigger
 
   @posts_join_through_table "posts_tags"
-  @user_triggers_join_through_table "posts_tags"
+  @user_triggers_join_through_table "user_triggers_tags"
   schema "tags" do
     field(:name, :string)
 
@@ -51,7 +51,6 @@ defmodule Sanbase.Tag do
     Repo.insert_all(__MODULE__, tags, on_conflict: :nothing, conflict_target: [:name])
 
     tag_names = tags |> Enum.map(& &1.name)
-
     tag_structures = by_names(tag_names)
 
     # The `by_names` functions can return the tags in a different order if any new
@@ -66,4 +65,14 @@ defmodule Sanbase.Tag do
   end
 
   def put_tags(%Ecto.Changeset{} = changeset, _), do: changeset
+
+  def drop_tags(%Post{id: id}) do
+    from(pt in @posts_join_through_table, where: pt.post_id == ^id)
+    |> Repo.delete_all()
+  end
+
+  def drop_tags(%UserTrigger{id: id}) do
+    from(pt in @user_triggers_join_through_table, where: pt.user_trigger_id == ^id)
+    |> Repo.delete_all()
+  end
 end

--- a/lib/sanbase_web/graphql/schema/types/insight_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/insight_types.ex
@@ -38,7 +38,7 @@ defmodule SanbaseWeb.Graphql.InsightTypes do
     field(:state, :string)
     field(:moderation_comment, :string)
     field(:ready_state, :string)
-    field(:images, list_of(:image_data), resolve: dataloader(SanbaseRepo))
+    field(:images, list_of(:image_data))
     field(:tags, list_of(:tag))
 
     field :comments_count, :integer do


### PR DESCRIPTION
#### Summary
Issue is that we need to order them by the id in the join through
posts_tags table. Instead, when queried through the many_to_many
association they are ordered by the tag id. Example: if you create a
post with first tag SAN and second BTC due to the fact that the tag BTC
has lower id it will always come before SAN when fetching it

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
