### PR TITLE
Change integer types to float because of aggregations

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
@@ -108,7 +108,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.InsightResolver do
     {:ok,
      %{
        total_votes: total_votes,
-       total_san_votes: total_san_votes |> round() |> trunc()
+       total_san_votes: total_san_votes |> Sanbase.Math.to_integer()
      }}
   end
 

--- a/lib/sanbase_web/graphql/schema/types/clickhouse_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/clickhouse_types.ex
@@ -3,25 +3,25 @@ defmodule SanbaseWeb.Graphql.ClickhouseTypes do
 
   object :active_addresses do
     field(:datetime, non_null(:datetime))
-    field(:active_addresses, non_null(:integer))
+    field(:active_addresses, non_null(:float))
   end
 
   object :active_deposits do
     field(:datetime, non_null(:datetime))
-    field(:active_deposits, non_null(:integer))
+    field(:active_deposits, non_null(:float))
   end
 
   object :share_of_deposits do
     field(:datetime, non_null(:datetime))
-    field(:active_addresses, non_null(:integer))
-    field(:active_deposits, non_null(:integer))
+    field(:active_addresses, non_null(:float))
+    field(:active_deposits, non_null(:float))
     field(:share_of_deposits, :float)
   end
 
   object :gas_used do
     field(:datetime, non_null(:datetime))
-    field(:eth_gas_used, :integer, deprecate: "Use gasUsed")
-    field(:gas_used, :integer)
+    field(:eth_gas_used, :float, deprecate: "Use gasUsed")
+    field(:gas_used, :float)
   end
 
   object :mining_pools_distribution do
@@ -38,7 +38,7 @@ defmodule SanbaseWeb.Graphql.ClickhouseTypes do
 
   object :network_growth do
     field(:datetime, non_null(:datetime))
-    field(:new_addresses, :integer)
+    field(:new_addresses, :float)
   end
 
   object :nvt_ratio do
@@ -49,8 +49,8 @@ defmodule SanbaseWeb.Graphql.ClickhouseTypes do
 
   object :realized_value do
     field(:datetime, non_null(:datetime))
-    field(:realized_value, :integer)
-    field(:non_exchange_realized_value, :integer)
+    field(:realized_value, :float)
+    field(:non_exchange_realized_value, :float)
   end
 
   object :percent_of_token_supply_on_exchanges do

--- a/lib/sanbase_web/graphql/schema/types/github_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/github_types.ex
@@ -9,6 +9,6 @@ defmodule SanbaseWeb.Graphql.GithubTypes do
 
   object :activity_point do
     field(:datetime, non_null(:datetime))
-    field(:activity, non_null(:integer))
+    field(:activity, non_null(:float))
   end
 end


### PR DESCRIPTION
Aggregating with `average` can make data response float that is otherwise integer like DAA

![image](https://user-images.githubusercontent.com/6518376/73664804-b1d1fb00-46a8-11ea-8b32-ae6bd8980378.png)

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
