### PR TITLE
Support selector with infrastructure and address in assets_held_by_address

### DIFF
--- a/lib/sanbase/clickhouse/historical_balance/fetchers/ltc_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/fetchers/ltc_balance.ex
@@ -30,7 +30,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.LtcBalance do
 
     ClickhouseRepo.query_transform(query, args, fn [value] ->
       %{
-        slug: "bitcoin",
+        slug: "litecoin",
         balance: value
       }
     end)

--- a/lib/sanbase/clickhouse/historical_balance/fetchers/utxo_sql_queries.ex
+++ b/lib/sanbase/clickhouse/historical_balance/fetchers/utxo_sql_queries.ex
@@ -24,7 +24,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.UtxoSqlQueries do
     SELECT balance
     FROM #{table}
     PREWHERE
-      address = ?1 AND
+      address = ?1
     ORDER BY dt DESC
     LIMIT 1
     """

--- a/lib/sanbase/signals/operation/operation_text_kv.ex
+++ b/lib/sanbase/signals/operation/operation_text_kv.ex
@@ -127,7 +127,7 @@ defmodule Sanbase.Signal.OperationText.KV do
   end
 
   # Amount
-  def to_template_kv(%{absolute_change: value}, %{amount_down: amount_down} = op, opts),
+  def to_template_kv(%{absolute_change: value}, %{amount_down: _} = op, opts),
     do: to_template_kv(value, op, opts)
 
   def to_template_kv(amount_change, %{amount_down: amount_down}, opts) do

--- a/lib/sanbase_web/graphql/resolvers/historical_balance_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/historical_balance_resolver.ex
@@ -9,8 +9,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.HistoricalBalanceResolver do
   # Return this number of datapoints is the provided interval is an empty string
   @datapoints 300
 
-  def assets_held_by_address(_root, %{address: address}, _resolution) do
-    HistoricalBalance.assets_held_by_address(address)
+  def assets_held_by_address(_root, args, _resolution) do
+    selector =
+      case Map.get(args, :selector) do
+        nil -> %{infrastructure: "ETH", address: Map.fetch!(args, :address)}
+        selector -> selector
+      end
+
+    HistoricalBalance.assets_held_by_address(selector)
     |> case do
       {:ok, result} ->
         # We do this, because many contracts emit a transfer
@@ -26,7 +32,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.HistoricalBalanceResolver do
 
       {:error, error} ->
         {:error,
-         handle_graphql_error("Assets held by address", address, error, description: "address")}
+         handle_graphql_error("Assets held by address", selector.address, error,
+           description: "address"
+         )}
     end
   end
 

--- a/lib/sanbase_web/graphql/schema/queries/historical_balance_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/historical_balance_queries.ex
@@ -15,7 +15,8 @@ defmodule SanbaseWeb.Graphql.Schema.HistoricalBalanceQueries do
     field :assets_held_by_address, list_of(:slug_balance) do
       meta(access: :free)
 
-      arg(:address, non_null(:string))
+      arg(:selector, :address_selector_input_object)
+      arg(:address, :string)
 
       cache_resolve(&HistoricalBalanceResolver.assets_held_by_address/3)
     end

--- a/lib/sanbase_web/graphql/schema/types/historical_balance_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/historical_balance_types.ex
@@ -11,6 +11,11 @@ defmodule SanbaseWeb.Graphql.HistoricalBalanceTypes do
     field(:balance, :float)
   end
 
+  input_object :address_selector_input_object do
+    field(:infrastructure, non_null(:string))
+    field(:address, non_null(:string))
+  end
+
   input_object :historical_balance_selector do
     field(:infrastructure, non_null(:string))
     field(:currency, :string)

--- a/test/sanbase/clickhouse/historical_balance/assets_held_by_address_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/assets_held_by_address_test.exs
@@ -32,7 +32,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.AssetsHeldByAdderssTest do
          {:ok, [%{balance: 1000.0, slug: context.eth_project.slug}]}
        end}
     ] do
-      assert HistoricalBalance.assets_held_by_address("0x123") ==
+      assert HistoricalBalance.assets_held_by_address(%{address: "0x123", infrastructure: "ETH"}) ==
                {:ok,
                 [
                   %{slug: context.eth_project.slug, balance: 1000.0},
@@ -44,32 +44,24 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.AssetsHeldByAdderssTest do
 
   test "clickhouse returns no results", _context do
     with_mocks [
-      {Sanbase.Clickhouse.HistoricalBalance.Erc20Balance, [:passthrough],
-       assets_held_by_address: fn _ ->
-         {:ok, []}
-       end},
-      {Sanbase.Clickhouse.HistoricalBalance.EthBalance, [:passthrough],
+      {Sanbase.Clickhouse.HistoricalBalance.BtcBalance, [:passthrough],
        assets_held_by_address: fn _ ->
          {:ok, []}
        end}
     ] do
-      assert HistoricalBalance.assets_held_by_address("0x123") ==
+      assert HistoricalBalance.assets_held_by_address(%{address: "0x123", infrastructure: "BTC"}) ==
                {:ok, []}
     end
   end
 
   test "clickhouse returns error", _context do
     with_mocks [
-      {Sanbase.Clickhouse.HistoricalBalance.Erc20Balance, [:passthrough],
-       assets_held_by_address: fn _ ->
-         {:ok, []}
-       end},
-      {Sanbase.Clickhouse.HistoricalBalance.EthBalance, [:passthrough],
+      {Sanbase.Clickhouse.HistoricalBalance.LtcBalance, [:passthrough],
        assets_held_by_address: fn _ ->
          {:error, "Something went wrong"}
        end}
     ] do
-      assert HistoricalBalance.assets_held_by_address("0x123") ==
+      assert HistoricalBalance.assets_held_by_address(%{address: "0x123", infrastructure: "LTC"}) ==
                {:error, "Something went wrong"}
     end
   end


### PR DESCRIPTION
#### Summary
Add support for all chains in `assetsHeldByAddress`

Request:
```graphql
{
  assetsHeldByAddress(selector:{infrastructure: "BTC" address: "35hK24tcLEWcgNA4JxpvbkNkoAcDGqQPsP"}){
    balance
    slug
  }
}
```


Response:
```json
{
  "data": {
    "assetsHeldByAddress": [
      {
        "balance": 255502.15259211,
        "slug": "bitcoin"
      }
    ]
  }
}
```
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
