### PR TITLE
Featured only public

### DIFF
--- a/lib/sanbase/chart/configuration.ex
+++ b/lib/sanbase/chart/configuration.ex
@@ -46,6 +46,8 @@ defmodule Sanbase.Chart.Configuration do
     get_chart_configuration(config_id, querying_user_id)
   end
 
+  def is_public?(%__MODULE__{is_public: is_public}), do: is_public
+
   def user_configurations(user_id, querying_user_id, project_id \\ nil) do
     user_chart_configurations_query(user_id, querying_user_id, project_id)
     |> Repo.all()

--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -126,6 +126,8 @@ defmodule Sanbase.Insight.Post do
   def draft(), do: @draft
   def preloads(), do: @preloads
 
+  def is_published?(%Post{ready_state: ready_state}), do: ready_state == @published
+
   def by_id(post_id) do
     from(p in __MODULE__, preload: ^@preloads)
     |> Repo.get(post_id)

--- a/lib/sanbase/signals/user_trigger.ex
+++ b/lib/sanbase/signals/user_trigger.ex
@@ -48,6 +48,8 @@ defmodule Sanbase.Signal.UserTrigger do
     ut |> cast(attrs, [])
   end
 
+  def is_public?(%__MODULE__{trigger: %{is_public: is_public}}), do: is_public
+
   @doc false
   @spec create_changeset(%UserTrigger{}, map()) :: Ecto.Changeset.t()
   def create_changeset(%UserTrigger{} = user_triggers, attrs \\ %{}) do

--- a/lib/sanbase/user_lists/user_list.ex
+++ b/lib/sanbase/user_lists/user_list.ex
@@ -72,6 +72,8 @@ defmodule Sanbase.UserList do
     |> Repo.one()
   end
 
+  def is_public?(%__MODULE__{is_public: is_public}), do: is_public
+
   @doc ~s"""
   Return a list of all projects in a watchlist.
   """

--- a/test/sanbase/featured_item/featured_item_test.exs
+++ b/test/sanbase/featured_item/featured_item_test.exs
@@ -11,29 +11,35 @@ defmodule Sanbase.FeaturedItemTest do
       assert FeaturedItem.insights() == []
     end
 
-    test "marking chart configurations as featured" do
-      chart_config = insert(:chart_configuration)
+    test "cannot make private chart configuration featured" do
+      chart_config = insert(:chart_configuration, is_public: false)
+      {:error, error_msg} = FeaturedItem.update_item(chart_config, true)
+      assert error_msg =~ "cannot be made featured"
+    end
 
-      FeaturedItem.update_item(chart_config, true)
+    test "marking chart configurations as featured" do
+      chart_config = insert(:chart_configuration, is_public: true)
+
+      :ok = FeaturedItem.update_item(chart_config, true)
       [featured_chart_config] = FeaturedItem.chart_configurations()
 
       assert featured_chart_config.id == chart_config.id
     end
 
     test "unmarking chart configurations as featured" do
-      chart_config = insert(:chart_configuration)
+      chart_config = insert(:chart_configuration, is_public: true)
 
-      FeaturedItem.update_item(chart_config, true)
-      FeaturedItem.update_item(chart_config, false)
+      :ok = FeaturedItem.update_item(chart_config, true)
+      :ok = FeaturedItem.update_item(chart_config, false)
       assert FeaturedItem.chart_configurations() == []
     end
 
     test "marking chart configuration as featured is idempotent" do
-      chart_config = insert(:chart_configuration)
+      chart_config = insert(:chart_configuration, is_public: true)
 
-      FeaturedItem.update_item(chart_config, true)
-      FeaturedItem.update_item(chart_config, true)
-      FeaturedItem.update_item(chart_config, true)
+      :ok = FeaturedItem.update_item(chart_config, true)
+      :ok = FeaturedItem.update_item(chart_config, true)
+      :ok = FeaturedItem.update_item(chart_config, true)
       [featured_chart_config] = FeaturedItem.chart_configurations()
       assert featured_chart_config.id == chart_config.id
     end
@@ -44,9 +50,15 @@ defmodule Sanbase.FeaturedItemTest do
       assert FeaturedItem.insights() == []
     end
 
