### PR TITLE
Rework Social Dominance

### DIFF
--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -166,13 +166,19 @@ defmodule Sanbase.SocialData.MetricAdapter do
 
   @impl Sanbase.Metric.Behaviour
   def metadata(metric) do
+    selectors =
+      case metric do
+        "community_messages_count" <> _ -> [:slug]
+        _ -> [:slug, :text]
+      end
+
     {:ok,
      %{
        metric: metric,
        min_interval: "5m",
        default_aggregation: :sum,
        available_aggregations: @aggregations,
-       available_selectors: [:slug, :text],
+       available_selectors: selectors,
        data_type: :histogram
      }}
   end

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -55,11 +55,11 @@ defmodule Sanbase.SocialData.MetricAdapter do
     |> transform_to_value_pairs(:mentions_count)
   end
 
-  def timeseries_data(metric, %{slug: slug}, from, to, interval, _aggregation)
+  def timeseries_data(metric, %{} = selector, from, to, interval, _aggregation)
       when metric in @social_dominance_timeseries_metrics do
     "social_dominance_" <> source = metric
 
-    Sanbase.SocialData.social_dominance(slug, from, to, interval, source)
+    Sanbase.SocialData.social_dominance(selector, from, to, interval, source)
     |> transform_to_value_pairs(:dominance)
   end
 

--- a/lib/sanbase/social_data/social_data.ex
+++ b/lib/sanbase/social_data/social_data.ex
@@ -13,7 +13,7 @@ defmodule Sanbase.SocialData do
 
   @recv_timeout 15_000
 
-  defdelegate social_dominance(slug, datetime_from, datetime_to, interval, source),
+  defdelegate social_dominance(selector, datetime_from, datetime_to, interval, source),
     to: SocialDominance
 
   defdelegate social_volume(slug, from, to, interval, source),

--- a/lib/sanbase_web/graphql/resolvers/social_data_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/social_data_resolver.ex
@@ -3,10 +3,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.SocialDataResolver do
 
   alias SanbaseWeb.Graphql.Helpers.Utils
 
-  alias Sanbase.{
-    SocialData,
-    TechIndicators
-  }
+  alias Sanbase.{SocialData, TechIndicators}
 
   @context_words_default_size 10
 
@@ -32,6 +29,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.SocialDataResolver do
         _resolution
       ) do
     # The `*_discussion_overview` are counting the total number of messages in a given medium
+    # Deprecated. To be replaced with `getMetric(metric: "community_messages_count_*")` and
+    # `getMetric(metric: "social_volume_*")`
     case type in [:telegram_discussion_overview, :discord_discussion_overview] do
       true ->
         SocialData.community_messages_count(slug, from, to, interval, type)
@@ -138,7 +137,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.SocialDataResolver do
         %{slug: slug, from: from, to: to, interval: interval, source: source},
         _resolution
       ) do
-    SocialData.social_dominance(slug, from, to, interval, source)
+    SocialData.social_dominance(%{slug: slug}, from, to, interval, source)
   end
 
   def news(_root, %{tag: tag, from: from, to: to, size: size}, _resolution) do

--- a/test/sanbase/social_data/social_dominance_test.exs
+++ b/test/sanbase/social_data/social_dominance_test.exs
@@ -26,8 +26,8 @@ defmodule Sanbase.SocialDominanceTest do
 
   describe "social_dominance/5" do
     test "response: success" do
-      from = DateTime.from_naive!(~N[2018-04-16 10:00:00], "Etc/UTC")
-      to = DateTime.from_naive!(~N[2018-04-16 22:00:00], "Etc/UTC")
+      from = ~U[2018-04-16 10:00:00Z]
+      to = ~U[2018-04-16 22:00:00Z]
 
       mock(
         HTTPoison,
@@ -35,7 +35,7 @@ defmodule Sanbase.SocialDominanceTest do
         {:ok, %HTTPoison.Response{body: @successful_response_body, status_code: 200}}
       )
 
-      result = SocialData.social_dominance("ethereum", from, to, "1h", :telegram)
+      result = SocialData.social_dominance(%{slug: "ethereum"}, from, to, "1h", :telegram)
 
       assert result ==
                {:ok,
@@ -46,8 +46,8 @@ defmodule Sanbase.SocialDominanceTest do
     end
 
     test "when computing for all sources" do
-      from = DateTime.from_naive!(~N[2018-04-16 10:00:00], "Etc/UTC")
-      to = DateTime.from_naive!(~N[2018-04-16 22:00:00], "Etc/UTC")
+      from = ~U[2018-04-16 10:00:00Z]
+      to = ~U[2018-04-16 22:00:00Z]
 
       with_mock(HTTPoison, [],
         get: fn _, _, _ ->
@@ -58,7 +58,7 @@ defmodule Sanbase.SocialDominanceTest do
            }}
         end
       ) do
