### PR TITLE
Order feed

### DIFF
--- a/lib/sanbase/ecto_helper.ex
+++ b/lib/sanbase/ecto_helper.ex
@@ -1,0 +1,40 @@
+defmodule Sanbase.EctoHelper do
+  @moduledoc """
+  Module with reusable Ecto helper queries.
+  """
+
+  import Ecto.Query
+
+  alias Sanbase.Repo
+
+  @doc """
+  Fetch a list of ids ordered by the count of items in has_many/many_to_many association.
+  """
+  @spec fetch_ids_ordered_by_assoc_count(Ecto.Query.t(), atom, Keyword.t()) ::
+          list(non_neg_integer())
+  def fetch_ids_ordered_by_assoc_count(query, assoc_table, opts \\ []) do
+    order_by_second = Keyword.get(opts, :order_by, :inserted_at)
+
+    from(
+      entity in query,
+      left_join: assoc in assoc(entity, ^assoc_table),
+      select: {entity.id, fragment("COUNT(?)", assoc.id)},
+      group_by: entity.id,
+      order_by: fragment("count DESC NULLS LAST, ? DESC", field(entity, ^order_by_second))
+    )
+    |> Repo.all()
+    |> Enum.map(fn {id, _} -> id end)
+  end
+
+  @doc """
+  Fetch records of entity by a list of ids and keep the order of the selected records same as the list.
+  """
+  @spec by_id_in_order_query(Ecto.Query.t(), list(non_neg_integer())) :: Ecto.Query.t()
+  def by_id_in_order_query(query, ids) do
+    from(
+      entity in query,
+      where: entity.id in ^ids,
+      order_by: fragment("array_position(?, ?::int)", ^ids, entity.id)
+    )
+  end
+end

--- a/lib/sanbase/timeline/timeline_event.ex
+++ b/lib/sanbase/timeline/timeline_event.ex
@@ -36,13 +36,17 @@ defmodule Sanbase.Timeline.TimelineEvent do
   schema @table do
     field(:event_type, :string)
     field(:payload, :map)
+
     belongs_to(:user, User)
     belongs_to(:post, Post)
     belongs_to(:user_list, UserList)
     belongs_to(:user_trigger, UserTrigger)
+
     has_many(:votes, Vote, on_delete: :delete_all)
 
-    many_to_many(:comments, Sanbase.Comment, join_through: "timeline_event_comments_mapping")
+    has_many(:event_comment_mapping, Sanbase.Timeline.TimelineEventComment, on_delete: :delete_all)
+
+    has_many(:comments, through: [:event_comment_mapping, :comment])
 
     timestamps()
   end

--- a/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
@@ -181,7 +181,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.InsightResolver do
     end)
   end
 
-  def comments_count(%Post{id: id}, _args, %{context: %{loader: loader}}) do
+  def comments_count(%{id: id}, _args, %{context: %{loader: loader}}) do
     loader
     |> Dataloader.load(SanbaseDataloader, :insights_comments_count, id)
     |> on_load(fn loader ->

--- a/lib/sanbase_web/graphql/resolvers/timeline/timeline_event_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/timeline/timeline_event_resolver.ex
@@ -68,7 +68,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.TimelineEventResolver do
     end)
   end
 
-  def comments_count(%TimelineEvent{id: id}, _args, %{context: %{loader: loader}}) do
+  def comments_count(%{id: id}, _args, %{context: %{loader: loader}}) do
     loader
     |> Dataloader.load(SanbaseDataloader, :timeline_events_comments_count, id)
     |> on_load(fn loader ->

--- a/lib/sanbase_web/graphql/schema/queries/timeline_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/timeline_queries.ex
@@ -12,6 +12,7 @@ defmodule SanbaseWeb.Graphql.Schema.TimelineQueries do
       meta(access: :free)
 
       arg(:cursor, :cursor_input)
+      arg(:order_by, :order_by_enum, default_value: :datetime)
       arg(:limit, :integer, default_value: 25)
 
       resolve(&TimelineEventResolver.timeline_events/3)

--- a/lib/sanbase_web/graphql/schema/types/timeline_event_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/timeline_event_types.ex
@@ -3,6 +3,13 @@ defmodule SanbaseWeb.Graphql.TimelineEventTypes do
 
   alias SanbaseWeb.Graphql.Resolvers.TimelineEventResolver
 
+  enum :order_by_enum do
+    value(:datetime)
+    value(:votes)
+    value(:comments)
+    value(:author)
+  end
+
   object :timeline_events_paginated do
     field(:events, list_of(:timeline_event))
     field(:cursor, :cursor)


### PR DESCRIPTION
by default ordering is by  `DATETIME` in  `descending` order.
other opts: `orderBy: VOTES`, `orderBy: COMMENTS`, `orderBy: AUTHOR` (last means by author username)

example: `timelineEvents(orderBy: COMMENTS, limit: 3)`