### PR TITLE
Add timeseries_data_complexity field to getMetric

### DIFF
--- a/lib/sanbase_web/graphql/complexity/complexity.ex
+++ b/lib/sanbase_web/graphql/complexity/complexity.ex
@@ -2,23 +2,29 @@ defmodule SanbaseWeb.Graphql.Complexity do
   require Logger
 
   @compile :inline_list_funcs
-  @compile inline: [calculate_complexity: 2, interval_seconds: 1, years_difference_weighted: 2]
-
+  @compile inline: [
+             calculate_complexity: 3,
+             interval_seconds: 1,
+             years_difference_weighted: 2,
+             get_metric_name: 1
+           ]
   @doc ~S"""
   Internal services use basic authentication. Return complexity = 0 to allow them
   to access everything without limits.
   """
-  def from_to_interval(_, _, %{context: %{auth: %{auth_method: :basic}}} = struct) do
+  def from_to_interval(_, _, %{context: %{auth: %{auth_method: :basic}}}) do
     # Does not pattern match on `%Absinthe.Complexity{}` so `%Absinthe.Resolution{}`
     # can be passed. This is possible because only the context is used
     0
   end
 
-  def from_to_interval(args, child_complexity, %{
-        context: %{auth: %{subscription: subscription}}
-      })
+  def from_to_interval(
+        args,
+        child_complexity,
+        %{context: %{auth: %{subscription: subscription}}} = struct
+      )
       when not is_nil(subscription) do
-    complexity = calculate_complexity(args, child_complexity)
+    complexity = calculate_complexity(args, child_complexity, struct)
 
     case Sanbase.Billing.Plan.plan_atom_name(subscription.plan) do
       :free -> complexity
@@ -36,19 +42,20 @@ defmodule SanbaseWeb.Graphql.Complexity do
   based only on the supplied arguments and avoids accessing the DB if the query
   is rejected.
   """
-  def from_to_interval(%{} = args, child_complexity, _complexity) do
-    calculate_complexity(args, child_complexity)
+  def from_to_interval(%{} = args, child_complexity, struct) do
+    calculate_complexity(args, child_complexity, struct)
   end
 
   # Private functions
 
-  defp calculate_complexity(%{from: from, to: to} = args, child_complexity) do
+  defp calculate_complexity(%{from: from, to: to} = args, child_complexity, struct) do
     seconds_difference = Timex.diff(from, to, :seconds) |> abs
     years_difference_weighted = years_difference_weighted(from, to)
     interval_seconds = interval_seconds(args) |> max(1)
+    metric = get_metric_name(struct)
 
     complexity_weight =
-      with metric when is_binary(metric) <- Process.get(:__metric_name_from_get_metric_api__),
+      with metric when is_binary(metric) <- metric,
            weight when is_number(weight) <- Sanbase.Metric.complexity_weight(metric) do
         weight
       else
@@ -58,6 +65,12 @@ defmodule SanbaseWeb.Graphql.Complexity do
     (child_complexity * (seconds_difference / interval_seconds) * years_difference_weighted *
        complexity_weight)
     |> Sanbase.Math.to_integer()
+  end
+
+  defp get_metric_name(%{source: %{metric: metric}}), do: metric
+
+  defp get_metric_name(_) do
+    Process.get(:__metric_name_from_get_metric_api__)
   end
 
   defp interval_seconds(args) do

--- a/lib/sanbase_web/graphql/complexity/complexity.ex
+++ b/lib/sanbase_web/graphql/complexity/complexity.ex
@@ -3,15 +3,18 @@ defmodule SanbaseWeb.Graphql.Complexity do
 
   @compile :inline_list_funcs
   @compile inline: [calculate_complexity: 2, interval_seconds: 1, years_difference_weighted: 2]
+
   @doc ~S"""
   Internal services use basic authentication. Return complexity = 0 to allow them
   to access everything without limits.
   """
-  def from_to_interval(_, _, %Absinthe.Complexity{context: %{auth: %{auth_method: :basic}}}) do
+  def from_to_interval(_, _, %{context: %{auth: %{auth_method: :basic}}} = struct) do
+    # Does not pattern match on `%Absinthe.Complexity{}` so `%Absinthe.Resolution{}`
+    # can be passed. This is possible because only the context is used
     0
   end
 
-  def from_to_interval(args, child_complexity, %Absinthe.Complexity{
+  def from_to_interval(args, child_complexity, %{
         context: %{auth: %{subscription: subscription}}
       })
       when not is_nil(subscription) do

--- a/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
@@ -27,6 +27,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     {:ok, AccessChecker.get_available_metrics_for_plan(product, plan)}
   end
 
+  def timeseries_data_complexity(_root, args, resolution) do
+    complexity = SanbaseWeb.Graphql.Complexity.from_to_interval(args, 2, resolution)
+    {:ok, complexity |> Sanbase.Math.to_integer()}
+  end
+
   def get_available_metrics(_root, _args, _resolution), do: {:ok, Metric.available_metrics()}
 
   def get_available_slugs(_root, _args, %{source: %{metric: metric}}),

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -250,6 +250,19 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     end
 
     @desc ~s"""
+    Returns the complexity that the metric would have given the timerange
+    arguments. The complexity is computed as if both `value` and `datetime` fields
+    are queried.
+    """
+    field :timeseries_data_complexity, :integer do
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+      arg(:interval, :interval, default_value: "1d")
+
+      resolve(&MetricResolver.timeseries_data_complexity/3)
+    end
+
+    @desc ~s"""
     A histogram is an approximate representation of the distribution of numerical or
     categorical data.
 


### PR DESCRIPTION
#### Summary
Request:
```graphql
{
  getMetric(metric: "price_usd"){
    timeseriesDataComplexity(
      from:"2020-01-01T00:00:00Z"
      to: "2020-05-01T00:00:00Z"
      interval: "1d")
  }
}
```
![image](https://user-images.githubusercontent.com/6518376/83502504-5b47c280-a4ca-11ea-8226-404c19ed798f.png)

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
