### PR TITLE
Rework age_distribution histogram's response format

### DIFF
--- a/lib/sanbase/billing/graphql_schema.ex
+++ b/lib/sanbase/billing/graphql_schema.ex
@@ -10,6 +10,7 @@ defmodule Sanbase.Billing.GraphqlSchema do
   require SanbaseWeb.Graphql.Schema
 
   @query_type Absinthe.Schema.lookup_type(SanbaseWeb.Graphql.Schema, :query)
+  # @query_type %{fields: %{}}
   @fields @query_type.fields |> Map.keys()
 
   @doc ~s"""

--- a/lib/sanbase/billing/graphql_schema.ex
+++ b/lib/sanbase/billing/graphql_schema.ex
@@ -10,7 +10,6 @@ defmodule Sanbase.Billing.GraphqlSchema do
   require SanbaseWeb.Graphql.Schema
 
   @query_type Absinthe.Schema.lookup_type(SanbaseWeb.Graphql.Schema, :query)
-  # @query_type %{fields: %{}}
   @fields @query_type.fields |> Map.keys()
 
   @doc ~s"""

--- a/lib/sanbase/clickhouse/github/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/github/metric_adapter.ex
@@ -128,6 +128,7 @@ defmodule Sanbase.Clickhouse.Github.MetricAdapter do
        min_interval: "1m",
        default_aggregation: :sum,
        available_aggregations: [:sum],
+       available_selectors: [:slug],
        data_type: :timeseries
      }}
   end

--- a/lib/sanbase/clickhouse/metric/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/available_v2_metrics.json
@@ -934,7 +934,6 @@
     "min_plan": "free",
     "aggregation": "last",
     "min_interval": "5m",
-    "label": "The amount of tokens last moved between {{from}} and {{to}}",
     "table": "distribution_deltas_5min",
     "has_incomplete_data": false,
     "data_type": "histogram"

--- a/lib/sanbase/clickhouse/metric/histogram_metric.ex
+++ b/lib/sanbase/clickhouse/metric/histogram_metric.ex
@@ -79,8 +79,7 @@ defmodule Sanbase.Clickhouse.Metric.HistogramMetric do
         key = price_to_range.(price)
         Map.update(acc, key, 0.0, fn curr_amount -> Float.round(curr_amount + value, 2) end)
       end)
-      |> Enum.map(fn {range, amount} -> %{ range: range, value: amount }
-      end)
+      |> Enum.map(fn {range, amount} -> %{range: range, value: amount} end)
       |> Enum.sort_by(fn %{range: [range_start | _]} -> range_start end)
 
     {:ok, data}

--- a/lib/sanbase/clickhouse/metric/histogram_metric.ex
+++ b/lib/sanbase/clickhouse/metric/histogram_metric.ex
@@ -79,11 +79,7 @@ defmodule Sanbase.Clickhouse.Metric.HistogramMetric do
         key = price_to_range.(price)
         Map.update(acc, key, 0.0, fn curr_amount -> Float.round(curr_amount + value, 2) end)
       end)
