### PR TITLE
Add aggregatedTimeseriesData project GQL type field

### DIFF
--- a/lib/sanbase/cache/cache.ex
+++ b/lib/sanbase/cache/cache.ex
@@ -1,7 +1,7 @@
 defmodule Sanbase.Cache do
   @behaviour Sanbase.Cache.Behaviour
   @cache_name :sanbase_cache
-  @max_cache_ttl 84600
+  @max_cache_ttl 86400
 
   def name, do: @cache_name
 
@@ -27,7 +27,7 @@ defmodule Sanbase.Cache do
   def get(cache \\ @cache_name, key)
 
   def get(cache, key) do
-    case ConCache.get(cache, key) do
+    case ConCache.get(cache, true_key(key)) do
       {:stored, value} -> value
       nil -> nil
     end
@@ -50,11 +50,7 @@ defmodule Sanbase.Cache do
   def get_or_store(cache \\ @cache_name, key, func)
 
   def get_or_store(cache, key, func) do
-    true_key =
-      case key do
-        {value, ttl} when is_integer(ttl) -> value
-        value -> value
-      end
+    true_key = true_key(key)
 
     {result, error_if_any} =
       case ConCache.get(cache, true_key) do
@@ -97,4 +93,7 @@ defmodule Sanbase.Cache do
   defp cache_item(cache, key, value) do
     ConCache.put(cache, key, value)
   end
+
+  defp true_key({key, ttl}) when is_integer(ttl) and ttl <= @max_cache_ttl, do: key
+  defp true_key(key), do: key
 end