-        result = SocialData.social_dominance("ethereum", from, to, "1h", :all)
+        result = SocialData.social_dominance(%{slug: "ethereum"}, from, to, "1h", :all)
 
         assert result ==
                  {:ok,
@@ -70,58 +70,30 @@ defmodule Sanbase.SocialDominanceTest do
     end
 
     test "when there are no mentions for any project" do
-      from = DateTime.from_naive!(~N[2018-04-16 10:00:00], "Etc/UTC")
-      to = DateTime.from_naive!(~N[2018-04-16 22:00:00], "Etc/UTC")
+      from = ~U[2018-04-16 10:00:00Z]
+      to = ~U[2018-04-16 22:00:00Z]
 
       mock(
         HTTPoison,
         :get,
         {:ok,
-         %HTTPoison.Response{
-           body: @successful_response_body_with_no_mentions,
-           status_code: 200
-         }}
+         %HTTPoison.Response{body: @successful_response_body_with_no_mentions, status_code: 200}}
       )
 
-      result =
-        SocialData.social_dominance(
-          "ethereum",
-          from,
-          to,
-          "1h",
-          :telegram
-        )
+      result = SocialData.social_dominance(%{slug: "ethereum"}, from, to, "1h", :telegram)
 
       assert result ==
-               {:ok,
-                [
-                  %{
-                    dominance: 0,
-                    datetime: from
-                  },
-                  %{
-                    dominance: 0,
-                    datetime: to
-                  }
-                ]}
+               {:ok, [%{dominance: 0, datetime: from}, %{dominance: 0, datetime: to}]}
     end
 
     test "response: 404" do
-      mock(
-        HTTPoison,
-        :get,
-        {:ok,
-         %HTTPoison.Response{
-           body: "Some message",
-           status_code: 404
-         }}
-      )
+      mock(HTTPoison, :get, {:ok, %HTTPoison.Response{body: "Some message", status_code: 404}})
 
       result = fn ->
         SocialData.social_dominance(
-          "santiment",
-          DateTime.from_naive!(~N[2018-04-16 10:00:00], "Etc/UTC"),
-          DateTime.from_naive!(~N[2018-04-16 22:00:00], "Etc/UTC"),
+          %{slug: "santiment"},
+          ~U[2018-04-16 10:00:00Z],
+          ~U[2018-04-16 22:00:00Z],
           "1h",
           :telegram
         )
@@ -132,20 +104,13 @@ defmodule Sanbase.SocialDominanceTest do
     end
 
     test "response: error" do
-      mock(
-        HTTPoison,
-        :get,
-        {:error,
-         %HTTPoison.Error{
-           reason: :econnrefused
-         }}
-      )
+      mock(HTTPoison, :get, {:error, %HTTPoison.Error{reason: :econnrefused}})
 
       result = fn ->
         SocialData.social_dominance(
-          "santiment",
-          DateTime.from_naive!(~N[2018-04-16 10:00:00], "Etc/UTC"),
-          DateTime.from_naive!(~N[2018-04-16 22:00:00], "Etc/UTC"),
+          %{slug: "santiment"},
+          ~U[2018-04-16 10:00:00Z],
+          ~U[2018-04-16 22:00:00Z],
           "1h",
           :telegram
         )


### PR DESCRIPTION
#### Summary
NOTE: Some issues need to be fixed in the social metrics API (tech_indicators) so in case of missing data proper intervals with 0 mentions will be returned
- Rework how the social dominance for projects is computed. Instead of taking the average dominance from all sources, it now sums all mentions from all sources for that project and divides it by all mentions for all other projects in top 50.
Previous result for bitcoin:
```json
{
  "data": {
    "socialDominance": [
      {
        "datetime": "2020-01-15T00:00:00Z",
        "dominance": 32.925000000000004
      },
      {
        "datetime": "2020-01-16T00:00:00Z",
        "dominance": 34.135
      },
      {
        "datetime": "2020-01-17T00:00:00Z",
        "dominance": 16.56
      },
      {
        "datetime": "2020-01-18T00:00:00Z",
        "dominance": 14.504999999999999
      },
...
```

New result for bitcoin:
```json
{
  "data": {
    "dom": {
      "timeseriesData": [
        {
          "datetime": "2020-01-15T00:00:00Z",
          "value": 33.6
        },
        {
          "datetime": "2020-01-16T00:00:00Z",
          "value": 34.26
        },
        {
          "datetime": "2020-01-17T00:00:00Z",
          "value": 34.57
        },
        {
          "datetime": "2020-01-18T00:00:00Z",
          "value": 28.57
        },
```

- Add social dominance for random text (words or any lucene query):
```graphql
{
  getMetric(metric: "social_dominance_total") {
    timeseriesData(
      selector: {text: "btc"}
      from: "2020-01-15T00:00:00Z"
      to: "2020-01-17T00:00:00Z"
      interval: "1d") {
        datetime
        value
    }
  }
}
```

Response:
```graphql
{
  "data": {
    "dom": {
      "timeseriesData": [
        {
          "datetime": "2020-01-15T00:00:00Z",
          "value": 3.01
        },
        {
          "datetime": "2020-01-16T00:00:00Z",
          "value": 2.23
        }
      ]
    }
  }
}
```
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
