### PR TITLE
Fix currently trading projects function

### DIFF
--- a/lib/sanbase/model/project/list/list.ex
+++ b/lib/sanbase/model/project/list/list.ex
@@ -399,10 +399,13 @@ defmodule Sanbase.Model.Project.List do
   def by_name_ticker_slug(values, opts) do
     values = List.wrap(values)
 
-    projects_query(opts)
-    |> where([p], fragment("lower(?)", p.name) in ^values)
-    |> or_where([p], fragment("lower(?)", p.ticker) in ^values)
-    |> or_where([p], fragment("lower(?)", p.slug) in ^values)
+    from(
+      p in projects_query(opts),
+      where:
+        fragment("lower(?)", p.name) in ^values or
+          fragment("lower(?)", p.ticker) in ^values or
+          fragment("lower(?)", p.slug) in ^values
+    )
     |> Repo.all()
   end
 


### PR DESCRIPTION
Usage of or_where was completely undermining the other checks. It had to
be replaced with `AND where(X or Y or Z). This was making projects with
is_hidden=true to be included

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
