### PR TITLE
Filter timeline events

### DIFF
--- a/lib/sanbase/timeline/cursor.ex
+++ b/lib/sanbase/timeline/cursor.ex
@@ -1,0 +1,33 @@
+defmodule Sanbase.Timeline.Cursor do
+  import Ecto.Query
+
+  def filter_by_cursor(query, :before, datetime) do
+    from(
+      event in query,
+      where: event.inserted_at < ^datetime
+    )
+  end
+
+  def filter_by_cursor(query, :after, datetime) do
+    from(
+      event in query,
+      where: event.inserted_at > ^datetime
+    )
+  end
+
+  def wrap_events_with_cursor([]), do: {:ok, %{events: [], cursor: %{}}}
+
+  def wrap_events_with_cursor(events) do
+    before_datetime = events |> List.last() |> Map.get(:inserted_at)
+    after_datetime = events |> List.first() |> Map.get(:inserted_at)
+
+    {:ok,
+     %{
+       events: events,
+       cursor: %{
+         before: before_datetime,
+         after: after_datetime
+       }
+     }}
+  end
+end

--- a/lib/sanbase/timeline/filter.ex
+++ b/lib/sanbase/timeline/filter.ex
@@ -1,0 +1,127 @@
+defmodule Sanbase.Timeline.Filter do
+  import Ecto.Query
+
+  alias Sanbase.Timeline.Query
+
+  alias Sanbase.UserList
+  alias Sanbase.Signal.UserTrigger
+  alias Sanbase.Insight.Post
+  alias Sanbase.Repo
+
+  def filter_by_query(query, filter_by, user_id) do
+    query
+    |> filter_by_author_query(filter_by, user_id)
+    |> filter_by_watchlists_query(filter_by)
+    |> filter_by_assets_query(filter_by, user_id)
+  end
+
+  defp filter_by_author_query(query, %{author: :all}, user_id) do
+    Query.events_by_sanfamily_or_followed_users_or_own_query(query, user_id)
+  end
+
+  defp filter_by_author_query(query, %{author: :sanfam}, _) do
+    Query.events_by_sanfamily_query(query)
+  end
+
+  defp filter_by_author_query(query, %{author: :followed}, user_id) do
+    Query.events_by_followed_users_query(query, user_id)
+  end
+
+  defp filter_by_author_query(query, %{author: :own}, user_id) do
+    Query.events_by_current_user_query(query, user_id)
+  end
+
+  defp filter_by_author_query(query, _, user_id) do
+    Query.events_by_sanfamily_or_followed_users_or_own_query(query, user_id)
+  end
+
+  defp filter_by_watchlists_query(query, %{watchlists: watchlists})
+       when is_list(watchlists) and length(watchlists) > 0 do
+    from(event in query, where: event.user_list_id in ^watchlists)
+  end
+
+  defp filter_by_watchlists_query(query, _), do: query
+
+  defp filter_by_assets_query(query, %{assets: assets} = filter_by, user_id)
+       when is_list(assets) and length(assets) > 0 do
+    {slugs, tickers} = get_slugs_and_tickers_by_asset_list(assets)
+    watchlist_ids = get_watchlist_ids_by_asset_list(assets, filter_by, user_id)
+    insight_ids = get_insight_ids_by_asset_list({slugs, tickers}, filter_by, user_id)
+    trigger_ids = get_trigger_ids_by_asset_list({slugs, tickers}, filter_by, user_id)
+
+    from(event in query,
+      where:
+        event.user_list_id in ^watchlist_ids or
+          event.post_id in ^insight_ids or
+          event.user_trigger_id in ^trigger_ids
+    )
+  end
+
+  defp filter_by_assets_query(query, _, _), do: query
+
+  defp get_watchlist_ids_by_asset_list(assets, filter_by, user_id) do
+    from(
+      entity in UserList,
+      join: li in assoc(entity, :list_items),
+      where: li.project_id in ^assets,
+      select: entity.id
+    )
+    |> filter_by_author_query(filter_by, user_id)
+    |> Repo.all()
+  end
+
+  defp get_slugs_and_tickers_by_asset_list(assets) do
+    project_slugs_and_tickers =
+      from(p in Sanbase.Model.Project, where: p.id in ^assets, select: [p.slug, p.ticker])
+      |> Repo.all()
+
+    slugs = project_slugs_and_tickers |> Enum.map(fn [slug, _] -> slug end)
+    tickers = project_slugs_and_tickers |> Enum.map(fn [_, ticker] -> ticker end)
+
+    {slugs, tickers}
+  end
+
+  defp get_insight_ids_by_asset_list({slugs, tickers}, filter_by, user_id) do
+    from(
+      entity in Post,
+      join: t in assoc(entity, :tags),
+      where: t.name in ^slugs or t.name in ^tickers,
+      select: entity.id
+    )
+    |> filter_by_author_query(filter_by, user_id)
+    |> Repo.all()
+  end
+
+  defp get_trigger_ids_by_asset_list({slugs, tickers}, filter_by, user_id) do
+    triggers =
+      from(ut in UserTrigger, select: [ut.id, fragment("trigger->'settings'->'target'")])
+      |> filter_by_author_query(filter_by, user_id)
+      |> Repo.all()
+
+    triggers
+    |> Enum.filter(fn [_id, target] -> filter_by_trigger_target(target, {slugs, tickers}) end)
+    |> Enum.map(fn [id, _] -> id end)
+  end
+
+  defp filter_by_trigger_target(%{"slug" => slug}, {slugs, _tickers}) when is_binary(slug),
+    do: slug in slugs
+
+  defp filter_by_trigger_target(%{"slug" => target_slugs}, {slugs, _tickers})
+       when is_binary(target_slugs) do
+    has_intersection?(target_slugs, slugs)
+  end
+
+  defp filter_by_trigger_target(%{"word" => word}, {slugs, tickers}) when is_binary(word) do
+    word in slugs or String.upcase(word) in tickers
+  end
+
+  defp filter_by_trigger_target(%{"word" => words}, {slugs, tickers}) when is_list(words) do
+    words_upcase = words |> Enum.map(&String.upcase/1)
+
+    has_intersection?(words, slugs) or has_intersection?(words_upcase, tickers)
+  end
+
+  defp has_intersection?(list1, list2) do
+    MapSet.intersection(MapSet.new(list1), MapSet.new(list2)) |> MapSet.size() > 0
+  end
+end