--- a/lib/sanbase/clickhouse/github/github.ex
+++ b/lib/sanbase/clickhouse/github/github.ex
@@ -55,7 +55,7 @@ defmodule Sanbase.Clickhouse.Github do
   Return the number of all github events for a given organization and time period
   """
 
-  @spec total_dev_activity(list(String.t()), DateTime.t(), DateTime.t()) ::
+  @spec total_github_activity(list(String.t()), DateTime.t(), DateTime.t()) ::
           {:ok, map()} | {:error, String.t()}
   def total_github_activity([], _from, _to), do: {:ok, []}
 

--- a/lib/sanbase/clickhouse/github/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/github/metric_adapter.ex
@@ -66,7 +66,15 @@ defmodule Sanbase.Clickhouse.Github.MetricAdapter do
 
   def aggregated_timeseries_data(metric, %{slug: slug_or_slugs}, from, to, aggregation) do
     slugs = slug_or_slugs |> List.wrap()
-    organizations = Enum.flat_map(slugs, &Project.github_organizations/1)
+
+    organizations =
+      slugs
+      |> Project.List.by_slugs(preload?: true, preload: [:github_organizations])
+      |> Enum.map(&Project.github_organizations/1)
+      |> Enum.filter(&match?({:ok, _}, &1))
+      |> Enum.map(&elem(&1, 1))
+      |> List.flatten()
+
     aggregated_timeseries_data(metric, %{organizations: organizations}, from, to, aggregation)
   end
 

--- a/lib/sanbase/clickhouse/metadata_helper.ex
+++ b/lib/sanbase/clickhouse/metadata_helper.ex
@@ -12,7 +12,9 @@ defmodule Sanbase.Clickhouse.MetadataHelper do
                                 |> Enum.into(%{}, fn {k, v} -> {v, k} end)
 
   def slug_to_asset_id_map() do
-    Sanbase.Cache.get_or_store({__MODULE__, __ENV__.function}, fn ->
+    cache_key = {__MODULE__, __ENV__.function} |> :erlang.phash2()
+
+    Sanbase.Cache.get_or_store({cache_key, 600}, fn ->
       query = "SELECT toUInt32(asset_id), name FROM asset_metadata"
       args = []
 
@@ -23,7 +25,9 @@ defmodule Sanbase.Clickhouse.MetadataHelper do
   end
 
   def asset_id_to_slug_map() do
-    Sanbase.Cache.get_or_store({__MODULE__, __ENV__.function}, fn ->
+    cache_key = {__MODULE__, __ENV__.function} |> :erlang.phash2()
+
+    Sanbase.Cache.get_or_store({cache_key, 600}, fn ->
       case slug_to_asset_id_map() do
         {:ok, data} ->
           {:ok, data |> Enum.into(%{}, fn {k, v} -> {v, k} end)}
@@ -35,7 +39,9 @@ defmodule Sanbase.Clickhouse.MetadataHelper do
   end
 
   def metric_name_to_metric_id_map() do
-    Sanbase.Cache.get_or_store({__MODULE__, __ENV__.function}, fn ->
+    cache_key = {__MODULE__, __ENV__.function} |> :erlang.phash2()
+
+    Sanbase.Cache.get_or_store({cache_key, 600}, fn ->
       query = "SELECT toUInt32(metric_id), name FROM metric_metadata"
       args = []
 
@@ -47,7 +53,9 @@ defmodule Sanbase.Clickhouse.MetadataHelper do
   end
 
   def metric_id_to_metric_name_map() do
-    Sanbase.Cache.get_or_store({__MODULE__, __ENV__.function}, fn ->
+    cache_key = {__MODULE__, __ENV__.function} |> :erlang.phash2()
+
+    Sanbase.Cache.get_or_store({cache_key, 600}, fn ->
       case metric_name_to_metric_id_map() do
         {:ok, data} ->
           {:ok, data |> Enum.into(%{}, fn {k, v} -> {v, k} end)}

--- a/lib/sanbase/clickhouse/metric/metric.ex
+++ b/lib/sanbase/clickhouse/metric/metric.ex
@@ -204,13 +204,14 @@ defmodule Sanbase.Clickhouse.Metric do
   end
 
   defp get_aggregated_timeseries_data(metric, slugs, from, to, aggregation)
-       when is_list(slugs) and length(slugs) > 20 do
+       when is_list(slugs) and length(slugs) > 50 do
     result =
-      Enum.chunk_every(slugs, 20)
+      Enum.chunk_every(slugs, 50)
       |> Sanbase.Parallel.map(&get_aggregated_timeseries_data(metric, &1, from, to, aggregation),
         timeout: 25_000,
         max_concurrency: 8,
-        ordered: false
+        ordered: false,
+        on_timeout: :kill_task
       )
       |> Enum.filter(&match?({:ok, _}, &1))
       |> Enum.map(&elem(&1, 1))

--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -1161,10 +1161,7 @@
     "access": "restricted",
     "aggregation": "last",
     "min_interval": "5m",
-    "table": [
-      "distribution_deltas_5min",
-      "intraday_metrics"
-    ],
+    "table": ["distribution_deltas_5min", "intraday_metrics"],
     "has_incomplete_data": false,
     "data_type": "histogram"
   },
@@ -1176,10 +1173,7 @@
     "access": "restricted",
     "aggregation": "last",
     "min_interval": "5m",
-    "table": [
-      "distribution_deltas_5min",
-      "intraday_metrics"
-    ],
+    "table": ["distribution_deltas_5min", "intraday_metrics"],
     "has_incomplete_data": false,
     "data_type": "histogram"
   },
@@ -1191,10 +1185,7 @@
     "access": "restricted",
     "aggregation": "last",
     "min_interval": "5m",
-    "table": [
-      "distribution_deltas_5min",
-      "intraday_metrics"
-    ],
+    "table": ["distribution_deltas_5min", "intraday_metrics"],
     "has_incomplete_data": false,
     "data_type": "histogram"
   },
@@ -1452,6 +1443,22 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Daily Development Activity",
+    "name": "dev_activity_1d",
+    "metric": "dev_activity",
+    "version": "2019-01-01",
+    "access": "free",
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "sum",
+    "min_interval": "1d",
+    "table": "intraday_metrics",
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   }
 ]

--- a/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
@@ -92,7 +92,7 @@ defmodule Sanbase.Clickhouse.TopHolders.MetricAdapter do
 
   @impl Sanbase.Metric.Behaviour
   def aggregated_timeseries_data(_, %{slug: _slug}, _from, _to, _aggregation) do
-    {:error, "not_implemented"}
+    {:error, "Aggregated timeseries data is not implemented for Top Holders."}
   end
 
   @impl Sanbase.Metric.Behaviour

--- a/lib/sanbase/metric/behaviour.ex
+++ b/lib/sanbase/metric/behaviour.ex
@@ -58,7 +58,7 @@ defmodule Sanbase.Metric.Behaviour do
               from :: DatetTime.t(),
               to :: DateTime.t(),
               opts :: options
-            ) :: {:ok, list()} | {:error, String.t()}
+            ) :: {:ok, map()} | {:error, String.t()}
 
   @callback has_incomplete_data?(metric :: metric) :: true | false
 

--- a/lib/sanbase/prices/price.ex
+++ b/lib/sanbase/prices/price.ex
@@ -256,6 +256,23 @@ defmodule Sanbase.Price do
 
   def aggregated_metric_timeseries_data([], _, _, _, _), do: {:ok, %{}}
 
+  def aggregated_metric_timeseries_data(slugs, metric, from, to, opts)
+      when is_list(slugs) and length(slugs) > 20 do
+    result =
+      Enum.chunk_every(slugs, 20)
+      |> Sanbase.Parallel.map(
+        &aggregated_metric_timeseries_data(metric, &1, from, to, opts),
+        timeout: 25_000,
+        max_concurrency: 8,
+        ordered: false
+      )
+      |> Enum.filter(&match?({:ok, _}, &1))
+      |> Enum.flat_map(&elem(&1, 1))
+      |> Enum.reduce(%{}, &Map.merge(&1, &2))
+
+    {:ok, result}
+  end
+
   def aggregated_metric_timeseries_data(slug_or_slugs, metric, from, to, opts)
       when metric in @metrics and (is_binary(slug_or_slugs) or is_list(slug_or_slugs)) do
     source = Keyword.get(opts, :source) || @default_source

--- a/lib/sanbase/prices/price.ex
+++ b/lib/sanbase/prices/price.ex
@@ -257,17 +257,17 @@ defmodule Sanbase.Price do
   def aggregated_metric_timeseries_data([], _, _, _, _), do: {:ok, %{}}
 
   def aggregated_metric_timeseries_data(slugs, metric, from, to, opts)
-      when is_list(slugs) and length(slugs) > 20 do
+      when is_list(slugs) and length(slugs) > 50 do
     result =
-      Enum.chunk_every(slugs, 20)
+      Enum.chunk_every(slugs, 50)
       |> Sanbase.Parallel.map(
-        &aggregated_metric_timeseries_data(metric, &1, from, to, opts),
+        &aggregated_metric_timeseries_data(&1, metric, from, to, opts),
         timeout: 25_000,
         max_concurrency: 8,
         ordered: false
       )
       |> Enum.filter(&match?({:ok, _}, &1))
-      |> Enum.flat_map(&elem(&1, 1))
+      |> Enum.map(&elem(&1, 1))
       |> Enum.reduce(%{}, &Map.merge(&1, &2))
 
     {:ok, result}

--- a/lib/sanbase_web/graphql/cache/con_cache_provider.ex
+++ b/lib/sanbase_web/graphql/cache/con_cache_provider.ex
@@ -45,6 +45,12 @@ defmodule SanbaseWeb.Graphql.ConCacheProvider do
 
   @impl true
   def get_or_store(cache, key, func, cache_modify_middleware) do
+    true_key =
+      case key do
+        {value, _ttl} -> value
+        value -> value
+      end
+
     {result, error_if_any} =
       case ConCache.get(cache, key) do
         {:stored, value} ->

--- a/lib/sanbase_web/graphql/dataloader/clickhouse_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/clickhouse_dataloader.ex
@@ -107,8 +107,6 @@ defmodule SanbaseWeb.Graphql.ClickhouseDataloader do
     |> case do
       {:ok, result} ->
         result
-        |> Enum.map(fn %{slug: slug, value: value} -> {slug, value} end)
-        |> Map.new()
 
       {:error, error} ->
         {:error, error}

--- a/lib/sanbase_web/graphql/dataloader/clickhouse_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/clickhouse_dataloader.ex
@@ -98,10 +98,9 @@ defmodule SanbaseWeb.Graphql.ClickhouseDataloader do
     |> case do
       {:ok, result} ->
         result
-        |> Enum.map(fn {org, dev_activity} ->
+        |> Enum.into(%{}, fn {org, dev_activity} ->
           {org, dev_activity / days}
         end)
-        |> Map.new()
 
       {:error, error} ->
         {:error, error}

--- a/lib/sanbase_web/graphql/dataloader/sanbase_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/sanbase_dataloader.ex
@@ -22,12 +22,19 @@ defmodule SanbaseWeb.Graphql.SanbaseDataloader do
           | :comment_timeline_event_id
           | :insights_comments_count
           | :timeline_events_comments_count
-          | :project_by_slug,
+          | :project_by_slug
+          | :aggregated_metric,
           any()
         ) :: {:error, String.t()} | {:ok, float()} | map()
   def query(queryable, args) do
     case queryable do
-      x when x in [:average_daily_active_addresses, :average_dev_activity, :eth_spent] ->
+      x
+      when x in [
+             :average_daily_active_addresses,
+             :average_dev_activity,
+             :eth_spent,
+             :aggregated_metric
+           ] ->
         ClickhouseDataloader.query(queryable, args)
 
       :volume_change_24h ->

--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -160,7 +160,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
     #    avg2: averageDailyActiveAddresses(from: <from2>, to: <to2>)
     #  }
     # }
-    # will correctly group and calculate the different average addresses.
+    # will correctly group and calculate the different average addresses
+
     average_daa_activity_map =
       loader
       |> Dataloader.get(SanbaseDataloader, :average_daily_active_addresses, {from, to}) ||

--- a/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
@@ -1,6 +1,7 @@
 defmodule SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver do
   import Sanbase.Utils.ErrorHandling, only: [handle_graphql_error: 3]
   import Absinthe.Resolution.Helpers
+  import SanbaseWeb.Graphql.Helpers.Utils
 
   alias Sanbase.Model.Project
   alias Sanbase.Metric
@@ -34,12 +35,17 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver do
     maybe_register_and_get(cache_key, fun, slug, query)
   end
 
-  def aggregated_metric(%Project{slug: slug}, %{metric: metric} = args, %{
+  def aggregated_timeseries_data(%Project{slug: slug}, %{metric: metric} = args, %{
         context: %{loader: loader}
       }) do
     case Metric.has_metric?(metric) do
       true ->
         %{from: from, to: to} = args
+        include_incomplete_data = Map.get(args, :include_incomplete_data, false)
+
+        {:ok, from, to} =
+          calibrate_incomplete_data_params(include_incomplete_data, Metric, metric, from, to)
+
         from = from |> Sanbase.DateTimeUtils.round_datetime(300)
         to = to |> Sanbase.DateTimeUtils.round_datetime(300)
         aggregation = Map.get(args, :aggregation)
@@ -65,14 +71,29 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver do
   # Private functions
 
   defp aggregated_metric_from_loader(loader, data) do
-    %{selector: selector, slug: slug} = data
+    %{selector: selector, slug: slug, metric: metric} = data
+
+    cache_key =
+      {__MODULE__, :available_slugs_for_metric, metric}
+      |> :erlang.phash2()
+
+    {:ok, slugs_for_metric} =
+      Sanbase.Cache.get_or_store({cache_key, 1800}, fn -> Metric.available_slugs(metric) end)
 
     loader
     |> Dataloader.get(SanbaseDataloader, :aggregated_metric, selector)
     |> case do
-      %{} = map -> {:ok, map |> Map.get(slug)}
-      nil -> {:ok, nil}
-      _ -> {:nocache, {:ok, nil}}
+      map when is_map(map) ->
+        case Map.fetch(map, slug) do
+          {:ok, value} ->
+            {:ok, value}
+
+          :error ->
+            if slug in slugs_for_metric, do: {:nocache, {:ok, nil}}, else: {:ok, nil}
+        end
+
+      _ ->
+        {:nocache, {:ok, nil}}
     end
   end
 

--- a/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
@@ -1,9 +1,11 @@
 defmodule SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver do
   import Sanbase.Utils.ErrorHandling, only: [handle_graphql_error: 3]
+  import Absinthe.Resolution.Helpers
 
   alias Sanbase.Model.Project
   alias Sanbase.Metric
   alias Sanbase.Cache.RehydratingCache
+  alias SanbaseWeb.Graphql.SanbaseDataloader
 
   require Logger
   @ttl 3600
@@ -30,6 +32,48 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver do
     cache_key = {__MODULE__, query, slug} |> :erlang.phash2()
     fun = fn -> Metric.available_histogram_metrics_for_slug(%{slug: slug}) end
     maybe_register_and_get(cache_key, fun, slug, query)
+  end
+
+  def aggregated_metric(%Project{slug: slug}, %{metric: metric} = args, %{
+        context: %{loader: loader}
+      }) do
+    case Metric.has_metric?(metric) do
+      true ->
+        %{from: from, to: to} = args
+        from = from |> Sanbase.DateTimeUtils.round_datetime(300)
+        to = to |> Sanbase.DateTimeUtils.round_datetime(300)
+        aggregation = Map.get(args, :aggregation)
+
+        data = %{
+          metric: metric,
+          slug: slug,
+          from: from,
+          to: to,
+          aggregation: aggregation,
+          selector: {metric, from, to, aggregation}
+        }
+
+        loader
+        |> Dataloader.load(SanbaseDataloader, :aggregated_metric, data)
+        |> on_load(&aggregated_metric_from_loader(&1, data))
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  # Private functions
+
+  defp aggregated_metric_from_loader(loader, data) do
+    %{selector: selector, slug: slug} = data
+
+    loader
+    |> Dataloader.get(SanbaseDataloader, :aggregated_metric, selector)
+    |> case do
+      %{} = map -> {:ok, map |> Map.get(slug)}
+      nil -> {:ok, nil}
+      _ -> {:nocache, {:ok, nil}}
+    end
   end
 
   # Get the available metrics from the rehydrating cache. If the function for computing it

--- a/lib/sanbase_web/graphql/resolvers/project/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_resolver.ex
@@ -244,7 +244,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
                month_ago,
                Timex.now()
              ) do
-          {:ok, total_activity} ->
+          {:ok, organizations_activity_map} ->
+            total_activity = organizations_activity_map |> Map.values() |> Enum.sum()
             {:ok, total_activity / days}
 
           _ ->

--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -186,6 +186,18 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       cache_resolve(&ProjectResolver.available_queries/3, ttl: 1800)
     end
 
+    field :aggregated_metric, :float do
+      arg(:metric, non_null(:string))
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+      arg(:aggregation, :aggregation, default_value: nil)
+
+      cache_resolve(&ProjectMetricsResolver.aggregated_metric/3,
+        ttl: 600,
+        max_ttl_offset: 600
+      )
+    end
+
     field(:id, non_null(:id))
     field(:name, non_null(:string))
     field(:slug, :string)

--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -20,6 +20,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
   alias Sanbase.Model.Project
   alias SanbaseWeb.Graphql.SanbaseRepo
   alias SanbaseWeb.Graphql.Complexity
+  alias SanbaseWeb.Graphql.Middlewares.AccessControl
 
   # Includes all available fields
   @desc ~s"""
