### PR TITLE
Switch Sanbase.Metric and getMetric API to use selector instead of binary slug

### DIFF
--- a/lib/sanbase/chart/chart.ex
+++ b/lib/sanbase/chart/chart.ex
@@ -157,7 +157,7 @@ defmodule Sanbase.Chart do
     from = Timex.shift(to, days: -size + 1)
 
     with {:ok, metric_name} <- Sanbase.Metric.human_readable_name(metric),
-         {:ok, data} <- Sanbase.Metric.timeseries_data(metric, slug, from, to, "1d"),
+         {:ok, data} <- Sanbase.Metric.timeseries_data(metric, %{slug: slug}, from, to, "1d"),
          [_ | _] = values <- data |> Enum.map(& &1.value) |> Enum.reject(&is_nil/1),
          {min, max} <- Math.min_max(values) do
       %{

--- a/lib/sanbase/clickhouse/daily_active_addresses.ex
+++ b/lib/sanbase/clickhouse/daily_active_addresses.ex
@@ -19,7 +19,7 @@ defmodule Sanbase.Clickhouse.DailyActiveAddresses do
   end
 
   def first_datetime(slug) when slug in @bitcoin do
-    Metric.first_datetime("daily_active_addresses", slug)
+    Metric.first_datetime("daily_active_addresses", %{slug: slug})
   end
 
   def first_datetime(contract) when is_binary(contract) do
@@ -41,7 +41,7 @@ defmodule Sanbase.Clickhouse.DailyActiveAddresses do
 
   def average_active_addresses(btc, from, to, interval)
       when is_binary(btc) and btc in @bitcoin do
-    Metric.timeseries_data("daily_active_addresses", "bitcoin", from, to, interval)
+    Metric.timeseries_data("daily_active_addresses", %{slug: "bitcoin"}, from, to, interval)
   end
 
   def average_active_addresses(eth, from, to, interval)
@@ -86,7 +86,7 @@ defmodule Sanbase.Clickhouse.DailyActiveAddresses do
   defp do_btc_average_active_addresses([], _, _), do: {:ok, []}
 
   defp do_btc_average_active_addresses([_ | _], from, to) do
-    case Metric.aggregated_timeseries_data("daily_active_addresses", "bitcoin", from, to) do
+    case Metric.aggregated_timeseries_data("daily_active_addresses", %{slug: "bitcoin"}, from, to) do
       {:ok, result} -> {:ok, [{"BTC", result}]}
       {:error, error} -> handle_error("Bitcoin", error)
     end

--- a/lib/sanbase/metric/behaviour.ex
+++ b/lib/sanbase/metric/behaviour.ex
@@ -9,11 +9,14 @@ defmodule Sanbase.Metric.Behaviour do
   @type options :: Keyword.t()
   @type available_data_types :: :timeseries | :histogram
 
+  @type selector :: slug | map()
+
   @type metadata :: %{
           metric: metric,
           min_interval: interval(),
           default_aggregation: atom(),
-          available_aggregations: list(),
+          available_aggregations: list(atom()),
+          available_selectors: list(atom()),
           data_type: available_data_types()
         }
 
@@ -31,7 +34,7 @@ defmodule Sanbase.Metric.Behaviour do
 
   @callback timeseries_data(
               metric :: metric(),
-              selector :: any(),
+              selector :: selector,
               from :: DatetTime.t(),
               to :: DateTime.t(),
               interval :: interval(),
@@ -41,7 +44,7 @@ defmodule Sanbase.Metric.Behaviour do
 
   @callback histogram_data(
               metric :: metric(),
-              selector :: any(),
+              selector :: selector,
               from :: DateTime.t(),
               to :: DateTime.t(),
               interval :: interval(),
@@ -50,7 +53,7 @@ defmodule Sanbase.Metric.Behaviour do
 
   @callback aggregated_timeseries_data(
               metric :: metric,
-              selector :: any(),
+              selector :: selector,
               from :: DatetTime.t(),
               to :: DateTime.t(),
               opts :: options
@@ -58,10 +61,10 @@ defmodule Sanbase.Metric.Behaviour do
 
   @callback has_incomplete_data?(metric :: metric) :: true | false
 
-  @callback first_datetime(metric, slug) ::
+  @callback first_datetime(metric, selector) ::
               {:ok, DateTime.t()} | {:error, String.t()}
 
-  @callback last_datetime_computed_at(metric, slug) ::
+  @callback last_datetime_computed_at(metric, selector) ::
               {:ok, DateTime.t()} | {:error, String.t()}
 
   @callback human_readable_name(metric) :: {:ok, String.t()} | {:error, String.t()}
@@ -76,7 +79,7 @@ defmodule Sanbase.Metric.Behaviour do
 
   @callback available_metrics() :: list(metric)
 
-  @callback available_metrics(slug) :: {:ok, list(metric)} | {:error, String.t()}
+  @callback available_metrics(selector) :: {:ok, list(metric)} | {:error, String.t()}
 
   @callback available_timeseries_metrics() :: list(metric)
 

--- a/lib/sanbase/prices/metric_adapter.ex
+++ b/lib/sanbase/prices/metric_adapter.ex
@@ -20,22 +20,22 @@ defmodule Sanbase.Price.MetricAdapter do
   def has_incomplete_data?(_), do: false
 
   @impl Sanbase.Metric.Behaviour
-  def timeseries_data(metric, slug, from, to, interval, aggregation) do
+  def timeseries_data(metric, %{slug: slug}, from, to, interval, aggregation) do
     Price.timeseries_metric_data(slug, metric, from, to, interval, aggregation: aggregation)
   end
 
   @impl Sanbase.Metric.Behaviour
-  def aggregated_timeseries_data(metric, slug, from, to, aggregation) do
+  def aggregated_timeseries_data(metric, %{slug: slug}, from, to, aggregation) do
     Price.aggregated_metric_timeseries_data(slug, metric, from, to, aggregation: aggregation)
   end
 
   @impl Sanbase.Metric.Behaviour
-  def first_datetime(_metric, slug) do
+  def first_datetime(_metric, %{slug: slug}) do
     Price.first_datetime(slug)
   end
 
   @impl Sanbase.Metric.Behaviour
-  def last_datetime_computed_at(_metric, slug) do
+  def last_datetime_computed_at(_metric, %{slug: slug}) do
     Price.last_datetime_computed_at(slug)
   end
 
@@ -47,6 +47,7 @@ defmodule Sanbase.Price.MetricAdapter do
        min_interval: "5m",
        default_aggregation: :last,
        available_aggregations: @aggregations,
+       available_selectors: [:slug],
        data_type: :timeseries
      }}
   end
@@ -74,9 +75,9 @@ defmodule Sanbase.Price.MetricAdapter do
   def available_metrics(), do: @metrics
 
   @impl Sanbase.Metric.Behaviour
-  def available_metrics("TOTAL_ERC20"), do: @metrics
+  def available_metrics(%{slug: "TOTAL_ERC20"}), do: @metrics
 
-  def available_metrics(slug) do
+  def available_metrics(%{slug: slug}) do
     case Price.has_data?(slug) do
       {:ok, true} -> {:ok, @metrics}
       {:ok, false} -> {:ok, []}

--- a/lib/sanbase/signals/history/daily_active_addresses_history.ex
+++ b/lib/sanbase/signals/history/daily_active_addresses_history.ex
@@ -57,7 +57,7 @@ defmodule Sanbase.Signal.History.DailyActiveAddressesHistory do
 
       Sanbase.Metric.timeseries_data(
         "daily_active_addresses",
-        slug,
+        %{slug: slug},
         Timex.shift(to, days: -shift),
         to,
         @historical_days_interval,

--- a/lib/sanbase/signals/history/metric_history.ex
+++ b/lib/sanbase/signals/history/metric_history.ex
@@ -45,7 +45,7 @@ defmodule Sanbase.Signal.History.MetricHistory do
 
       Sanbase.Metric.timeseries_data(
         metric,
-        slug,
+        %{slug: slug},
         Timex.shift(to, days: -shift),
         to,
         @historical_days_interval

--- a/lib/sanbase/signals/trigger/settings/metric_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/metric_trigger_settings.ex
@@ -87,7 +87,7 @@ defmodule Sanbase.Signal.Trigger.MetricTriggerSettings do
       |> :erlang.phash2()
 
     Cache.get_or_store(cache_key, fn ->
-      case Metric.timeseries_data(metric, slug, from, to, interval) do
+      case Metric.timeseries_data(metric, %{slug: slug}, from, to, interval) do
         {:ok, [_ | _] = result} -> result |> Enum.take(-2)
         _ -> nil
       end

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -40,7 +40,7 @@ defmodule Sanbase.SocialData.MetricAdapter do
   def has_incomplete_data?(_), do: false
 
   @impl Sanbase.Metric.Behaviour
-  def timeseries_data(metric, slug, from, to, interval, _aggregation)
+  def timeseries_data(metric, %{slug: slug}, from, to, interval, _aggregation)
       when metric in @social_volume_timeseries_metrics do
     [source, _] = String.split(metric, "_", parts: 2)
 
@@ -54,7 +54,7 @@ defmodule Sanbase.SocialData.MetricAdapter do
     |> transform_to_value_pairs(:mentions_count)
   end
 
-  def timeseries_data(metric, slug, from, to, interval, _aggregation)
+  def timeseries_data(metric, %{slug: slug}, from, to, interval, _aggregation)
       when metric in @social_dominance_timeseries_metrics do
     [source, _] = String.split(metric, "_", parts: 2)
 
@@ -69,7 +69,7 @@ defmodule Sanbase.SocialData.MetricAdapter do
   end
 
   @impl Sanbase.Metric.Behaviour
-  def aggregated_timeseries_data(metric, slug, from, to, _aggregation)
+  def aggregated_timeseries_data(metric, %{slug: slug}, from, to, _aggregation)
       when is_binary(slug) and metric in @social_volume_timeseries_metrics do
     [source, _] = String.split(metric, "_", parts: 2)
     source = Map.get(@social_volume_source_type, source)
@@ -85,7 +85,7 @@ defmodule Sanbase.SocialData.MetricAdapter do
     end
   end
 
-  def aggregated_timeseries_data(metric, slug, from, to, _aggregation)
+  def aggregated_timeseries_data(metric, %{slug: slug}, from, to, _aggregation)
       when metric in @social_dominance_timeseries_metrics do
     [source, _] = String.split(metric, "_", parts: 2)
     source = Map.get(@social_dominance_source_type, source)
@@ -137,7 +137,7 @@ defmodule Sanbase.SocialData.MetricAdapter do
   def available_metrics(), do: @metrics
 
   @impl Sanbase.Metric.Behaviour
-  def available_metrics(slug) do
+  def available_metrics(%{slug: slug}) do
     with {:ok, slugs} <- available_slugs(),
          true <- slug in slugs do
       {:ok, @metrics}
@@ -167,6 +167,7 @@ defmodule Sanbase.SocialData.MetricAdapter do
        min_interval: "5m",
        default_aggregation: :sum,
        available_aggregations: @aggregations,
+       available_selectors: [:slug, :word],
        data_type: :histogram
      }}
   end

--- a/lib/sanbase/utils/error_handling.ex
+++ b/lib/sanbase/utils/error_handling.ex
@@ -20,7 +20,12 @@ defmodule Sanbase.Utils.ErrorHandling do
 
   def handle_graphql_error(metric, identifier, reason, opts \\ []) do
     target = Keyword.get(opts, :description, "project with slug")
-    error_msg = "[#{Ecto.UUID.generate()}] Can't fetch #{metric} for #{target}: #{identifier}"
+
+    error_msg =
+      "[#{Ecto.UUID.generate()}] Can't fetch #{metric} for #{target}: #{
+        identifier_to_string(identifier)
+      }"
+
     error_msg_with_reason = error_msg <> ", Reason: #{inspect(reason)}"
 
     Logger.warn(error_msg_with_reason)
@@ -39,6 +44,10 @@ defmodule Sanbase.Utils.ErrorHandling do
   end
 
   # Private functions
+
+  defp identifier_to_string(str) when is_binary(str), do: str
+  defp identifier_to_string(data), do: inspect(data)
+
   defp format_error({msg, opts}) do
     Enum.reduce(opts, msg, fn {key, value}, acc ->
       String.replace(acc, "%{#{key}}", to_string(inspect(value)))

--- a/lib/sanbase_web/graphql/dataloader/clickhouse_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/clickhouse_dataloader.ex
@@ -60,7 +60,13 @@ defmodule SanbaseWeb.Graphql.ClickhouseDataloader do
       |> Enum.map(fn %{project: project} -> project.slug end)
       |> Enum.reject(&is_nil/1)
 
-    Sanbase.Metric.aggregated_timeseries_data("daily_active_addresses", slugs, from, to, :avg)
+    Sanbase.Metric.aggregated_timeseries_data(
+      "daily_active_addresses",
+      %{slug: slugs},
+      from,
+      to,
+      :avg
+    )
     |> case do
       {:ok, result} ->
         result
@@ -83,7 +89,12 @@ defmodule SanbaseWeb.Graphql.ClickhouseDataloader do
         organizations
       end)
 
-    Sanbase.Metric.aggregated_timeseries_data("dev_activity", organizations, from, to)
+    Sanbase.Metric.aggregated_timeseries_data(
+      "dev_activity",
+      %{organizations: organizations},
+      from,
+      to
+    )
     |> case do
       {:ok, result} ->
         result

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -9,6 +9,16 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
   alias SanbaseWeb.Graphql.Middlewares.AccessControl
   alias SanbaseWeb.Graphql.Resolvers.MetricResolver
 
+  enum :selector_name do
+    value(:slug)
+    value(:word)
+  end
+
+  enum :metric_data_type do
+    value(:timeseries)
+    value(:histogram)
+  end
+
   object :metric_data do
     field(:datetime, non_null(:datetime))
     field(:value, :float)
@@ -81,6 +91,8 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     """
     field(:available_aggregations, list_of(:aggregation))
 
+    field(:available_selectors, list_of(:selector_name))
+
     field(:data_type, :metric_data_type)
 
     field(:is_restricted, :boolean)
@@ -88,6 +100,11 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:restricted_from, :datetime)
 
     field(:restricted_to, :datetime)
+  end
+
+  input_object :metric_target_selector_input_object do
+    field(:slug, :string)
+    field(:word, :string)
   end
 
   object :metric do
@@ -114,7 +131,8 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     the incomplete gives more timely signal.
     """
     field :timeseries_data, list_of(:metric_data) do
-      arg(:slug, non_null(:string))
+      arg(:slug, :string)
+      arg(:selector, :metric_target_selector_input_object)
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:interval, :interval, default_value: "1d")
@@ -128,7 +146,8 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     end
 
     field :aggregated_timeseries_data, :float do
-      arg(:slug, non_null(:string))
+      arg(:slug, :string)
+      arg(:selector, :metric_target_selector_input_object)
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:aggregation, :aggregation, default_value: nil)
@@ -140,7 +159,8 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     end
 
     field :histogram_data, :histogram_data do
