### PR TITLE
Add transform to getMetric timesries data

### DIFF
--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -141,6 +141,11 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:text, :string)
   end
 
+  input_object :timeseries_metric_transform_input_object do
+    field(:type, :string)
+    field(:moving_average_base, :integer)
+  end
+
   object :metric do
     @desc ~s"""
     Return a list of 'datetime' and 'value' for a given metric, slug
@@ -171,6 +176,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       arg(:to, non_null(:datetime))
       arg(:interval, :interval, default_value: "1d")
       arg(:aggregation, :aggregation, default_value: nil)
+      arg(:transform, :timeseries_metric_transform_input_object)
       arg(:include_incomplete_data, :boolean, default_value: false)
 
       complexity(&Complexity.from_to_interval/3)

--- a/test/sanbase_web/graphql/metric/api_metric_timeseries_data_transform_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_timeseries_data_transform_test.exs
@@ -1,0 +1,108 @@
+defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesDataTransformTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import Mock
+  import Sanbase.Factory
+  import SanbaseWeb.Graphql.TestHelpers
+  import Sanbase.DateTimeUtils, only: [from_iso8601!: 1]
+
+  alias Sanbase.Metric
+
+  setup do
+    %{user: user} = insert(:subscription_pro_sanbase, user: insert(:user))
+    conn = setup_jwt_auth(build_conn(), user)
+
+    [conn: conn, slug: "ethereum"]
+  end
+
+  test "moving average transform", context do
+    %{conn: conn, slug: slug} = context
+    [metric | _] = Metric.available_timeseries_metrics()
+
+    with_mock Metric, [:passthrough],
+      timeseries_data: fn _, _, _, _, _, _ ->
+        {:ok,
+         [
+           %{datetime: ~U[2019-01-01T00:00:00Z], value: 100.0},
+           %{datetime: ~U[2019-01-02T00:00:00Z], value: 200.0},
+           %{datetime: ~U[2019-01-03T00:00:00Z], value: 50.0},
+           %{datetime: ~U[2019-01-04T00:00:00Z], value: 400.0},
+           %{datetime: ~U[2019-01-05T00:00:00Z], value: 300.0},
+           %{datetime: ~U[2019-01-06T00:00:00Z], value: 10.0},
+           %{datetime: ~U[2019-01-07T00:00:00Z], value: 200.0},
+           %{datetime: ~U[2019-01-08T00:00:00Z], value: 320.0}
+         ]}
+      end do
+      result =
+        get_timeseries_metric(
+          conn,
+          metric,
+          slug,
+          ~U[2019-01-04T00:00:00Z],
+          ~U[2019-01-08T00:00:00Z],
+          "1d",
+          :avg,
+          %{type: "moving_average", moving_average_base: 3}
+        )
+        |> extract_timeseries_data()
+
+      assert result == [
+               %{"datetime" => "2019-01-04T00:00:00Z", "value" => 216.67},
+               %{"datetime" => "2019-01-05T00:00:00Z", "value" => 250.0},
+               %{"datetime" => "2019-01-06T00:00:00Z", "value" => 236.67},
+               %{"datetime" => "2019-01-07T00:00:00Z", "value" => 170.0},
+               %{"datetime" => "2019-01-08T00:00:00Z", "value" => 176.67}
+             ]
+
+      assert_called(
+        Metric.timeseries_data(
+          metric,
+          %{slug: slug},
+          ~U[2019-01-01T00:00:00Z],
+          ~U[2019-01-08T00:00:00Z],
+          "1d",
+          :avg
+        )
+      )
+    end
+  end
+
+  # Private functions
+
+  defp get_timeseries_metric(conn, metric, slug, from, to, interval, aggregation, transform) do
+    query = get_timeseries_query(metric, slug, from, to, interval, aggregation, transform)
+
+    conn
+    |> post("/graphql", query_skeleton(query, "getMetric"))
+    |> json_response(200)
+  end
+
+  defp extract_timeseries_data(result) do
+    %{"data" => %{"getMetric" => %{"timeseriesData" => timeseries_data}}} = result
+    timeseries_data
+  end
+
+  defp get_timeseries_query(metric, slug, from, to, interval, aggregation, transform) do
+    transform_text =
+      Enum.map(transform, fn {key, value} -> "#{key}: #{inspect(value)}" end)
+      |> Enum.join(", ")
+
+    """
+      {
+        getMetric(metric: "#{metric}"){
+          timeseriesData(
+            slug: "#{slug}"
+            from: "#{from}"
+            to: "#{to}"
+            interval: "#{interval}"
+            aggregation: #{Atom.to_string(aggregation) |> String.upcase()}
+            transform: {#{transform_text}}
+            ){
+              datetime
+              value
+            }
+        }
+      }
+    """
+  end
+end


### PR DESCRIPTION
#### Summary
Request
```graphql
{
  getMetric(metric: "dev_activity") {
    timeseriesData(
      selector: {slug: "santiment"}
      from: "2020-01-15T00:00:00Z"
      to: "2020-01-25T23:59:00Z"
      interval: "1d"
      transform: {type: "moving_average", movingAverageBase: 7}) {
        datetime
        value
    }
  }
}
```

Response:
```graphql
{
  "data": {
    "getMetric": {
      "timeseriesData": [
        {
          "datetime": "2020-01-15T00:00:00Z",
          "value": 44.57
        },
        {
          "datetime": "2020-01-15T00:00:00Z",
          "value": 48.14
        },
...
```
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
