### PR TITLE
Fix how the limit of top holders is applied

### DIFF
--- a/lib/sanbase/clickhouse/top_holders/top_holders_sql_query.ex
+++ b/lib/sanbase/clickhouse/top_holders/top_holders_sql_query.ex
@@ -65,7 +65,7 @@ defmodule Sanbase.Clickhouse.TopHolders.SqlQuery do
     decimals = Sanbase.Math.ipow(10, decimals)
 
     query = """
-    SELECT dt, SUM(value)
+    SELECT dt, SUM(value) AS value
     FROM (
       SELECT
         address,
@@ -81,8 +81,6 @@ defmodule Sanbase.Clickhouse.TopHolders.SqlQuery do
           rank IS NOT NULL
       )
       GROUP BY dt, address
-      ORDER BY dt, value DESC
-      LIMIT ?3 BY dt
     )
     GLOBAL ANY INNER JOIN (
       SELECT address
@@ -90,7 +88,8 @@ defmodule Sanbase.Clickhouse.TopHolders.SqlQuery do
       PREWHERE blockchain = ?6 AND label IN ('centralized_exchange', 'decentralized_exchange')
     ) USING address
     GROUP BY dt
-    ORDER BY dt
+    ORDER BY dt, value DESC
+    LIMIT ?3 BY dt
     """
 
     args = [
@@ -120,7 +119,7 @@ defmodule Sanbase.Clickhouse.TopHolders.SqlQuery do
     decimals = Sanbase.Math.ipow(10, decimals)
 
     query = """
-    SELECT dt, SUM(value)
+    SELECT dt, SUM(value) AS value
     FROM (
       SELECT
         #{aggregation(aggregation, "value", "dt")} / #{decimals} AS value,
@@ -138,11 +137,10 @@ defmodule Sanbase.Clickhouse.TopHolders.SqlQuery do
         dt < toDateTime(?5) AND
         rank IS NOT NULL
       GROUP BY dt, address
-      ORDER BY dt, value DESC
-      LIMIT ?3 BY dt
     )
     GROUP BY dt
-    ORDER BY dt
+    ORDER BY dt, value DESC
+    LIMIT ?3 BY dt
     """
 
     args = [


### PR DESCRIPTION
#### Summary
The limit should be applied after the joining/filtering with the
exchange addresses. In case the top holders that are exchanges are all
with rank 10+ then fetching for top 10 exchange holders will return
empty list.

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