--- a/lib/sanbase/timeline/order.ex
+++ b/lib/sanbase/timeline/order.ex
@@ -1,0 +1,54 @@
+defmodule Sanbase.Timeline.Order do
+  import Ecto.Query
+
+  alias Sanbase.EctoHelper
+  alias Sanbase.Repo
+
+  def events_order_limit_preload_query(query, order_by, limit) do
+    query
+    |> limit(^limit)
+    |> order_by_query(order_by)
+    |> preload([:user_trigger, [post: :tags], :user_list, :user, :votes])
+  end
+
+  defp order_by_query(query, :datetime) do
+    from(
+      event in query,
+      order_by: [desc: event.inserted_at]
+    )
+  end
+
+  defp order_by_query(query, :author) do
+    from(
+      event in query,
+      join: u in assoc(event, :user),
+      order_by: [asc: u.username, desc: event.inserted_at]
+    )
+  end
+
+  defp order_by_query(query, :votes) do
+    # order by: date, votes count, datetime
+    ids =
+      from(
+        entity in query,
+        left_join: assoc in assoc(entity, :votes),
+        select: {entity.id, fragment("COUNT(?)", assoc.id)},
+        group_by: entity.id,
+        order_by:
+          fragment(
+            "?::date DESC, count DESC NULLS LAST, ? DESC",
+            entity.inserted_at,
+            entity.inserted_at
+          )
+      )
+      |> Repo.all()
+      |> Enum.map(fn {id, _} -> id end)
+
+    EctoHelper.by_id_in_order_query(query, ids)
+  end
+
+  defp order_by_query(query, :comments) do
+    ids = EctoHelper.fetch_ids_ordered_by_assoc_count(query, :comments)
+    EctoHelper.by_id_in_order_query(query, ids)
+  end
+end

--- a/lib/sanbase/timeline/query.ex
+++ b/lib/sanbase/timeline/query.ex
@@ -5,7 +5,7 @@ defmodule Sanbase.Timeline.Query do
   alias Sanbase.UserList
   alias Sanbase.Signal.UserTrigger
 
