### PR TITLE
Return only events with trigger_fired and published_inight types

### DIFF
--- a/lib/sanbase/timeline/query.ex
+++ b/lib/sanbase/timeline/query.ex
@@ -6,6 +6,13 @@ defmodule Sanbase.Timeline.Query do
   alias Sanbase.Signal.UserTrigger
 
   # Events with public entities and current user private events
+  def events_with_event_type(query, types) do
+    from(
+      event in query,
+      where: event.type in ^types
+    )
+  end
+
   def events_with_public_entities_query(query) do
     from(
       event in query,

--- a/lib/sanbase/timeline/timeline_event.ex
+++ b/lib/sanbase/timeline/timeline_event.ex
@@ -91,6 +91,7 @@ defmodule Sanbase.Timeline.TimelineEvent do
     |> Cursor.filter_by_cursor(cursor_type, cursor_datetime)
     |> Query.events_by_sanfamily_query()
     |> Query.events_with_public_entities_query()
+    |> Query.events_with_event_type([@publish_insight_type, @trigger_fired])
     |> Order.events_order_limit_preload_query(order_by, min(limit, @max_events_returned))
     |> Repo.all()
     |> Cursor.wrap_events_with_cursor()


### PR DESCRIPTION
Filter only those two events as a hotfix. The event types will be
accepted as an API argument in the future and controlled by the client
side

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
