### PR TITLE
Fix available metrics APIs

### DIFF
--- a/lib/sanbase/cache/rehydrating_cache.ex
+++ b/lib/sanbase/cache/rehydrating_cache.ex
@@ -1,0 +1,281 @@
+defmodule Sanbase.Cache.RehydratingCache do
+  @moduledoc ~s"""
+  A service that automatically re-runs functions and caches their values at
+  intervals smaller than the TTL so the cache never expires but is just renewed.
+
+  This service is useful when heavy queries need to be cached without any waiting
+  for recalculation when the cache expires.
+
+  Example usage: cache the function `f` under the key `:key` for up to 1 hour
+  but refresh the data every 15 minutes. Under expected conditions the value
+  will be refreshed every 15 minutes and the cache will expire only if the
+  function fails to evaluate for more than 1 hour.
+  """
+  use GenServer
+
+  @name :__rehydrating_cache__
+
+  @run_interval 15_000
+  @purge_timeout_interval 30_000
+
+  defguard are_proper_function_arguments(fun, ttl, refresh_time_delta)
+           when is_function(fun, 0) and is_integer(ttl) and ttl > 0 and
+                  is_integer(refresh_time_delta) and
+                  refresh_time_delta < ttl
+
+  @doc ~s"""
+  Start the self rehydrating cache service.
+
+  Options:
+    functions: A list of function descriptions. A function description is a
+    map with the following keys:
+      - function: Anonymous 0-arity function that computes the value
+      - key: The key the computed value will be associated with
+      - ttl: The maximal time the value will be stored for in seconds
+      - refresh_time_delta: A number of seconds strictly smaller than ttl. Every
+      refresh_time_delta seconds the cache will be recomputed and stored again.
+      The count for ttl starts from 0 again when value is recomputed.
+  """
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: @name)
+  end
+
+  def init(opts) do
+    functions =
+      Keyword.get(opts, :functions, %{})
+      |> Enum.into(
+        %{},
+        fn %{key: key, ttl: ttl, refresh_time_delta: refresh_time_delta, function: fun} = fun_map
+           when are_proper_function_arguments(fun, ttl, refresh_time_delta) ->
+          {key, fun_map}
+        end
+      )
+
+    initial_state = %{
+      task_supervisor: Keyword.fetch!(opts, :task_supervisor),
+      functions: functions,
+      store: %{},
+      progress: %{},
+      waiting: %{}
+    }
+
+    Process.send_after(self(), :purge_timeouts, @purge_timeout_interval)
+    {:ok, initial_state, {:continue, :initialize}}
+  end
+
+  # Public API
+  @doc ~s"""
+  Register a new cache function record. The arguments are:
+    - function: Anonymous 0-arity function that computes the value
+    - key: The key the computed value will be associated with
+    - ttl: The maximal time the value will be stored for in seconds
+    - refresh_time_delta: A number of seconds strictly smaller than ttl. Every
+      refresh_time_delta seconds the cache will be recomputed and stored again.
+      The count for ttl starts from 0 again when value is recomputed.
+  """
+  @spec register_function((() -> any()), any(), pos_integer(), pos_integer()) ::
+          :ok | {:error, String.t()}
+  def register_function(fun, key, ttl, refresh_time_delta)
+      when are_proper_function_arguments(fun, ttl, refresh_time_delta) do
+    map = %{function: fun, key: key, ttl: ttl, refresh_time_delta: refresh_time_delta}
+    GenServer.call(@name, {:register_function, map})
+  end
+
+  @doc ~s"""
+  Get the value associated with key. If the function computing this key is not
+  registered return an error straight away. If the function is registered there are
+  two cases. The timeout cannot be :infinity.
+  1. The first computation of the value is still going. In this case wait at most
+  timeout seconds for the result. If the result is computed in that time it is
+  returned
+  2. The value has been already computed and it's returned straight away. Note that
+  if a recomputation is running when get is invoked, the old value is returned.
+  """
+  @spec get(any(), non_neg_integer()) :: {:ok, any()} | {:error, :timeout} | {:error, String.t()}
+  def get(key, timeout \\ 30_000) when is_integer(timeout) and timeout > 0 do
+    try do
+      GenServer.call(@name, {:get, key, timeout}, timeout)
+    catch
+      :exit, {:timeout, _} ->
+        {:error, :timeout}
+    end
+  end
+
+  # handle_* callbacks
+
+  def handle_continue(:initialize, state) do
+    {:noreply, do_run(state)}
+  end
+
+  def handle_call({:get, key, timeout}, from, state) do
+    # There a few different cases that need to be handled
+    # 1. The value is present in the store - serve it
+    # 2. Computation is in progress - add the caller to the wait list
+    # 3. Computation is not in progress but the function is registered -
+    #    re-register the function and add the caller to the wait list
+    # 4. None of the above - the key has not been registered
+    tuple = %{
+      value: Map.get(state.store, key),
+      progress: Map.get(state.progress, key),
+      function: Map.get(state.functions, key)
+    }
+
+    case tuple do
+      %{value: {:ok, value}} ->
+        {:reply, {:ok, value}, state}
+
+      %{progress: :in_progress} ->
+        # If the value is still computing the response will be sent
+        # once the value is computed
+        new_state = do_fill_waiting_list(state, key, from, timeout)
+        {:noreply, new_state}
+
+      %{function: fun_map} when is_map(fun_map) ->
+        new_state =
+          state
+          |> do_register_function(fun_map)
+          |> do_fill_waiting_list(key, from, timeout)
+
+        {:noreply, new_state}
+
+      _ ->
+        {:reply, {:error, "The key #{inspect(key)} is not registered"}, state}
+    end
+  end
+
+  def handle_call({:register_function, %{key: key} = fun_map}, _from, state) do
+    case Map.has_key?(state.functions, key) do
+      true ->
+        {:reply, {:error, "Key #{inspect(key)} is already registered"}, state}
+
+      false ->
+        new_state = do_register_function(state, fun_map)
+        {:reply, :ok, new_state}
+    end
+  end
+
+  def handle_info(:run, state) do
+    new_state = do_run(state)
+    {:noreply, new_state}
+  end
+
+  def handle_info({:store_result, fun_map, result}, state) do
+    %{progress: progress} = state
+    %{key: key} = fun_map
+
+    now_unix = Timex.now() |> DateTime.to_unix()
+
+    case result do
+      {:error, _} ->
+        new_progress = Map.put(progress, key, now_unix)
+        {:noreply, %{state | progress: new_progress}}
+
+      {:ok, value} ->
+        %{store: store, waiting: waiting} = state
+        %{refresh_time_delta: refresh_time_delta} = fun_map
+
+        {reply_to_list, new_waiting} = Map.pop(waiting, key, [])
+        reply_to_waiting(reply_to_list, value)
+
+        new_progress = Map.put(progress, key, now_unix + refresh_time_delta)
+        new_store = Map.put(store, key, {:ok, value})
+
+        {:noreply, %{state | store: new_store, progress: new_progress, waiting: new_waiting}}
+    end
+  end
+
+  def handle_info(:purge_timeouts, state) do
+    new_state = do_purge_timeouts(state)
+    {:noreply, new_state}
+  end
+
+  def handle_info({ref, _}, state) when is_reference(ref) do
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, _ref, _, _pid, _reason}, state) do
+    {:noreply, state}
+  end
+
+  defp do_register_function(state, fun_map) do
+    %{key: key} = fun_map
+    _task = run_function(self(), fun_map, state.task_supervisor)
+
+    new_progress = Map.put(state.progress, key, :in_progress)
+    new_functions = Map.put(state.functions, key, fun_map)
+
+    %{state | functions: new_functions, progress: new_progress}
+  end
+
+  defp do_purge_timeouts(state) do
+    %{waiting: waiting} = state
+    now = Timex.now()
+
+    new_waiting =
+      Enum.reduce(waiting, %{}, fn {key, waiting_for_key}, acc ->
+        # Remove from the waiting list all timed out records. These are the `call`s
+        # that are no longer waiting for response.
+        still_waiting_for_key =
+          waiting_for_key
+          |> Enum.filter(fn {_from, send_before} ->
+            DateTime.compare(send_before, now) != :lt
+          end)
+
+        case still_waiting_for_key do
+          [] -> acc
+          _ -> Map.put(acc, key, still_waiting_for_key)
+        end
+      end)
+
+    Process.send_after(self(), :purge_timeouts, @purge_timeout_interval)
+    %{state | waiting: new_waiting}
+  end
+
+  defp do_run(state) do
+    now_unix = Timex.now() |> DateTime.to_unix()
+    %{progress: progress, functions: functions, task_supervisor: task_supervisor} = state
+
+    new_progress =
+      Enum.reduce(functions, %{}, fn {key, fun_map}, acc ->
+        case Map.get(progress, key, now_unix) do
+          run_after_unix when is_integer(run_after_unix) and now_unix >= run_after_unix ->
+            _task = run_function(self(), fun_map, task_supervisor)
+            Map.put(acc, key, :in_progress)
+
+          _ ->
+            acc
+        end
+      end)
+
+    Process.send_after(self(), :run, @run_interval)
+    %{state | progress: new_progress}
+  end
+
+  defp reply_to_waiting([], _), do: :ok
+
+  defp reply_to_waiting(from_list, value) do
+    now = Timex.now()
+
+    Enum.each(from_list, fn {from, send_before} ->
+      # Do not reply in case of timeout
+      case DateTime.compare(send_before, now) do
+        :lt -> :ok
+        _ -> GenServer.reply(from, {:ok, value})
+      end
+    end)
+  end
+
+  defp do_fill_waiting_list(state, key, from, timeout) do
+    elem = {from, Timex.shift(Timex.now(), milliseconds: timeout)}
+    new_waiting = Map.update(state.waiting, key, [elem], fn list -> [elem | list] end)
+    %{state | waiting: new_waiting}
+  end
+
+  defp run_function(pid, fun_map, task_supervisor) do
+    Task.Supervisor.async_nolink(task_supervisor, fn ->
+      %{function: fun} = fun_map
+      result = fun.()
+      Process.send(pid, {:store_result, fun_map, result}, [])
+    end)
+  end
+end