+    test "cannot make not published insights featured" do
+      insight = insert(:post, state: Post.approved_state(), ready_state: Post.draft())
+      {:error, error_msg} = FeaturedItem.update_item(insight, true)
+      assert error_msg =~ "cannot be made featured"
+    end
+
     test "marking insights as featured" do
       insight = insert(:post, state: Post.approved_state(), ready_state: Post.published())
-      FeaturedItem.update_item(insight, true)
+      :ok = FeaturedItem.update_item(insight, true)
       [featured_insight] = FeaturedItem.insights()
 
       assert featured_insight.id == insight.id
@@ -54,17 +66,17 @@ defmodule Sanbase.FeaturedItemTest do
 
     test "unmarking insights as featured" do
       insight = insert(:post, state: Post.approved_state(), ready_state: Post.published())
-      FeaturedItem.update_item(insight, true)
-      FeaturedItem.update_item(insight, false)
+      :ok = FeaturedItem.update_item(insight, true)
+      :ok = FeaturedItem.update_item(insight, false)
       assert FeaturedItem.insights() == []
     end
 
     test "marking insight as featured is idempotent" do
       insight = insert(:post, state: Post.approved_state(), ready_state: Post.published())
 
-      FeaturedItem.update_item(insight, true)
-      FeaturedItem.update_item(insight, true)
-      FeaturedItem.update_item(insight, true)
+      :ok = FeaturedItem.update_item(insight, true)
+      :ok = FeaturedItem.update_item(insight, true)
+      :ok = FeaturedItem.update_item(insight, true)
       [featured_insight] = FeaturedItem.insights()
       assert featured_insight.id == insight.id
     end
@@ -75,24 +87,30 @@ defmodule Sanbase.FeaturedItemTest do
       assert FeaturedItem.watchlists() == []
     end
 
+    test "cannot make private watchlist featured" do
+      watchlist = insert(:watchlist, is_public: false)
+      {:error, error_msg} = FeaturedItem.update_item(watchlist, true)
+      assert error_msg =~ "cannot be made featured"
+    end
+
     test "marking watchlists as featured" do
-      watchlist = insert(:watchlist) |> Sanbase.Repo.preload([:list_items])
-      FeaturedItem.update_item(watchlist, true)
+      watchlist = insert(:watchlist, is_public: true) |> Sanbase.Repo.preload([:list_items])
+      :ok = FeaturedItem.update_item(watchlist, true)
       assert FeaturedItem.watchlists() == [watchlist]
     end
 
     test "unmarking watchlists as featured" do
-      watchlist = insert(:watchlist)
+      watchlist = insert(:watchlist, is_public: true)
       FeaturedItem.update_item(watchlist, true)
       FeaturedItem.update_item(watchlist, false)
       assert FeaturedItem.watchlists() == []
     end
 
     test "marking watchlist as featured is idempotent" do
-      watchlist = insert(:watchlist) |> Sanbase.Repo.preload([:list_items])
-      FeaturedItem.update_item(watchlist, true)
-      FeaturedItem.update_item(watchlist, true)
-      FeaturedItem.update_item(watchlist, true)
+      watchlist = insert(:watchlist, is_public: true) |> Sanbase.Repo.preload([:list_items])
+      :ok = FeaturedItem.update_item(watchlist, true)
+      :ok = FeaturedItem.update_item(watchlist, true)
+      :ok = FeaturedItem.update_item(watchlist, true)
 
       assert FeaturedItem.watchlists() == [watchlist]
     end
@@ -103,24 +121,30 @@ defmodule Sanbase.FeaturedItemTest do
       assert FeaturedItem.user_triggers() == []
     end
 
+    test "cannot make private user_trigger featured" do
+      user_trigger = insert(:user_trigger, is_public: false)
+      {:error, error_msg} = FeaturedItem.update_item(user_trigger, true)
+      assert error_msg =~ "cannot be made featured"
+    end
+
     test "marking user_triggers as featured" do
-      user_trigger = insert(:user_trigger) |> Sanbase.Repo.preload([:tags])
-      FeaturedItem.update_item(user_trigger, true)
+      user_trigger = insert(:user_trigger, is_public: true) |> Sanbase.Repo.preload([:tags])
+      :ok = FeaturedItem.update_item(user_trigger, true)
       assert FeaturedItem.user_triggers() == [user_trigger]
     end
 
     test "unmarking user_triggers as featured" do
