### PR TITLE
Support 'selector' in dynamic watchlists.

### DIFF
--- a/lib/sanbase/model/project/list/list_selector.ex
+++ b/lib/sanbase/model/project/list/list_selector.ex
@@ -3,15 +3,46 @@ defmodule Sanbase.Model.Project.ListSelector do
 
   alias Sanbase.Model.Project
 
+  @doc ~s"""
+  Return a list of projects described by the selector object.
+
+  See `args_to_opts/1` for description of the argument format.
+  """
   def projects(args) do
     opts = args_to_opts(args)
 
-    projects = Project.List.projects(opts)
-
-    {:ok, projects}
+    {:ok, Project.List.projects(opts)}
   end
 
-  defp args_to_opts(args) do
+  @doc ~s"""
+  Transform a selector to a keyword list that can be passed to the functions
+  in the `Project.List` module to apply filtering/ordering/pagination.
+
+  The argument is a map in the following format:
+  %{
+    selector: %{
+      filters: [
+        %{
+          metric: "daily_active_addresses",
+          from: ~U[2020-04-22 00:00:00Z],
+          to: ~U[2020-04-29 00:00:00Z],
+          aggregation: :avg,
+          operator: :greater_than,
+          threshold: 10
+        }
+      ],
+      order_by: %{
+        metric: "circulation",
+        from: ~U[2020-04-25 00:00:00Z],
+        to: ~U[2020-04-29 00:00:00Z],
+        aggregation: :last
+        direction: :desc
+      },
+      pagination: %{page: 1, page_size: 10}
+    }
+  }
+  """
+  def args_to_opts(args) do
     filters = get_in(args, [:selector, :filters])
     order_by = get_in(args, [:selector, :order_by])
     pagination = get_in(args, [:selector, :pagination])

--- a/lib/sanbase/model/project/list/list_selector.ex
+++ b/lib/sanbase/model/project/list/list_selector.ex
@@ -1,0 +1,84 @@
+defmodule Sanbase.Model.Project.ListSelector do
+  import Sanbase.DateTimeUtils
+
+  alias Sanbase.Model.Project
+
+  def projects(args) do
+    opts = args_to_opts(args)
+
+    projects = Project.List.projects(opts)
+
+    {:ok, projects}
+  end
+
+  defp args_to_opts(args) do
+    filters = get_in(args, [:selector, :filters])
+    order_by = get_in(args, [:selector, :order_by])
+    pagination = get_in(args, [:selector, :pagination])
+
+    included_slugs = filters |> included_slugs_by_filters()
+    ordered_slugs = order_by |> ordered_slugs_by_order_by(included_slugs)
+
+    [
+      has_selector?: not is_nil(args[:selector]),
+      has_order?: not is_nil(order_by),
+      has_filters?: not is_nil(filters),
+      has_pagination?: not is_nil(pagination),
+      pagination: pagination,
+      min_volume: Map.get(args, :min_volume),
+      included_slugs: included_slugs,
+      ordered_slugs: ordered_slugs
+    ]
+  end
+
+  defp included_slugs_by_filters(nil), do: :all
+  defp included_slugs_by_filters([]), do: :all
+
+  defp included_slugs_by_filters(filters) when is_list(filters) do
+    filters
+    |> Sanbase.Parallel.map(
+      fn filter ->
+        cache_key =
+          {:included_slugs_by_filters,
+           %{filter | from: round_datetime(filter.from), to: round_datetime(filter.to)}}
+          |> Sanbase.Cache.hash()
+
+        {:ok, slugs} =
+          Sanbase.Cache.get_or_store(cache_key, fn ->
+            Sanbase.Metric.slugs_by_filter(
+              filter.metric,
+              filter.from,
+              filter.to,
+              filter.operator,
+              filter.threshold,
+              filter.aggregation
+            )
+          end)
+
+        slugs |> MapSet.new()
+      end,
+      ordered: false,
+      max_concurrency: 8
+    )
+    |> Enum.reduce(&MapSet.intersection(&1, &2))
+    |> Enum.to_list()
+  end
+
+  defp ordered_slugs_by_order_by(nil, slugs), do: slugs
+
+  defp ordered_slugs_by_order_by(order_by, slugs) do
+    %{metric: metric, from: from, to: to, direction: direction} = order_by
+    aggregation = Map.get(order_by, :aggregation)
+
+    {:ok, ordered_slugs} = Sanbase.Metric.slugs_order(metric, from, to, direction, aggregation)
+
+    case slugs do
+      :all ->
+        ordered_slugs
+
+      ^slugs when is_list(slugs) ->
+        slugs_mapset = slugs |> MapSet.new()
+        Enum.filter(ordered_slugs, &(&1 in slugs_mapset))
+    end
+  end
+end

--- a/lib/sanbase/signals/trigger/trigger.ex
+++ b/lib/sanbase/signals/trigger/trigger.ex
@@ -168,11 +168,16 @@ defmodule Sanbase.Signal.Trigger do
       nil ->
         %{list: [], type: :slug}
 
-      %Sanbase.UserList{} = ul ->
-        ul
-        |> Sanbase.UserList.get_projects()
-        |> Enum.map(& &1.slug)
-        |> remove_targets_on_cooldown(trigger, :slug)
+      %Sanbase.UserList{} = user_list ->
+        case Sanbase.UserList.get_projects(user_list) do
+          {:ok, projects} ->
+            projects
+            |> Enum.map(& &1.slug)
+            |> remove_targets_on_cooldown(trigger, :slug)
+
+          {:error, _error} ->
+            []
+        end
     end
   end
 

