### PR TITLE
Rework github queries to use WITH FILL

### DIFF
--- a/lib/sanbase/clickhouse/github/github.ex
+++ b/lib/sanbase/clickhouse/github/github.ex
@@ -63,7 +63,7 @@ defmodule Sanbase.Clickhouse.Github do
     {query, args} = total_github_activity_query(organizations, from, to)
 
     ClickhouseRepo.query_transform(query, args, fn [github_activity] ->
-      github_activity |> Sanbase.Math.to_integer()
+      github_activity |> Sanbase.Math.to_integer(0)
     end)
     |> maybe_unwrap_ok_value()
   end
@@ -96,7 +96,7 @@ defmodule Sanbase.Clickhouse.Github do
     {query, args} = total_dev_activity_query(organizations, from, to)
 
     ClickhouseRepo.query_transform(query, args, fn [organization, dev_activity] ->
-      {organization, dev_activity |> Sanbase.Math.to_integer()}
+      {organization, dev_activity |> Sanbase.Math.to_integer(0)}
     end)
   end
 
@@ -274,7 +274,7 @@ defmodule Sanbase.Clickhouse.Github do
     ClickhouseRepo.query_transform(query, args, fn [datetime, contributors] ->
       %{
         datetime: datetime |> DateTime.from_unix!(),
-        contributors_count: contributors |> Sanbase.Math.to_integer()
+        contributors_count: contributors |> Sanbase.Math.to_integer(0)
       }
     end)
   end
@@ -285,7 +285,7 @@ defmodule Sanbase.Clickhouse.Github do
     ClickhouseRepo.query_transform(query, args, fn [datetime, contributors] ->
       %{
         datetime: datetime |> DateTime.from_unix!(),
-        contributors_count: contributors |> Sanbase.Math.to_integer()
+        contributors_count: contributors |> Sanbase.Math.to_integer(0)
       }
     end)
   end
@@ -294,7 +294,7 @@ defmodule Sanbase.Clickhouse.Github do
     ClickhouseRepo.query_transform(query, args, fn [datetime, events_count] ->
       %{
         datetime: datetime |> DateTime.from_unix!(),
-        activity: events_count |> Sanbase.Math.to_integer()
+        activity: events_count |> Sanbase.Math.to_integer(0)
       }
     end)
   end
