### PR TITLE
Pass the downcased github organizations to the db

### DIFF
--- a/lib/sanbase/clickhouse/github/github.ex
+++ b/lib/sanbase/clickhouse/github/github.ex
@@ -326,7 +326,7 @@ defmodule Sanbase.Clickhouse.Github do
 
     args = [
       interval,
-      organizations,
+      organizations |> Enum.map(&String.downcase/1),
       from_unix,
       to_unix,
       @non_dev_events
@@ -361,7 +361,7 @@ defmodule Sanbase.Clickhouse.Github do
 
     args = [
       interval,
-      organizations,
+      organizations |> Enum.map(&String.downcase/1),
       from_unix,
       to_unix
     ]
@@ -399,7 +399,7 @@ defmodule Sanbase.Clickhouse.Github do
 
     args = [
       interval,
-      organizations,
+      organizations |> Enum.map(&String.downcase/1),
       from_unix,
       to_unix,
       @non_dev_events
@@ -437,7 +437,7 @@ defmodule Sanbase.Clickhouse.Github do
 
     args = [
       interval,
-      organizations,
+      organizations |> Enum.map(&String.downcase/1),
       from_unix,
       to_unix
     ]
@@ -459,7 +459,7 @@ defmodule Sanbase.Clickhouse.Github do
     """
 
     args = [
-      organizations,
+      organizations |> Enum.map(&String.downcase/1),
       DateTime.to_unix(from),
       DateTime.to_unix(to)
     ]
@@ -484,7 +484,7 @@ defmodule Sanbase.Clickhouse.Github do
     """
 
     args = [
-      organizations,
+      organizations |> Enum.map(&String.downcase/1),
       DateTime.to_unix(from),
       DateTime.to_unix(to),
       @non_dev_events


### PR DESCRIPTION
#### Summary
All owners (organizations) in the github table are downcased. If a
mixed-case github organization is stored for a project this leads to
issues

There are around 45 such cases in the prod database now, this will fix them all

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