--- a/lib/sanbase/clickhouse/github/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/github/metric_adapter.ex
@@ -153,6 +153,20 @@ defmodule Sanbase.Clickhouse.Github.MetricAdapter do
   def available_metrics(), do: @metrics
 
   @impl Sanbase.Metric.Behaviour
+  def available_metrics(slug) do
+    case Project.github_organizations(slug) do
+      {:ok, []} ->
+        {:ok, []}
+
+      {:ok, organizations} when is_list(organizations) ->
+        {:ok, @metrics}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  @impl Sanbase.Metric.Behaviour
   def available_slugs() do
     # Providing a 2 element tuple `{any, integer}` will use that second element
     # as TTL for the cache key

--- a/lib/sanbase/clickhouse/metric/file_handler.ex
+++ b/lib/sanbase/clickhouse/metric/file_handler.ex
@@ -43,7 +43,7 @@ defmodule Sanbase.Clickhouse.Metric.FileHandler do
   @aggregations [:any, :sum, :avg, :min, :max, :last, :first, :median]
 
   @metrics_data_type_map Helper.name_to_field_map(@metrics_json, "data_type", &String.to_atom/1)
-  @name_to_column_map Helper.name_to_field_map(@metrics_json, "metric")
+  @name_to_metric_map Helper.name_to_field_map(@metrics_json, "metric")
   @access_map Helper.name_to_field_map(@metrics_json, "access", &String.to_atom/1)
   @table_map Helper.name_to_field_map(@metrics_json, "table")
   @aggregation_map Helper.name_to_field_map(@metrics_json, "aggregation", &String.to_atom/1)
