### PR TITLE
Remove handlebars template for trial follow-up emails

### DIFF
--- a/lib/sanbase/billing/subscription/sign_up_trial.ex
+++ b/lib/sanbase/billing/subscription/sign_up_trial.ex
@@ -260,9 +260,7 @@ defmodule Sanbase.Billing.Subscription.SignUpTrial do
         }"
       )
 
-      Sanbase.MandrillApi.send(template, user.email, %{name: user.username || user.email}, %{
-        merge_language: "handlebars"
-      })
+      Sanbase.MandrillApi.send(template, user.email, %{name: user.username || user.email})
 
       update_trial(sign_up_trial, %{email_type => true})
     end

--- a/test/sanbase/billing/sign_up_trial_test.exs
+++ b/test/sanbase/billing/sign_up_trial_test.exs
@@ -25,7 +25,7 @@ defmodule Sanbase.Billing.SignUpTrialTest do
 
       sign_up_trial = SignUpTrial |> Repo.all() |> hd()
 
-      assert_called(Sanbase.MandrillApi.send("first-edu-email", :_, :_, :_))
+      assert_called(Sanbase.MandrillApi.send("first-edu-email", :_, :_))
       assert sign_up_trial.sent_first_education_email
     end
 
@@ -43,7 +43,7 @@ defmodule Sanbase.Billing.SignUpTrialTest do
 
       sign_up_trial = SignUpTrial |> Repo.all() |> hd()
 
-      assert_called(Sanbase.MandrillApi.send("second-edu-email", :_, :_, :_))
+      assert_called(Sanbase.MandrillApi.send("second-edu-email", :_, :_))
       assert sign_up_trial.sent_second_education_email
     end
 
@@ -57,7 +57,7 @@ defmodule Sanbase.Billing.SignUpTrialTest do
 
         sign_up_trial = SignUpTrial |> Repo.all() |> hd()
 
-        assert_called(Sanbase.MandrillApi.send("trial-finished", :_, :_, :_))
+        assert_called(Sanbase.MandrillApi.send("trial-finished", :_, :_))
         assert sign_up_trial.sent_cc_will_be_charged
       end
     end

--- a/test/sanbase/billing/subscription_test.exs
+++ b/test/sanbase/billing/subscription_test.exs
@@ -95,7 +95,7 @@ defmodule Sanbase.Billing.SubscriptionTest do
         Subscription.cancel_about_to_expire_trials()
 
         assert_called(Sanbase.StripeApi.delete_subscription(subscription.stripe_id))
-        assert_called(Sanbase.MandrillApi.send("trial-finished-without-card", :_, :_, :_))
+        assert_called(Sanbase.MandrillApi.send("trial-finished-without-card", :_, :_))
       end
     end
 
@@ -123,7 +123,7 @@ defmodule Sanbase.Billing.SubscriptionTest do
         Subscription.cancel_about_to_expire_trials()
 
         assert_called(Sanbase.StripeApi.delete_subscription(subscription.stripe_id))
-        assert_called(Sanbase.MandrillApi.send("trial-finished-without-card", :_, :_, :_))
+        assert_called(Sanbase.MandrillApi.send("trial-finished-without-card", :_, :_))
       end
     end
 
@@ -151,7 +151,7 @@ defmodule Sanbase.Billing.SubscriptionTest do
         Subscription.cancel_about_to_expire_trials()
 
         assert_called(Sanbase.StripeApi.delete_subscription(subscription.stripe_id))
-        refute called(Sanbase.MandrillApi.send("trial-finished-without-card", :_, :_, :_))
+        refute called(Sanbase.MandrillApi.send("trial-finished-without-card", :_, :_))
       end
     end
   end


### PR DESCRIPTION
{{name}} -> "\*|name|\*" in all follow-up templates
templates that use `name` should be changed :
* "sanbase-post-registration"
* "first-edu-email"
* "second-edu-email"
* "trial-three-days-before-end"
* "trial-finished"
* "trial-finished-without-card"

Also adding an ''/unsubscribe" to the unsubscribe link.
