### PR TITLE
Add complexity_weight to getMetric

### DIFF
--- a/lib/sanbase/clickhouse/github/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/github/metric_adapter.ex
@@ -28,8 +28,13 @@ defmodule Sanbase.Clickhouse.Github.MetricAdapter do
   @free_metrics @metrics
   @restricted_metrics []
 
+  @default_complexity_weight 0.3
+
   @impl Sanbase.Metric.Behaviour
   def has_incomplete_data?(_), do: false
+
+  @impl Sanbase.Metric.Behaviour
+  def complexity_weight(_), do: @default_complexity_weight
 
   @impl Sanbase.Metric.Behaviour
   def timeseries_data(metric, %{slug: slug}, from, to, interval, _aggregation) do
@@ -147,7 +152,8 @@ defmodule Sanbase.Clickhouse.Github.MetricAdapter do
        default_aggregation: :sum,
        available_aggregations: [:sum],
        available_selectors: [:slug],
-       data_type: :timeseries
+       data_type: :timeseries,
+       complexity_weight: @default_complexity_weight
      }}
   end
 

--- a/lib/sanbase/clickhouse/metric/metric.ex
+++ b/lib/sanbase/clickhouse/metric/metric.ex
@@ -42,6 +42,8 @@ defmodule Sanbase.Clickhouse.Metric do
   @incomplete_data_map FileHandler.incomplete_data_map()
   @tables_list FileHandler.table_map() |> Map.values() |> List.flatten() |> Enum.uniq()
 
+  @default_complexity_weight 0.3
+
   @type slug :: String.t()
   @type metric :: String.t()
   @type interval :: String.t()
@@ -60,6 +62,9 @@ defmodule Sanbase.Clickhouse.Metric do
 
   @impl Sanbase.Metric.Behaviour
   def has_incomplete_data?(metric), do: Map.get(@incomplete_data_map, metric)
+
+  @impl Sanbase.Metric.Behaviour
+  def complexity_weight(_), do: @default_complexity_weight
 
   @doc ~s"""
   Get a given metric for a slug and time range. The metric's aggregation
@@ -121,7 +126,8 @@ defmodule Sanbase.Clickhouse.Metric do
        default_aggregation: default_aggregation,
        available_aggregations: @plain_aggregations,
        available_selectors: [:slug],
-       data_type: Map.get(@metrics_data_type_map, metric)
+       data_type: Map.get(@metrics_data_type_map, metric),
+       complexity_weight: @default_complexity_weight
      }}
   end
 

--- a/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
@@ -13,6 +13,8 @@ defmodule Sanbase.Clickhouse.TopHolders.MetricAdapter do
 
   @supported_infrastructures ["eosio.token/EOS", "EOS", "ETH", "BNB", "BEP2"]
 
+  @default_complexity_weight 0.3
+
   def supported_infrastructures(), do: @supported_infrastructures
 
   @infrastructure_to_table %{
@@ -116,7 +118,8 @@ defmodule Sanbase.Clickhouse.TopHolders.MetricAdapter do
        default_aggregation: :last,
        available_aggregations: @aggregations,
        available_selectors: [:slug, :holders_count],
-       data_type: data_type
+       data_type: data_type,
+       complexity_weight: @default_complexity_weight
      }}
   end
 
@@ -131,6 +134,9 @@ defmodule Sanbase.Clickhouse.TopHolders.MetricAdapter do
 
   @impl Sanbase.Metric.Behaviour
   def has_incomplete_data?(_), do: false
+
+  @impl Sanbase.Metric.Behaviour
+  def complexity_weight(_), do: @default_complexity_weight
 
   @impl Sanbase.Metric.Behaviour
   def available_aggregations(), do: @aggregations

--- a/lib/sanbase/metric/behaviour.ex
+++ b/lib/sanbase/metric/behaviour.ex
@@ -20,7 +20,8 @@ defmodule Sanbase.Metric.Behaviour do
           default_aggregation: atom(),
           available_aggregations: list(atom()),
           available_selectors: list(atom()),
-          data_type: available_data_types()
+          data_type: available_data_types(),
+          complexity_weight: number()
         }
 
   @type histogram_value :: String.t() | float() | integer()
@@ -82,6 +83,8 @@ defmodule Sanbase.Metric.Behaviour do
             ) :: {:ok, list(slug())} | {:error, String.t()}
 
   @callback has_incomplete_data?(metric :: metric) :: true | false
+
+  @callback complexity_weight(metric :: metric) :: number
 
   @callback first_datetime(metric, selector) ::
               {:ok, DateTime.t()} | {:error, String.t()}

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -275,6 +275,21 @@ defmodule Sanbase.Metric do
   def human_readable_name(metric), do: metric_not_available_error(metric)
 
   @doc ~s"""
