### PR TITLE
Fix social metrics datetime issue

### DIFF
--- a/lib/sanbase/social_data/sentiment.ex
+++ b/lib/sanbase/social_data/sentiment.ex
@@ -63,8 +63,8 @@ defmodule Sanbase.SocialData.Sentiment do
         recv_timeout: @recv_timeout,
         params: [
           {"search_text", search_text},
-          {"from_timestamp", from |> DateTime.to_iso8601()},
-          {"to_timestamp", to |> DateTime.to_iso8601()},
+          {"from_timestamp", from |> DateTime.truncate(:second) |> DateTime.to_iso8601()},
+          {"to_timestamp", to |> DateTime.truncate(:second) |> DateTime.to_iso8601()},
           {"interval", interval},
           {"source", source}
         ]

--- a/lib/sanbase/social_data/social_volume.ex
+++ b/lib/sanbase/social_data/social_volume.ex
@@ -81,8 +81,8 @@ defmodule Sanbase.SocialData.SocialVolume do
         recv_timeout: @recv_timeout,
         params: [
           {"search_text", search_text},
-          {"from_timestamp", from |> DateTime.to_iso8601()},
-          {"to_timestamp", to |> DateTime.to_iso8601()},
+          {"from_timestamp", from |> DateTime.truncate(:second) |> DateTime.to_iso8601()},
+          {"to_timestamp", to |> DateTime.truncate(:second) |> DateTime.to_iso8601()},
           {"interval", interval},
           {"source", source}
         ]


### PR DESCRIPTION
#### Summary
A PR to fix an issue, that when the datetime interval gets "cut" into a smaller piece because of the subcription, it has milliseconds, which aren't supported by metricshub