### PR TITLE
Increase parallel map and social volume timeouts from 15s to 25s

### DIFF
--- a/lib/sanbase/social_data/social_volume.ex
+++ b/lib/sanbase/social_data/social_volume.ex
@@ -9,7 +9,7 @@ defmodule Sanbase.SocialData.SocialVolume do
   require Mockery.Macro
   defp http_client, do: Mockery.Macro.mockable(HTTPoison)
 
-  @recv_timeout 15_000
+  @recv_timeout 25_000
   @sources [:telegram, :professional_traders_chat, :reddit, :discord]
 
   def social_volume(slug, from, to, interval, source)

--- a/lib/sanbase/utils/parallel.ex
+++ b/lib/sanbase/utils/parallel.ex
@@ -3,7 +3,7 @@ defmodule Sanbase.Parallel do
   Module implementing concurrent map and filter functions on enumerable under Sanbase.TaskSupervisor
   """
 
-  @default_timeout 15_000
+  @default_timeout 25_000
 
   def flat_map(collection, func, opts \\ [])
 


### PR DESCRIPTION
The social data (topic_search) started timing out for some reason

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
