### PR TITLE
Expose aggregated_timeseries_data through the get_metric api

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_sql_query.ex
+++ b/lib/sanbase/clickhouse/metric/metric_sql_query.ex
@@ -109,7 +109,7 @@ defmodule Sanbase.Clickhouse.Metric.SqlQuery do
     query = """
     SELECT
       toUInt32(asset_id),
-      #{aggregation(aggregation, "value", "t")}
+      #{aggregation(aggregation, "value", "dt")}
     FROM(
       SELECT
         dt,

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -121,6 +121,18 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       cache_resolve(&MetricResolver.timeseries_data/3)
     end
 
+    field :aggregated_timeseries_data, :float do
+      arg(:slug, non_null(:string))
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+      arg(:aggregation, :aggregation, default_value: nil)
+
+      complexity(&Complexity.from_to_interval/3)
+      middleware(AccessControl)
+
+      cache_resolve(&MetricResolver.aggregated_timeseries_data/3)
+    end
+
     field :histogram_data, :histogram_data do
       arg(:slug, non_null(:string))
       arg(:from, non_null(:datetime))

--- a/test/sanbase_web/graphql/metric/api_metric_aggregated_timeseries_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_aggregated_timeseries_data_test.exs
@@ -1,0 +1,146 @@
+defmodule SanbaseWeb.Graphql.ApiMetricAggregatedTimeseriesDataTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import Mock
+  import Sanbase.Factory
+  import SanbaseWeb.Graphql.TestHelpers
+  import Sanbase.DateTimeUtils, only: [from_iso8601!: 1]
+
+  alias Sanbase.Metric
+
+  setup do
+    %{user: user} = insert(:subscription_pro_sanbase, user: insert(:user))
+    conn = setup_jwt_auth(build_conn(), user)
+
+    [
+      conn: conn,
+      slug: "ethereum",
+      from: from_iso8601!("2019-01-01T00:00:00Z"),
+      to: from_iso8601!("2019-01-02T00:00:00Z")
+    ]
+  end
+
+  test "returns data for an available metric", context do
+    %{conn: conn, slug: slug, from: from, to: to} = context
+    aggregation = :avg
+    [metric | _] = Metric.available_timeseries_metrics()
+
+    with_mock Metric, [:passthrough],
+      aggregated_timeseries_data: fn _, slug, _, _, _ ->
+        {:ok, [%{slug: slug, value: 100}]}
+      end do
+      result =
+        get_aggregated_timeseries_metric(conn, metric, slug, from, to, aggregation)
+        |> extract_aggregated_timeseries_data()
+
+      assert result == 100
+
+      assert_called(Metric.aggregated_timeseries_data(metric, slug, from, to, aggregation))
+    end
+  end
+
+  test "returns data for all available metrics", context do
+    %{conn: conn, slug: slug, from: from, to: to} = context
+    aggregation = :avg
+    metrics = Metric.available_timeseries_metrics()
+
+    with_mock Metric, [:passthrough],
+      aggregated_timeseries_data: fn _, slug, _, _, _ ->
+        {:ok, [%{slug: slug, value: 100}]}
+      end do
+      for metric <- metrics do
+        result =
+          get_aggregated_timeseries_metric(conn, metric, slug, from, to, aggregation)
+          |> extract_aggregated_timeseries_data()
+
+        assert result == 100
+      end
+    end
+  end
+
+  test "returns data for all available aggregations", context do
+    %{conn: conn, slug: slug, from: from, to: to} = context
+    aggregations = Metric.available_aggregations()
+    # nil means aggregation is not passed, we should not explicitly pass it
+    aggregations = aggregations -- [nil]
+    [metric | _] = Metric.available_timeseries_metrics()
+
+    with_mock Metric, [:passthrough],
+      aggregated_timeseries_data: fn _, slug, _, _, _ ->
+        {:ok, [%{slug: slug, value: 100}]}
+      end do
+      for aggregation <- aggregations do
+        result =
+          get_aggregated_timeseries_metric(conn, metric, slug, from, to, aggregation)
+          |> extract_aggregated_timeseries_data()
+
+        assert result == 100
+      end
+
+      # Assert that all results are lists where we have a map with values
+    end
+  end
+
+  test "returns error for unavailable aggregations", context do
+    %{conn: conn, slug: slug, from: from, to: to} = context
+    aggregations = Metric.available_aggregations()
+    rand_aggregations = Enum.map(1..10, fn _ -> rand_str() |> String.to_atom() end)
+    rand_aggregations = rand_aggregations -- aggregations
+    [metric | _] = Metric.available_timeseries_metrics()
+
+    # Do not mock the `get` function. It will reject the query if the execution
+    # reaches it. Currently the execution is halted even earlier because the
+    # aggregation is an enum with available values
+    result =
+      for aggregation <- rand_aggregations do
+        get_aggregated_timeseries_metric(conn, metric, slug, from, to, aggregation)
+      end
+
+    # Assert that all results are lists where we have a map with values
+    assert Enum.all?(result, &match?(%{"errors" => _}, &1))
+  end
+
+  test "returns error for unavailable metrics", context do
+    %{conn: conn, slug: slug, from: from, to: to} = context
+    aggregation = :avg
+    rand_metrics = Enum.map(1..20, fn _ -> rand_str() end)
+    rand_metrics = rand_metrics -- Metric.available_timeseries_metrics()
+
+    # Do not mock the `timeseries_data` function because it's the one that rejects
+    for metric <- rand_metrics do
+      %{"errors" => [%{"message" => error_message}]} =
+        get_aggregated_timeseries_metric(conn, metric, slug, from, to, aggregation)
+
+      assert error_message == "The metric '#{metric}' is not supported or is mistyped."
+    end
+  end
+
+  # Private functions
+
+  defp get_aggregated_timeseries_metric(conn, metric, slug, from, to, aggregation) do
+    query = get_aggregated_timeseries_query(metric, slug, from, to, aggregation)
+
+    conn
+    |> post("/graphql", query_skeleton(query, "getMetric"))
+    |> json_response(200)
+  end
+
+  defp extract_aggregated_timeseries_data(result) do
+    result
+    |> get_in(["data", "getMetric", "aggregatedTimeseriesData"])
+  end
+
+  defp get_aggregated_timeseries_query(metric, slug, from, to, aggregation) do
+    """
+      {
+        getMetric(metric: "#{metric}"){
+          aggregatedTimeseriesData(
+            slug: "#{slug}"
+            from: "#{from}"
+            to: "#{to}"
+            aggregation: #{Atom.to_string(aggregation) |> String.upcase()})
+        }
+      }
+    """
+  end
+end


### PR DESCRIPTION
#### Summary
![image](https://user-images.githubusercontent.com/6518376/73550081-9b2f6800-444c-11ea-80da-1b05044a4f85.png)

```graphql
{
  getMetric(metric: "price_usd") {
    open_price: aggregatedTimeseriesData(slug: "santiment", from: "2020-01-01T00:00:00Z", to: "2020-01-05T00:00:00Z", aggregation: FIRST)
    close_price: aggregatedTimeseriesData(slug: "santiment", from: "2020-01-01T00:00:00Z", to: "2020-01-05T00:00:00Z", aggregation: LAST)
  }
}
```

Some notes: This can be improved by passing a list of aggregations and constructing a single SQL query that will fetch all the data instead of making 1 query per field
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
