### PR TITLE
Rework price_histogram

### DIFF
--- a/lib/sanbase/clickhouse/metric/histogram_metric.ex
+++ b/lib/sanbase/clickhouse/metric/histogram_metric.ex
@@ -71,7 +71,7 @@ defmodule Sanbase.Clickhouse.Metric.HistogramMetric do
     # Generate limit number of ranges to properly empty ranges as 0
     ranges_map =
       Stream.unfold(min, price_ranges)
-      |> Enum.take_while(fn [_lower, upper] -> upper > max end)
+      |> Enum.take(limit)
       |> Enum.into(%{}, fn range -> {range, 0.0} end)
 
     # Map every price to the proper range
@@ -110,7 +110,7 @@ defmodule Sanbase.Clickhouse.Metric.HistogramMetric do
   defp break_bucket(bucketed_data, original_data, [low, high], divider) do
     {lower_half_amount, upper_half_amount} =
       original_data
-      |> Enum.reduce({0, 0}, fn %{price: price, value: value}, {acc_lower, acc_upper} ->
+      |> Enum.reduce({0.0, 0.0}, fn %{price: price, value: value}, {acc_lower, acc_upper} ->
         cond do
           price >= low and price < divider -> {acc_lower + value, acc_upper}
           price >= divider and price < high -> {acc_lower, acc_upper + value}

--- a/lib/sanbase/clickhouse/metric/histogram_metric.ex
+++ b/lib/sanbase/clickhouse/metric/histogram_metric.ex
@@ -30,7 +30,7 @@ defmodule Sanbase.Clickhouse.Metric.HistogramMetric do
         value: Sanbase.Math.to_float(amount)
       }
     end)
-    |> maybe_transform_into_buckets(limit)
+    |> maybe_transform_into_buckets(slug, from, to, limit)
   end
 
   def first_datetime("price_histogram", %{slug: _} = selector) do
@@ -48,13 +48,14 @@ defmodule Sanbase.Clickhouse.Metric.HistogramMetric do
   end
 
   # Aggregate the separate prices into `limit` number of evenly spaced buckets
-  defp maybe_transform_into_buckets({:ok, data}, limit) do
+  defp maybe_transform_into_buckets({:ok, data}, slug, from, to, limit) do
     {min, max} = Enum.map(data, & &1.price) |> Sanbase.Math.min_max()
 
     # Avoid precision issues when using `round` for prices.
     min = Float.floor(min, 2)
     max = Float.ceil(max, 2)
-    bucket_size = Enum.max([Float.round((max - min) / limit, 2), 0.01])
+    # `limit - 1` because one of the buckets will be split into 2
+    bucket_size = Enum.max([Float.round((max - min) / (limit - 1), 2), 0.01])
 
     # Generate the range for given low and high price
     low_high_range = fn low, high ->
@@ -70,7 +71,7 @@ defmodule Sanbase.Clickhouse.Metric.HistogramMetric do
     # Generate limit number of ranges to properly empty ranges as 0
     ranges_map =
       Stream.unfold(min, price_ranges)
-      |> Enum.take(limit)
+      |> Enum.take_while(fn [_lower, upper] -> upper > max end)
       |> Enum.into(%{}, fn range -> {range, 0.0} end)
 
     # Map every price to the proper range
@@ -82,17 +83,44 @@ defmodule Sanbase.Clickhouse.Metric.HistogramMetric do
       low_high_range.(lower, upper)
     end
 
+    # Get the average price for the queried. time range. It will break the [X,Y]
+    # price interval containing that price into [X, price_break] and [price_break, Y]
+    {:ok, %{^slug => price_break}} =
+      Sanbase.Metric.aggregated_timeseries_data("price_usd", %{slug: slug}, from, to, :avg)
+
+    price_break = price_break |> Sanbase.Math.round_float()
+    price_break_range = price_to_range.(price_break)
+
     # Put every amount moved at a given price in the proper bucket
-    data =
+    bucketed_data =
       Enum.reduce(data, ranges_map, fn %{price: price, value: value}, acc ->
         key = price_to_range.(price)
         Map.update(acc, key, 0.0, fn curr_amount -> Float.round(curr_amount + value, 2) end)
       end)
+      |> break_bucket(data, price_break_range, price_break)
       |> Enum.map(fn {range, amount} -> %{range: range, value: amount} end)
       |> Enum.sort_by(fn %{range: [range_start | _]} -> range_start end)
 
-    {:ok, data}
+    {:ok, bucketed_data}
   end
 
-  defp maybe_transform_into_buckets({:error, error}, _), do: {:error, error}
+  defp maybe_transform_into_buckets({:error, error}, _slug, _from, _to, _limit),
+    do: {:error, error}
+
+  defp break_bucket(bucketed_data, original_data, [low, high], divider) do
+    {lower_half_amount, upper_half_amount} =
+      original_data
+      |> Enum.reduce({0, 0}, fn %{price: price, value: value}, {acc_lower, acc_upper} ->
+        cond do
+          price >= low and price < divider -> {acc_lower + value, acc_upper}
+          price >= divider and price < high -> {acc_lower, acc_upper + value}
+          true -> {acc_lower, acc_upper}
+        end
+      end)
+
+    bucketed_data
+    |> Map.delete([low, high])
+    |> Map.put([low, divider], Float.round(lower_half_amount, 2))
+    |> Map.put([divider, high], Float.round(upper_half_amount, 2))
+  end
 end

