### PR TITLE
Improvements to the graphql caching

### DIFF
--- a/lib/sanbase_web/graphql/absinthe_before_send.ex
+++ b/lib/sanbase_web/graphql/absinthe_before_send.ex
@@ -47,6 +47,8 @@ defmodule SanbaseWeb.Graphql.AbsintheBeforeSend do
     "allProjectsByFunction"
   ]
 
+  def cached_queries(), do: @cached_queries
+
   def before_send(conn, %Absinthe.Blueprint{} = blueprint) do
     # Do not cache in case of:
     # -`:nocache` returend from a resolver


### PR DESCRIPTION
Catch early the queries that don't need work in the DocumentProvider
Use Map.take instead of multiple cases in GQL Cache

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
