### PR TITLE
Remove entries from availableQueries if the metric is available in getMetric

### DIFF
--- a/lib/sanbase/model/project/available_queries.ex
+++ b/lib/sanbase/model/project/available_queries.ex
@@ -151,15 +151,9 @@ defmodule Sanbase.Model.Project.AvailableQueries do
 
   @mineable_specific_queries ["exchangeWallets", "allExchanges"]
 
-  @ethereum_specific_queries [
-    "exchangeWallets",
-    "miningPoolsDistribution",
-    "dailyActiveDeposits",
-    "gasUsed"
-  ]
+  @ethereum_specific_queries ["miningPoolsDistribution", "dailyActiveDeposits", "gasUsed"]
 
   @erc20_specific_queries [
-    "exchangeFundsFlow",
     "historicalBalance",
     "topHoldersPercentOfTotalSupply",
     "percentOfTokenSupplyOnExchanges",
@@ -170,23 +164,11 @@ defmodule Sanbase.Model.Project.AvailableQueries do
   @bitcoin_specific_queries []
 
   @common_blockchain_queries [
-    "realizedValue",
-    "networkGrowth",
-    "mvrvRatio",
-    "dailyActiveAddresses",
-    "tokenAgeConsumed",
-    "burnRate",
-    "averageTokenAgeConsumedInDays",
-    "tokenVelocity",
-    "nvtRatio",
-    "transactionVolume",
-    "tokenCirculation"
+    "averageTokenAgeConsumedInDays"
   ]
 
   defp blockchain_queries(%Project{} = project) do
-    is_erc20? = Project.is_erc20?(project)
-
-    case {project, is_erc20?} do
+    case {project, Project.is_erc20?(project)} do
       {%Project{slug: "ethereum"}, _} ->
         @mineable_specific_queries ++
           @ethereum_specific_queries ++ @erc20_specific_queries ++ @common_blockchain_queries

--- a/test/sanbase/project/project_available_queries_test.exs
+++ b/test/sanbase/project/project_available_queries_test.exs
@@ -129,15 +129,6 @@ defmodule Sanbase.Project.AvailableQueriesTest do
            )
 
     # some ERC20 metrics
-    assert Enum.all?(
-             [
-               "dailyActiveAddresses",
-               "transactionVolume",
-               "tokenVelocity",
-               "exchangeFundsFlow",
-               "historicalBalance"
-             ],
-             &Enum.member?(available_metrics, &1)
-           )
+    assert Enum.all?(["historicalBalance"], &Enum.member?(available_metrics, &1))
   end
 end


### PR DESCRIPTION
#### Summary
Discourage using graphql queries `burnRate` in favor of `getMetric(metric: "age_destroyed")`
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
