### PR TITLE
Fix holders distributions for custom api plan

### DIFF
--- a/lib/sanbase/billing/plan.ex
+++ b/lib/sanbase/billing/plan.ex
@@ -12,7 +12,7 @@ defmodule Sanbase.Billing.Plan do
   alias Sanbase.Repo
   alias Sanbase.Billing.{Product, Subscription}
 
-  @plans_order [free: 0, basic: 1, pro: 2, premium: 3, enterprise: 4]
+  @plans_order [free: 0, basic: 1, pro: 2, premium: 3, custom: 4]
   def plans_order(), do: @plans_order
   def sort_plans(plans), do: Enum.sort_by(plans, fn plan -> Keyword.get(@plans_order, plan) end)
 
@@ -52,8 +52,8 @@ defmodule Sanbase.Billing.Plan do
       %{name: "ESSENTIAL"} -> :basic
       %{name: "PRO"} -> :pro
       %{name: "PREMIUM"} -> :premium
-      %{name: "CUSTOM"} -> :enterprise
-      %{name: "ENTERPRISE"} -> :enterprise
+      %{name: "CUSTOM"} -> :custom
+      %{name: "ENTERPRISE"} -> :custom
       %{name: "EXTENSION"} -> :extension
       %{name: name} -> String.downcase(name) |> String.to_existing_atom()
     end

--- a/lib/sanbase/billing/plan/access_checker.ex
+++ b/lib/sanbase/billing/plan/access_checker.ex
@@ -112,7 +112,6 @@ defmodule Sanbase.Billing.Plan.AccessChecker do
       :basic -> plan != :free
       :pro -> plan not in [:free, :basic]
       :premium -> plan not in [:free, :basic, :pro]
-      :enterprise -> plan not in [:free, :eseential, :pro, :premium]
       :custom -> plan == :custom
       # extensions plans can be with other plan. They're handled separately
       _ -> true

--- a/lib/sanbase/billing/plan/api_access_checker.ex
+++ b/lib/sanbase/billing/plan/api_access_checker.ex
@@ -28,7 +28,7 @@ defmodule Sanbase.Billing.Plan.ApiAccessChecker do
     api_calls_month: 500_000
   }
 
-  @enterprise_plan_stats @premium_plan_stats
+  @custom_plan_stats @premium_plan_stats
 
   # Some queries/metrics are further restricted for basic/essential plan.
   # They are served with the free timeframe restriction.
@@ -52,7 +52,7 @@ defmodule Sanbase.Billing.Plan.ApiAccessChecker do
       :basic -> @basic_plan_stats[:historical_data_in_days]
       :pro -> @pro_plan_stats[:historical_data_in_days]
       :premium -> @premium_plan_stats[:historical_data_in_days]
-      :enterprise -> @enterprise_plan_stats[:historical_data_in_days]
+      :custom -> @custom_plan_stats[:historical_data_in_days]
     end
   end
 
@@ -67,7 +67,7 @@ defmodule Sanbase.Billing.Plan.ApiAccessChecker do
       :basic -> @basic_plan_stats[:realtime_data_cut_off_in_days]
       :pro -> @pro_plan_stats[:realtime_data_cut_off_in_days]
       :premium -> @premium_plan_stats[:realtime_data_cut_off_in_days]
-      :enterprise -> @premium_plan_stats[:realtime_data_cut_off_in_days]
+      :custom -> @premium_plan_stats[:realtime_data_cut_off_in_days]
     end
   end
 end

--- a/lib/sanbase/billing/plan/sanbase_access_checker.ex
+++ b/lib/sanbase/billing/plan/sanbase_access_checker.ex
@@ -36,7 +36,7 @@ defmodule Sanbase.Billing.Plan.SanbaseAccessChecker do
 
   @basic_plan_stats @pro_plan_stats
 
-  @enterprise_plan_stats @pro_plan_stats
+  @custom_plan_stats @pro_plan_stats
 
   def historical_data_in_days(plan, _query) do
     plan_stats(plan)
