### PR TITLE
Add description to the functions in rehydrating cache

### DIFF
--- a/lib/sanbase/cache/rehydrating_cache/rehydrating_cache.ex
+++ b/lib/sanbase/cache/rehydrating_cache/rehydrating_cache.ex
@@ -87,7 +87,8 @@ defmodule Sanbase.Cache.RehydratingCache do
       key: key,
       ttl: ttl,
       refresh_time_delta: refresh_time_delta,
-      description: description
+      description: description,
+      registered_at: Timex.now()
     }
 
     GenServer.call(@name, {:register_function, map})

--- a/lib/sanbase/cache/rehydrating_cache/rehydrating_cache.ex
+++ b/lib/sanbase/cache/rehydrating_cache/rehydrating_cache.ex
@@ -80,9 +80,16 @@ defmodule Sanbase.Cache.RehydratingCache do
   """
   @spec register_function((() -> any()), any(), pos_integer(), pos_integer()) ::
           :ok | {:error, :already_registered}
-  def register_function(fun, key, ttl, refresh_time_delta)
+  def register_function(fun, key, ttl, refresh_time_delta, description \\ nil)
       when are_proper_function_arguments(fun, ttl, refresh_time_delta) do
-    map = %{function: fun, key: key, ttl: ttl, refresh_time_delta: refresh_time_delta}
+    map = %{
+      function: fun,
+      key: key,
+      ttl: ttl,
+      refresh_time_delta: refresh_time_delta,
+      description: description
+    }
+
     GenServer.call(@name, {:register_function, map})
   end
 

--- a/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
@@ -48,7 +48,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver do
 
       {:error, :not_registered} ->
         refresh_time_delta = @refresh_time_delta + :rand.uniform(@refresh_time_max_offset)
-        RehydratingCache.register_function(fun, cache_key, @ttl, refresh_time_delta)
+        description = "#{query} for #{slug} from project metrics resolver"
+        RehydratingCache.register_function(fun, cache_key, @ttl, refresh_time_delta, description)
 
         maybe_register_and_get(cache_key, fun, slug, query, attempts - 1)
 


### PR DESCRIPTION
#### Summary
- Add description of the function - they key is a hash that does not lead to the actual function. Including description allows to understand what the function is doing
- Add init_time to the registered functions

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
