### PR TITLE
Add exchange/non-exchange top holders metrics

### DIFF
--- a/lib/sanbase/clickhouse/top_holders/top_holders_sql_query.ex
+++ b/lib/sanbase/clickhouse/top_holders/top_holders_sql_query.ex
@@ -5,9 +5,10 @@ defmodule Sanbase.Clickhouse.TopHolders.SqlQuery do
   import Sanbase.Metric.SqlQuery.Helper, only: [aggregation: 3]
 
   def timeseries_data_query(
-        table,
         "amount_in_top_holders",
+        table,
         contract,
+        _blockchain,
         count,
         from,
         to,
@@ -22,14 +23,17 @@ defmodule Sanbase.Clickhouse.TopHolders.SqlQuery do
     FROM (
       SELECT
         toUnixTimestamp(intDiv(toUInt32(toDateTime(dt)), ?1) * ?1) AS dt,
-       #{aggregation(aggregation, "value", "dt")} / #{decimals} AS value
+        #{aggregation(aggregation, "value", "dt")} / #{decimals} AS value
       FROM #{table} FINAL
       PREWHERE
         contract = ?2 AND
         rank <= ?3 AND
         dt >= toDateTime(?4) AND
-        dt < toDateTime(?5)
+        dt < toDateTime(?5) AND
+        rank IS NOT NULL
       GROUP BY dt, address
+      ORDER BY dt, value desc
+      LIMIT ?3 BY dt
     )
     GROUP BY dt
     ORDER BY dt
@@ -41,6 +45,113 @@ defmodule Sanbase.Clickhouse.TopHolders.SqlQuery do
       count,
       from |> DateTime.to_unix(),
       to |> DateTime.to_unix()
+    ]
+
+    {query, args}
+  end
+
+  def timeseries_data_query(
+        "amount_in_exchange_top_holders",
+        table,
+        contract,
+        blockchain,
+        count,
+        from,
+        to,
+        interval,
+        decimals,
+        aggregation
+      ) do
+    decimals = Sanbase.Math.ipow(10, decimals)
+
+    query = """
+    SELECT dt, SUM(value)
+    FROM (
+      SELECT
+        address,
+        toUnixTimestamp(intDiv(toUInt32(toDateTime(dt)), ?1) * ?1) AS dt,
+        #{aggregation(aggregation, "value", "dt")} / #{decimals} AS value
+      FROM (
+        SELECT dt, address, value
+        FROM #{table} FINAL
+        PREWHERE
+          contract = ?2 AND
+          dt >= toDateTime(?4) AND
+          dt < toDateTime(?5) AND
+          rank IS NOT NULL
+      )
+      GROUP BY dt, address
+      ORDER BY dt, value DESC
+      LIMIT ?3 BY dt
+    )
+    GLOBAL ANY INNER JOIN (
+      SELECT address
+      FROM blockchain_address_labels
+      PREWHERE blockchain = ?6 AND label IN ('centralized_exchange', 'decentralized_exchange')
+    ) USING address
+    GROUP BY dt
+    ORDER BY dt
+    """
+
+    args = [
+      interval |> str_to_sec(),
+      contract,
+      count,
+      from |> DateTime.to_unix(),
+      to |> DateTime.to_unix(),
+      blockchain
+    ]
+
+    {query, args}
+  end
+
+  def timeseries_data_query(
+        "amount_in_non_exchange_top_holders",
+        table,
+        contract,
+        blockchain,
+        count,
+        from,
+        to,
+        interval,
+        decimals,
+        aggregation
+      ) do
+    decimals = Sanbase.Math.ipow(10, decimals)
+
+    query = """
+    SELECT dt, SUM(value)
+    FROM (
+      SELECT
+        #{aggregation(aggregation, "value", "dt")} / #{decimals} AS value,
+        toUnixTimestamp(intDiv(toUInt32(toDateTime(dt)), ?1) * ?1) AS dt,
+        address
+      FROM #{table} FINAL
+      PREWHERE
+        address GLOBAL NOT IN (
+          SELECT address
+          FROM blockchain_address_labels
+          PREWHERE blockchain = ?6 AND label IN ('centralized_exchange', 'decentralized_exchange')
+        ) AND
+        contract = ?2 AND
+        dt >= toDateTime(?4) AND
+        dt < toDateTime(?5) AND
+        rank IS NOT NULL
+      GROUP BY dt, address
+      ORDER BY dt, value DESC
+      LIMIT ?3 BY dt
+    )
+    GROUP BY dt
+    ORDER BY dt
+    """
+
+    args = [
+      interval |> str_to_sec(),
+      contract,
+      count,
+      from |> DateTime.to_unix(),
+      to |> DateTime.to_unix(),
+      blockchain
     ]
 
     {query, args}

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -138,8 +138,11 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
       "supply_on_exchanges",
       "supply_outside_exchanges",
       "percent_of_total_supply_on_exchanges",
-      # holders metrics
+      # top holders metrics
       "amount_in_top_holders",
+      "amount_in_exchange_top_holders",
+      "amount_in_non_exchange_top_holders",
+      # holders distribution metrics
       "holders_distribution_0.001_to_0.01",
       "holders_distribution_0.01_to_0.1",
       "holders_distribution_0.1_to_1",


### PR DESCRIPTION
#### Summary
Add `amount_in_(non_)exchange_top_holders` metrics. It fetches the amount held by the top N (non-)exchange holders
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