--- a/lib/sanbase/user_lists/user_list.ex
+++ b/lib/sanbase/user_lists/user_list.ex
@@ -78,9 +78,18 @@ defmodule Sanbase.UserList do
   Return a list of all projects in a watchlist.
   """
   def get_projects(%__MODULE__{function: fun} = user_list) do
-    (WatchlistFunction.evaluate(fun) ++ ListItem.get_projects(user_list))
-    |> Enum.reject(&is_nil(&1.slug))
-    |> Enum.uniq_by(& &1.id)
+    case WatchlistFunction.evaluate(fun) do
+      {:error, error} ->
+        {:error, error}
+
+      projects ->
+        result =
+          (projects ++ ListItem.get_projects(user_list))
+          |> Enum.reject(&is_nil(&1.slug))
+          |> Enum.uniq_by(& &1.id)
+
+        {:ok, result}
+    end
   end
 
   def create_user_list(%User{id: user_id} = _user, params \\ %{}) do

--- a/lib/sanbase_web/graphql/resolvers/project/project_list_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_list_resolver.ex
@@ -21,7 +21,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectListResolver do
   defp get_projects(args, paged_fun, fun) do
     page = Map.get(args, :page)
     page_size = Map.get(args, :page_size)
-    opts = args_to_opts(args)
+    opts = Project.ListSelector.args_to_opts(args)
 
     projects =
       if page_arguments_valid?(page, page_size) do
@@ -45,7 +45,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectListResolver do
   end
 
   def projects_count(_root, args, _resolution) do
-    opts = args_to_opts(args)
+    opts = Project.ListSelector.args_to_opts(args)
 
     {:ok,
      %{
@@ -62,75 +62,4 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectListResolver do
   end
 
   defp page_arguments_valid?(_, _), do: false
-
-  defp args_to_opts(args) do
-    filters = get_in(args, [:selector, :filters])
-    order_by = get_in(args, [:selector, :order_by])
-    pagination = get_in(args, [:selector, :pagination])
-
-    included_slugs = filters |> included_slugs_by_filters()
-    ordered_slugs = order_by |> ordered_slugs_by_order_by(included_slugs)
-
-    [
-      has_selector?: not is_nil(args[:selector]),
-      has_order?: not is_nil(order_by),
-      has_filters?: not is_nil(filters),
-      has_pagination?: not is_nil(pagination),
-      pagination: pagination,
-      min_volume: Map.get(args, :min_volume),
-      included_slugs: included_slugs,
-      ordered_slugs: ordered_slugs
-    ]
-  end
-
-  defp included_slugs_by_filters(nil), do: :all
-  defp included_slugs_by_filters([]), do: :all
-
-  defp included_slugs_by_filters(filters) when is_list(filters) do
-    filters
-    |> Sanbase.Parallel.map(
-      fn filter ->
-        cache_key =
-          {:included_slugs_by_filters,
-           %{filter | from: round_datetime(filter.from), to: round_datetime(filter.to)}}
-          |> Sanbase.Cache.hash()
-
-        {:ok, slugs} =
-          Sanbase.Cache.get_or_store(cache_key, fn ->
-            Sanbase.Metric.slugs_by_filter(
-              filter.metric,
-              filter.from,
-              filter.to,
-              filter.operator,
-              filter.threshold,
-              filter.aggregation
-            )
-          end)
-
-        slugs |> MapSet.new()
-      end,
-      ordered: false,
-      max_concurrency: 8
-    )
-    |> Enum.reduce(&MapSet.intersection(&1, &2))
-    |> Enum.to_list()
-  end
-
-  defp ordered_slugs_by_order_by(nil, slugs), do: slugs
-
-  defp ordered_slugs_by_order_by(order_by, slugs) do
-    %{metric: metric, from: from, to: to, direction: direction} = order_by
-    aggregation = Map.get(order_by, :aggregation)
-
-    {:ok, ordered_slugs} = Sanbase.Metric.slugs_order(metric, from, to, direction, aggregation)
-
-    case slugs do
-      :all ->
-        ordered_slugs
-
-      ^slugs when is_list(slugs) ->
-        slugs_mapset = slugs |> MapSet.new()
-        Enum.filter(ordered_slugs, &(&1 in slugs_mapset))
-    end
-  end
 end


### PR DESCRIPTION
#### Summary
Rework some watchlist internals to support :ok/:error tuples
Support dynamic watchlists with `selector` function. It accepts the same arguments as the selector in the `allProjects` queries - `filters`, `orderBy` and `pagination`. Check the description of [this PR](https://github.com/santiment/sanbase2/pull/1936) for all supported fields.
Example:

```graphql
    mutation {
      createWatchlist(
        name: \"My list\"
        color: BLACK
        function: \"{\"args\":{\"filters\":[{\"aggregation\":\"last\",\"from\":\"2020-06-09 11:08:42.006876Z\",\"metric\":\"daily_active_addresses\",\"operator\":\"greater_than_or_equal_to\",\"threshold\":10,\"to\":\"2020-06-16 11:08:42.016549Z\"}]},\"name\":\"selector\"}\"
        ) {
         id
         name
         color
         isPublic
         user{ id }

         listItems{
           project{ slug }
         }
      }
    }
```

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
