### PR TITLE
Extend get_metric and get_anomaly api call data

### DIFF
--- a/lib/sanbase/kafka/kafka_exporter.ex
+++ b/lib/sanbase/kafka/kafka_exporter.ex
@@ -109,8 +109,8 @@ defmodule Sanbase.KafkaExporter do
   end
 
   def handle_call(:flush, _from, state) do
-    send_data(state.data, state)
-    {:reply, %{state | data: [], size: 0}}
+    send_data_immediately(state.data, state)
+    {:reply, :ok, %{state | data: [], size: 0}}
   end
 
   @spec handle_cast({:persist, data | [data]}, state) :: {:noreply, state}

--- a/lib/sanbase_web/graphql/middlewares/access_control.ex
+++ b/lib/sanbase_web/graphql/middlewares/access_control.ex
@@ -46,16 +46,17 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
   defp transform_resolution(%Resolution{} = resolution) do
     %{context: context, definition: definition} = resolution
 
-    query_name =
+    query_atom_name =
       definition.name
       |> Macro.underscore()
       |> String.to_existing_atom()
       |> get_query(resolution.source)
 
-    %Resolution{
-      resolution
-      | context: Map.put(context, :__query_atom_name__, query_name)
-    }
+    context =
+      context
+      |> Map.put(:__query_atom_name__, query_atom_name)
+
+    %Resolution{resolution | context: context}
   end
 
   # If the query is resolved there's nothing to do here

--- a/lib/sanbase_web/graphql/middlewares/transform_resolution.ex
+++ b/lib/sanbase_web/graphql/middlewares/transform_resolution.ex
@@ -1,0 +1,34 @@
+defmodule SanbaseWeb.Graphql.Middlewares.TransformResolution do
+  @moduledoc """
+
+  """
+  @behaviour Absinthe.Middleware
+  alias Absinthe.Resolution
+
+  def call(%Resolution{} = resolution, _opts) do
+    %{context: context, definition: definition} = resolution
+
+    case definition.name |> Macro.underscore() |> String.to_existing_atom() do
+      :get_metric ->
+        %{arguments: %{metric: metric}} = resolution
+        elem = {:get_metric, metric}
+
+        %Resolution{
+          resolution
+          | context: Map.update(context, :__get_query_name_arg__, [elem], &[elem | &1])
+        }
+
+      :get_anomaly ->
+        %{arguments: %{anomaly: anomaly}} = resolution
+        elem = {:get_anomaly, anomaly}
+
+        %Resolution{
+          resolution
+          | context: Map.update(context, :__get_query_name_arg__, [elem], &[elem | &1])
+        }
+
+      _ ->
+        resolution
+    end
+  end
+end

--- a/lib/sanbase_web/graphql/schema/queries/anomaly_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/anomaly_queries.ex
@@ -4,6 +4,7 @@ defmodule SanbaseWeb.Graphql.Schema.AnomalyQueries do
   import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 2]
 
   alias SanbaseWeb.Graphql.Resolvers.AnomalyResolver
+  alias SanbaseWeb.Graphql.Middlewares.TransformResolution
 
   object :anomaly_queries do
     @desc ~s"""
@@ -13,6 +14,7 @@ defmodule SanbaseWeb.Graphql.Schema.AnomalyQueries do
       meta(access: :free)
       arg(:anomaly, non_null(:string))
 
+      middleware(TransformResolution)
       resolve(&AnomalyResolver.get_anomaly/3)
     end
 

--- a/lib/sanbase_web/graphql/schema/queries/metric_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/metric_queries.ex
@@ -4,6 +4,7 @@ defmodule SanbaseWeb.Graphql.Schema.MetricQueries do
   import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 2]
 
   alias SanbaseWeb.Graphql.Resolvers.MetricResolver
+  alias SanbaseWeb.Graphql.Middlewares.TransformResolution
 
   object :metric_queries do
     @desc ~s"""
@@ -13,6 +14,7 @@ defmodule SanbaseWeb.Graphql.Schema.MetricQueries do
       meta(access: :free)
       arg(:metric, non_null(:string))
 
+      middleware(TransformResolution)
       resolve(&MetricResolver.get_metric/3)
     end
 

--- a/test/sanbase_web/graphql/clickhouse/api_call_data_api_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/api_call_data_api_test.exs
@@ -1,0 +1,60 @@
+defmodule SanbaseWeb.Graphql.ApiCallDataApiTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import SanbaseWeb.Graphql.TestHelpers
+  import Sanbase.Factory
+
+  setup do
+    user = insert(:user)
+    insert(:subscription_premium, user: user)
+    conn = setup_jwt_auth(build_conn(), user)
+    {:ok, conn: conn}
+  end
+
+  test "export get_metric api calls with the metric as argument", context do
+    %{conn: conn} = context
+
+    Sanbase.Mock.prepare_mock2(&Sanbase.Metric.timeseries_data/6, {:ok, []})
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      from = ~U[2019-01-05 00:00:00Z]
+      to = ~U[2019-01-06 00:00:00Z]
+
+      Sanbase.InMemoryKafka.Producer.clear_state()
+      get_metric(conn, "price_usd", "santiment", from, to, "1d")
+      get_metric(conn, "nvt", "santiment", from, to, "1d")
+      get_metric(conn, "daily_active_addresses", "santiment", from, to, "1d")
+
+      # force the sending
+      Sanbase.KafkaExporter.flush(:api_call_exporter)
+
+      %{"sanbase_api_call_data" => api_calls} = Sanbase.InMemoryKafka.Producer.get_state()
+
+      api_calls_queries =
+        Enum.map(api_calls, fn {"", data} -> Jason.decode!(data) |> Map.get("query") end)
+
+      # There could be some test that exported api calls data and that happens async
+      # so something could happend even after the `clear_state` is called
+      assert length(api_calls_queries) >= 3
+      assert "getMetric|nvt" in api_calls_queries
+      assert "getMetric|price_usd" in api_calls_queries
+      assert "getMetric|daily_active_addresses" in api_calls_queries
+    end)
+  end
+
+  defp get_metric(conn, metric, slug, from, to, interval) do
+    query = """
+    {
+      get_metric(metric: "#{metric}") {
+        timeseriesData(slug: "#{slug}", from: "#{from}", to: "#{to}", interval: "#{interval}"){
+          datetime
+          value
+        }
+      }
+    }
+    """
+
+    conn
+    |> post("/graphql", query_skeleton(query))
+    |> json_response(200)
+  end
+end


### PR DESCRIPTION
- Rename all `getMetric` queries to `getMetric|<metric>` in the api exported data.
- Rename all `getAnomaly` queries to `getAnomaly|<anomaly>` in the api exported data.

This is done so we can run better analysis on our api calls
#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
