### PR TITLE
Add webhook as a signal channel

### DIFF
--- a/docs/user-triggers-api.md
+++ b/docs/user-triggers-api.md
@@ -43,7 +43,7 @@ These are the fields describing a trigger.
 
 - **type** Defines the type of the trigger. Can be one of: `["daily_active_addresses", "price_absolute_change", "price_percent_change", "trending_words", "price_volume_difference", "metric_signal"]`
 - **target**: Slug or list of slugs or watchlist or ethereum addresses or list of ethereum addresses - `{"slug": "naga"} | {"slug": ["ethereum", "santiment"]} | {"watchlist_id": watchlsit_id} | {"eth_address": "0x123"} | {"eth_address": ["0x123", "0x234"]}`.
-- **channel**: A channel where the signal is sent. Can be one of `"telegram" | "email"` or a list of both.
+- **channel**: A channel where the signal is sent. Can be one of `"telegram" | "email" | "web_push" | {"webhook": <webhook_url>}` or a list of any combination.
 - **time_window**: `1d`, `4w`, `1h` - Time string we use throughout the API for `interval`
 - **operation** - A map describing the operation that triggers the signal. Check the examples.
 - **threshold** - Float threshold used in `price_volume_difference`
@@ -58,7 +58,7 @@ These are the fields describing a trigger.
 {
   "type": "price_absolute_change",
   "target": { "slug": "santiment" },
-  "channel": "telegram",
+  "channel": ["telegram", { "webhook": "http://mywebhook.com/signal" }],
   "operation": { "above": 0.51 }
 }
 ```

--- a/lib/sanbase/signals/signal.ex
+++ b/lib/sanbase/signals/signal.ex
@@ -34,8 +34,7 @@ defimpl Sanbase.Signal, for: Any do
           id: user_trigger_id,
           trigger: %{
             settings: %{
-              payload: payload_map,
-              template_kv: template_kv
+              payload: payload_map
             }
           }
         },

--- a/lib/sanbase/signals/signal.ex
+++ b/lib/sanbase/signals/signal.ex
@@ -23,9 +23,46 @@ defimpl Sanbase.Signal, for: Any do
     |> Enum.map(fn
       "telegram" -> send_telegram(user_trigger)
       "email" -> send_email(user_trigger)
+      %{webhook: webhook_url} -> send_webhook(user_trigger, webhook_url)
       "web_push" -> []
     end)
     |> List.flatten()
+  end
+
+  def send_webhook(
+        %{
+          id: user_trigger_id,
+          trigger: %{
+            settings: %{
+              payload: payload_map,
+              template_kv: template_kv
+            }
+          }
+        },
+        webhook_url
+      ) do
+    Enum.map(payload_map, fn {identifier, payload} ->
+      payload =
+        %{
+          timestamp: DateTime.utc_now() |> DateTime.to_unix(),
+          identifier: identifier,
+          payload: payload,
+          trigger_id: user_trigger_id,
+          trigger_url: SanbaseWeb.Endpoint.show_signal_url(user_trigger_id)
+        }
+        |> Jason.encode!()
+
+      case HTTPoison.post(webhook_url, payload) do
+        {:ok, %HTTPoison.Response{status_code: 200}} ->
+          {identifier, :ok}
+
+        {:ok, %HTTPoison.Response{status_code: code}} ->
+          {identifier, {:error, "Error sending webhook alert. Status code: #{code}"}}
+
+        {:error, reason} ->
+          {identifier, {:error, "Error sending webhook alert. Reason: #{inspect(reason)}"}}
+      end
+    end)
   end
 
   def send_email(%{
@@ -54,7 +91,7 @@ defimpl Sanbase.Signal, for: Any do
     )
 
     payload_map
-    |> Enum.map(fn {identifier, _} ->
+    |> Enum.map(fn {identifier, _payload} ->
       {identifier, {:error, "No email linked for user with id #{id}"}}
     end)
   end

--- a/lib/sanbase/signals/trigger/validation/notification_channel_validation.ex
+++ b/lib/sanbase/signals/trigger/validation/notification_channel_validation.ex
@@ -1,13 +1,16 @@
 defmodule Sanbase.Signal.Validation.NotificationChannel do
-  @notification_channels ["telegram", "email", "web_push"]
+  @notification_channels ["telegram", "email", "web_push", "webhook"]
 
   def valid_notification_channels(), do: @notification_channels
+
+  def valid_notification_channel?(%{"webhook" => webhook_url}) when is_binary(webhook_url),
+    do: :ok
 
   def valid_notification_channel?(channel) when channel in @notification_channels, do: :ok
 
   def valid_notification_channel?(channels) when is_list(channels) do
     channels
-    |> Enum.all?(fn channel -> channel in @notification_channels end)
+    |> Enum.all?(&valid_notification_channel?(&1))
     |> case do
       true ->
         :ok

--- a/lib/sanbase/signals/types.ex
+++ b/lib/sanbase/signals/types.ex
@@ -1,6 +1,6 @@
 defmodule Sanbase.Signal.Type do
   @type trigger_type :: String.t()
-  @type channel :: String.t() | list(String.t())
+  @type channel :: String.t() | list(String.t() | {String.t(), String.t()})
   @type target :: String.t()
   @type metric :: String.t()
   @type complex_target :: target | list(target) | map()

--- a/test/sanbase/signals/trigger_test.exs
+++ b/test/sanbase/signals/trigger_test.exs
@@ -123,14 +123,14 @@ defmodule Sanbase.Signal.TriggersTest do
         assert error_msg =~ "Trigger structure is invalid. Key `settings` is not valid. "
 
         assert error_msg =~
-                 ~s/Reason: [\"\\\"unknown\\\" is not a valid notification channel. The available notification channels are [telegram, email, web_push]\\n\"]/
+                 ~s/Reason: [\"\\\"unknown\\\" is not a valid notification channel. The available notification channels are [telegram, email, web_push, webhook]\\n\"]/
       end)
 
     assert error_log =~
              "UserTrigger struct is not valid."
 
     assert error_log =~
-             ~s/Reason: [\"\\\"unknown\\\" is not a valid notification channel. The available notification channels are [telegram, email, web_push]\\n\"]/
+             ~s/Reason: [\"\\\"unknown\\\" is not a valid notification channel. The available notification channels are [telegram, email, web_push, webhook]\\n\"]/
   end
 
   test "try creating user trigger with required field in struct" do
@@ -154,7 +154,7 @@ defmodule Sanbase.Signal.TriggersTest do
              assert error_msg =~ "Trigger structure is invalid. Key `settings` is not valid."
 
              assert error_msg =~
-                      ~s/Reason: ["nil is not a valid notification channel. The available notification channels are [telegram, email, web_push]\\n\"]/
+                      ~s/Reason: ["nil is not a valid notification channel. The available notification channels are [telegram, email, web_push, webhook]\\n\"]/
            end) =~ "UserTrigger struct is not valid"
   end
 


### PR DESCRIPTION
#### Summary
The webhook will be sent the following:
```json
{
   "timestamp": 1591696398,
   "trigger_url": "https://app.santiment.net/sonar/signal/119",
   "trigger_id": 119,
   "identifier": "santiment",
   "payload": "<The text of the signal goes here>"
}
```
         
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
