### PR TITLE
Add dev_activity_change_30d metric

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -1478,6 +1478,22 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Development Activity 30 Days Change",
+    "name": "dev_activity_change_30d",
+    "metric": "dev_activity_change_30d",
+    "version": "2019-01-01",
+    "access": "free",
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "intraday_metrics",
+    "has_incomplete_data": true,
+    "data_type": "timeseries"
+  },
+  {
     "human_readable_name": "Stock to Flow",
     "name": "stock_to_flow",
     "metric": "stock_to_flow_ratio",

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -25,6 +25,7 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "daily_trading_volume_usd",
         "dev_activity",
         "dev_activity_1d",
+        "dev_activity_change_30d",
         "github_activity",
         "dev_activity_contributors_count",
         "github_activity_contributors_count",


### PR DESCRIPTION
#### Summary
Now this metric can be used to properly fill the `Buidl Heroes` page table:
![image](https://user-images.githubusercontent.com/6518376/83757645-799ff080-a679-11ea-8a18-2a2b9faf20ca.png)

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
