### PR TITLE
Replace UNION ALL with WITH FILL STEP in clickhouse queries

### DIFF
--- a/lib/sanbase/clickhouse/github/github.ex
+++ b/lib/sanbase/clickhouse/github/github.ex
@@ -304,34 +304,29 @@ defmodule Sanbase.Clickhouse.Github do
     from_unix = DateTime.to_unix(from)
     to_unix = DateTime.to_unix(to)
     interval = Sanbase.DateTimeUtils.str_to_sec(interval)
-    span = div(to_unix - from_unix, interval) |> max(1)
 
     query = """
     SELECT time, toUInt32(SUM(uniq_actors)) AS uniq_actors
-      FROM (
-        SELECT
-          toUnixTimestamp(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) AS time,
-          0 AS uniq_actors
-        FROM numbers(?2)
-
-        UNION ALL
-
-        SELECT toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time, uniq(actor) AS uniq_actors
-        FROM #{@table}
-        PREWHERE
-          owner IN (?3) AND
-          dt >= toDateTime(?4) AND
-          dt < toDateTime(?5) AND
-          event NOT IN (?6)
-        GROUP BY time
-      )
+    FROM (
+      SELECT
+        toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time,
+        uniq(actor) AS uniq_actors
+      FROM #{@table}
+      PREWHERE
+        owner IN (?2) AND
+        dt >= toDateTime(?3) AND
+        dt < toDateTime(?4) AND
+        event NOT IN (?5)
       GROUP BY time
-      ORDER BY time
+    )
+    GROUP BY time
+    ORDER BY time
+    WITH FILL STEP ?1
+
     """
 
     args = [
       interval,
-      span,
       organizations,
       from_unix,
       to_unix,
@@ -346,33 +341,27 @@ defmodule Sanbase.Clickhouse.Github do
     from_unix = DateTime.to_unix(from)
     to_unix = DateTime.to_unix(to)
     interval = Sanbase.DateTimeUtils.str_to_sec(interval)
-    span = div(to_unix - from_unix, interval) |> max(1)
 
     query = """
     SELECT time, toUInt32(SUM(uniq_actors)) AS uniq_actors
-      FROM (
-        SELECT
-          toUnixTimestamp(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) AS time,
-          0 AS uniq_actors
-        FROM numbers(?2)
-
-        UNION ALL
-
-        SELECT toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time, uniq(actor) AS uniq_actors
-        FROM #{@table}
-        PREWHERE
-          owner IN (?3) AND
-          dt >= toDateTime(?4) AND
-          dt < toDateTime(?5)
-        GROUP BY time
-      )
+    FROM (
+      SELECT
+        toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time,
+        uniq(actor) AS uniq_actors
+      FROM #{@table}
+      PREWHERE
+        owner IN (?2) AND
+        dt >= toDateTime(?3) AND
+        dt < toDateTime(?4)
       GROUP BY time
-      ORDER BY time
+    )
+    GROUP BY time
+    ORDER BY time
+    WITH FILL STEP ?1
     """
 
     args = [
       interval,
-      span,
       organizations,
       from_unix,
       to_unix
@@ -385,38 +374,32 @@ defmodule Sanbase.Clickhouse.Github do
     to = Enum.min_by([to, Timex.now()], &DateTime.to_unix/1)
     from_unix = DateTime.to_unix(from)
     to_unix = DateTime.to_unix(to)
-    span = div(to_unix - from_unix, interval) |> max(1)
 
     query = """
     SELECT time, SUM(events) AS events_count
+    FROM (
+      SELECT
+        toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time,
+        count(events) AS events
       FROM (
-        SELECT
-          toUnixTimestamp(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) AS time,
-          0 AS events
-        FROM numbers(?2)
-
-        UNION ALL
-
-        SELECT toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time, count(events) AS events
-          FROM (
-            SELECT any(event) AS events, dt
-            FROM #{@table}
-            PREWHERE
-              owner IN (?3)
-            AND dt >= toDateTime(?4)
-            AND dt < toDateTime(?5)
-            AND event NOT IN (?6)
-            GROUP BY owner, repo, dt, event
-          )
-          GROUP BY time
+        SELECT any(event) AS events, dt
+        FROM #{@table}
+        PREWHERE
+          owner IN (?2)
+        AND dt >= toDateTime(?3)
+        AND dt < toDateTime(?4)
+        AND event NOT IN (?5)
+        GROUP BY owner, repo, dt, event
       )
       GROUP BY time
-      ORDER BY time
+    )
+    GROUP BY time
+    ORDER BY time
+    WITH FILL STEP ?1
     """
 
     args = [
       interval,
-      span,
       organizations,
       from_unix,
       to_unix,
@@ -430,37 +413,31 @@ defmodule Sanbase.Clickhouse.Github do
     to = Enum.min_by([to, Timex.now()], &DateTime.to_unix/1)
     from_unix = DateTime.to_unix(from)
     to_unix = DateTime.to_unix(to)
-    span = div(to_unix - from_unix, interval) |> max(1)
 
     query = """
     SELECT time, SUM(events) AS events_count
+    FROM (
+      SELECT
+        toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time,
+        count(events) AS events
       FROM (
-        SELECT
-          toUnixTimestamp(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) AS time,
-          0 AS events
-        FROM numbers(?2)
-
-        UNION ALL
-
-        SELECT toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time, count(events) AS events
-          FROM (
-            SELECT any(event) AS events, dt
-            FROM #{@table}
-            PREWHERE
-              owner IN (?3)
-              AND dt >= toDateTime(?4)
-              AND dt <= toDateTime(?5)
-            GROUP BY owner, repo, dt, event
-          )
-          GROUP BY time
+        SELECT any(event) AS events, dt
+        FROM #{@table}
+        PREWHERE
+          owner IN (?2)
+          AND dt >= toDateTime(?3)
+          AND dt <= toDateTime(?4)
+        GROUP BY owner, repo, dt, event
       )
       GROUP BY time
-      ORDER BY time
+    )
+    GROUP BY time
+    ORDER BY time
+    WITH FILL STEP ?1
     """
 
     args = [
       interval,
-      span,
       organizations,
       from_unix,
       to_unix


### PR DESCRIPTION
#### Summary
This way of writing queryies is much simpler and it also solves an issue
when a very old 'from' is provided - it included a lot of zeroes for the
period of this from to where the data actually starts

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