@@ -82,8 +82,8 @@ defmodule Sanbase.Billing.Plan.SanbaseAccessChecker do
       :free -> @free_plan_stats
       :basic -> @basic_plan_stats
       :pro -> @pro_plan_stats
-      :premium -> @enterprise_plan_stats
-      :enterprise -> @enterprise_plan_stats
+      :premium -> @custom_plan_stats
+      :custom -> @custom_plan_stats
     end
   end
 end

--- a/lib/sanbase_web/graphql/complexity/complexity.ex
+++ b/lib/sanbase_web/graphql/complexity/complexity.ex
@@ -22,7 +22,7 @@ defmodule SanbaseWeb.Graphql.Complexity do
       :basic -> div(complexity, 2)
       :pro -> div(complexity, 3)
       :premium -> div(complexity, 5)
-      :enterprise -> div(complexity, 5)
+      :custom -> div(complexity, 5)
     end
   end
 

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -12,7 +12,7 @@ defmodule SanbaseWeb.Graphql.Schema do
     > basic
     > pro
     > premium
-    > enterprise
+    > custom
   """
   use Absinthe.Schema
 

--- a/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_product_access_test.exs
+++ b/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_product_access_test.exs
@@ -377,6 +377,23 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
     end
   end
 
+  describe "SanAPI product, user with CUSTOM plan" do
+    setup context do
+      insert(:subscription_custom, user: context.user)
+      :ok
+    end
+
+    test "can access holders distributions", context do
+      {from, to} = from_to(2500, 0)
+      metric = "holders_distribution_0.01_to_0.1"
+      slug = context.project.slug
+      query = metric_query(metric, slug, from, to)
+      result = execute_query(context.conn, query, "getMetric")
+      assert_called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
+      assert result != nil
+    end
+  end
+
   # Private functions
 
   defp metric_query(metric, slug, from, to) do

--- a/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_product_access_test.exs
+++ b/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_product_access_test.exs
@@ -332,9 +332,9 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
     end
   end
 
-  describe "SanAPI product, user with PREMIUM plan" do
+  describe "SanAPI product, user with CUSTOM plan" do
     setup context do
-      insert(:subscription_premium, user: context.user)
+      insert(:subscription_custom, user: context.user)
       :ok
     end
 
@@ -359,7 +359,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
 
     test "can access RESTRICTED metrics for all time & realtime", context do
       {from, to} = from_to(2500, 0)
-      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :premium)
+      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :custom)
       slug = context.project.slug
       query = metric_query(metric, slug, from, to)
       result = execute_query(context.conn, query, "getMetric")
@@ -375,15 +375,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       assert_called(Metric.timeseries_data("network_growth", :_, :_, :_, :_, :_))
       assert result != nil
     end
-  end
 
-  describe "SanAPI product, user with CUSTOM plan" do
-    setup context do
-      insert(:subscription_custom, user: context.user)
-      :ok
-    end
-
-    test "can access holders distributions", context do
+    test "can access holders distributions for all time & realtime", context do
       {from, to} = from_to(2500, 0)
       metric = "holders_distribution_0.01_to_0.1"
       slug = context.project.slug

--- a/test/support/sanbase_factory.ex
+++ b/test/support/sanbase_factory.ex
@@ -482,6 +482,15 @@ defmodule Sanbase.Factory do
     }
   end
 
+  def subscription_custom_factory() do
+    %Subscription{
+      stripe_id: rand_str(),
+      plan_id: 5,
+      current_period_end: Timex.shift(Timex.now(), days: 1),
+      status: "active"
+    }
+  end
+
   def subscription_basic_sanbase_factory() do
     %Subscription{
       plan_id: 12,
@@ -498,7 +507,7 @@ defmodule Sanbase.Factory do
     }
   end
 
-  def subscription_pro_enterprise_factory() do
+  def subscription_pro_custom_factory() do
     %Subscription{
       plan_id: 24,
       current_period_end: Timex.shift(Timex.now(), days: 1),


### PR DESCRIPTION
* Holders distributions should be accessible in `custom` plan
* Use `custom` instead of `enterprise` internally
* Move premium tests to custom - since we removed premium api plan
