### PR TITLE
Add the proper min_interval of 5m for active_addresses_24h

### DIFF
--- a/lib/sanbase/clickhouse/metric/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/available_v2_metrics.json
@@ -124,7 +124,7 @@
     "access": "free",
     "min_plan": "free",
     "aggregation": "avg",
-    "min_interval": "1d",
+    "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": true,
     "data_type": "timeseries"


### PR DESCRIPTION
Having intraday_metric with 1d min_interval caused issue with generating
the prewhere from/to clause

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