@@ -186,13 +187,17 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       cache_resolve(&ProjectResolver.available_queries/3, ttl: 1800)
     end
 
-    field :aggregated_metric, :float do
+    field :aggregated_timeseries_data, :float do
       arg(:metric, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:aggregation, :aggregation, default_value: nil)
+      arg(:include_incomplete_data, :boolean, default_value: false)
 
-      cache_resolve(&ProjectMetricsResolver.aggregated_metric/3,
+      complexity(&Complexity.from_to_interval/3)
+      middleware(AccessControl)
+
+      cache_resolve(&ProjectMetricsResolver.aggregated_timeseries_data/3,
         ttl: 600,
         max_ttl_offset: 600
       )

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -24,6 +24,7 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "daily_opening_price_usd",
         "daily_trading_volume_usd",
         "dev_activity",
+        "dev_activity_1d",
         "github_activity",
         "dev_activity_contributors_count",
         "github_activity_contributors_count",

--- a/test/sanbase/clickhouse/metric/clickhouse_metric_helper_test.exs
+++ b/test/sanbase/clickhouse/metric/clickhouse_metric_helper_test.exs
@@ -10,14 +10,14 @@ defmodule Sanbase.Clickhouse.Metric.HelperTest do
          %{
            rows: [
              [1, "daily_active_addresses"],
-             [2, "dev_activity"]
+             [2, "nvt"]
            ]
          }}
       end do
       {:ok, map} = Sanbase.Clickhouse.MetadataHelper.metric_name_to_metric_id_map()
 
       assert {"daily_active_addresses", 1} in map
