### PR TITLE
Downgrade Absinthe

### DIFF
--- a/lib/sanbase_web/graphql/absinthe_before_send.ex
+++ b/lib/sanbase_web/graphql/absinthe_before_send.ex
@@ -102,7 +102,8 @@ defmodule SanbaseWeb.Graphql.AbsintheBeforeSend do
 
   # Create an API Call event for every query in a Document separately.
   defp export_api_call_data(queries, conn, blueprint) do
-    duration_ms = div(System.monotonic_time() - blueprint.telemetry.start_time_mono, 1_000_000)
+    now = DateTime.utc_now() |> DateTime.to_unix(:nanosecond)
+    duration_ms = div(now - blueprint.telemetry.start_time, 1_000_000)
 
     user_agent = Plug.Conn.get_req_header(conn, "user-agent") |> List.first()
 
@@ -121,7 +122,7 @@ defmodule SanbaseWeb.Graphql.AbsintheBeforeSend do
 
     Enum.map(queries, fn query ->
       %{
-        timestamp: DateTime.utc_now() |> DateTime.to_unix(:nanosecond),
+        timestamp: div(now, 1_000_000_000),
         id: id,
         query: query |> construct_query_name(),
         status_code: 200,

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "absinthe": {:git, "https://github.com/absinthe-graphql/absinthe.git", "9f5f9ea27f30e69e32ebcb81042f23ce3427d607", []},
+  "absinthe": {:git, "https://github.com/absinthe-graphql/absinthe.git", "d1485f728b0fe4cea90cfbc45e92864eeb1c07dd", []},
   "absinthe_metrics": {:hex, :absinthe_metrics, "1.0.0", "c4dd0444168a1d32a432cab2ced498069e58fd4b90aa9e1ec16b49557bee2cf1", [:mix], [{:absinthe, "~> 1.3", [hex: :absinthe, repo: "hexpm", optional: false]}, {:prometheus_ex, "~> 3.0", [hex: :prometheus_ex, repo: "hexpm", optional: true]}], "hexpm", "c21485a8d207c78c32040b9588c254c43362fbaf7dfaa50a7c7b016f015f5643"},
   "absinthe_phoenix": {:git, "https://github.com/absinthe-graphql/absinthe_phoenix.git", "1d832570ffdd031a209a9218c6fc54cde4488665", []},
   "absinthe_plug": {:git, "https://github.com/absinthe-graphql/absinthe_plug.git", "7c52e5d583252b8d44bed395f16a01b1c15fde10", []},


### PR DESCRIPTION
#### Summary
The newer versions of Absinthe now error on not correct typespecs. Our
frontend has queries where the type of intervals is not properly set to
Int. First the FE will be fixed and we'll wait 1-2 weeks so there are
no clients with cached old versions that might cause troubles.

![image](https://user-images.githubusercontent.com/6518376/82650885-0c756f80-9c24-11ea-94e9-c9781d866a7a.png)

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
