### PR TITLE
Switch percent of total supply on exchanges query to use metric.

### DIFF
--- a/lib/sanbase/cache/rehydrating_cache/rehydrating_cache.ex
+++ b/lib/sanbase/cache/rehydrating_cache/rehydrating_cache.ex
@@ -88,7 +88,7 @@ defmodule Sanbase.Cache.RehydratingCache do
   if a recomputation is running when get is invoked, the old value is returned.
   """
   @spec get(any(), non_neg_integer(), Keyword.t()) ::
-          {:ok, any()} | {:error, :timeout} | {:error, :not_registered}
+          {:ok, any()} | {:nocache, {:ok, any()}} | {:error, :timeout} | {:error, :not_registered}
   def get(key, timeout \\ 30_000, opts \\ []) when is_integer(timeout) and timeout > 0 do
     try do
       case Store.get(@store_name, key) do

--- a/lib/sanbase/clickhouse/metric/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/available_v2_metrics.json
@@ -996,8 +996,22 @@
 
   {
     "human_readable_name": "Tokens/Coins On Exchanges",
-    "name": "exchange_token_supply",
+    "name": "supply_on_exchanges",
     "metric": "exchange_token_supply",
+    "version": "2020-01-01",
+    "access": "restricted",
+    "min_plan": "free",
+    "aggregation": "avg",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2",
+    "has_incomplete_data": true,
+    "data_type": "timeseries"
+  },
+
+  {
+    "human_readable_name": "Tokens/Coins On Exchanges",
+    "name": "supply_outside_exchanges",
+    "metric": "non_exchange_token_supply",
     "version": "2020-01-01",
     "access": "restricted",
     "min_plan": "free",

--- a/lib/sanbase_web/graphql/cache/cache.ex
+++ b/lib/sanbase_web/graphql/cache/cache.ex
@@ -222,6 +222,7 @@ defmodule SanbaseWeb.Graphql.Cache do
     cache_key = [name, args] |> :erlang.phash2()
 
     {cache_key, ttl}
+    |> IO.inspect(label: "KEY: #{inspect({name, additional_args})}", limit: :infinity)
   end
 
   # Convert the values for using in the cache. A special treatement is done for

--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -243,30 +243,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
         %{slug: _, from: _, to: _, interval: _} = args,
         _resolution
       ) do
-    # TODO: After percent_of_total_supply_on_exchanges metric is fully computed
-    # on production, this one would be replaced with a single call to it
-    with {:ok, total_supply} <-
-           SanbaseWeb.Graphql.Resolvers.MetricResolver.timeseries_data(
-             %{},
-             args,
-             %{source: %{metric: "circulation"}}
-           ),
-         {:ok, supply_on_exchanges} <-
-           SanbaseWeb.Graphql.Resolvers.MetricResolver.timeseries_data(
-             %{},
-             args,
-             %{source: %{metric: "exchange_token_supply"}}
-           ) do
-      result =
-        Enum.zip(supply_on_exchanges, total_supply)
-        |> Enum.map(fn {%{datetime: datetime, value: supply_on_exchanges}, %{value: total_supply}} ->
-          %{
-            datetime: datetime,
-            percent_on_exchanges: Sanbase.Math.percent_of(supply_on_exchanges, total_supply)
-          }
-        end)
-
-      {:ok, result}
-    end
+    SanbaseWeb.Graphql.Resolvers.MetricResolver.timeseries_data(
+      %{},
+      args,
+      %{source: %{metric: "percent_of_total_supply_on_exchanges"}}
+    )
   end
 end

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -135,7 +135,8 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
       "age_distribution",
       "price_histogram",
       # exchange supply metrics
-      "exchange_token_supply",
+      "supply_on_exchanges",
+      "supply_outside_exchanges",
       "percent_of_total_supply_on_exchanges"
     ]
 


### PR DESCRIPTION
#### Summary
- Rename an existing unused metric to a more proper name
- Switch percent of total supply on exchanges to use the dedicated metric
- Add non-exchange supply
- Fix typespecs

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