-      assert {"dev_activity", 2} in map
+      assert {"nvt", 2} in map
     end
   end
 end

--- a/test/sanbase_web/cache/con_cache_provider_test.exs
+++ b/test/sanbase_web/cache/con_cache_provider_test.exs
@@ -10,9 +10,10 @@ defmodule SanbaseWeb.Graphql.ConCacheProviderTest do
   end
 
   test "return {:ok, value} when {:ok, value} is explicitly stored" do
-    key = {123_123, 60}
+    key = 123_123
+    cache_key = {key, 60}
     value = "something"
-    CacheProvider.store(@cache_name, key, {:ok, value})
+    CacheProvider.store(@cache_name, cache_key, {:ok, value})
     assert {:ok, value} == CacheProvider.get(@cache_name, key)
   end
 

--- a/test/sanbase_web/graphql/projects/project_api_aggregated_timeseries_data_test.exs
+++ b/test/sanbase_web/graphql/projects/project_api_aggregated_timeseries_data_test.exs
@@ -1,0 +1,63 @@
+defmodule SanbaseWeb.Graphql.ProjectApiAggregatedTimeseriesDataTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import Sanbase.Factory
+  import SanbaseWeb.Graphql.TestHelpers
+
+  setup do
+    %{
+      p1: insert(:random_erc20_project),
+      p2: insert(:random_erc20_project),
+      p3: insert(:random_erc20_project),
+      p4: insert(:random_erc20_project),
+      p5: insert(:random_project)
+    }
+  end
+
+  test "fetch aggregated timeseries data projects", context do
+    slugs = [context.p1, context.p2, context.p3, context.p4, context.p5] |> Enum.map(& &1.slug)
+
+    Sanbase.Mock.prepare_mock(
+      Sanbase.Metric,
+      :aggregated_timeseries_data,
+      fn _, %{slug: slugs}, _, _, _ ->
+        result = slugs |> Enum.into(%{}, fn slug -> {slug, :rand.uniform(100)} end)
+        {:ok, result}
+      end
+    )
+    |> Sanbase.Mock.prepare_mock2(&Sanbase.Metric.available_slugs/1, {:ok, slugs})
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      result =
+        execute(
+          context.conn,
+          "dev_activity_1d",
+          ~U[2020-01-01 00:00:00Z],
+          ~U[2020-02-01 00:00:00Z],
+          :avg
+        )
+        |> get_in(["data", "allProjects"])
+
+      assert length(result) == 5
+      Enum.each(result, &match?(%{"aggregatedTimeseriesData" => _, "slug" => _}, &1))
+    end)
+  end
+
+  defp execute(conn, metric, from, to, aggregation) do
+    query = """
+    {
+      allProjects {
+        aggregatedTimeseriesData(
+          metric: "#{metric}"
+          from: "#{from}"
+          to: "#{to}"
+          aggregation: #{Atom.to_string(aggregation) |> String.upcase()})
+        slug
+      }
+    }
+    """
+
+    conn
+    |> post("graphql", query_skeleton(query))
+    |> json_response(200)
+  end
+end