+  Get the complexity weight of a metric. This is a multiplier applied to the
+  computed complexity. Clickhouse is faster compared to Elasticsearch for fetching
+  timeseries data, so it has a smaller weight
+  """
+  def complexity_weight(metric)
+
+  for %{metric: metric, module: module} <- @metric_module_mapping do
+    def complexity_weight(unquote(metric)) do
+      unquote(module).complexity_weight(unquote(metric))
+    end
+  end
+
+  def complexity_weight(metric), do: metric_not_available_error(metric)
+
+  @doc ~s"""
   Get metadata for a given metric. This includes:
   - The minimal interval for which the metric is available
     (every 5 minutes, once a day, etc.)

--- a/lib/sanbase/prices/metric_adapter.ex
+++ b/lib/sanbase/prices/metric_adapter.ex
@@ -17,8 +17,13 @@ defmodule Sanbase.Price.MetricAdapter do
   @restricted_metrics Enum.filter(@access_map, fn {_, level} -> level == :restricted end)
                       |> Keyword.keys()
 
+  @default_complexity_weight 0.3
+
   @impl Sanbase.Metric.Behaviour
   def has_incomplete_data?(_), do: false
+
+  @impl Sanbase.Metric.Behaviour
+  def complexity_weight(_), do: @default_complexity_weight
 
   @impl Sanbase.Metric.Behaviour
   def timeseries_data(metric, %{slug: slug}, from, to, interval, aggregation) do
@@ -63,7 +68,8 @@ defmodule Sanbase.Price.MetricAdapter do
        default_aggregation: @default_aggregation,
        available_aggregations: @aggregations,
        available_selectors: [:slug],
-       data_type: :timeseries
+       data_type: :timeseries,
+       complexity_weight: @default_complexity_weight
      }}
   end
 

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -43,8 +43,13 @@ defmodule Sanbase.SocialData.MetricAdapter do
   @access_map Enum.reduce(@metrics, %{}, fn metric, acc -> Map.put(acc, metric, :restricted) end)
   @min_plan_map Enum.reduce(@metrics, %{}, fn metric, acc -> Map.put(acc, metric, :free) end)
 
+  @default_complexity_weight 1
+
   @impl Sanbase.Metric.Behaviour
   def has_incomplete_data?(_), do: false
+
+  @impl Sanbase.Metric.Behaviour
+  def complexity_weight(_), do: @default_complexity_weight
 
   @impl Sanbase.Metric.Behaviour
   def timeseries_data(metric, %{slug: slug}, from, to, interval, _aggregation)
@@ -196,7 +201,8 @@ defmodule Sanbase.SocialData.MetricAdapter do
        default_aggregation: :sum,
        available_aggregations: @aggregations,
        available_selectors: selectors,
-       data_type: :histogram
+       data_type: :timeseries,
+       complexity_weight: @default_complexity_weight
      }}
   end
 

--- a/lib/sanbase/twitter/metric_adapter.ex
+++ b/lib/sanbase/twitter/metric_adapter.ex
@@ -17,8 +17,13 @@ defmodule Sanbase.Twitter.MetricAdapter do
   @restricted_metrics Enum.filter(@access_map, fn {_, level} -> level == :restricted end)
                       |> Keyword.keys()
 
+  @default_complexity_weight 1
+
   @impl Sanbase.Metric.Behaviour
   def has_incomplete_data?(_), do: false
+
+  @impl Sanbase.Metric.Behaviour
+  def complexity_weight(_), do: @default_complexity_weight
 
   @impl Sanbase.Metric.Behaviour
   def timeseries_data("twitter_followers", %{slug: slug}, from, to, interval, _aggregation) do
@@ -84,7 +89,8 @@ defmodule Sanbase.Twitter.MetricAdapter do
        default_aggregation: :last,
        available_aggregations: @aggregations,
        available_selectors: [:slug],
-       data_type: :timeseries
+       data_type: :timeseries,
+       complexity_weight: @default_complexity_weight
      }}
   end
 


### PR DESCRIPTION
#### Summary
Different metrics are fetched from different databases. Fetching timeseries data from ClickHouse is much faster and cheaper than computing the data in Elasticsearch. That's why different metrics have different complexity weights.

The old behaviour is kept with complexity_weight = 1
Clickhouse metrics now have complexity_weight < 1, so multiplying complexity and complexity_weight yields a smaller number.

This change makes it possible to fetch 2009-2020 range with 1d interval and free account.

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
