### PR TITLE
Add the active_addresses_24h intraday metric

### DIFF
--- a/lib/sanbase/clickhouse/metric/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/available_v2_metrics.json
@@ -108,6 +108,18 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Active Addresses for the last 24 hours",
+    "name": "active_addresses_24h",
+    "metric": "active_addresses_24h",
+    "version": "2019-01-01",
+    "access": "free",
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "intraday_metrics",
+    "has_incomplete_data": true,
+    "data_type": "timeseries"
+  },
+  {
     "human_readable_name": "Mean Realized USD Price",
     "name": "mean_realized_price_usd",
     "metric": "mean_realized_price_usd_20y",

--- a/test/sanbase/billing/access_level_test.exs
+++ b/test/sanbase/billing/access_level_test.exs
@@ -101,6 +101,7 @@ defmodule Sanbase.Billing.AccessLevelTest do
 
     expected_free_queries =
       [
+        "active_addresses_24h",
         "daily_active_addresses",
         "daily_avg_marketcap_usd",
         "daily_avg_price_usd",

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -102,6 +102,7 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
 
       expected_free_queries =
         [
+          "active_addresses_24h",
           "daily_active_addresses",
           "daily_avg_marketcap_usd",
           "daily_avg_price_usd",


### PR DESCRIPTION
#### Summary
Every 5 minutes the number of active addresses for the past 24 hours are
computed. This is equivalent to the daily active addresses only at 00:00

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