--- a/test/sanbase_web/graphql/projects/project_api_dev_activity_test.exs
+++ b/test/sanbase_web/graphql/projects/project_api_dev_activity_test.exs
@@ -33,7 +33,7 @@ defmodule SanbaseWeb.Graphql.ProjectApiDevActivityTest do
 
     with_mock Github,
       total_dev_activity: fn _, _, _ ->
-        {:ok, [{org, 300}]}
+        {:ok, %{org => 300}}
       end do
       result = avg_dev_activity(context.conn, project.slug)
 
@@ -48,7 +48,7 @@ defmodule SanbaseWeb.Graphql.ProjectApiDevActivityTest do
 
     with_mock Github,
       total_dev_activity: fn _, _, _ ->
-        {:ok, [{org1, 300}, {org2, 600}]}
+        {:ok, %{org1 => 300, org2 => 600}}
       end do
       result = avg_dev_activity(context.conn, project.slug)
 
@@ -78,7 +78,7 @@ defmodule SanbaseWeb.Graphql.ProjectApiDevActivityTest do
 
     with_mock Github,
       total_dev_activity: fn _, _, _ ->
-        {:ok, []}
+        {:ok, %{}}
       end do
       result = avg_dev_activity(context.conn, project.slug)
 


### PR DESCRIPTION
#### Summary
Reworks:
- aggregated_timeseries_data internally should always return maps.

