### PR TITLE
Disallow inspecting the apikey list with apikey authentication

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/user/apikey_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/apikey_resolver.ex
@@ -48,6 +48,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.ApikeyResolver do
   @doc ~s"""
   Returns a list of all apikeys for the currently JWT authenticated user.
   """
+  def apikeys_list(%User{} = user, _args, %{context: %{auth: %{auth_method: :apikey}}}) do
+    {:error, "Only JWT authenticated users can access their apikeys."}
+  end
+
   def apikeys_list(%User{} = user, _args, _resolution) do
     Apikey.apikeys_list(user)
   end


### PR DESCRIPTION
Sometimes apikeys are shared from a generic user
(free_apikey@santiment.net). This change prevents one apikey from
inspecting the other apikeys

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