--- a/lib/sanbase/clickhouse/metric/histogram_metric.ex
+++ b/lib/sanbase/clickhouse/metric/histogram_metric.ex
@@ -48,6 +48,8 @@ defmodule Sanbase.Clickhouse.Metric.HistogramMetric do
   end
 
   # Aggregate the separate prices into `limit` number of evenly spaced buckets
+  defp maybe_transform_into_buckets({:ok, []}, _slug, _from, _to, _limit), do: {:ok, []}
+
   defp maybe_transform_into_buckets({:ok, data}, slug, from, to, limit) do
     {min, max} = Enum.map(data, & &1.price) |> Sanbase.Math.min_max()
 

--- a/lib/sanbase/clickhouse/metric/sql_query/metric_histogram_sql_query.ex
+++ b/lib/sanbase/clickhouse/metric/sql_query/metric_histogram_sql_query.ex
@@ -9,8 +9,8 @@ defmodule Sanbase.Clickhouse.Metric.HistogramSqlQuery do
     interval_sec = interval |> str_to_sec()
 
     metric =
-      case interval_sec do
-        val when val >= 86400 -> "age_distribution_1day_delta"
+      case rem(interval_sec, 86400) do
+        0 -> "age_distribution_1day_delta"
         _ -> "age_distribution_5min_delta"
       end
 

--- a/lib/sanbase/clickhouse/metric/sql_query/metric_histogram_sql_query.ex
+++ b/lib/sanbase/clickhouse/metric/sql_query/metric_histogram_sql_query.ex
@@ -6,6 +6,14 @@ defmodule Sanbase.Clickhouse.Metric.HistogramSqlQuery do
   @name_to_metric_map FileHandler.name_to_metric_map()
 
   def histogram_data_query("price_histogram", slug, from, to, interval, _limit) do
+    interval_sec = interval |> str_to_sec()
+
+    metric =
+      case interval_sec do
+        val when val >= 86400 -> "age_distribution_1day_delta"
+        _ -> "age_distribution_5min_delta"
+      end
+
     query = """
     SELECT round(price, 2) AS price, sum(tokens_amount) AS tokens_amount
     FROM (
@@ -16,10 +24,14 @@ defmodule Sanbase.Clickhouse.Metric.HistogramSqlQuery do
             -sum(measure) AS tokens_amount
         FROM distribution_deltas_5min FINAL
         PREWHERE
+          metric_id = ( SELECT argMax(metric_id, computed_at) FROM metric_metadata PREWHERE name = '#{
+      metric
+    }' ) AND
           asset_id = ( SELECT argMax(asset_id, computed_at) FROM asset_metadata PREWHERE name = ?1 ) AND
           dt >= toDateTime(?2) AND
           dt < toDateTime(?3) AND
-          dt != value
+          dt != value AND
+          value < toDateTime(?2)
         GROUP BY t
         ORDER BY t ASC
       )
@@ -43,7 +55,7 @@ defmodule Sanbase.Clickhouse.Metric.HistogramSqlQuery do
       slug,
       from |> DateTime.to_unix(),
       to |> DateTime.to_unix(),
-      interval |> str_to_sec()
+      interval_sec
     ]
 
     {query, args}
@@ -53,16 +65,17 @@ defmodule Sanbase.Clickhouse.Metric.HistogramSqlQuery do
     query = """
     SELECT
       toUnixTimestamp(intDiv(toUInt32(toDateTime(value)), ?5) * ?5) AS t,
-      -sum(measure)
+      -sum(measure) AS sum_measure
     FROM #{Map.get(@table_map, metric)} FINAL
     PREWHERE
       metric_id = ( SELECT argMax(metric_id, computed_at) FROM metric_metadata PREWHERE name = ?1 ) AND
       asset_id = ( SELECT argMax(asset_id, computed_at) FROM asset_metadata PREWHERE name = ?2 ) AND
       dt != value AND
       dt >= toDateTime(?3) AND
-      dt < toDateTime(?4)
+      dt < toDateTime(?4) AND
+      value < toDateTime(?3)
     GROUP BY t
-    ORDER BY t DESC
+    ORDER BY sum_measure DESC
     LIMIT ?6
     """
 

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -206,12 +206,13 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:interval, :interval, default_value: "1d")
-      arg(:limit, :integer, default_value: 100)
+      arg(:limit, :integer, default_value: 20)
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
 
-      resolve(&MetricResolver.histogram_data/3)
+      # middleware(AccessControl)
+
+      cache_resolve(&MetricResolver.histogram_data/3)
     end
 
     field :available_since, :datetime do

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -209,8 +209,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       arg(:limit, :integer, default_value: 20)
 
       complexity(&Complexity.from_to_interval/3)
-
-      # middleware(AccessControl)
+      middleware(AccessControl)
 
       cache_resolve(&MetricResolver.histogram_data/3)
     end


### PR DESCRIPTION
#### Summary
Break the bucket containing the average price for the queried interval
into 2 buckets with that price as divider. This way it can clearly be
seen how many tokens were acquired at lower and higher prices

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
