### PR TITLE
Add availableAnomalies field to the GraphQL project type

### DIFF
--- a/lib/sanbase/anomaly/available_anomalies.json
+++ b/lib/sanbase/anomaly/available_anomalies.json
@@ -20,5 +20,16 @@
     "min_interval": "1d",
     "table": "anomalies",
     "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Development Activity Anomaly",
+    "model_name": "prophet_v1",
+    "name": "exchange_balance_anomaly",
+    "metric": "exchange_balance",
+    "access": "free",
+    "aggregation": "count",
+    "min_interval": "1d",
+    "table": "anomalies",
+    "data_type": "timeseries"
   }
 ]

--- a/lib/sanbase/anomaly/file_handler.ex
+++ b/lib/sanbase/anomaly/file_handler.ex
@@ -14,6 +14,16 @@ defmodule Sanbase.Anomaly.FileHandler do
       |> Enum.reject(&is_nil/1)
       |> Map.new()
     end
+
+    def fields_to_name_map(map, fields) do
+      map
+      |> Enum.into(
+        %{},
+        fn %{"name" => name} = elem ->
+          {Map.take(elem, fields), name}
+        end
+      )
+    end
   end
 
   # Structure
@@ -40,6 +50,10 @@ defmodule Sanbase.Anomaly.FileHandler do
   @human_readable_name_map Helper.name_to_field_map(@anomalies_json, "human_readable_name")
   @model_name_map Helper.name_to_field_map(@anomalies_json, "model_name")
   @data_type_map Helper.name_to_field_map(@anomalies_json, "data_type", &String.to_atom/1)
+  @metric_and_model_to_anomaly_map Helper.fields_to_name_map(@anomalies_json, [
+                                     "metric",
+                                     "model_name"
+                                   ])
 
   @anomalies_list @anomalies_json |> Enum.map(fn %{"name" => name} -> name end)
   @anomalies_mapset MapSet.new(@anomalies_list)
@@ -54,6 +68,7 @@ defmodule Sanbase.Anomaly.FileHandler do
   def table_map(), do: @table_map
   def data_type_map(), do: @data_type_map
   def model_name_map(), do: @model_name_map
+  def metric_and_model_to_anomaly_map(), do: @metric_and_model_to_anomaly_map
 
   def anomalies_with_access(level) when level in [:free, :restricted] do
     @access_map

--- a/lib/sanbase/anomaly/helper.ex
+++ b/lib/sanbase/anomaly/helper.ex
@@ -1,2 +1,0 @@
-defmodule Sanbase.Anomaly.Helper do
-end

--- a/lib/sanbase_web/graphql/resolvers/project/project_anomalies_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_anomalies_resolver.ex
@@ -1,0 +1,10 @@
+defmodule SanbaseWeb.Graphql.Resolvers.ProjectAnomaliesResolver do
+  require Logger
+
+  alias Sanbase.Model.Project
+  alias Sanbase.Anomaly
+
+  def available_anomalies(%Project{slug: slug}, _args, _resolution) do
+    Anomaly.available_anomalies(slug)
+  end
+end

--- a/test/sanbase/clickhouse/metric/clickhouse_metric_helper_test.exs
+++ b/test/sanbase/clickhouse/metric/clickhouse_metric_helper_test.exs
@@ -3,20 +3,21 @@ defmodule Sanbase.Clickhouse.Metric.HelperTest do
 
   import Mock
 
-  test "metric id to name map correctly uses the version" do
+  test "metric id to name map" do
     with_mock Sanbase.ClickhouseRepo,
       query: fn _, _ ->
         {:ok,
          %{
            rows: [
-             [1, "daily_active_addresses", "2019-01-01"],
-             [2, "daily_active_addresses", "2019-11-03"]
+             [1, "daily_active_addresses"],
+             [2, "dev_activity"]
            ]
          }}
       end do
-      {:ok, version_map} = Sanbase.Clickhouse.MetadataHelper.metric_name_to_metric_id_map()
-      assert {"daily_active_addresses", 1} in version_map
-      refute {"daily_active_addresses", 2} in version_map
+      {:ok, map} = Sanbase.Clickhouse.MetadataHelper.metric_name_to_metric_id_map()
+
+      assert {"daily_active_addresses", 1} in map
+      assert {"dev_activity", 2} in map
     end
   end
 end

--- a/test/sanbase_web/graphql/anomaly/api_project_available_metrics_test.exs
+++ b/test/sanbase_web/graphql/anomaly/api_project_available_metrics_test.exs
@@ -1,0 +1,63 @@
+defmodule Sanbase.Project.AvailableMetricsApiTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import Sanbase.Factory
+  import SanbaseWeb.Graphql.TestHelpers
+
+  test "get project's available anomalies" do
+    project = insert(:random_erc20_project)
+    project2 = insert(:random_erc20_project)
+
+    Sanbase.Mock.prepare_mock2(
+      &Sanbase.ClickhouseRepo.query/2,
+      {:ok,
+       %{
+         rows: [
+           ["prophet_v1", 1, 1],
+           ["prophet_v1", 1, 2],
+           ["prophet_v1", 1, 3],
+           ["prophet_v1", 2, 3]
+         ]
+       }}
+    )
+    |> Sanbase.Mock.prepare_mock2(
+      &Sanbase.Clickhouse.MetadataHelper.asset_id_to_slug_map/0,
+      {:ok, %{1 => project.slug, 2 => project2.slug}}
+    )
+    |> Sanbase.Mock.prepare_mock2(
+      &Sanbase.Clickhouse.MetadataHelper.metric_id_to_metric_name_map/0,
+      {:ok, %{1 => "dev_activity", 2 => "daily_active_addresses", 3 => "exchange_balance"}}
+    )
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      result = get_available_anomalies(project)
+      %{"data" => %{"projectBySlug" => %{"availableAnomalies" => available_metrics}}} = result
+
+      assert available_metrics |> Enum.sort() ==
+               [
+                 "dev_activity_anomaly",
+                 "daily_active_addresses_anomaly",
+                 "exchange_balance_anomaly"
+               ]
+               |> Enum.sort()
+
+      result2 = get_available_anomalies(project2)
+      %{"data" => %{"projectBySlug" => %{"availableAnomalies" => available_metrics2}}} = result2
+
+      assert available_metrics2 == ["exchange_balance_anomaly"]
+    end)
+  end
+
+  defp get_available_anomalies(project) do
+    query = """
+    {
+      projectBySlug(slug: "#{project.slug}"){
+        availableAnomalies
+      }
+    }
+    """
+
+    build_conn()
+    |> post("/graphql", query_skeleton(query))
+    |> json_response(200)
+  end
+end


### PR DESCRIPTION
#### Summary
Request
```graphql
{
  # The availableAnomalies field actually checks what part of the
  # anomalies are available for a given project
  
  # All three currently available anomalies are present
  san_anomalies: projectBySlug(slug: "santiment"){
    availableAnomalies
  }
  
  # No exchange anomalies currently
  bitcoin_anomalies: projectBySlug(slug:"bitcoin"){
    availableAnomalies
  }
}
```
Response
```graphql
{
  "data": {
    "bitcoin_anomalies": {
      "availableAnomalies": [
        "daily_active_addresses_anomaly",
        "dev_activity_anomaly"
      ]
    },
    "san_anomalies": {
      "availableAnomalies": [
        "daily_active_addresses_anomaly",
        "exchange_balance_anomaly",
        "dev_activity_anomaly"
      ]
    }
  }
}
```
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
