### PR TITLE
Optimizing logo size

### DIFF
--- a/lib/sanbase/external_services/coinmarketcap/logo_fetcher.ex
+++ b/lib/sanbase/external_services/coinmarketcap/logo_fetcher.ex
@@ -96,6 +96,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.LogoFetcher do
 
     Mogrify.open(source_filepath)
     |> Mogrify.resize("#{@size}x#{@size}")
+    |> Mogrify.custom("type", "PaletteAlpha")
     |> Mogrify.save(path: dest_filepath)
 
     {:ok, dest_filepath}


### PR DESCRIPTION
The idea is to optimise the filesize of the logos, so they aren't that big and at the same time, they don't lose a significant portion of their quality.

https://favro.com/organization/bdbb4f24afc48b29c74f4fa4/cffeb6e3eaf254588cb68a9a?card=San-6948

Did a little search on morgify and with the help of Ivan, found that I can change the type of the image, so it can use a different colour pattern:
http://www.imagemagick.org/script/command-line-options.php#type