@@ -75,7 +75,7 @@ defmodule Sanbase.Clickhouse.Metric.FileHandler do
   def metrics_mapset(), do: @metrics_mapset
   def aggregation_map(), do: @aggregation_map
   def min_interval_map(), do: @min_interval_map
-  def name_to_column_map(), do: @name_to_column_map
+  def name_to_metric_map(), do: @name_to_metric_map
   def human_readable_name_map(), do: @human_readable_name_map
   def metric_version_map(), do: @metric_version_map
   def metrics_data_type_map(), do: @metrics_data_type_map

--- a/lib/sanbase/clickhouse/metric/precached_functions.ex
+++ b/lib/sanbase/clickhouse/metric/precached_functions.ex
@@ -1,0 +1,2 @@
+defmodule Sanbase.Clickhouse.Metric.PrecachedFunctions do
+end

--- a/lib/sanbase/metric/behaviour.ex
+++ b/lib/sanbase/metric/behaviour.ex
@@ -74,11 +74,13 @@ defmodule Sanbase.Metric.Behaviour do
 
   @callback available_slugs(metric) :: {:ok, list(slug)} | {:error, String.t()}
 
+  @callback available_metrics() :: list(metric)
+
+  @callback available_metrics(slug) :: {:ok, list(metric)} | {:error, String.t()}
+
   @callback available_timeseries_metrics() :: list(metric)
 
   @callback available_histogram_metrics() :: list(metric)
