### PR TITLE
Update triggered_at regardless of the outcome of the send to channel

### DIFF
--- a/lib/sanbase/signals/evaluator/scheduler.ex
+++ b/lib/sanbase/signals/evaluator/scheduler.ex
@@ -102,22 +102,18 @@ defmodule Sanbase.Signal.Scheduler do
     # all signals will be different, sometimes only by a second
     now = Timex.now() |> Timex.set(second: 0, microsecond: {0, 0})
 
+    # Update all triggered_at regardless if the send to the channel succeed
+    # because the signal will be stored in the timeline events.
     last_triggered =
       send_results_list
       |> Enum.reduce(last_triggered, fn
-        # If the key is a list we'll record each individual element separately
-        # because we're checking every item in the list separately if it was
-        # triggered or not.
-        {list, :ok}, acc when is_list(list) ->
+        {list, _}, acc when is_list(list) ->
           Enum.reduce(list, acc, fn elem, inner_acc ->
             Map.put(inner_acc, elem, now)
           end)
 
-        {slug, :ok}, acc ->
+        {slug, _}, acc ->
           Map.put(acc, slug, now)
-
-        _, acc ->
-          acc
       end)
 
     UserTrigger.update_user_trigger(user, %{


### PR DESCRIPTION
This is done because otherwise the signal won't be processed as in
cooldown and it will generate many timeline events and historical
activities as it will run over and over.

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
