### PR TITLE
Properly handle multiple ethSpent aliases

### DIFF
--- a/lib/sanbase_web/graphql/dataloader/clickhouse_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/clickhouse_dataloader.ex
@@ -3,8 +3,6 @@ defmodule SanbaseWeb.Graphql.ClickhouseDataloader do
   alias Sanbase.Model.Project
   alias Sanbase.Metric
 
-  @max_concurrency 8
-
   def data(), do: Dataloader.KV.new(&query/2)
 
   def query(:aggregated_metric, args) do
@@ -59,9 +57,12 @@ defmodule SanbaseWeb.Graphql.ClickhouseDataloader do
     args = Enum.to_list(args)
 
     Enum.group_by(args, fn %{days: days} -> days end)
-    |> Sanbase.Parallel.map(fn {days, group} ->
-      {days, average_dev_activity(group, days)}
-    end)
+    |> Sanbase.Parallel.map(
+      fn {days, group} ->
+        {days, average_dev_activity(group, days)}
+      end,
+      ordered: false
+    )
     |> Map.new()
   end
 
@@ -75,19 +76,13 @@ defmodule SanbaseWeb.Graphql.ClickhouseDataloader do
   def query(:eth_spent, args) do
     args = Enum.to_list(args)
 
-    eth_spent =
-      eth_addresses(args)
-      |> Enum.chunk_every(10)
-      |> Sanbase.Parallel.map(&eth_spent(&1, args),
-        map_type: :flat_map,
-        max_concurrency: @max_concurrency
-      )
-      |> Map.new()
-
-    args
-    |> Enum.map(fn %{project: project} ->
-      {project.id, eth_spent_per_project(project, eth_spent)}
-    end)
+    Enum.group_by(args, fn %{days: days} -> days end)
+    |> Sanbase.Parallel.map(
+      fn {days, group} ->
+        {days, eth_spent_for_days_group(group |> Enum.map(& &1.project), days)}
+      end,
+      ordered: false
+    )
     |> Map.new()
   end
 
@@ -142,37 +137,56 @@ defmodule SanbaseWeb.Graphql.ClickhouseDataloader do
     end
   end
 
+  defp eth_spent_for_days_group(projects, days) do
+    from = Timex.shift(Timex.now(), days: -days)
+    to = Timex.now()
+
+    eth_spent_per_address =
+      eth_addresses(projects)
+      |> Enum.chunk_every(10)
+      |> Sanbase.Parallel.map(&eth_spent(&1, from, to),
+        map_type: :flat_map,
+        max_concurrency: 8,
+        ordered: false
+      )
+      |> Map.new()
+
+    projects
+    |> Enum.map(fn project ->
+      {project.id, eth_spent_per_project(project, eth_spent_per_address)}
+    end)
+    |> Map.new()
+  end
+
   # Calculate the ethereum spent for a single project by summing the ethereum
   # spent for each of its ethereum addresses. If an error is encountered while
   # calculating, the value will be wrapped in a :nocache tuple that the cache
   # knows how to handle
-  defp eth_spent_per_project(project, eth_spent) do
+  defp eth_spent_per_project(project, eth_spent_per_address) do
     {:ok, addresses} = Project.eth_addresses(project)
 
-    eth_spent_per_address =
+    project_addresses_eth_spent =
       addresses
       |> Enum.map(fn address ->
-        Map.get(eth_spent, address, {:ok, 0})
+        Map.get(eth_spent_per_address, address, {:ok, 0})
       end)
 
     project_eth_spent =
-      for({:ok, value} <- eth_spent_per_address, do: value)
+      for({:ok, value} <- project_addresses_eth_spent, do: value)
       |> Enum.sum()
 
-    eth_spent_per_address
+    project_addresses_eth_spent
     |> Enum.any?(&match?({:error, _}, &1))
-    |> result(project_eth_spent)
+    |> project_eth_spent_result(project_eth_spent)
   end
 
-  defp result(has_errors?, value)
-  defp result(true, value) when value < 0, do: {:nocache, {:ok, abs(value)}}
-  defp result(true, _), do: {:nocache, 0}
-  defp result(false, value) when value < 0, do: {:ok, abs(value)}
-  defp result(false, _), do: {:ok, 0}
+  defp project_eth_spent_result(has_errors?, value)
+  defp project_eth_spent_result(true, value) when value < 0, do: {:nocache, {:ok, abs(value)}}
+  defp project_eth_spent_result(true, _), do: {:nocache, {:ok, 0}}
+  defp project_eth_spent_result(false, value) when value < 0, do: {:ok, abs(value)}
+  defp project_eth_spent_result(false, _), do: {:ok, 0}
 
-  defp eth_spent(eth_addresses, args) do
-    [%{from: from, to: to} | _] = args
-
+  defp eth_spent(eth_addresses, from, to) do
     case Clickhouse.HistoricalBalance.EthSpent.eth_balance_change(eth_addresses, from, to) do
       {:ok, balance_changes} ->
         balance_changes
@@ -184,9 +198,9 @@ defmodule SanbaseWeb.Graphql.ClickhouseDataloader do
     end
   end
 
-  defp eth_addresses(args) do
-    args
-    |> Enum.map(fn %{project: project} ->
+  defp eth_addresses(projects) do
+    projects
+    |> Enum.map(fn project ->
       case Project.eth_addresses(project) do
         {:ok, addresses} when addresses != [] ->
           addresses


### PR DESCRIPTION
#### Summary
Using aliases with different arguments should be handled properly - there should be different groups according to the arguments. In the following examples the computation should be split into 3 groups for 1 day, 7 days and 30 days:
```graphql
{
  allErc20Projects {
    slug
    ethSpent30d: ethSpent(days: 30)
    ethSpent7d: ethSpent(days: 7)
    ethSpent1d: ethSpent(days: 1)
  }
}
```
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
