### PR TITLE
Use float instad of integer in topicSearch

### DIFF
--- a/lib/sanbase_web/graphql/schema/types/social_data_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/social_data_types.ex
@@ -68,7 +68,7 @@ defmodule SanbaseWeb.Graphql.SocialDataTypes do
   end
 
   object :chart_data do
-    field(:mentions_count, :integer)
+    field(:mentions_count, :float)
     field(:datetime, non_null(:datetime))
   end
 


### PR DESCRIPTION
Sometimes a 0.0 float comes as result and breaks the API.

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
