### PR TITLE
Last datetime metric computed at

### DIFF
--- a/lib/sanbase/clickhouse/github/github.ex
+++ b/lib/sanbase/clickhouse/github/github.ex
@@ -208,21 +208,6 @@ defmodule Sanbase.Clickhouse.Github do
     |> maybe_unwrap_ok_value()
   end
 
-  def first_datetime2(organization) do
-    query = """
-    SELECT toUnixTimestamp(min(dt))
-    FROM #{@table}
-    PREWHERE owner IN (?1)
-    """
-
-    args = [organization]
-
-    ClickhouseRepo.query_transform(query, args, fn [datetime] ->
-      datetime |> DateTime.from_unix!()
-    end)
-    |> maybe_unwrap_ok_value()
-  end
-
   def last_datetime_computed_at(organization) when is_binary(organization) do
     query = """
     SELECT toUnixTimestamp(max(dt))

--- a/lib/sanbase/clickhouse/github/github.ex
+++ b/lib/sanbase/clickhouse/github/github.ex
@@ -1,6 +1,6 @@
 defmodule Sanbase.Clickhouse.Github do
   @moduledoc ~s"""
-  Uses ClickHouse to work with ETH transfers.
+  Uses ClickHouse to work with github events.
   Allows to filter on particular events in the queries. Development activity can
   be more clearly calculated by excluding events releated to commenting, issues, forks, stars, etc.
   """
@@ -14,6 +14,8 @@ defmodule Sanbase.Clickhouse.Github do
         }
 
   use Ecto.Schema
+
+  import Sanbase.Utils.Transform, only: [maybe_unwrap_ok_value: 1]
 
   require Logger
   require Sanbase.ClickhouseRepo, as: ClickhouseRepo
@@ -60,12 +62,10 @@ defmodule Sanbase.Clickhouse.Github do
   def total_github_activity(organizations, from, to) do
     {query, args} = total_github_activity_query(organizations, from, to)
 
-    case ClickhouseRepo.query_transform(query, args, fn [github_activity] ->
-           github_activity |> String.to_integer()
-         end) do
-      {:ok, [result]} -> {:ok, result}
-      {:error, error} -> {:error, error}
-    end
+    ClickhouseRepo.query_transform(query, args, fn [github_activity] ->
+      github_activity |> Sanbase.Math.to_integer()
+    end)
+    |> maybe_unwrap_ok_value()
   end
 
   @doc ~s"""
@@ -96,7 +96,7 @@ defmodule Sanbase.Clickhouse.Github do
     {query, args} = total_dev_activity_query(organizations, from, to)
 
     ClickhouseRepo.query_transform(query, args, fn [organization, dev_activity] ->
-      {organization, dev_activity |> String.to_integer()}
+      {organization, dev_activity |> Sanbase.Math.to_integer()}
     end)
   end
 
@@ -193,20 +193,49 @@ defmodule Sanbase.Clickhouse.Github do
     end
   end
 
-  def first_datetime(slug) do
+  def first_datetime(organization) when is_binary(organization) do
     query = """
-    SELECT min(dt) FROM #{@table} WHERE owner = ?1
+    SELECT toUnixTimestamp(min(dt))
+    FROM #{@table}
+    PREWHERE owner = ?1
     """
 
-    args = [slug]
+    args = [organization]
 
     ClickhouseRepo.query_transform(query, args, fn [datetime] ->
-      datetime |> Sanbase.DateTimeUtils.from_erl!()
+      datetime |> DateTime.from_unix!()
     end)
-    |> case do
-      {:ok, [first_datetime]} -> {:ok, first_datetime}
-      error -> error
-    end
+    |> maybe_unwrap_ok_value()
+  end
+
+  def first_datetime2(organization) do
+    query = """
+    SELECT toUnixTimestamp(min(dt))
+    FROM #{@table}
+    PREWHERE owner IN (?1)
+    """
+
+    args = [organization]
+
+    ClickhouseRepo.query_transform(query, args, fn [datetime] ->
+      datetime |> DateTime.from_unix!()
+    end)
+    |> maybe_unwrap_ok_value()
+  end
+
+  def last_datetime_computed_at(organization) when is_binary(organization) do
+    query = """
+    SELECT toUnixTimestamp(max(dt))
+    FROM #{@table}
+    PREWHERE owner = ?1
+    """
+
+    args = [organization]
+
+    ClickhouseRepo.query_transform(query, args, fn [datetime] ->
+      datetime |> DateTime.from_unix!()
+    end)
+    |> maybe_unwrap_ok_value()
   end
 
   # Private functions
