### PR TITLE
Remove 'More info at' parts of the signal

### DIFF
--- a/docs/user-triggers-api.md
+++ b/docs/user-triggers-api.md
@@ -831,7 +831,7 @@ mutation {
       "activity": [
         {
           "payload": {
-            "all": "Trending words for: `2019-03-11`\n\n```\nWord    | Score\n------- | -------\ntheta   | 704\nxlm     | 425\nqlc     | 224\nnxs     | 210\nmining  | 207\nnano    | 196\nherpes  | 178\nxrp     | 178\nasic    | 152\ntattoos | 128\n```\nMore info: http://localhost:4000/sonar\n"
+            "all": "Trending words for: `2019-03-11`\n\n```\nWord    | Score\n------- | -------\ntheta   | 704\nxlm     | 425\nqlc     | 224\nnxs     | 210\nmining  | 207\nnano    | 196\nherpes  | 178\nxrp     | 178\nasic    | 152\ntattoos | 128\n```\n"
           },
           "triggeredAt": "2019-03-11T11:56:41.970284Z",
           "trigger": {

--- a/lib/sanbase/notifications/discord/daa_signal.ex
+++ b/lib/sanbase/notifications/discord/daa_signal.ex
@@ -149,7 +149,6 @@ defmodule Sanbase.Notifications.Discord.DaaSignal do
     }%** for the last **#{hours} hour(s)**.
     Daily Active Addresses for last **#{hours} hour(s)** : **#{current_daa - last_triggered_daa}**
     Average Daily Active Addresses for last **#{config_timeframe_from() - 1} days**: **#{avg_daa}**.
-    More info here: #{Project.sanbase_link(project)}
     """
 
     {project, content, current_daa}

--- a/lib/sanbase/signals/trigger/settings/daily_active_addresses_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/daily_active_addresses_settings.ex
@@ -153,7 +153,6 @@ defmodule Sanbase.Signal.Trigger.DailyActiveAddressesSettings do
       #{curr_value_template}.
 
       Average 24 hours Active Addresses for last **{{interval}}*: **{{average_value}}**.
-      More info here: #{Project.sanbase_link(project)}
       """
 
       {template, kv}

--- a/lib/sanbase/signals/trigger/settings/eth_wallet_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/eth_wallet_trigger_settings.ex
@@ -206,8 +206,6 @@ defmodule Sanbase.Signal.Trigger.EthWalletTriggerSettings do
       template = """
       🔔 \#{{project_ticker}} | **{{project_name}}**'s {{asset}} balance {{balance_change_text}} by {{balance_change}} since {{since}}.
       was: {{previous_balance}}, now: {{balance}}.
-
-      More info here: #{Project.sanbase_link(project)}
       """
 
       {template, kv}
@@ -233,8 +231,6 @@ defmodule Sanbase.Signal.Trigger.EthWalletTriggerSettings do
       template = """
       🔔The address {{address}}'s {{asset}} balance #{operation_text(settings.operation)} by {{balance_change_abs}} since {{since}}.
       was: {{previous_balance}, now: {{balance}}
-
-      More info here: {{historical_balance_link}}
       """
 
       {template, kv}

--- a/lib/sanbase/signals/trigger/settings/metric_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/metric_trigger_settings.ex
@@ -195,7 +195,6 @@ defmodule Sanbase.Signal.Trigger.MetricTriggerSettings do
         operation_template
       }.
       #{curr_value_template}.
-      More info here: #{Project.sanbase_link(project)}
       """
 
       {template, kv}

--- a/lib/sanbase/signals/trigger/settings/price_absolute_change_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/price_absolute_change_settings.ex
@@ -145,8 +145,6 @@ defmodule Sanbase.Signal.Trigger.PriceAbsoluteChangeSettings do
       template = """
       🔔 \#{{project_ticker}} | **{{project_name}}**'s USD price #{operation_template}.
       #{curr_value_template}.
-
-      More information for the project you can find here: #{Project.sanbase_link(project)}
       """
 
       {template, kv}

--- a/lib/sanbase/signals/trigger/settings/price_percent_change_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/price_percent_change_settings.ex
@@ -161,8 +161,6 @@ defmodule Sanbase.Signal.Trigger.PricePercentChangeSettings do
       template = """
       🔔 \#{{project_ticker}} | **{{project_name}}**'s USD price #{operation_template}.
       #{curr_value_template}.
-
-      More info here: #{Project.sanbase_link(project)}
       """
 
       {template, kv}

--- a/lib/sanbase/signals/trigger/settings/price_volume_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/price_volume_trigger_settings.ex
@@ -154,8 +154,6 @@ defmodule Sanbase.Signal.Trigger.PriceVolumeDifferenceTriggerSettings do
       template = """
       🔔 \#{{project_ticker}} | **{{project_name}}**'s price and trading volume have diverged.
       The price is increasing while the volume is decreasing.
-
-      More info here: #{Sanbase.Model.Project.sanbase_link(project)}
       """
 
       {template, kv}

--- a/lib/sanbase/signals/trigger/settings/trending_words_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/trending_words_trigger_settings.ex
@@ -196,7 +196,6 @@ defmodule Sanbase.Signal.Trigger.TrendingWordsTriggerSettings do
       ```
       {{trending_words_str}}
       ```
-      More info: {{sonar_url}}
       """
 
       {template, kv}
@@ -213,8 +212,6 @@ defmodule Sanbase.Signal.Trigger.TrendingWordsTriggerSettings do
 
       template = """
       🔔 The word {{trending_words_str}} is in the trending words.
-
-      More info here: {{trending_words_url}}
       """
 
       {template, kv}
@@ -234,8 +231,6 @@ defmodule Sanbase.Signal.Trigger.TrendingWordsTriggerSettings do
 
       template = """
       🔔 The words {{trending_words_str}} are in the trending words.
-
-      More info here: {{trending_words_url}}
       """
 
       {template, kv}
@@ -252,8 +247,6 @@ defmodule Sanbase.Signal.Trigger.TrendingWordsTriggerSettings do
 
       template = """
       🔔 \#{{project_ticker}} | **{{project_name}}** is in the trending words.
-
-      More info here: #{Project.sanbase_link(project)}
       """
 
       {template, kv}

--- a/lib/sanbase/signals/trigger/settings/wallet_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/wallet_trigger_settings.ex
@@ -238,8 +238,6 @@ defmodule Sanbase.Signal.Trigger.WalletTriggerSettings do
         operation_template
       }.
       #{curr_value_template}
-
-      More information about the project can be found here: #{Project.sanbase_link(project)}
       """
 
       {template, kv}


### PR DESCRIPTION
#### Summary
We are linking to the alert that triggered the signal, so there is no point in `More info at: {projec_url}` now.

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