-
-  @callback available_metrics() :: list(metric)
 
   @callback free_metrics() :: list(metric)
 

--- a/lib/sanbase/prices/metric_adapter.ex
+++ b/lib/sanbase/prices/metric_adapter.ex
@@ -73,6 +73,17 @@ defmodule Sanbase.Price.MetricAdapter do
   def available_metrics(), do: @metrics
 
   @impl Sanbase.Metric.Behaviour
+  def available_metrics("TOTAL_ERC20"), do: @metrics
+
+  def available_metrics(slug) do
+    case Price.first_datetime(slug) do
+      {:ok, %DateTime{}} -> {:ok, @metrics}
+      {:ok, nil} -> {:ok, []}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  @impl Sanbase.Metric.Behaviour
   def available_slugs() do
     Sanbase.Cache.get_or_store({:slugs_with_prices, 1800}, fn ->
       Price.available_slugs()

--- a/lib/sanbase/prices/price.ex
+++ b/lib/sanbase/prices/price.ex
@@ -470,7 +470,7 @@ defmodule Sanbase.Price do
   @doc ~s"""
   Return the first datetime for which `slug` has data
   """
-  @spec first_datetime(slug, opts) :: {:ok, DateTime.t()} | {:error, error}
+  @spec first_datetime(slug, opts) :: {:ok, DateTime.t()} | {:ok, nil} | {:error, error}
   def first_datetime(slug, opts \\ [])
 
   def first_datetime("TOTAL_ERC20", _), do: ~U[2015-07-30 00:00:00Z]
@@ -479,8 +479,8 @@ defmodule Sanbase.Price do
     source = Keyword.get(opts, :source, @default_source)
     {query, args} = first_datetime_query(slug, source)
 
-    ClickhouseRepo.query_transform(query, args, fn [timestamp] ->
-      DateTime.from_unix!(timestamp)
+    ClickhouseRepo.query_transform(query, args, fn
+      [timestamp] -> DateTime.from_unix!(timestamp)
     end)
     |> maybe_unwrap_ok_value()
   end

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -136,6 +136,17 @@ defmodule Sanbase.SocialData.MetricAdapter do
   def available_metrics(), do: @metrics
 
   @impl Sanbase.Metric.Behaviour
+  def available_metrics(slug) do
+    with {:ok, slugs} <- available_slugs(),
+         true <- slug in slugs do
+      {:ok, @metrics}
+    else
+      false -> {:ok, []}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  @impl Sanbase.Metric.Behaviour
   def free_metrics(), do: []
 
   @impl Sanbase.Metric.Behaviour

--- a/lib/sanbase/utils/transform.ex
+++ b/lib/sanbase/utils/transform.ex
@@ -77,5 +77,6 @@ defmodule Sanbase.Utils.Transform do
   end
 
   def maybe_unwrap_ok_value({:ok, [value]}), do: {:ok, value}
+  def maybe_unwrap_ok_value({:ok, []}), do: {:ok, nil}
   def maybe_unwrap_ok_value({:error, error}), do: {:error, error}
 end

--- a/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
@@ -5,41 +5,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver do
   alias Sanbase.Metric
 
   def available_metrics(%Project{slug: slug}, _args, _resolution) do
-    case Sanbase.Cache.get_or_store(
-           {:metric_available_slugs_mapset, 600},
-           fn -> Metric.available_slugs_mapset() end
-         ) do
-      {:ok, list} ->
-        if slug in list, do: {:ok, Metric.available_metrics()}, else: {:ok, []}
-
-      {:error, error} ->
-        {:error, error}
-    end
+    Metric.available_metrics_for_slug(slug)
   end
 
   def available_timeseries_metrics(%Project{slug: slug}, _args, _resolution) do
-    case Sanbase.Cache.get_or_store(
-           {:metric_available_slugs_mapset, 600},
-           fn -> Metric.available_slugs_mapset() end
-         ) do
-      {:ok, list} ->
-        if slug in list, do: {:ok, Metric.available_timeseries_metrics()}, else: {:ok, []}
-
-      {:error, error} ->
-        {:error, error}
-    end
+    Metric.available_timeseries_metrics_for_slug(slug)
   end
 
   def available_histogram_metrics(%Project{slug: slug}, _args, _resolution) do
-    case Sanbase.Cache.get_or_store(
-           {:metric_available_slugs_mapset, 600},
-           fn -> Metric.available_slugs_mapset() end
-         ) do
-      {:ok, list} ->
-        if slug in list, do: {:ok, Metric.available_histogram_metrics()}, else: {:ok, []}
-
-      {:error, error} ->
-        {:error, error}
-    end
+    Metric.available_histogram_metrics_for_slug(slug)
   end
 end

--- a/test/sanbase/project/project_available_metrics_test.exs
+++ b/test/sanbase/project/project_available_metrics_test.exs
@@ -1,23 +1,23 @@
 defmodule Sanbase.Project.AvailableMetricsTest do
   use SanbaseWeb.ConnCase, async: false
 
-  import Mock
   import Sanbase.Factory
   import SanbaseWeb.Graphql.TestHelpers
 
   test "get project's available metrics" do
     project = insert(:random_erc20_project)
+    available_metrics = Sanbase.Metric.available_metrics()
 
-    with_mocks([
-      {Sanbase.Metric, [:passthrough],
-       available_slugs_mapset: fn -> {:ok, [project.slug] |> MapSet.new()} end},
-      {Sanbase.TechIndicators, [], social_volume_projects: fn -> {:ok, [project]} end}
-    ]) do
+    metrics =
+      available_metrics |> Enum.shuffle() |> Enum.take(Enum.random(1..length(available_metrics)))
+
+    Sanbase.Mock.prepare_mock2(&Sanbase.Metric.available_metrics_for_slug/1, {:ok, metrics})
+    |> Sanbase.Mock.run_with_mocks(fn ->
       result = get_available_metrics(project)
       %{"data" => %{"projectBySlug" => %{"availableMetrics" => available_metrics}}} = result
 
-      assert available_metrics == Sanbase.Metric.available_metrics()
-    end
+      assert available_metrics == metrics
+    end)
   end
 
   defp get_available_metrics(project) do


### PR DESCRIPTION
#### Summary
In the end I am not using the self rehydrating cache. It is still included in the PR as it could be used in the future though.

Known issue: There are exchange metrics written for some coins (binance/bch/ltc) but are only zeroes. This should be fixed by the bigdata team

![image](https://user-images.githubusercontent.com/6518376/74162492-8a8ba880-4c29-11ea-8957-94323befa009.png)
![image](https://user-images.githubusercontent.com/6518376/74162519-95463d80-4c29-11ea-8037-1ffe19bdd72a.png)

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