-      user_trigger = insert(:user_trigger)
-      FeaturedItem.update_item(user_trigger, true)
-      FeaturedItem.update_item(user_trigger, false)
+      user_trigger = insert(:user_trigger, is_public: true)
+      :ok = FeaturedItem.update_item(user_trigger, true)
+      :ok = FeaturedItem.update_item(user_trigger, false)
       assert FeaturedItem.user_triggers() == []
     end
 
     test "marking user_trigger as featured is idempotent" do
-      user_trigger = insert(:user_trigger) |> Sanbase.Repo.preload([:tags])
-      FeaturedItem.update_item(user_trigger, true)
-      FeaturedItem.update_item(user_trigger, true)
-      FeaturedItem.update_item(user_trigger, true)
+      user_trigger = insert(:user_trigger, is_public: true) |> Sanbase.Repo.preload([:tags])
+      :ok = FeaturedItem.update_item(user_trigger, true)
+      :ok = FeaturedItem.update_item(user_trigger, true)
+      :ok = FeaturedItem.update_item(user_trigger, true)
 
       assert FeaturedItem.user_triggers() == [user_trigger]
     end

--- a/test/sanbase_web/graphql/featured_item/featured_item_api_test.exs
+++ b/test/sanbase_web/graphql/featured_item/featured_item_api_test.exs
@@ -15,9 +15,9 @@ defmodule Sanbase.FeaturedItemApiTest do
     end
 
     test "marking watchlists as featured", context do
-      chart_configuration = insert(:chart_configuration)
+      chart_configuration = insert(:chart_configuration, is_public: true)
 