@@ -214,8 +243,8 @@ defmodule Sanbase.Clickhouse.Github do
   defp datetime_activity_execute({query, args}) do
     ClickhouseRepo.query_transform(query, args, fn [datetime, events_count] ->
       %{
-        datetime: datetime |> Sanbase.DateTimeUtils.from_erl!(),
-        activity: events_count |> String.to_integer()
+        datetime: datetime |> DateTime.from_unix!(),
+        activity: events_count |> Sanbase.Math.to_integer()
       }
     end)
   end
@@ -226,20 +255,21 @@ defmodule Sanbase.Clickhouse.Github do
     span = div(to_datetime_unix - from_datetime_unix, interval) |> max(1)
 
     query = """
-    SELECT time, SUM(events) as events_count
+    SELECT time, SUM(events) AS events_count
       FROM (
         SELECT
-          toDateTime(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) as time,
+          toUnixTimestamp(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) AS time,
           0 AS events
         FROM numbers(?2)
 
         UNION ALL
 
-        SELECT toDateTime(intDiv(toUInt32(dt), ?1) * ?1) as time, count(events) as events
+        SELECT toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time, count(events) AS events
           FROM (
-            SELECT any(event) as events, dt
+            SELECT any(event) AS events, dt
             FROM #{@table}
-            PREWHERE owner IN (?3)
+            PREWHERE
+              owner IN (?3)
             AND dt >= toDateTime(?4)
             AND dt <= toDateTime(?5)
             AND event NOT IN (?6)
@@ -269,22 +299,23 @@ defmodule Sanbase.Clickhouse.Github do
     span = div(to_datetime_unix - from_datetime_unix, interval) |> max(1)
 
     query = """
