### PR TITLE
Metric human readable name

### DIFF
--- a/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
@@ -115,7 +115,7 @@ defmodule Sanbase.Clickhouse.TopHolders.MetricAdapter do
     case metric do
       "amount_in_top_holders" -> {:ok, "Top Holders Balance"}
       "amount_in_exchange_top_holders" -> {:ok, "Exchange Top Holders Balance"}
-      "amount_in_non_exchange top_holders" -> {:ok, "Non-Exchange Top Holders Balance"}
+      "amount_in_non_exchange_top_holders" -> {:ok, "Non-Exchange Top Holders Balance"}
     end
   end
 

--- a/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
@@ -22,6 +22,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   def get_available_slugs(_root, _args, %{source: %{metric: metric}}),
     do: Metric.available_slugs(metric)
 
+  def get_human_readable_name(_root, _args, %{source: %{metric: metric}}),
+    do: Metric.human_readable_name(metric)
+
   def get_metadata(%{}, _args, %{source: %{metric: metric}} = resolution) do
     %{context: %{product_id: product_id, auth: %{subscription: subscription}}} = resolution
 

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -137,8 +137,27 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     """
     field(:available_aggregations, list_of(:aggregation))
 
+    @desc ~s"""
+    The supported selector types for the metric. It is used to choose the
+    target for which the metric is computed. Available selectors are:
+      - slug - Identifies an asset/project
+      - text - Provides random text/search term for the social metrics
+      - holders_count - Provides the number of holders used in holders metrics
+
+    Every metric has `availableSelectors` in its metadata, showing exactly
+    which of the selectors can be used.
+    """
     field(:available_selectors, list_of(:selector_name))
 
+    @desc ~s"""
+    The data type of the metric can be either timeseries or histogram.
+      - Timeseries data is a sequence taken at successive equally spaced points
+        in time (every 5 minutes, every day, every year, etc.).
+      - Histogram data is an approximate representation of the distribution of
+        numerical or categorical data. The metric is represented as a list of data
+        points, where every point is represented represented by a tuple containing
+        a range an a value.
+    """
     field(:data_type, :metric_data_type)
 
     field(:is_restricted, :boolean)
@@ -187,6 +206,14 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       cache_resolve(&MetricResolver.timeseries_data/3)
     end
 
+    @desc ~s"""
+    A derivative of the `timeseriesData` - read its full descriptio if not
+    familiar with it.
+
+    `aggregatedTimeseriesData` returns a single float value instead of list
+    of datetimes and values. The single values is computed by aggregating all
+    of the values in the specified from-to range with the `aggregation` aggregation.
+    """
     field :aggregated_timeseries_data, :float do
       arg(:slug, :string)
       arg(:selector, :metric_target_selector_input_object)
@@ -200,6 +227,42 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       cache_resolve(&MetricResolver.aggregated_timeseries_data/3)
     end
 
+    @desc ~s"""
+    A histogram is an approximate representation of the distribution of numerical or
+    categorical data.
+
+    The metric is represented as a list of data points, where every point is
+    represented represented by a tuple containing a range an a value.
+
+    Example (histogram data) The price_histogram (or spent_coins_cost) shows at what
+    price were acquired the coins/tokens transacted on a given day D. The metric is
+    represented as a list of price ranges and values with the following meaning: Out
+    of all coins/tokens transacted on day D, value amount of them were acquired when
+    the price was in the range range.
+
+    On April 07, the bitcoins that circulated during that day were 124k and the
+    average price for the day was $7307. Out of all of the 124k bitcoins, 13.8k of
+    them were acquired when the price was in the range $8692.08 - $10845.62, so
+    they were last moved when the price was higher. The same logic applies for all
+    of the ranges.
+
+    [
+      ...
+      {
+        "range": [7307.7, 8692.08],
+        "value": 2582.64
+      },
+      {
+        "range": [8692.08, 10845.62],
+        "value": 13804.97
+      },
+      {
+        "range": [10845.62, 12999.16],
+        "value": 130.33
+      },
+      ...
+    ]
+    """
     field :histogram_data, :histogram_data do
       arg(:slug, :string)
       arg(:selector, :metric_target_selector_input_object)

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -102,6 +102,14 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:metric, non_null(:string))
 
     @desc ~s"""
+    A human readable name of the metric.
+    For example the human readable name of `mvrv_usd_5y` is `MVRV for coins that moved in the past 5 years`
+    """
+    field :human_readable_name, non_null(:string) do
+      cache_resolve(&MetricResolver.get_human_readable_name/3, ttl: 3600)
+    end
+
+    @desc ~s"""
     List of slugs which can be provided to the `timeseriesData` field to fetch
     the metric.
     """

--- a/test/sanbase_web/graphql/metric/api_metric_metadata_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_metadata_test.exs
@@ -22,6 +22,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricMetadataTest do
                metadata
              )
 
+      assert metadata["humanReadableName"] |> is_binary()
       assert metadata["defaultAggregation"] in aggregations
       assert metadata["minInterval"] in ["1m", "5m", "6h", "1d"]
       assert metadata["dataType"] in ["TIMESERIES", "HISTOGRAM"]
@@ -66,6 +67,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricMetadataTest do
           defaultAggregation
           dataType
           metric
+          humanReadableName
           isRestricted
           restrictedFrom
           restrictedTo


### PR DESCRIPTION
#### Summary
Adding the human readable name of metrics:
```graphql
{
  getMetric(metric: "mvrv_usd_5y"){
    metadata{
      humanReadableName
    }
  }
}
```
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