-  # Events with public antities and current user private events
+  # Events with public entities and current user private events
   def events_with_public_entities_query(query, user_id) do
     from(
       event in query,

--- a/lib/sanbase/timeline/query.ex
+++ b/lib/sanbase/timeline/query.ex
@@ -1,0 +1,65 @@
+defmodule Sanbase.Timeline.Query do
+  import Ecto.Query
+
+  alias Sanbase.Auth.{UserFollower, Role}
+  alias Sanbase.UserList
+  alias Sanbase.Signal.UserTrigger
+
+  # Events with public antities and current user private events
+  def events_with_public_entities_query(query, user_id) do
+    from(
+      event in query,
+      left_join: ut in UserTrigger,
+      on: event.user_trigger_id == ut.id,
+      left_join: ul in UserList,
+      on: event.user_list_id == ul.id,
+      where:
+        event.user_id == ^user_id or
+          (event.user_id != ^user_id and
+             (not is_nil(event.post_id) or
+                ul.is_public == true or
+                fragment("trigger->>'is_public' = 'true'")))
+    )
+  end
+
+  def events_by_sanfamily_or_followed_users_or_own_query(query, user_id) do
+    sanclan_or_followed_users_or_own_ids =
+      UserFollower.followed_by(user_id)
+      |> Enum.map(& &1.id)
+      |> Enum.concat(Role.san_family_ids())
+      |> Enum.concat([user_id])
+      |> Enum.dedup()
+
+    from(
+      event in query,
+      where: event.user_id in ^sanclan_or_followed_users_or_own_ids
+    )
+  end
+
+  def events_by_sanfamily_query(query) do
+    sanfamily_ids = Sanbase.Auth.Role.san_family_ids()
+
+    from(
+      event in query,
+      where: event.user_id in ^sanfamily_ids
+    )
+  end
+
+  def events_by_followed_users_query(query, user_id) do
+    followed_users_ids =
+      UserFollower.followed_by(user_id)
+      |> Enum.map(& &1.id)
+
+    from(
+      event in query,
+      where: event.user_id in ^followed_users_ids
+    )
+  end
+
+  def events_by_current_user_query(query, user_id) do
+    from(
+      event in query,
+      where: event.user_id == ^user_id
+    )
+  end
+end

--- a/lib/sanbase/timeline/timeline_event.ex
+++ b/lib/sanbase/timeline/timeline_event.ex
@@ -14,7 +14,7 @@ defmodule Sanbase.Timeline.TimelineEvent do
   alias Sanbase.UserList
   alias Sanbase.Signal.UserTrigger
   alias Sanbase.Vote
-  alias Sanbase.EctoHelper
+  alias Sanbase.Timeline.{Query, Filter, Order, Cursor, Type}
 
   alias __MODULE__
 
@@ -23,6 +23,7 @@ defmodule Sanbase.Timeline.TimelineEvent do
   * Publish Insight
   * Update a public Watchlist with projects
   * Create a public UserTrigger
+  * Signal for UserTrigger fires
   """
   @publish_insight_type "publish_insight"
   @update_watchlist_type "update_watchlist"
@@ -50,37 +51,6 @@ defmodule Sanbase.Timeline.TimelineEvent do
 
     timestamps()
   end
-
-  @type event_type() :: String.t()
-  @type autor_type() :: :all | :followed | :sanfam | :own
-  @type filter() :: %{
-          author: autor_type(),
-          watchlists: list(non_neg_integer()),
-          assets: list(String.t())
-        }
-  @type cursor_type() :: :before | :after
-  @type cursor() :: %{type: cursor_type(), datetime: DateTime.t()}
-  @type order() :: :datetime | :author | :votes | :comments
-  @type timeline_event_args :: %{
-          limit: non_neg_integer(),
-          cursor: cursor(),
-          filter_by: filter(),
-          order_by: order()
-        }
-  @type events_with_cursor ::
-          %{
-            events: list(%TimelineEvent{}),
-            cursor: %{
-              before: DateTime.t(),
-              after: DateTime.t()
-            }
-          }
-  @type fired_triggers_map :: %{
-          user_trigger_id: non_neg_integer(),
-          user_id: non_neg_integer(),
-          payload: map(),
-          triggered_at: DateTime.t()
-        }
 
   def publish_insight_type(), do: @publish_insight_type
   def update_watchlist_type(), do: @update_watchlist_type
@@ -116,26 +86,27 @@ defmodule Sanbase.Timeline.TimelineEvent do
         cursor: %{type: cursor_type, datetime: cursor_datetime}
       }) do
     TimelineEvent
-    |> by_cursor(cursor_type, cursor_datetime)
-    |> events_by_sanfamily_query()
-    |> events_order_limit_preload_query(order_by, min(limit, @max_events_returned))
+    |> Cursor.filter_by_cursor(cursor_type, cursor_datetime)
+    |> Query.events_by_sanfamily_query()
+    |> Order.events_order_limit_preload_query(order_by, min(limit, @max_events_returned))
     |> Repo.all()
-    |> events_with_cursor()
+    |> Cursor.wrap_events_with_cursor()
   end
 
   def events(%{order_by: order_by, limit: limit}) do
     TimelineEvent
-    |> events_by_sanfamily_query()
-    |> events_order_limit_preload_query(order_by, min(limit, @max_events_returned))
+    |> Query.events_by_sanfamily_query()
+    |> Order.events_order_limit_preload_query(order_by, min(limit, @max_events_returned))
     |> Repo.all()
-    |> events_with_cursor()
+    |> Cursor.wrap_events_with_cursor()
   end
 
   @doc """
   Events by current user, followed users or sanfamily members.
   The events can be paginated with time-based cursor pagination.
   """
-  @spec events(%User{}, timeline_event_args) :: {:ok, events_with_cursor} | {:error, String.t()}
+  @spec events(%User{}, Type.timeline_event_args()) ::
+          {:ok, Type.events_with_cursor()} | {:error, String.t()}
   def events(
         %User{id: user_id},
         %{
@@ -146,21 +117,21 @@ defmodule Sanbase.Timeline.TimelineEvent do
         }
       ) do
     TimelineEvent
-    |> by_cursor(cursor_type, cursor_datetime)
-    |> filter_by_query(filter_by, user_id)
-    |> events_with_public_entities_query(user_id)
-    |> events_order_limit_preload_query(order_by, min(limit, @max_events_returned))
+    |> Cursor.filter_by_cursor(cursor_type, cursor_datetime)
+    |> Filter.filter_by_query(filter_by, user_id)
+    |> Query.events_with_public_entities_query(user_id)
+    |> Order.events_order_limit_preload_query(order_by, min(limit, @max_events_returned))
     |> Repo.all()
-    |> events_with_cursor()
+    |> Cursor.wrap_events_with_cursor()
   end
 
   def events(%User{id: user_id}, %{order_by: order_by, filter_by: filter_by, limit: limit}) do
     TimelineEvent
-    |> filter_by_query(filter_by, user_id)
-    |> events_with_public_entities_query(user_id)
-    |> events_order_limit_preload_query(order_by, min(limit, @max_events_returned))
+    |> Filter.filter_by_query(filter_by, user_id)
+    |> Query.events_with_public_entities_query(user_id)
+    |> Order.events_order_limit_preload_query(order_by, min(limit, @max_events_returned))
     |> Repo.all()
-    |> events_with_cursor()
+    |> Cursor.wrap_events_with_cursor()
   end
 
   def events(_, _), do: {:error, "Bad arguments"}
@@ -174,7 +145,7 @@ defmodule Sanbase.Timeline.TimelineEvent do
     - changeset: the changes used to determine if an event should be created.
   """
   @spec maybe_create_event_async(
-          event_type,
+          Type.event_type(),
           %Post{} | %UserList{} | %UserTrigger{},
           Ecto.Changeset.t()
         ) :: Task.t()
@@ -191,7 +162,7 @@ defmodule Sanbase.Timeline.TimelineEvent do
     end)
   end
 
