### PR TITLE
Support text selector for social volume in getMetric

### DIFF
--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -71,6 +71,14 @@ defmodule Sanbase.SocialData.MetricAdapter do
     |> transform_to_value_pairs(:mentions_count)
   end
 
+  def timeseries_data(metric, %{text: text}, from, to, interval, _aggregation)
+      when metric in @social_volume_timeseries_metrics do
+    "social_volume_" <> source = metric
+
+    Sanbase.SocialData.topic_search(text, from, to, interval, source)
+    |> transform_to_value_pairs(:mentions_count)
+  end
+
   @impl Sanbase.Metric.Behaviour
   def aggregated_timeseries_data(metric, selector, from, to, aggregation)
       when metric in @social_volume_timeseries_metrics or
@@ -164,7 +172,7 @@ defmodule Sanbase.SocialData.MetricAdapter do
        min_interval: "5m",
        default_aggregation: :sum,
        available_aggregations: @aggregations,
-       available_selectors: [:slug, :word],
+       available_selectors: [:slug, :text],
        data_type: :histogram
      }}
   end

--- a/lib/sanbase/social_data/social_data.ex
+++ b/lib/sanbase/social_data/social_data.ex
@@ -19,6 +19,9 @@ defmodule Sanbase.SocialData do
   defdelegate social_volume(slug, from, to, interval, source),
     to: SocialVolume
 
+  defdelegate topic_search(text, from, to, interval, source),
+    to: SocialVolume
+
   defdelegate community_messages_count(slug, from, to, interval, source),
     to: Community
 

--- a/lib/sanbase_web/graphql/resolvers/social_data_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/social_data_resolver.ex
@@ -50,7 +50,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.SocialDataResolver do
         %{source: source, search_text: search_text, from: from, to: to, interval: interval},
         _resolution
       ) do
-    SocialData.SocialVolume.topic_search(source, search_text, from, to, interval)
+    case SocialData.SocialVolume.topic_search(search_text, from, to, interval, source) do
+      {:ok, data} -> {:ok, %{chart_data: data}}
+      {:error, error} -> {:error, error}
+    end
   end
 
   def get_trending_words(

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -11,7 +11,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
 
   enum :selector_name do
     value(:slug)
-    value(:word)
+    value(:text)
   end
 
   enum :metric_data_type do
@@ -138,7 +138,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
 
   input_object :metric_target_selector_input_object do
     field(:slug, :string)
-    field(:word, :string)
+    field(:text, :string)
   end
 
   object :metric do

--- a/lib/sanbase_web/graphql/schema/types/social_data_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/social_data_types.ex
@@ -53,7 +53,6 @@ defmodule SanbaseWeb.Graphql.SocialDataTypes do
   end
 
   object :topic_search do
-    field(:messages, list_of(:messages))
     field(:chart_data, list_of(:chart_data))
   end
 

--- a/test/sanbase/internal_services/tech_indicators_test.exs
+++ b/test/sanbase/internal_services/tech_indicators_test.exs
@@ -281,23 +281,14 @@ defmodule Sanbase.TechIndicatorsTest do
          }}
       )
 
-      result = SocialVolume.topic_search(:telegram, "btc moon", from, to, "6h")
+      result = SocialVolume.topic_search("btc moon", from, to, "6h", :telegram)
 
       assert result ==
                {:ok,
-                %{
-                  chart_data: [
-                    %{datetime: DateTime.from_unix!(1_533_146_400), mentions_count: 1},
-                    %{datetime: DateTime.from_unix!(1_533_168_000), mentions_count: 0}
-                  ],
-                  messages: [
-                    %{datetime: DateTime.from_unix!(1_533_307_652), text: "BTC moon"},
-                    %{
-                      datetime: DateTime.from_unix!(1_533_694_150),
-                      text: "0.1c of usd won't make btc moon, you realize that?"
-                    }
-                  ]
-                }}
+                [
+                  %{datetime: DateTime.from_unix!(1_533_146_400), mentions_count: 1},
+                  %{datetime: DateTime.from_unix!(1_533_168_000), mentions_count: 0}
+                ]}
     end
 
     test "response: 404" do
@@ -307,7 +298,7 @@ defmodule Sanbase.TechIndicatorsTest do
       mock(HTTPoison, :get, {:ok, %HTTPoison.Response{body: "Some message", status_code: 404}})
 
       assert capture_log(fn ->
-               SocialVolume.topic_search(:telegram, "btc moon", from, to, "6h")
+               SocialVolume.topic_search("btc moon", from, to, "6h", :reddit)
              end) =~
                "Error status 404 fetching results for search text \"btc moon\": Some message\n"
     end
@@ -319,7 +310,7 @@ defmodule Sanbase.TechIndicatorsTest do
       mock(HTTPoison, :get, {:error, %HTTPoison.Error{reason: :econnrefused}})
 
       assert capture_log(fn ->
-               SocialVolume.topic_search(:telegram, "btc moon", from, to, "6h")
+               SocialVolume.topic_search("btc moon", from, to, "6h", :discord)
              end) =~
                "Cannot fetch results for search text \"btc moon\": :econnrefused\n"
     end


### PR DESCRIPTION
#### Summary
Request:
```graphql
{
  getMetric(metric: "social_volume_total") {
    timeseriesData(
      selector: {text: "btc"}
      from: "2020-01-15T00:00:00Z"
      to: "2020-02-20T00:00:00Z"
      interval: "7d") {
        datetime
        value
    }
  }
}
```

Response:
```graphql
{
  "data": {
    "getMetric": {
      "timeseriesData": [
        {
          "datetime": "2020-01-09T00:00:00Z",
          "value": 2896
        },
        {
          "datetime": "2020-01-16T00:00:00Z",
          "value": 7687
        },
        {
          "datetime": "2020-01-23T00:00:00Z",
          "value": 11974
        },
        {
          "datetime": "2020-01-30T00:00:00Z",
          "value": 11956
        },
        {
          "datetime": "2020-02-06T00:00:00Z",
          "value": 19764
        },
        {
          "datetime": "2020-02-13T00:00:00Z",
          "value": 21519
        }
      ]
    }
  }
}
```
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
