### PR TITLE
Fix metric query

### DIFF
--- a/lib/sanbase/anomaly/anomaly_sql_query.ex
+++ b/lib/sanbase/anomaly/anomaly_sql_query.ex
@@ -32,7 +32,7 @@ defmodule Sanbase.Anomaly.SqlQuery do
     query = """
     SELECT
       toUnixTimestamp(intDiv(toUInt32(toDateTime(dt)), ?1) * ?1) AS t,
-      toFloat32(#{aggregation(aggregation, "value", "t")})
+      toFloat32(#{aggregation(aggregation, "value", "dt")})
     FROM(
       SELECT
         dt,
@@ -71,7 +71,7 @@ defmodule Sanbase.Anomaly.SqlQuery do
     query = """
     SELECT
       toUInt32(asset_id),
-      toFloat32(#{aggregation(aggregation, "value", "t")})
+      toFloat32(#{aggregation(aggregation, "value", "dt")})
     FROM(
       SELECT
         dt,

--- a/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
+++ b/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
@@ -32,7 +32,7 @@ defmodule Sanbase.Clickhouse.Metric.SqlQuery do
     query = """
     SELECT
       toUnixTimestamp(intDiv(toUInt32(toDateTime(dt)), ?1) * ?1) AS t,
-      #{aggregation(aggregation, "value", "t")}
+      #{aggregation(aggregation, "value", "dt")}
     FROM(
       SELECT
         dt,

--- a/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
+++ b/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
@@ -41,8 +41,8 @@ defmodule Sanbase.Clickhouse.Metric.SqlQuery do
       PREWHERE
         #{maybe_convert_to_date(:after, metric, "dt", "toDateTime(?3)")} AND
         #{maybe_convert_to_date(:before, metric, "dt", "toDateTime(?4)")} AND
-        asset_id = ( SELECT argMax(asset_id, computed_at) FROM asset_metadata FINAL PREWHERE name = ?5 ) AND
-        metric_id = ( SELECT argMax(metric_id, computed_at) AS metric_id FROM metric_metadata FINAL PREWHERE name = ?2 )
+        asset_id = ( SELECT asset_id FROM asset_metadata FINAL PREWHERE name = ?5 ) AND
+        metric_id = ( SELECT metric_id FROM metric_metadata FINAL PREWHERE name = ?2 )
       GROUP BY dt
     )
     GROUP BY t

--- a/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
+++ b/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
@@ -41,19 +41,8 @@ defmodule Sanbase.Clickhouse.Metric.SqlQuery do
       PREWHERE
         #{maybe_convert_to_date(:after, metric, "dt", "toDateTime(?3)")} AND
         #{maybe_convert_to_date(:before, metric, "dt", "toDateTime(?4)")} AND
-        asset_id = (
-          SELECT argMax(asset_id, computed_at)
-          FROM asset_metadata
-          PREWHERE name = ?5
-        ) AND
-        metric_id = (
-          SELECT
-            argMax(metric_id, computed_at) AS metric_id
-          FROM
-            metric_metadata
-          PREWHERE
-            name = ?2
-        )
+        asset_id = ( SELECT argMax(asset_id, computed_at) FROM asset_metadata FINAL PREWHERE name = ?5 ) AND
+        metric_id = ( SELECT argMax(metric_id, computed_at) AS metric_id FROM metric_metadata FINAL PREWHERE name = ?2 )
       GROUP BY dt
     )
     GROUP BY t
@@ -63,8 +52,8 @@ defmodule Sanbase.Clickhouse.Metric.SqlQuery do
     args = [
       str_to_sec(interval),
       Map.get(@name_to_metric_map, metric),
-      from,
-      to,
+      from |> DateTime.to_unix(),
+      to |> DateTime.to_unix(),
       slug
     ]
 


### PR DESCRIPTION
#### Summary
The aggregation should happen on the original `dt` field and not on `t` after applying the interval rounding. Applying it on `t` would result on applying it on the same value and aggregations like first/last does no longer work properly, but semi-randomly.
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