-      FeaturedItem.update_item(chart_configuration, true)
+      :ok = FeaturedItem.update_item(chart_configuration, true)
 
       assert chart_configurations(context.conn) == %{
                "data" => %{
@@ -32,9 +32,9 @@ defmodule Sanbase.FeaturedItemApiTest do
     end
 
     test "unmarking chart configurations as featured", context do
-      chart_configuration = insert(:chart_configuration)
-      FeaturedItem.update_item(chart_configuration, true)
-      FeaturedItem.update_item(chart_configuration, false)
+      chart_configuration = insert(:chart_configuration, is_public: true)
+      :ok = FeaturedItem.update_item(chart_configuration, true)
+      :ok = FeaturedItem.update_item(chart_configuration, false)
 
       assert chart_configurations(context.conn) == %{
                "data" => %{"featuredChartConfigurations" => []}
@@ -42,10 +42,10 @@ defmodule Sanbase.FeaturedItemApiTest do
     end
 
     test "marking chart configuration as featured is idempotent", context do
-      chart_configuration = insert(:chart_configuration)
-      FeaturedItem.update_item(chart_configuration, true)
-      FeaturedItem.update_item(chart_configuration, true)
-      FeaturedItem.update_item(chart_configuration, true)
+      chart_configuration = insert(:chart_configuration, is_public: true)
+      :ok = FeaturedItem.update_item(chart_configuration, true)
+      :ok = FeaturedItem.update_item(chart_configuration, true)
+      :ok = FeaturedItem.update_item(chart_configuration, true)
 
       assert chart_configurations(context.conn) == %{
                "data" => %{
@@ -84,7 +84,7 @@ defmodule Sanbase.FeaturedItemApiTest do
       insight = insert(:post, state: Post.approved_state(), ready_state: Post.published())
       tags = insight.tags |> Enum.map(fn %{name: name} -> %{"name" => name} end)
 
-      FeaturedItem.update_item(insight, true)
+      :ok = FeaturedItem.update_item(insight, true)
 
       assert fetch_insights(context.conn) == %{
                "data" => %{
@@ -95,17 +95,17 @@ defmodule Sanbase.FeaturedItemApiTest do
              }
     end
 
-    test "Only approved and published insights can be featured", context do
+    test "Not published insight cannot be featured", context do
       insight = insert(:post)
-      FeaturedItem.update_item(insight, true)
+      {:error, _} = FeaturedItem.update_item(insight, true)
 
       assert fetch_insights(context.conn) == %{"data" => %{"featuredInsights" => []}}
     end
 
     test "unmarking insights as featured", context do
       insight = insert(:post, state: Post.approved_state(), ready_state: Post.published())
-      FeaturedItem.update_item(insight, true)
-      FeaturedItem.update_item(insight, false)
+      :ok = FeaturedItem.update_item(insight, true)
+      :ok = FeaturedItem.update_item(insight, false)
       assert fetch_insights(context.conn) == %{"data" => %{"featuredInsights" => []}}
     end
 
@@ -152,8 +152,8 @@ defmodule Sanbase.FeaturedItemApiTest do
     end
 
     test "marking watchlists as featured", context do
-      watchlist = insert(:watchlist)
-      FeaturedItem.update_item(watchlist, true)
+      watchlist = insert(:watchlist, is_public: true)
+      :ok = FeaturedItem.update_item(watchlist, true)
 
       assert fetch_watchlists(context.conn) == %{
                "data" => %{
@@ -165,17 +165,17 @@ defmodule Sanbase.FeaturedItemApiTest do
     end
 
     test "unmarking watchlists as featured", context do
-      watchlist = insert(:watchlist)
-      FeaturedItem.update_item(watchlist, true)
-      FeaturedItem.update_item(watchlist, false)
+      watchlist = insert(:watchlist, is_public: true)
+      :ok = FeaturedItem.update_item(watchlist, true)
+      :ok = FeaturedItem.update_item(watchlist, false)
       assert fetch_watchlists(context.conn) == %{"data" => %{"featuredWatchlists" => []}}
     end
 
     test "marking watchlist as featured is idempotent", context do
-      watchlist = insert(:watchlist)
-      FeaturedItem.update_item(watchlist, true)
-      FeaturedItem.update_item(watchlist, true)
-      FeaturedItem.update_item(watchlist, true)
+      watchlist = insert(:watchlist, is_public: true)
+      :ok = FeaturedItem.update_item(watchlist, true)
+      :ok = FeaturedItem.update_item(watchlist, true)
+      :ok = FeaturedItem.update_item(watchlist, true)
 
       assert fetch_watchlists(context.conn) == %{
                "data" => %{
@@ -208,8 +208,8 @@ defmodule Sanbase.FeaturedItemApiTest do
     end
 
     test "marking user_triggers as featured", context do
-      user_trigger = insert(:user_trigger)
-      FeaturedItem.update_item(user_trigger, true)
+      user_trigger = insert(:user_trigger, is_public: true)
+      :ok = FeaturedItem.update_item(user_trigger, true)
 
       assert fetch_user_triggers(context.conn) == %{
                "data" => %{
@@ -226,17 +226,17 @@ defmodule Sanbase.FeaturedItemApiTest do
     end
 
     test "unmarking user_triggers as featured", context do
-      user_trigger = insert(:user_trigger)
-      FeaturedItem.update_item(user_trigger, true)
-      FeaturedItem.update_item(user_trigger, false)
+      user_trigger = insert(:user_trigger, is_public: true)
+      :ok = FeaturedItem.update_item(user_trigger, true)
+      :ok = FeaturedItem.update_item(user_trigger, false)
       assert fetch_user_triggers(context.conn) == %{"data" => %{"featuredUserTriggers" => []}}
     end
 
     test "marking user_trigger as featured is idempotent", context do
-      user_trigger = insert(:user_trigger)
-      FeaturedItem.update_item(user_trigger, true)
-      FeaturedItem.update_item(user_trigger, true)
-      FeaturedItem.update_item(user_trigger, true)
+      user_trigger = insert(:user_trigger, is_public: true)
+      :ok = FeaturedItem.update_item(user_trigger, true)
+      :ok = FeaturedItem.update_item(user_trigger, true)
+      :ok = FeaturedItem.update_item(user_trigger, true)
 
       assert fetch_user_triggers(context.conn) == %{
                "data" => %{


### PR DESCRIPTION
#### Summary
Private/not published post/triggers/watchlists/chart configs cannot be made featured, but they can be marked as not-featured. This later behaviour is so if an item is made private the featured status can be changed.

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
