### PR TITLE
Support text target in signal historical activity

### DIFF
--- a/lib/sanbase/signals/history/metric_history.ex
+++ b/lib/sanbase/signals/history/metric_history.ex
@@ -23,29 +23,37 @@ defmodule Sanbase.Signal.History.MetricHistory do
     @historical_days_from 90
     @historical_days_interval "1d"
 
+    defguard has_binary_key?(map, key)
+             when is_map(map) and is_map_key(map, key) and is_binary(:erlang.map_get(key, map))
+
     @spec historical_trigger_points(%MetricTriggerSettings{}, String.t()) ::
             {:ok, list(MetricHistory.historical_trigger_points_type())}
             | {:error, String.t()}
-    def historical_trigger_points(
-          %MetricTriggerSettings{target: %{slug: slug}} = settings,
-          cooldown
-        )
-        when is_binary(slug) do
+    def historical_trigger_points(%MetricTriggerSettings{target: target} = settings, cooldown)
+        when has_binary_key?(target, :slug) or has_binary_key?(target, :text) do
       %MetricTriggerSettings{metric: metric, time_window: time_window} = settings
 
-      case get_data(metric, slug, time_window) do
+      case get_data(metric, target, time_window) do
         {:ok, data} -> ResultBuilder.build(data, settings, cooldown, value_key: :value)
         {:error, error} -> {:error, error}
       end
     end
 
-    def get_data(metric, slug, time_window) when is_binary(slug) do
+    def historical_trigger_points(%MetricTriggerSettings{target: target}, _) do
+      {:error,
+       """
+       Target must be a single slug in the format '{slug: "single_string_slug"}' or
+       text in the format '{text: "buy OR sell"}'. Got #{inspect(target)} instead.
+       """}
+    end
+
+    def get_data(metric, target, time_window) do
       to = Timex.now()
       shift = @historical_days_from + str_to_days(time_window) - 1
 
       Sanbase.Metric.timeseries_data(
         metric,
-        %{slug: slug},
+        target,
         Timex.shift(to, days: -shift),
         to,
         @historical_days_interval

--- a/lib/sanbase_web/graphql/resolvers/promoter_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/promoter_resolver.ex
@@ -7,7 +7,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.PromoterResolver do
     FirstPromoter.create_promoter(current_user, args)
   end
 
-  def show_promoter(_root, args, %{
+  def show_promoter(_root, _args, %{
         context: %{auth: %{current_user: current_user}}
       }) do
     FirstPromoter.show_promoter(current_user)

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Sanbase.Mixfile do
       app: :sanbase,
       name: "Sanbase",
       version: "0.0.1",
-      elixir: "~> 1.8",
+      elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
#### Summary
Add support for `text` in the historical activity of signals:
```
 {
  historicalTriggerPoints(
    cooldown:"2d"
    settings: "{\"type\":\"metric_signal\",\"metric\":\"social_volume_total\",\"target\":{\"text\":\"corona\"},\"operation\":{\"above\":300}}"
  )
}
```
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