-      arg(:slug, non_null(:string))
+      arg(:slug, :string)
+      arg(:selector, :metric_target_selector_input_object)
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:interval, :interval, default_value: "1d")
@@ -153,22 +173,19 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     end
 
     field :available_since, :datetime do
-      arg(:slug, non_null(:string))
+      arg(:slug, :string)
+      arg(:selector, :metric_target_selector_input_object)
       cache_resolve(&MetricResolver.available_since/3)
     end
 
     field :last_datetime_computed_at, :datetime do
-      arg(:slug, non_null(:string))
+      arg(:slug, :string)
+      arg(:selector, :metric_target_selector_input_object)
       cache_resolve(&MetricResolver.last_datetime_computed_at/3)
     end
 
     field :metadata, :metric_metadata do
       cache_resolve(&MetricResolver.get_metadata/3)
     end
-  end
-
-  enum :metric_data_type do
-    value(:timeseries)
-    value(:histogram)
   end
 end

--- a/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_include_incomplete_data_flag_test.exs
+++ b/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_include_incomplete_data_flag_test.exs
@@ -35,10 +35,17 @@ defmodule Sanbase.Billing.ApiIncludeIncompleteDataFlagTest do
     query = metric_query(metric, project.slug, from, to, interval, false)
     execute_query(conn, query, "getMetric")
 