-  @spec create_trigger_fired_events(list(fired_triggers_map)) :: Task.t()
+  @spec create_trigger_fired_events(list(Type.fired_triggers_map())) :: Task.t()
   def create_trigger_fired_events(fired_triggers) do
     Task.Supervisor.async_nolink(Sanbase.TaskSupervisor, fn ->
       fired_triggers
@@ -259,252 +230,5 @@ defmodule Sanbase.Timeline.TimelineEvent do
 
   defp create_event(type, id, params) do
     %__MODULE__{} |> create_changeset(Map.put(params, type, id)) |> Repo.insert()
-  end
-
-  # show private and public entities only if they belong to current user, otherwise show only public entities
-  defp events_with_public_entities_query(query, user_id) do
-    from(
-      event in query,
-      left_join: ut in UserTrigger,
-      on: event.user_trigger_id == ut.id,
-      left_join: ul in UserList,
-      on: event.user_list_id == ul.id,
-      where:
-        event.user_id == ^user_id or
-          (event.user_id != ^user_id and
-             (not is_nil(event.post_id) or
-                ul.is_public == true or
-                fragment("trigger->>'is_public' = 'true'")))
-    )
-  end
-
-  defp filter_by_query(query, filter_by, user_id) do
-    query
-    |> filter_by_author_query(filter_by, user_id)
-    |> filter_by_watchlists_query(filter_by)
-    |> filter_by_assets_query(filter_by, user_id)
-  end
-
-  defp filter_by_author_query(query, %{author: :all}, user_id) do
-    events_by_sanfamily_or_followed_users_or_own_query(query, user_id)
-  end
-
-  defp filter_by_author_query(query, %{author: :sanfam}, _) do
-    events_by_sanfamily_query(query)
-  end
-
-  defp filter_by_author_query(query, %{author: :followed}, user_id) do
-    events_by_followed_users_query(query, user_id)
-  end
-
-  defp filter_by_author_query(query, %{author: :own}, user_id) do
-    events_by_current_user_query(query, user_id)
-  end
-
-  defp filter_by_author_query(query, _, user_id) do
-    events_by_sanfamily_or_followed_users_or_own_query(query, user_id)
-  end
-
-  defp filter_by_watchlists_query(query, %{watchlists: watchlists})
-       when is_list(watchlists) and length(watchlists) > 0 do
-    from(event in query, where: event.user_list_id in ^watchlists)
-  end
-
-  defp filter_by_watchlists_query(query, _), do: query
-
-  defp filter_by_assets_query(query, %{assets: assets} = filter_by, user_id)
-       when is_list(assets) and length(assets) > 0 do
-    {slugs, tickers} = get_slugs_and_tickers_by_asset_list(assets)
-    watchlist_ids = get_watchlist_ids_by_asset_list(assets, filter_by, user_id)
-    insight_ids = get_insight_ids_by_asset_list({slugs, tickers}, filter_by, user_id)
-    trigger_ids = get_trigger_ids_by_asset_list({slugs, tickers}, filter_by, user_id)
-
-    from(event in query,
-      where:
-        event.user_list_id in ^watchlist_ids or
-          event.post_id in ^insight_ids or
-          event.user_trigger_id in ^trigger_ids
-    )
-  end
-
-  defp filter_by_assets_query(query, _, _), do: query
-
-  defp get_watchlist_ids_by_asset_list(assets, filter_by, user_id) do
-    from(
-      entity in UserList,
-      join: li in assoc(entity, :list_items),
-      where: li.project_id in ^assets,
-      select: entity.id
-    )
-    |> filter_by_author_query(filter_by, user_id)
-    |> Repo.all()
-  end
-
-  defp get_slugs_and_tickers_by_asset_list(assets) do
-    project_slugs_and_tickers =
-      from(p in Sanbase.Model.Project, where: p.id in ^assets, select: [p.slug, p.ticker])
-      |> Repo.all()
-
-    slugs = project_slugs_and_tickers |> Enum.map(fn [slug, _] -> slug end)
-    tickers = project_slugs_and_tickers |> Enum.map(fn [_, ticker] -> ticker end)
-
-    {slugs, tickers}
-  end
-
-  defp get_insight_ids_by_asset_list({slugs, tickers}, filter_by, user_id) do
-    from(
-      entity in Post,
-      join: t in assoc(entity, :tags),
-      where: t.name in ^slugs or t.name in ^tickers,
-      select: entity.id
-    )
-    |> filter_by_author_query(filter_by, user_id)
-    |> Repo.all()
-  end
-
-  defp get_trigger_ids_by_asset_list({slugs, tickers}, filter_by, user_id) do
-    triggers =
-      from(ut in UserTrigger, select: [ut.id, fragment("trigger->'settings'->'target'")])
-      |> filter_by_author_query(filter_by, user_id)
-      |> Repo.all()
-
-    triggers
-    |> Enum.filter(fn
-      [_, %{"slug" => slug}] when is_binary(slug) ->
-        slug in slugs
-
-      [_, %{"slug" => target_slugs}] when is_list(slugs) ->
-        MapSet.new(target_slugs) |> MapSet.intersection(MapSet.new(slugs)) |> MapSet.size() > 0
-
-      [_, %{"word" => word}] when is_binary(word) ->
-        word in slugs or String.upcase(word) in tickers
-
-      [_, %{"word" => words}] when is_list(words) ->
-        words_upcase = words |> Enum.map(&String.upcase/1)
-
-        MapSet.new(words) |> MapSet.intersection(MapSet.new(slugs)) |> MapSet.size() > 0 or
-          MapSet.new(words_upcase) |> MapSet.intersection(MapSet.new(tickers)) |> MapSet.size() >
-            0
-    end)
-    |> Enum.map(fn [id, _] -> id end)
-  end
-
-  defp events_by_sanfamily_or_followed_users_or_own_query(query, user_id) do
-    sanclan_or_followed_users_or_own_ids =
-      Sanbase.Auth.UserFollower.followed_by(user_id)
-      |> Enum.map(& &1.id)
-      |> Enum.concat(Sanbase.Auth.Role.san_family_ids())
-      |> Enum.concat([user_id])
-      |> Enum.dedup()
-
-    from(
-      event in query,
-      where: event.user_id in ^sanclan_or_followed_users_or_own_ids
-    )
-  end
-
-  defp events_by_sanfamily_query(query) do
-    sanfamily_ids = Sanbase.Auth.Role.san_family_ids()
-
-    from(
-      event in query,
-      where: event.user_id in ^sanfamily_ids
-    )
-  end
-
-  defp events_by_followed_users_query(query, user_id) do
-    followed_users_ids =
-      Sanbase.Auth.UserFollower.followed_by(user_id)
-      |> Enum.map(& &1.id)
-
-    from(
-      event in query,
-      where: event.user_id in ^followed_users_ids
-    )
-  end
-
-  defp events_by_current_user_query(query, user_id) do
-    from(
-      event in query,
-      where: event.user_id == ^user_id
-    )
-  end
-
-  defp events_order_limit_preload_query(query, order_by, limit) do
-    query
-    |> limit(^limit)
-    |> order_by_query(order_by)
-    |> preload([:user_trigger, [post: :tags], :user_list, :user, :votes])
-  end
-
-  defp order_by_query(query, :datetime) do
-    from(
-      event in query,
-      order_by: [desc: event.inserted_at]
-    )
-  end
-
-  defp order_by_query(query, :author) do
-    from(
-      event in query,
-      join: u in assoc(event, :user),
-      order_by: [asc: u.username, desc: event.inserted_at]
-    )
-  end
-
-  defp order_by_query(query, :votes) do
-    # order by: date, votes count, datetime
-    ids =
-      from(
-        entity in query,
-        left_join: assoc in assoc(entity, :votes),
-        select: {entity.id, fragment("COUNT(?)", assoc.id)},
-        group_by: entity.id,
-        order_by:
-          fragment(
-            "?::date DESC, count DESC NULLS LAST, ? DESC",
-            entity.inserted_at,
-            entity.inserted_at
-          )
-      )
-      |> Repo.all()
-      |> Enum.map(fn {id, _} -> id end)
-
-    EctoHelper.by_id_in_order_query(query, ids)
-  end
-
-  defp order_by_query(query, :comments) do
-    ids = EctoHelper.fetch_ids_ordered_by_assoc_count(query, :comments)
-    EctoHelper.by_id_in_order_query(query, ids)
-  end
-
-  defp by_cursor(query, :before, datetime) do
-    from(
-      event in query,
-      where: event.inserted_at < ^datetime
-    )
-  end
-
-  defp by_cursor(query, :after, datetime) do
-    from(
-      event in query,
-      where: event.inserted_at > ^datetime
-    )
-  end
-
-  defp events_with_cursor([]), do: {:ok, %{events: [], cursor: %{}}}
-
-  defp events_with_cursor(events) do
-    before_datetime = events |> List.last() |> Map.get(:inserted_at)
-    after_datetime = events |> List.first() |> Map.get(:inserted_at)
-
-    {:ok,
-     %{
-       events: events,
-       cursor: %{
-         before: before_datetime,
-         after: after_datetime
-       }
-     }}
   end
 end

--- a/lib/sanbase/timeline/type.ex
+++ b/lib/sanbase/timeline/type.ex
@@ -1,0 +1,32 @@
+defmodule Sanbase.Timeline.Type do
+  @type event_type() :: String.t()
+  @type autor_type() :: :all | :followed | :sanfam | :own
+  @type filter() :: %{
+          author: autor_type(),
+          watchlists: list(non_neg_integer()),
+          assets: list(String.t())
+        }
+  @type cursor_type() :: :before | :after
+  @type cursor() :: %{type: cursor_type(), datetime: DateTime.t()}
+  @type order() :: :datetime | :author | :votes | :comments
+  @type timeline_event_args :: %{
+          limit: non_neg_integer(),
+          cursor: cursor(),
+          filter_by: filter(),
+          order_by: order()
+        }
+  @type events_with_cursor ::
+          %{
+            events: list(%Sanbase.Timeline.TimelineEvent{}),
+            cursor: %{
+              before: DateTime.t(),
+              after: DateTime.t()
+            }
+          }
+  @type fired_triggers_map :: %{
+          user_trigger_id: non_neg_integer(),
+          user_id: non_neg_integer(),
+          payload: map(),
+          triggered_at: DateTime.t()
+        }
+end

--- a/lib/sanbase_web/graphql/schema/queries/timeline_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/timeline_queries.ex
@@ -14,7 +14,7 @@ defmodule SanbaseWeb.Graphql.Schema.TimelineQueries do
       arg(:cursor, :cursor_input)
 
       arg(:filter_by, :timeline_events_filter_input,
-        default_value: %{author: :sanfam_and_followed, watchlists: nil, assets: nil}
+        default_value: %{author: :all, watchlists: nil, assets: nil}
       )
 
       arg(:order_by, :order_by_enum, default_value: :datetime)

--- a/lib/sanbase_web/graphql/schema/queries/timeline_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/timeline_queries.ex
@@ -12,6 +12,11 @@ defmodule SanbaseWeb.Graphql.Schema.TimelineQueries do
       meta(access: :free)
 
       arg(:cursor, :cursor_input)
+
+      arg(:filter_by, :timeline_events_filter_input,
+        default_value: %{author: :sanfam_and_followed, watchlists: nil, assets: nil}
+      )
+
       arg(:order_by, :order_by_enum, default_value: :datetime)
       arg(:limit, :integer, default_value: 25)
 

--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -442,7 +442,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
 
   object :currency_amount do
     field(:currency_code, :string)
-    field(:amount, :float)
+    field(:amount, :decimal)
   end
 
   object :eth_spent_data do

--- a/lib/sanbase_web/graphql/schema/types/timeline_event_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/timeline_event_types.ex
@@ -13,9 +13,9 @@ defmodule SanbaseWeb.Graphql.TimelineEventTypes do
   enum(:author_filter, values: [:all, :own, :followed, :sanfam])
 
   input_object :timeline_events_filter_input do
-    field(:author, :author_filter)
-    field(:watchlists, list_of(:integer))
-    field(:assets, list_of(:string))
+    field(:author, :author_filter, default_value: :all)
+    field(:watchlists, list_of(:integer), default_value: nil)
+    field(:assets, list_of(:integer), default_value: nil)
   end
 
   object :timeline_events_paginated do

--- a/lib/sanbase_web/graphql/schema/types/timeline_event_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/timeline_event_types.ex
@@ -10,6 +10,14 @@ defmodule SanbaseWeb.Graphql.TimelineEventTypes do
     value(:author)
   end
 
+  enum(:author_filter, values: [:all, :own, :followed, :sanfam])
+
+  input_object :timeline_events_filter_input do
+    field(:author, :author_filter)
+    field(:watchlists, list_of(:integer))
+    field(:assets, list_of(:string))
+  end
+
   object :timeline_events_paginated do
     field(:events, list_of(:timeline_event))
     field(:cursor, :cursor)

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "absinthe": {:git, "https://github.com/absinthe-graphql/absinthe.git", "5b5079f03402f482c5f52a35efc263a5a6ccaf64", []},
+  "absinthe": {:git, "https://github.com/absinthe-graphql/absinthe.git", "24deff116d1194be32ffb647e36be8d072475caa", []},
   "absinthe_ecto": {:hex, :absinthe_ecto, "0.1.3", "420b68129e79fe4571a4838904ba03e282330d335da47729ad52ffd7b8c5fcb1", [:mix], [{:absinthe, "~> 1.3.0 or ~> 1.4.0", [hex: :absinthe, repo: "hexpm", optional: false]}, {:ecto, ">= 0.0.0", [hex: :ecto, repo: "hexpm", optional: false]}], "hexpm"},
   "absinthe_metrics": {:hex, :absinthe_metrics, "1.0.0", "c4dd0444168a1d32a432cab2ced498069e58fd4b90aa9e1ec16b49557bee2cf1", [:mix], [{:absinthe, "~> 1.3", [hex: :absinthe, repo: "hexpm", optional: false]}, {:prometheus_ex, "~> 3.0", [hex: :prometheus_ex, repo: "hexpm", optional: true]}], "hexpm"},
   "absinthe_phoenix": {:git, "https://github.com/absinthe-graphql/absinthe_phoenix.git", "1d832570ffdd031a209a9218c6fc54cde4488665", []},

--- a/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_product_access_test.exs
+++ b/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_product_access_test.exs
@@ -430,8 +430,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
   defp daily_active_deposits_resp() do
     {:ok,
      [
-       %{active_deposits: 0.1, datetime: ~U[2019-01-01 00:00:00Z]},
-       %{active_deposits: 0.2, datetime: ~U[2019-01-02 00:00:00Z]}
+       %{active_deposits: 1, datetime: ~U[2019-01-01 00:00:00Z]},
+       %{active_deposits: 2, datetime: ~U[2019-01-02 00:00:00Z]}
      ]}
   end
 

--- a/test/sanbase_web/graphql/billing/timeframe_access_restrictions/sanbase_product_access_test.exs
+++ b/test/sanbase_web/graphql/billing/timeframe_access_restrictions/sanbase_product_access_test.exs
@@ -418,8 +418,8 @@ defmodule Sanbase.Billing.SanbaseProductAccessTest do
   defp daily_active_deposits_resp() do
     {:ok,
      [
-       %{active_deposits: 0.1, datetime: ~U[2019-01-01 00:00:00Z]},
-       %{active_deposits: 0.2, datetime: ~U[2019-01-02 00:00:00Z]}
+       %{active_deposits: 1, datetime: ~U[2019-01-01 00:00:00Z]},
+       %{active_deposits: 2, datetime: ~U[2019-01-02 00:00:00Z]}
      ]}
   end
 

--- a/test/sanbase_web/graphql/projects/project_api_eth_spent_over_time_test.exs
+++ b/test/sanbase_web/graphql/projects/project_api_eth_spent_over_time_test.exs
@@ -85,12 +85,12 @@ defmodule SanbaseWeb.Graphql.ProjectApiEthSpentOverTimeTest do
 
       assert %{
                "datetime" => "2017-05-16T00:00:00Z",
-               "ethSpent" => 0
+               "ethSpent" => 0.0
              } in eth_spent_over_time
 
       assert %{
                "datetime" => "2017-05-17T00:00:00Z",
-               "ethSpent" => 0
+               "ethSpent" => 0.0
              } in eth_spent_over_time
 
       assert %{


### PR DESCRIPTION
* fixed cursor bug on ordered events
* order by `VOTES` - means `order_by: date, votes, datetime`
* order by `COMMENTS` - order only by timeline events comments

`filterBy` opts:

* `filterBy: {author: ALL | SANFAM | FOLLOWED | OWN}`
* `filterBy: {author: ALL, watchlists: [100]}`
* `filterBy: {author: ALL, assets: [200]}`