@@ -308,25 +308,21 @@ defmodule Sanbase.Clickhouse.Github do
 
     query = """
     SELECT time, toUInt32(SUM(uniq_actors)) AS uniq_actors
-      FROM (
-        SELECT
-          toUnixTimestamp(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) AS time,
-          0 AS uniq_actors
-        FROM numbers(?2)
-
-        UNION ALL
-
-        SELECT toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time, uniq(actor) AS uniq_actors
-        FROM #{@table}
-        PREWHERE
-          owner IN (?3) AND
-          dt >= toDateTime(?4) AND
-          dt < toDateTime(?5) AND
-          event NOT IN (?6)
-        GROUP BY time
-      )
+    FROM (
+      SELECT
+        toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time,
+        uniqExact(actor) AS uniq_actors
+      FROM #{@table}
+      PREWHERE
+        owner IN (?2) AND
+        dt >= toDateTime(?3) AND
+        dt < toDateTime(?4) AND
+        event NOT IN (?5)
       GROUP BY time
-      ORDER BY time
+    )
+    GROUP BY time
+    ORDER BY time
+    WITH FILL FROM toUnixTimestamp(intDiv(toUInt32(?3), ?1) * ?1) TO ?4 STEP ?1
     """
 
     args = [
@@ -350,24 +346,20 @@ defmodule Sanbase.Clickhouse.Github do
 
     query = """
     SELECT time, toUInt32(SUM(uniq_actors)) AS uniq_actors
-      FROM (
-        SELECT
-          toUnixTimestamp(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) AS time,
-          0 AS uniq_actors
-        FROM numbers(?2)
-
-        UNION ALL
-
-        SELECT toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time, uniq(actor) AS uniq_actors
-        FROM #{@table}
-        PREWHERE
-          owner IN (?3) AND
-          dt >= toDateTime(?4) AND
-          dt < toDateTime(?5)
-        GROUP BY time
-      )
+    FROM (
+      SELECT
+        toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time,
+        uniqExact(actor) AS uniq_actors
+      FROM #{@table}
+      PREWHERE
+        owner IN (?2) AND
+        dt >= toDateTime(?3) AND
+        dt < toDateTime(?4)
       GROUP BY time
-      ORDER BY time
+    )
+    GROUP BY time
+    ORDER BY time
+    WITH FILL FROM toUnixTimestamp(intDiv(toUInt32(?3), ?1) * ?1) TO ?4 STEP ?1
     """
 
     args = [
@@ -388,30 +380,26 @@ defmodule Sanbase.Clickhouse.Github do
     span = div(to_unix - from_unix, interval) |> max(1)
 
     query = """
-    SELECT time, SUM(events) AS events_count
+    SELECT time, SUM(events)
+    FROM (
+      SELECT
+        toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time,
+        count(events) AS events
       FROM (
-        SELECT
-          toUnixTimestamp(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) AS time,
-          0 AS events
-        FROM numbers(?2)
-
-        UNION ALL
-
-        SELECT toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time, count(events) AS events
-          FROM (
-            SELECT any(event) AS events, dt
-            FROM #{@table}
-            PREWHERE
-              owner IN (?3)
-            AND dt >= toDateTime(?4)
-            AND dt < toDateTime(?5)
-            AND event NOT IN (?6)
-            GROUP BY owner, repo, dt, event
-          )
-          GROUP BY time
+        SELECT any(event) AS events, dt
+        FROM #{@table}
+        PREWHERE
+          owner IN (?2) AND
+          dt >= toDateTime(?3) AND
+          dt < toDateTime(?4) AND
+          event NOT IN (?5)
+        GROUP BY owner, repo, dt, event
       )
       GROUP BY time
-      ORDER BY time
+    )
+    GROUP BY time
+    ORDER BY time
+    WITH FILL FROM toUnixTimestamp(intDiv(toUInt32(?3), ?1) * ?1) TO ?4 STEP ?1
     """
 
     args = [
@@ -433,29 +421,25 @@ defmodule Sanbase.Clickhouse.Github do
     span = div(to_unix - from_unix, interval) |> max(1)
 
     query = """
-    SELECT time, SUM(events) AS events_count
+    SELECT time, SUM(events)
+    FROM (
+      SELECT
+        toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time,
+        count(events) AS events
       FROM (
-        SELECT
-          toUnixTimestamp(intDiv(toUInt32(?4 + number * ?1), ?1) * ?1) AS time,
-          0 AS events
-        FROM numbers(?2)
-
-        UNION ALL
-
-        SELECT toUnixTimestamp(intDiv(toUInt32(dt), ?1) * ?1) AS time, count(events) AS events
-          FROM (
-            SELECT any(event) AS events, dt
-            FROM #{@table}
-            PREWHERE
-              owner IN (?3)
-              AND dt >= toDateTime(?4)
-              AND dt <= toDateTime(?5)
-            GROUP BY owner, repo, dt, event
-          )
-          GROUP BY time
+        SELECT any(event) AS events, dt
+        FROM #{@table}
+        PREWHERE
+          owner IN (?2) AND
+          dt >= toDateTime(?3) AND
+          dt < toDateTime(?4)
+        GROUP BY owner, repo, dt, event
       )
       GROUP BY time
-      ORDER BY time
+    )
+    GROUP BY time
+    ORDER BY time
+    WITH FILL FROM toUnixTimestamp(intDiv(toUInt32(?3), ?1) * ?1) TO ?4 STEP ?1
     """
 
     args = [

--- a/lib/sanbase/utils/math.ex
+++ b/lib/sanbase/utils/math.ex
@@ -127,19 +127,13 @@ defmodule Sanbase.Math do
       iex> Sanbase.Math.to_integer(500)
       500
   """
-  def to_integer(x) when is_integer(x), do: x
+  def to_integer(x, default_when_nil \\ nil)
 
-  def to_integer(f) when is_float(f) do
-    f |> round() |> trunc()
-  end
-
-  def to_integer(%Decimal{} = d) do
-    d |> Decimal.round() |> Decimal.to_integer()
-  end
-
-  def to_integer(str) when is_binary(str) do
-    String.trim(str) |> String.to_integer()
-  end
+  def to_integer(nil, default_when_nil), do: default_when_nil
+  def to_integer(x, _) when is_integer(x), do: x
+  def to_integer(f, _) when is_float(f), do: f |> round() |> trunc()
+  def to_integer(%Decimal{} = d, _), do: d |> Decimal.round() |> Decimal.to_integer()
+  def to_integer(str, _) when is_binary(str), do: String.trim(str) |> String.to_integer()
 
   @doc ~S"""
   Convert a string that potentially contains trailing non-digit symbols to an integer


### PR DESCRIPTION
#### Summary
- Use `WITH FILL FROM from TO to STEP step` instead of just `WITH FILL step` because of time rounding
- Convert `nil`s to integer 0 as the default of uniqExact is null and not 0
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