-    refute called(Metric.timeseries_data(metric, project.slug, from, to, interval, :_))
+    refute called(Metric.timeseries_data(metric, %{slug: project.slug}, from, to, interval, :_))
 
     assert called(
-             Metric.timeseries_data(metric, project.slug, from, beginning_of_day, interval, :_)
+             Metric.timeseries_data(
+               metric,
+               %{slug: project.slug},
+               from,
+               beginning_of_day,
+               interval,
+               :_
+             )
            )
   end
 
@@ -53,10 +60,17 @@ defmodule Sanbase.Billing.ApiIncludeIncompleteDataFlagTest do
     query = metric_query(metric, project.slug, from, to, interval, true)
     execute_query(conn, query, "getMetric")
 
-    assert called(Metric.timeseries_data(metric, project.slug, from, to, interval, :_))
+    assert called(Metric.timeseries_data(metric, %{slug: project.slug}, from, to, interval, :_))
 
     refute called(
-             Metric.timeseries_data(metric, project.slug, from, beginning_of_day, interval, :_)
+             Metric.timeseries_data(
+               metric,
+               %{slug: project.slug},
+               from,
+               beginning_of_day,
+               interval,
+               :_
+             )
            )
   end
 

--- a/test/sanbase_web/graphql/metric/api_metric_aggregated_timeseries_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_aggregated_timeseries_data_test.exs
@@ -35,7 +35,9 @@ defmodule SanbaseWeb.Graphql.ApiMetricAggregatedTimeseriesDataTest do
 
       assert result == 100
 
