### PR TITLE
Improve rehydrating cache and available metrics cache

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
@@ -42,7 +42,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver do
   end
 
   defp maybe_register_and_get(cache_key, fun, slug, query, attempts) do
-    case RehydratingCache.get(cache_key, 5_000) do
+    case RehydratingCache.get(cache_key, 5_000, return_nocache: true) do
+      {:nocache, {:ok, value}} ->
+        {:nocache, {:ok, value}}
+
       {:ok, value} ->
         {:ok, value}
 

--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -109,7 +109,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     ```
     """
     field :available_metrics, list_of(:string) do
-      resolve(&ProjectMetricsResolver.available_metrics/3)
+      cache_resolve(&ProjectMetricsResolver.available_metrics/3, ttl: 1200)
     end
 
     @desc ~s"""
@@ -131,10 +131,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     ```
     """
     field :available_timeseries_metrics, list_of(:string) do
-      cache_resolve(&ProjectMetricsResolver.available_timeseries_metrics/3,
-        ttl: 10,
-        max_ttl_offset: 20
-      )
+      cache_resolve(&ProjectMetricsResolver.available_timeseries_metrics/3, ttl: 1200)
     end
 
     @desc ~s"""
@@ -157,10 +154,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     ```
     """
     field :available_histogram_metrics, list_of(:string) do
-      cache_resolve(&ProjectMetricsResolver.available_histogram_metrics/3,
-        ttl: 10,
-        max_ttl_offset: 20
-      )
+      cache_resolve(&ProjectMetricsResolver.available_histogram_metrics/3, ttl: 1200)
     end
 
     @desc ~s"""


### PR DESCRIPTION
- Properly handle get handle call
- Return :nocache if :return_nocache is provided. This allows the
cache_resolve to cache fully computed values for 20 minutes

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