-    SELECT time, SUM(events) as events_count
+    SELECT time, SUM(events) AS events_count
       FROM (
         SELECT
-          toDateTime(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) as time,
+          toUnixTimestamp(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) AS time,
           0 AS events
         FROM numbers(?2)
 
         UNION ALL
 
-        SELECT toDateTime(intDiv(toUInt32(dt), ?1) * ?1) as time, count(events) as events
+        SELECT toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time, count(events) AS events
           FROM (
-            SELECT any(event) as events, dt
+            SELECT any(event) AS events, dt
             FROM #{@table}
-            PREWHERE owner IN (?3)
-            AND dt >= toDateTime(?4)
-            AND dt <= toDateTime(?5)
+            PREWHERE
+              owner IN (?3)
+              AND dt >= toDateTime(?4)
+              AND dt <= toDateTime(?5)
             GROUP BY owner, repo, dt, event
           )
           GROUP BY time
@@ -306,7 +337,7 @@ defmodule Sanbase.Clickhouse.Github do
 
   defp total_github_activity_query(organizations, from, to) do
     query = """
-    SELECT COUNT(*) FROM (
+    SELECT toUInt64(COUNT(*)) FROM (
       SELECT COUNT(*)
       FROM #{@table}
       PREWHERE
@@ -328,7 +359,7 @@ defmodule Sanbase.Clickhouse.Github do
 
   defp total_dev_activity_query(organizations, from, to) do
     query = """
-    SELECT owner, COUNT(*)
+    SELECT owner, toUInt64(COUNT(*))
     FROM(
       SELECT owner, COUNT(*)
       FROM #{@table}

--- a/lib/sanbase/clickhouse/github/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/github/metric_adapter.ex
@@ -58,7 +58,52 @@ defmodule Sanbase.Clickhouse.Github.MetricAdapter do
 
   @impl Sanbase.Metric.Behaviour
   def first_datetime(_metric, slug) do
-    Github.first_datetime(slug)
+    case Project.github_organizations(slug) do
+      {:ok, []} ->
+        {:ok, nil}
+
+      {:ok, [_ | _] = organizations} ->
+        datetime =
+          organizations
+          |> Enum.map(fn org ->
+            case Github.first_datetime(org) do
+              {:ok, datetime} -> datetime
+              _ -> nil
+            end
+          end)
+          |> Enum.reject(&is_nil/1)
+          |> Enum.min_by(&DateTime.to_unix(&1))
+
+        {:ok, datetime}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def last_datetime_computed_at(_metric, slug) do
+    case Project.github_organizations(slug) do
+      {:ok, []} ->
+        {:ok, nil}
+
+      {:ok, [_ | _] = organizations} ->
+        datetime =
+          organizations
+          |> Enum.map(fn org ->
+            case Github.last_datetime_computed_at(org) do
+              {:ok, datetime} -> datetime
+              _ -> nil
+            end
+          end)
+          |> Enum.reject(&is_nil/1)
+          |> Enum.max_by(&DateTime.to_unix(&1))
+
+        {:ok, datetime}
+
+      {:error, error} ->
+        {:error, error}
+    end
   end
 
   @impl Sanbase.Metric.Behaviour

--- a/lib/sanbase/clickhouse/metric/metric.ex
+++ b/lib/sanbase/clickhouse/metric/metric.ex
@@ -11,6 +11,7 @@ defmodule Sanbase.Clickhouse.Metric do
 
   import Sanbase.Clickhouse.MetadataHelper
   import Sanbase.Clickhouse.Metric.SqlQuery
+  import Sanbase.Utils.Transform, only: [maybe_unwrap_ok_value: 1]
 
   alias Sanbase.Clickhouse.Metric.LabelTemplate
   alias __MODULE__.FileHandler
@@ -165,10 +166,17 @@ defmodule Sanbase.Clickhouse.Metric do
     ClickhouseRepo.query_transform(query, args, fn [datetime] ->
       DateTime.from_unix!(datetime)
     end)
-    |> case do
-      {:ok, [result]} -> {:ok, result}
-      {:error, error} -> {:error, error}
-    end
+    |> maybe_unwrap_ok_value()
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def last_datetime_computed_at(metric, slug) do
+    {query, args} = last_datetime_computed_at_query(metric, slug)
+
+    ClickhouseRepo.query_transform(query, args, fn [datetime] ->
+      DateTime.from_unix!(datetime)
+    end)
+    |> maybe_unwrap_ok_value()
   end
 
   # Private functions

--- a/lib/sanbase/clickhouse/metric/metric_sql_query.ex
+++ b/lib/sanbase/clickhouse/metric/metric_sql_query.ex
@@ -152,6 +152,19 @@ defmodule Sanbase.Clickhouse.Metric.SqlQuery do
     {query, args}
   end
 
+  def last_datetime_computed_at_query(metric, slug) do
+    query = """
+    SELECT toUnixTimestamp(argMax(computed_at, dt))
+    FROM #{Map.get(@table_map, metric)} FINAL
+    PREWHERE
+      metric_id = ( SELECT argMax(metric_id, computed_at) FROM metric_metadata PREWHERE name = ?1 ) AND
+      asset_id = ( SELECT argMax(asset_id, computed_at) FROM asset_metadata PREWHERE name = ?2 )
+    """
+
+    args = [metric, slug]
+    {query, args}
+  end
+
   def first_datetime_query(metric, nil) do
     query = """
     SELECT

--- a/lib/sanbase/metric/behaviour.ex
+++ b/lib/sanbase/metric/behaviour.ex
@@ -61,6 +61,9 @@ defmodule Sanbase.Metric.Behaviour do
   @callback first_datetime(metric, slug) ::
               {:ok, DateTime.t()} | {:error, String.t()}
 
+  @callback last_datetime_computed_at(metric, slug) ::
+              {:ok, DateTime.t()} | {:error, String.t()}
+
   @callback human_readable_name(metric) :: {:ok, String.t()} | {:error, String.t()}
 
   @callback metadata(metric) :: {:ok, metadata()} | {:error, String.t()}

--- a/lib/sanbase/metric/helper.ex
+++ b/lib/sanbase/metric/helper.ex
@@ -10,4 +10,42 @@ defmodule Sanbase.Metric.Helper do
   end
 
   def transform_to_value_pairs({:error, error}, _), do: {:error, error}
+
+  @doc ~s"""
+  Replace all values except :slug and :datetime in every element with `nil`
+  if :has_changed is 0
+  """
+  def maybe_nullify_values({:ok, data}) do
+    result =
+      Enum.map(
+        data,
+        fn
+          %{has_changed: 0} = elem ->
+            # use :maps.map/2 instead of Enum.map/2 to avoid unnecessary Map.new/1
+            :maps.map(
+              fn
+                key, value when key in [:slug, :datetime] -> value
+                _, _ -> nil
+              end,
+              Map.delete(elem, :has_changed)
+            )
+
+          elem ->
+            Map.delete(elem, :has_changed)
+        end
+      )
+
+    {:ok, result}
+  end
+
+  def maybe_nullify_values({:error, error}), do: {:error, error}
+
+  @doc ~s"""
+  Remove all elements for which :has_changed is 0
+  """
+  def remove_missing_values({:ok, data}) do
+    {:ok, Enum.reject(data, &(&1.has_changed == 0))}
+  end
+
+  def remove_missing_values({:error, error}), do: {:error, error}
 end

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -197,6 +197,16 @@ defmodule Sanbase.Metric do
 
   def first_datetime(metric, _), do: metric_not_available_error(metric)
 
+  def last_datetime_computed_at(metric, slug)
+
+  for %{metric: metric, module: module} <- @metric_module_mapping do
+    def last_datetime_computed_at(unquote(metric), slug) do
+      unquote(module).last_datetime_computed_at(unquote(metric), slug)
+    end
+  end
+
+  def last_datetime_computed_at(metric, _), do: metric_not_available_error(metric)
+
   @doc ~s"""
   Get all available slugs for a given metric
   """

--- a/lib/sanbase/prices/metric_adapter.ex
+++ b/lib/sanbase/prices/metric_adapter.ex
@@ -34,6 +34,11 @@ defmodule Sanbase.Price.MetricAdapter do
   end
 
   @impl Sanbase.Metric.Behaviour
+  def last_datetime_computed_at(_metric, slug) do
+    Price.last_datetime_computed_at(slug)
+  end
+
+  @impl Sanbase.Metric.Behaviour
   def metadata(metric) do
     {:ok,
      %{

--- a/lib/sanbase/prices/price_sql_query.ex
+++ b/lib/sanbase/prices/price_sql_query.ex
@@ -327,6 +327,17 @@ defmodule Sanbase.Price.SqlQuery do
     {query, args}
   end
 
+  def last_datetime_computed_at_query(slug) do
+    query = """
+    SELECT toUnixTimestamp(max(dt))
+    FROM #{@table}
+    PREWHERE slug = cast(?1, 'LowCardinality(String)')
+    """
+
+    args = [slug]
+    {query, args}
+  end
+
   def first_datetime_query(slug, source) do
     query = """
     SELECT

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -165,4 +165,7 @@ defmodule Sanbase.SocialData.MetricAdapter do
 
   def first_datetime(<<"professional_traders_chat", _rest::binary>>, _slug),
     do: {:ok, ~U[2018-02-09 00:00:00Z]}
+
+  @impl Sanbase.Metric.Behaviour
+  def last_datetime_computed_at(_metric, _slug), do: {:ok, Timex.now()}
 end

--- a/lib/sanbase/utils/transform.ex
+++ b/lib/sanbase/utils/transform.ex
@@ -76,6 +76,6 @@ defmodule Sanbase.Utils.Transform do
     |> Enum.into(%{})
   end
 
-  def unpack_value({:ok, [value]}), do: {:ok, value}
-  def unpack_value({:error, error}), do: {:error, error}
+  def maybe_unwrap_ok_value({:ok, [value]}), do: {:ok, value}
+  def maybe_unwrap_ok_value({:error, error}), do: {:error, error}
 end

--- a/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
@@ -35,6 +35,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   def available_since(_root, %{slug: slug}, %{source: %{metric: metric}}),
     do: Metric.first_datetime(metric, slug)
 
+  def last_datetime_computed_at(_root, %{slug: slug}, %{source: %{metric: metric}}),
+    do: Metric.last_datetime_computed_at(metric, slug)
+
   def timeseries_data(
         _root,
         %{slug: slug, from: from, to: to, interval: interval} = args,

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -139,6 +139,11 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       cache_resolve(&MetricResolver.available_since/3)
     end
 
+    field :last_datetime_computed_at, :datetime do
+      arg(:slug, non_null(:string))
+      cache_resolve(&MetricResolver.last_datetime_computed_at/3)
+    end
+
     field :metadata, :metric_metadata do
       cache_resolve(&MetricResolver.get_metadata/3)
     end

--- a/test/sanbase_web/graphql/metric/api_metric_computed_at_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_computed_at_test.exs
@@ -1,0 +1,63 @@
+defmodule SanbaseWeb.Graphql.ApiMetricComputedAtTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import Sanbase.Factory
+  import SanbaseWeb.Graphql.TestHelpers
+
+  alias Sanbase.Metric
+
+  setup do
+    project = insert(:random_project)
+    %{project: project}
+  end
+
+  test "returns last datetime computed at for all available metric", context do
+    %{conn: conn, project: project} = context
+    metrics = Metric.available_metrics()
+
+    datetime = ~U[2020-01-01 12:45:40Z]
+    clickhouse_response = {:ok, %{rows: [[datetime |> DateTime.to_unix()]]}}
+
+    Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, clickhouse_response)
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      for metric <- metrics do
+        %{"data" => %{"getMetric" => %{"lastDatetimeComputedAt" => last_dt}}} =
+          get_last_datetime_computed_at(conn, metric, project.slug)
+
+        last_dt = Sanbase.DateTimeUtils.from_iso8601!(last_dt)
+        assert match?(%DateTime{}, last_dt)
+      end
+    end)
+  end
+
+  test "returns error for unavailable metric", context do
+    %{conn: conn, project: project} = context
+    rand_metrics = Enum.map(1..10, fn _ -> rand_str() end)
+    rand_metrics = rand_metrics -- Metric.available_metrics()
+
+    # Do not mock the `histogram_data` function because it's the one that rejects
+    for metric <- rand_metrics do
+      %{
+        "errors" => [
+          %{"message" => error_message}
+        ]
+      } = get_last_datetime_computed_at(conn, metric, project.slug)
+
+      assert error_message == "The metric '#{metric}' is not supported or is mistyped."
+    end
+  end
+
+  defp get_last_datetime_computed_at(conn, metric, slug) do
+    query = """
+    {
+      getMetric(metric: "#{metric}"){
+        lastDatetimeComputedAt(slug: "#{slug}")
+      }
+    }
+    """
+
+    conn
+    |> post("/graphql", query_skeleton(query))
+    |> json_response(200)
+  end
+end

--- a/test/sanbase_web/graphql/metric/api_metric_histogram_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_histogram_data_test.exs
@@ -1,4 +1,4 @@
-defmodule SanbaseWeb.Graphql.Clickhouse.ApiMetricHistogramDataTest do
+defmodule SanbaseWeb.Graphql.ApiMetricHistogramDataTest do
   use SanbaseWeb.ConnCase, async: false
 
   import Mock
@@ -75,7 +75,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ApiMetricHistogramDataTest do
 
   test "returns error for unavailable metrics", context do
     %{conn: conn, slug: slug, from: from, to: to} = context
-    rand_metrics = Enum.map(1..100, fn _ -> rand_str() end)
+    rand_metrics = Enum.map(1..20, fn _ -> rand_str() end)
     rand_metrics = rand_metrics -- Metric.available_histogram_metrics()
 
     # Do not mock the `histogram_data` function because it's the one that rejects

--- a/test/sanbase_web/graphql/metric/api_metric_metadata_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_metadata_test.exs
@@ -1,4 +1,4 @@
-defmodule SanbaseWeb.Graphql.Clickhouse.ApiMetricMetadataTest do
+defmodule SanbaseWeb.Graphql.ApiMetricMetadataTest do
   use SanbaseWeb.ConnCase, async: false
 
   import Sanbase.Factory, only: [rand_str: 0]
@@ -29,7 +29,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ApiMetricMetadataTest do
   end
 
   test "returns error for unavailable metric", %{conn: conn} do
-    rand_metrics = Enum.map(1..100, fn _ -> rand_str() end)
+    rand_metrics = Enum.map(1..20, fn _ -> rand_str() end)
     rand_metrics = rand_metrics -- Metric.available_metrics()
 
     # Do not mock the `histogram_data` function because it's the one that rejects

--- a/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
@@ -1,4 +1,4 @@
-defmodule SanbaseWeb.Graphql.Clickhouse.ApiMetricTimeseriesDataTest do
+defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesDataTest do
   use SanbaseWeb.ConnCase, async: false
 
   import Mock
@@ -125,7 +125,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ApiMetricTimeseriesDataTest do
   test "returns error for unavailable metrics", context do
     %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
     aggregation = :avg
-    rand_metrics = Enum.map(1..100, fn _ -> rand_str() end)
+    rand_metrics = Enum.map(1..20, fn _ -> rand_str() end)
     rand_metrics = rand_metrics -- Metric.available_timeseries_metrics()
 
     # Do not mock the `timeseries_data` function because it's the one that rejects


### PR DESCRIPTION
#### Summary
Adds a field to the `getMetric` API to fetch when was the last data point computed:
Request:
```graphql
{
  getMetric(metric: "daily_active_addresses"){
    lastDatetimeComputedAt(slug: "santiment")
  }
}
```
Response:
```graphql
{
  "data": {
    "getMetric": {
      "lastDatetimeComputedAt": "2020-01-24T13:02:04Z"
    }
  }
}
```

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
