### PR TITLE
Get the availble metrics from the self rehydrating cache

### DIFF
--- a/lib/sanbase/auth/user.ex
+++ b/lib/sanbase/auth/user.ex
@@ -198,7 +198,7 @@ defmodule Sanbase.Auth.User do
     |> change(san_balance: san_balance, san_balance_updated_at: Timex.now())
   end
 
-  @spec san_balance(%User{}) :: {:ok, float()} | {:error, String.t()}
+  @spec san_balance(%User{}) :: {:ok, float()} | {:ok, nil} | {:error, String.t()}
   def san_balance(%User{test_san_balance: test_san_balance})
       when not is_nil(test_san_balance) do
     {:ok, test_san_balance |> Sanbase.Math.to_float()}
@@ -220,6 +220,7 @@ defmodule Sanbase.Auth.User do
     end
   end
 
+  @spec san_balance!(%User{}) :: float | nil | no_return
   def san_balance!(%User{} = user) do
     case san_balance(user) do
       {:ok, san_balance} -> san_balance

--- a/lib/sanbase/billing/subscription.ex
+++ b/lib/sanbase/billing/subscription.ex
@@ -290,9 +290,8 @@ defmodule Sanbase.Billing.Subscription do
   @spec realtime_data_cut_off_in_days(
           %__MODULE__{},
           AccessChecker.query_or_metric(),
-          non_neg_integer() | nil
-        ) ::
           non_neg_integer()
+        ) :: non_neg_integer() | nil
   def realtime_data_cut_off_in_days(%__MODULE__{plan: plan}, query_or_metric, product_id) do
     plan
     |> Plan.plan_atom_name()

--- a/lib/sanbase/prices/metric_adapter.ex
+++ b/lib/sanbase/prices/metric_adapter.ex
@@ -76,9 +76,9 @@ defmodule Sanbase.Price.MetricAdapter do
   def available_metrics("TOTAL_ERC20"), do: @metrics
 
   def available_metrics(slug) do
-    case Price.first_datetime(slug) do
-      {:ok, %DateTime{}} -> {:ok, @metrics}
-      {:ok, nil} -> {:ok, []}
+    case Price.has_data?(slug) do
+      {:ok, true} -> {:ok, @metrics}
+      {:ok, false} -> {:ok, []}
       {:error, error} -> {:error, error}
     end
   end

--- a/lib/sanbase/prices/price.ex
+++ b/lib/sanbase/prices/price.ex
@@ -467,6 +467,17 @@ defmodule Sanbase.Price do
     ClickhouseRepo.query_transform(query, args, fn [slug] -> slug end)
   end
 
+  def has_data?(slug) do
+    {query, args} = select_any_record_query(slug)
+
+    ClickhouseRepo.query_transform(query, args, & &1)
+    |> case do
+      {:ok, [_]} -> {:ok, true}
+      {:ok, []} -> {:ok, false}
+      {:error, error} -> {:error, error}
+    end
+  end
+
   @doc ~s"""
   Return the first datetime for which `slug` has data
   """

--- a/lib/sanbase/prices/price_sql_query.ex
+++ b/lib/sanbase/prices/price_sql_query.ex
@@ -338,6 +338,17 @@ defmodule Sanbase.Price.SqlQuery do
     {query, args}
   end
 
+  def select_any_record_query(slug) do
+    query = """
+    SELECT any(dt)
+    FROM #{@table}
+    PREWHERE slug = cast(?1, 'LowCardinality(String)')
+    """
+
+    args = [slug]
+    {query, args}
+  end
+
   def first_datetime_query(slug, source) do
     query = """
     SELECT

--- a/lib/sanbase/web.ex
+++ b/lib/sanbase/web.ex
@@ -39,6 +39,9 @@ defmodule Sanbase.Application.Web do
       # Time sereies TwitterData DB connection
       Sanbase.ExternalServices.TwitterData.Store.child_spec(),
 
+      # Self rehydrating cache
+      {Sanbase.Cache.RehydratingCache, task_supervisor: Sanbase.TaskSupervisor},
+
       # Transform a list of transactions into a list of transactions
       # where addresses are marked whether or not they are an exchange address
       Sanbase.Clickhouse.MarkExchanges,

--- a/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
@@ -1,18 +1,49 @@
 defmodule SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver do
-  require Logger
+  import Sanbase.Utils.ErrorHandling, only: [maybe_handle_graphql_error: 2]
 
   alias Sanbase.Model.Project
   alias Sanbase.Metric
+  alias Sanbase.Cache.RehydratingCache
+
+  require Logger
+  @ttl 3600
+  @refresh_time_delta 600
+  @refresh_time_max_offset 120
 
   def available_metrics(%Project{slug: slug}, _args, _resolution) do
-    Metric.available_metrics_for_slug(slug)
+    cache_key = {__MODULE__, :available_metrics, slug} |> :erlang.phash2()
+    fun = fn -> Metric.available_metrics_for_slug(slug) end
+
+    maybe_register_and_get(cache_key, fun, slug)
   end
 
   def available_timeseries_metrics(%Project{slug: slug}, _args, _resolution) do
-    Metric.available_timeseries_metrics_for_slug(slug)
+    cache_key = {__MODULE__, :available_timeseries_metrics, slug} |> :erlang.phash2()
+    fun = fn -> Metric.available_timeseries_metrics_for_slug(slug) end
+    maybe_register_and_get(cache_key, fun, slug)
   end
 
   def available_histogram_metrics(%Project{slug: slug}, _args, _resolution) do
-    Metric.available_histogram_metrics_for_slug(slug)
+    cache_key = {__MODULE__, :available_histogram_metrics, slug} |> :erlang.phash2()
+    fun = fn -> Metric.available_histogram_metrics_for_slug(slug) end
+    maybe_register_and_get(cache_key, fun, slug)
+  end
+
+  defp get_error_handler(_error, slug), do: {:error, "Cannot fetch available metrics for #{slug}"}
+
+  # Get the available metrics from the rehydrating cache. If the function for computing it
+  # is not register - register it and get the result after that.z
+  defp maybe_register_and_get(cache_key, fun, slug) do
+    case RehydratingCache.get(cache_key) do
+      {:error, :not_registered} ->
+        refresh_time_delta = @refresh_time_delta + :rand.uniform(@refresh_time_max_offset)
+        RehydratingCache.register_function(fun, cache_key, @ttl, refresh_time_delta)
+
+        RehydratingCache.get(cache_key)
+        |> maybe_handle_graphql_error(&get_error_handler(&1, slug))
+
+      {:ok, value} ->
+        {:ok, value}
+    end
   end
 end


### PR DESCRIPTION
#### Summary
Also:
- Improve check for available prices
- Return atoms instead of string errors from the rehydrating cache

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