-      assert_called(Metric.aggregated_timeseries_data(metric, slug, from, to, aggregation))
+      assert_called(
+        Metric.aggregated_timeseries_data(metric, %{slug: slug}, from, to, aggregation)
+      )
     end
   end
 

--- a/test/sanbase_web/graphql/metric/api_metric_histogram_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_histogram_data_test.exs
@@ -43,7 +43,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricHistogramDataTest do
                "values" => %{"__typename" => "FloatList", "data" => [1, 2, 3]}
              }
 
-      assert_called(Metric.histogram_data(metric, slug, from, to, "1d", 3))
+      assert_called(Metric.histogram_data(metric, %{slug: slug}, from, to, "1d", 3))
     end
   end
 

--- a/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
@@ -49,7 +49,9 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesDataTest do
                }
              ]
 
-      assert_called(Metric.timeseries_data(metric, slug, from, to, interval, aggregation))
+      assert_called(
+        Metric.timeseries_data(metric, %{slug: slug}, from, to, interval, aggregation)
+      )
     end
   end
 


### PR DESCRIPTION
#### Summary
- Rework Sanbase.Metric + all metric adapters to accept selector instead of slug. This has a few benefits:
-- More explicit - the argument is known to be slug.
-- Allows for different selectors - not all metrics can work only on slugs. For some social metrics it would be nice to be able to pass random words
--  Fix the outstanding issue where github aggregated timeseries data is accepting list of organizations while the other functions are accepting slug.
- Introduce `selector` input object for the getMetric API. The `slug` arugment is not removed and it is transformed to a selector interaly to preserve the API.

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