-      |> Enum.map(fn {range, amount} ->
-        %{
-          range: range,
-          value: amount
-        }
+      |> Enum.map(fn {range, amount} -> %{ range: range, value: amount }
       end)
       |> Enum.sort_by(fn %{range: [range_start | _]} -> range_start end)
 

--- a/lib/sanbase/clickhouse/metric/histogram_metric.ex
+++ b/lib/sanbase/clickhouse/metric/histogram_metric.ex
@@ -4,7 +4,7 @@ defmodule Sanbase.Clickhouse.Metric.HistogramMetric do
 
   require Sanbase.ClickhouseRepo, as: ClickhouseRepo
 
-  def histogram_data("age_distribution" = metric, slug, from, to, interval, limit) do
+  def histogram_data("age_distribution" = metric, %{slug: slug}, from, to, interval, limit) do
     {query, args} = histogram_data_query(metric, slug, from, to, interval, limit)
 
     ClickhouseRepo.query_transform(query, args, fn [unix, value] ->
@@ -21,7 +21,7 @@ defmodule Sanbase.Clickhouse.Metric.HistogramMetric do
     end)
   end
 
-  def histogram_data("price_histogram" = metric, slug, from, to, interval, limit) do
+  def histogram_data("price_histogram" = metric, %{slug: slug}, from, to, interval, limit) do
     {query, args} = histogram_data_query(metric, slug, from, to, interval, limit)
 
     ClickhouseRepo.query_transform(query, args, fn [price, amount] ->

--- a/lib/sanbase/clickhouse/metric/metric.ex
+++ b/lib/sanbase/clickhouse/metric/metric.ex
@@ -36,7 +36,7 @@ defmodule Sanbase.Clickhouse.Metric do
                      |> Enum.uniq()
   @metrics_mapset @metrics_name_list |> MapSet.new()
   @incomplete_data_map FileHandler.incomplete_data_map()
-  @tables_list FileHandler.table_map() |> Map.values() |> Enum.uniq()
+  @tables_list FileHandler.table_map() |> Map.values() |> List.flatten() |> Enum.uniq()
 
   @type slug :: String.t()
   @type metric :: String.t()
@@ -135,8 +135,11 @@ defmodule Sanbase.Clickhouse.Metric do
   def available_metrics(%{slug: slug}) when is_binary(slug) do
     Enum.reduce_while(@tables_list, [], fn table, acc ->
       case available_metrics_in_table(table, slug) do
-        {:ok, metrics} -> {:cont, metrics ++ acc}
-        _ -> {:halt, {:error, "Error fetching available metrics for #{slug}"}}
+        {:ok, metrics} ->
+          {:cont, metrics ++ acc}
+
+        _ ->
+          {:halt, {:error, "Error fetching available metrics for #{slug}"}}
       end
     end)
     |> case do

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -260,9 +260,9 @@ defmodule Sanbase.Metric do
 
   @spec available_metrics_for_slug(any) ::
           {:ok, list(String.t())} | {:nocache, {:ok, list(String.t())}}
-  def available_metrics_for_slug(slug) do
+  def available_metrics_for_slug(selector) do
     metrics_in_modules =
-      Sanbase.Parallel.map(@metric_modules, fn module -> module.available_metrics(slug) end,
+      Sanbase.Parallel.map(@metric_modules, fn module -> module.available_metrics(selector) end,
         ordered: false,
         max_concurrency: 8,
         timeout: 25_000

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -167,7 +167,7 @@ defmodule Sanbase.SocialData.MetricAdapter do
        min_interval: "5m",
        default_aggregation: :sum,
        available_aggregations: @aggregations,
-       available_selectors: [:slug, :word],
+       available_selectors: [:slug],
        data_type: :histogram
      }}
   end

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -41,10 +41,24 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:value, :float)
   end
 
+  object :datetime_range_float_value_list do
+    field(:data, list_of(:datetime_range_float_value))
+  end
+
+  object :datetime_range_float_value do
+    field(:range, list_of(:datetime))
+    field(:value, :float)
+  end
+
   union :value_list do
     description("Type Parameterized Array")
 
-    types([:string_list, :float_list, :float_range_float_value_list])
+    types([
+      :string_list,
+      :float_list,
+      :float_range_float_value_list,
+      :datetime_range_float_value_list
+    ])
 
     resolve_type(fn
       %{data: [value | _]}, _ when is_number(value) ->
@@ -55,6 +69,9 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
 
       %{data: [%{range: [r | _], value: f} | _]}, _ when is_float(r) and is_float(f) ->
         :float_range_float_value_list
+
+      %{data: [%{range: [%DateTime{} | _], value: f} | _]}, _ when is_float(f) ->
+        :datetime_range_float_value_list
 
       %{data: []}, _ ->
         :float_list


### PR DESCRIPTION
#### Summary
Rework the old response format where 2 separate lists with labels and values were returned with:

Request:
```graphql
{
  getMetric(metric: "age_distribution") {
    histogramData(slug: "santiment", from: "2020-01-01T00:00:00Z", to: "2020-02-20T00:00:00Z") {
    	values{
        ... on DatetimeRangeFloatValueList{
          data{
            range
            value
          }
        }
      }
    }
  }
}
```

Response:
```json
{
  "data": {
    "getMetric": {
      "histogramData": {
        "values": {
          "data": [
            {
              "range": [
                "2020-02-19T00:00:00Z",
                "2020-02-20T00:00:00Z"
              ],
              "value": 15360.104668836859
            },
            {
              "range": [
                "2020-02-18T00:00:00Z",
                "2020-02-19T00:00:00Z"
              ],
              "value": 7290.224431187021
            },
            {
              "range": [
                "2020-02-17T00:00:00Z",
                "2020-02-18T00:00:00Z"
              ],
              "value": 65048.935701165516
            },
            {
              "range": [
                "2020-02-16T00:00:00Z",
                "2020-02-17T00:00:00Z"
              ],
              "value": 1886.7596715216885
            },
```
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
