### PR TITLE
Fix metric test to use default aggregation

### DIFF
--- a/test/sanbase/metric/metric_test.exs
+++ b/test/sanbase/metric/metric_test.exs
@@ -92,7 +92,7 @@ defmodule Sanbase.MetricTest do
     test "fetch a single metric", %{project: project} do
       [metric | _] = Metric.available_timeseries_metrics()
 
-      result = Metric.timeseries_data(metric, %{slug: project.slug}, @from, @to, "1d", :avg)
+      result = Metric.timeseries_data(metric, %{slug: project.slug}, @from, @to, "1d")
 
       assert result == {:ok, @resp}
     end


### PR DESCRIPTION
#### Summary
After the rework where unsupported aggregation for a metric used directly fails the request, some tests are failing.
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