Additions:
- dev_activity_1d metric
- aggregatedMetric field - Allow to aggregate fast a lot of metrics from the project GQL type that can be used in allProjects queries.
This field should eventually replace averageTokenAgeConsumed, averageDailyActiveAddresses, price change, volume change, averageDevActivity, etc.

Example:

```graphql
{
  allProjects(page: 1, pageSize: 5) {
    slug
    githubLinks
    daa_30d_avg: aggregatedTimeseriesData(metric: "daily_active_addresses", from: "2020-03-15T00:00:00Z", to: "2020-04-16T00:00:00Z", aggregation: AVG)
    vol_change_24h: aggregatedTimeseriesData(metric: "volume_usd_change_1d", from: "2020-04-14T00:00:00Z", to: "2020-04-16T00:00:00Z", aggregation: LAST)
    vol_now: aggregatedTimeseriesData(metric: "volume_usd", from: "2020-04-14T17:45:00Z", to: "2020-04-16T00:00:00Z", aggregation: LAST)
    vol_24h_ago: aggregatedTimeseriesData(metric: "volume_usd", from: "2020-04-14T17:48:00Z", to: "2020-04-16T00:00:00Z", aggregation: FIRST)
    dev_30d_avg: aggregatedTimeseriesData(metric: "dev_activity_1d", from: "2020-03-15T00:00:00Z", to: "2020-04-16T00:00:00Z", aggregation: AVG)
  }
}
```
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
