### PR TITLE
Rework chart configuration queries

### DIFF
--- a/lib/sanbase/chart/configuration.ex
+++ b/lib/sanbase/chart/configuration.ex
@@ -57,7 +57,8 @@ defmodule Sanbase.Chart.Configuration do
   end
 
   def configurations(querying_user_id \\ nil) do
-    configurations_query(querying_user_id)
+    __MODULE__
+    |> accessible_by_user_query(querying_user_id)
     |> Repo.all()
   end
 
@@ -91,7 +92,7 @@ defmodule Sanbase.Chart.Configuration do
   end
 
   defp get_chart_configuration(config_id, querying_user_id) do
-    case from(conf in __MODULE__, where: conf.id == ^config_id) |> Repo.one() do
+    case Repo.get(__MODULE__, config_id) do
       %__MODULE__{user_id: user_id, is_public: is_public} = conf
       when user_id == querying_user_id or is_public == true ->
         {:ok, conf}
@@ -105,7 +106,7 @@ defmodule Sanbase.Chart.Configuration do
   end
 
   defp get_chart_configuration_if_owner(config_id, user_id) do
-    case from(conf in __MODULE__, where: conf.id == ^config_id) |> Repo.one() do
+    case Repo.get(__MODULE__, config_id) do
       %__MODULE__{user_id: ^user_id} = conf ->
         {:ok, conf}
 
@@ -118,42 +119,35 @@ defmodule Sanbase.Chart.Configuration do
     end
   end
 
-  defp all_user_configurations_query(user_id, querying_user_id) do
-    from(
-      conf in __MODULE__,
-      where:
-        conf.user_id == ^user_id and
-          (conf.user_id == ^querying_user_id or conf.is_public == true)
-    )
-  end
-
   defp user_chart_configurations_query(user_id, querying_user_id, nil) do
-    all_user_configurations_query(user_id, querying_user_id)
+    __MODULE__
+    |> where([conf], conf.user_id == ^user_id)
+    |> accessible_by_user_query(querying_user_id)
   end
 
   defp user_chart_configurations_query(user_id, querying_user_id, project_id) do
-    from(
-      conf in __MODULE__,
-      where:
-        conf.user_id == ^user_id and conf.project_id == ^project_id and
-          (conf.user_id == ^querying_user_id or conf.is_public == true)
-    )
+    filter_by_project_query(project_id)
+    |> where([conf], conf.user_id == ^user_id)
+    |> accessible_by_user_query(querying_user_id)
   end
 
   defp project_chart_configurations_query(project_id, querying_user_id) do
-    from(
-      conf in __MODULE__,
-      where:
-        conf.project_id == ^project_id and
-          (conf.user_id == ^querying_user_id or conf.is_public == true)
-    )
+    filter_by_project_query(project_id)
+    |> accessible_by_user_query(querying_user_id)
   end
 
-  defp configurations_query(nil) do
-    from(conf in __MODULE__, where: conf.is_public == true)
+  defp filter_by_project_query(project_id) when not is_nil(project_id) do
+    __MODULE__
+    |> where([conf], conf.project_id == ^project_id)
   end
 
-  defp configurations_query(querying_user_id) do
-    from(conf in __MODULE__, where: conf.is_public == true or conf.user_id == ^querying_user_id)
+  defp accessible_by_user_query(query, nil) do
+    query
+    |> where([conf], conf.is_public == true)
+  end
+
+  defp accessible_by_user_query(query, querying_user_id) do
+    query
+    |> where([conf], conf.is_public == true or conf.user_id == ^querying_user_id)
   end
 end

--- a/lib/sanbase_web/graphql/resolvers/project/project_transactions_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_transactions_resolver.ex
@@ -52,9 +52,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectTransactionsResolver do
   end
 
   def eth_spent(%Project{} = project, %{days: days}, %{context: %{loader: loader}}) do
-    from = Timex.shift(Timex.now(), days: -days) |> round_datetime(600)
-    to = Timex.now() |> round_datetime(600)
-
     loader
     |> Dataloader.load(SanbaseDataloader, :eth_spent, %{
       project: project,


### PR DESCRIPTION
#### Summary
Rework the queries so there are no comparisons with nil.
conf.user_id == ^querying_user_id fails due to security reasons if the
variable holds nil.

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
