### PR TITLE
Do not propagade clickhouse internal errors to API

### DIFF
--- a/lib/sanbase/anomaly/anomaly.ex
+++ b/lib/sanbase/anomaly/anomaly.ex
@@ -4,7 +4,7 @@ defmodule Sanbase.Anomaly do
 
   alias Sanbase.Anomaly.FileHandler
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @aggregations FileHandler.aggregations()
   @aggregation_map FileHandler.aggregation_map()

--- a/lib/sanbase/application.ex
+++ b/lib/sanbase/application.ex
@@ -1,6 +1,8 @@
 defmodule Sanbase.Application do
   use Application
 
+  import Sanbase.ApplicationUtils
+
   require Logger
   require Sanbase.Utils.Config, as: Config
 
@@ -171,7 +173,7 @@ defmodule Sanbase.Application do
       SanbaseWeb.Telemetry,
 
       # Start the Clickhouse Repo
-      Sanbase.ClickhouseRepo,
+      start_in(Sanbase.ClickhouseRepo, [:prod, :dev]),
 
       # Time series Prices DB connection
       Sanbase.Prices.Store.child_spec(),

--- a/lib/sanbase/clickhouse/api_call_data.ex
+++ b/lib/sanbase/clickhouse/api_call_data.ex
@@ -4,7 +4,7 @@ defmodule Sanbase.Clickhouse.ApiCallData do
   Get data about the API Calls that were made by users
   """
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @doc ~s"""
   Get a timeseries with the total number of api calls made by a user in a given interval

--- a/lib/sanbase/clickhouse/erc20_transfers.ex
+++ b/lib/sanbase/clickhouse/erc20_transfers.ex
@@ -17,7 +17,7 @@ defmodule Sanbase.Clickhouse.Erc20Transfers do
 
   use Ecto.Schema
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @table "erc20_transfers"
 

--- a/lib/sanbase/clickhouse/eth_transfers.ex
+++ b/lib/sanbase/clickhouse/eth_transfers.ex
@@ -30,7 +30,7 @@ defmodule Sanbase.Clickhouse.EthTransfers do
   use Ecto.Schema
 
   require Logger
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   alias Sanbase.Model.Project
   alias Sanbase.DateTimeUtils

--- a/lib/sanbase/clickhouse/exchanges/market_depth.ex
+++ b/lib/sanbase/clickhouse/exchanges/market_depth.ex
@@ -3,7 +3,7 @@ defmodule Sanbase.Clickhouse.Exchanges.MarketDepth do
 
   @exchanges ["Binance", "Bitfinex", "Kraken", "Poloniex", "Bitrex"]
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @table "exchange_market_depth"
   schema @table do

--- a/lib/sanbase/clickhouse/exchanges/trades.ex
+++ b/lib/sanbase/clickhouse/exchanges/trades.ex
@@ -3,7 +3,7 @@ defmodule Sanbase.Clickhouse.Exchanges.Trades do
 
   @exchanges ["Binance", "Bitfinex", "Kraken", "Poloniex", "Bitrex"]
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @table "exchange_trades"
   schema @table do

--- a/lib/sanbase/clickhouse/gas_used.ex
+++ b/lib/sanbase/clickhouse/gas_used.ex
@@ -5,7 +5,7 @@ defmodule Sanbase.Clickhouse.GasUsed do
 
   import Sanbase.Math, only: [to_integer: 1]
   alias Sanbase.DateTimeUtils
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @type gas_used :: %{
           datetime: DateTime.t(),

--- a/lib/sanbase/clickhouse/github/github.ex
+++ b/lib/sanbase/clickhouse/github/github.ex
@@ -18,7 +18,7 @@ defmodule Sanbase.Clickhouse.Github do
   import Sanbase.Utils.Transform, only: [maybe_unwrap_ok_value: 1]
 
   require Logger
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @non_dev_events [
     "IssueCommentEvent",

--- a/lib/sanbase/clickhouse/historical_balance/fetchers/bch_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/fetchers/bch_balance.ex
@@ -9,7 +9,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.BchBalance do
   import Sanbase.Clickhouse.HistoricalBalance.Utils
   import Sanbase.Clickhouse.HistoricalBalance.UtxoSqlQueries
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @table "bch_balances"
   schema @table do

--- a/lib/sanbase/clickhouse/historical_balance/fetchers/bnb_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/fetchers/bnb_balance.ex
@@ -8,7 +8,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.BnbBalance do
 
   import Sanbase.Clickhouse.HistoricalBalance.Utils
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @table "bnb_balances"
   schema @table do

--- a/lib/sanbase/clickhouse/historical_balance/fetchers/btc_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/fetchers/btc_balance.ex
@@ -9,7 +9,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.BtcBalance do
   import Sanbase.Clickhouse.HistoricalBalance.Utils
   import Sanbase.Clickhouse.HistoricalBalance.UtxoSqlQueries
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @table "btc_balances"
   schema @table do

--- a/lib/sanbase/clickhouse/historical_balance/fetchers/erc20_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/fetchers/erc20_balance.ex
@@ -8,7 +8,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20Balance do
 
   import Sanbase.Clickhouse.HistoricalBalance.Utils
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @table "erc20_balances"
   schema @table do

--- a/lib/sanbase/clickhouse/historical_balance/fetchers/eth_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/fetchers/eth_balance.ex
@@ -8,7 +8,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EthBalance do
 
   import Sanbase.Clickhouse.HistoricalBalance.Utils
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @eth_decimals 1_000_000_000_000_000_000
 

--- a/lib/sanbase/clickhouse/historical_balance/fetchers/ltc_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/fetchers/ltc_balance.ex
@@ -9,7 +9,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.LtcBalance do
   import Sanbase.Clickhouse.HistoricalBalance.Utils
   import Sanbase.Clickhouse.HistoricalBalance.UtxoSqlQueries
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @table "ltc_balances"
   schema @table do

--- a/lib/sanbase/clickhouse/historical_balance/fetchers/xrp_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/fetchers/xrp_balance.ex
@@ -8,7 +8,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
 
   import Sanbase.Clickhouse.HistoricalBalance.Utils
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @table "xrp_balances_orderby_currency"
   schema @table do

--- a/lib/sanbase/clickhouse/historical_balance/miners_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/miners_balance.ex
@@ -4,7 +4,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.MinersBalance do
   """
 
   import Sanbase.DateTimeUtils, only: [str_to_sec: 1]
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @table "eth_miners_metrics"
   @miners_balance_id 102

--- a/lib/sanbase/clickhouse/metadata_helper.ex
+++ b/lib/sanbase/clickhouse/metadata_helper.ex
@@ -4,7 +4,7 @@ defmodule Sanbase.Clickhouse.MetadataHelper do
   anomalies metadata from ClickHouse
   """
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   # Map from the names used in ClickHouse to the publicly exposed ones.
   # Example: stack_circulation_20y -> circulation

--- a/lib/sanbase/clickhouse/metric/histogram_metric.ex
+++ b/lib/sanbase/clickhouse/metric/histogram_metric.ex
@@ -2,7 +2,7 @@ defmodule Sanbase.Clickhouse.Metric.HistogramMetric do
   import Sanbase.DateTimeUtils, only: [str_to_sec: 1]
   import Sanbase.Clickhouse.Metric.HistogramSqlQuery
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @spent_coins_cost_histograms ["price_histogram", "spent_coins_cost", "all_spent_coins_cost"]
 

--- a/lib/sanbase/clickhouse/metric/metric.ex
+++ b/lib/sanbase/clickhouse/metric/metric.ex
@@ -15,7 +15,7 @@ defmodule Sanbase.Clickhouse.Metric do
 
   alias __MODULE__.{HistogramMetric, FileHandler}
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @metrics_file "metric_files/available_v2_metrics.json"
   @holders_file "metric_files/holders_metrics.json"

--- a/lib/sanbase/clickhouse/mining_pools_distribution.ex
+++ b/lib/sanbase/clickhouse/mining_pools_distribution.ex
@@ -5,7 +5,7 @@ defmodule Sanbase.Clickhouse.MiningPoolsDistribution do
   """
 
   alias Sanbase.DateTimeUtils
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @type distribution :: %{
           datetime: DateTime.t(),

--- a/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
@@ -9,7 +9,7 @@ defmodule Sanbase.Clickhouse.TopHolders.MetricAdapter do
 
   alias Sanbase.Model.Project
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @supported_infrastructures ["ETH", "BNB", "BEP2"]
 

--- a/lib/sanbase/clickhouse/top_holders/top_holders.ex
+++ b/lib/sanbase/clickhouse/top_holders/top_holders.ex
@@ -5,7 +5,7 @@ defmodule Sanbase.Clickhouse.TopHolders do
 
   alias Sanbase.DateTimeUtils
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @type percent_of_total_supply :: %{
           datetime: DateTime.t(),

--- a/lib/sanbase/clickhouse_repo.ex
+++ b/lib/sanbase/clickhouse_repo.ex
@@ -4,6 +4,7 @@ defmodule Sanbase.ClickhouseRepo do
   use Ecto.Repo, otp_app: :sanbase, adapter: @adapter
 
   require Sanbase.Utils.Config, as: Config
+  require Logger
 
   @doc """
   Dynamically loads the repository url from the
@@ -46,7 +47,16 @@ defmodule Sanbase.ClickhouseRepo do
         end
       rescue
         e ->
-          {:error, "Cannot execute ClickHouse query. Reason: #{Exception.message(e)}"}
+          log_id = Ecto.UUID.generate()
+
+          Logger.warn(
+            "[#{log_id}] Cannot execute ClickHouse query_transform/2. Reason: #{
+              Exception.message(e)
+            }"
+          )
+
+          {:error,
+           "[#{log_id}] Cannot execute database query. If issue persist please contact Santiment Support."}
       end
     end
   end
@@ -62,7 +72,17 @@ defmodule Sanbase.ClickhouseRepo do
         {:error, error} -> {:error, error}
       end
     rescue
-      e -> {:error, "Cannot execute ClickHouse query. Reason: #{Exception.message(e)}"}
+      e ->
+        log_id = Ecto.UUID.generate()
+
+        Logger.warn(
+          "[#{log_id}] Cannot execute ClickHouse query_transform/3. Reason: #{
+            Exception.message(e)
+          }"
+        )
+
+        {:error,
+         "[#{log_id}] Cannot execute database query. If issue persist please contact Santiment Support."}
     end
   end
 
@@ -78,7 +98,14 @@ defmodule Sanbase.ClickhouseRepo do
       end
     rescue
       e ->
-        {:error, "Cannot execute ClickHouse query. Reason: #{Exception.message(e)}"}
+        log_id = Ecto.UUID.generate()
+
+        Logger.warn(
+          "[#{log_id}] Cannot execute ClickHouse query_reduce/4. Reason: #{Exception.message(e)}"
+        )
+
+        {:error,
+         "[#{log_id}] Cannot execute database query. If issue persist please contact Santiment Support."}
     end
   end
 

--- a/lib/sanbase/clickhouse_repo.ex
+++ b/lib/sanbase/clickhouse_repo.ex
@@ -37,7 +37,7 @@ defmodule Sanbase.ClickhouseRepo do
       end
     rescue
       e ->
-        log_and_return_error(Exception.message(e), "query_transform/3")
+        log_and_return_error(e, "query_transform/3")
     end
   end
 
@@ -53,8 +53,21 @@ defmodule Sanbase.ClickhouseRepo do
       end
     rescue
       e ->
-        log_and_return_error(Exception.message(e), "query_reduce/4")
+        log_and_return_error(e, "query_reduce/4")
     end
+  end
+
+  defp log_and_return_error(%{} = e, function_executed) do
+    log_id = Ecto.UUID.generate()
+
+    Logger.warn("""
+    [#{log_id}] Cannot execute ClickHouse #{function_executed}. Reason: #{Exception.message(e)}
+
+    Stacktrace:
+    #{Exception.format_stacktrace()}
+    """)
+
+    {:error, "[#{log_id}] #{@error_message}"}
   end
 
   defp log_and_return_error(error_str, function_executed) do

--- a/lib/sanbase/prices/price.ex
+++ b/lib/sanbase/prices/price.ex
@@ -8,7 +8,7 @@ defmodule Sanbase.Price do
   import Sanbase.Metric.Helper, only: [maybe_nullify_values: 1, remove_missing_values: 1]
   alias Sanbase.Model.Project
 
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @default_source "coinmarketcap"
   @metrics [:price_usd, :price_btc, :price_eth, :marketcap_usd, :volume_usd]

--- a/lib/sanbase/social_data/trending_words.ex
+++ b/lib/sanbase/social_data/trending_words.ex
@@ -21,7 +21,7 @@ defmodule Sanbase.SocialData.TrendingWords do
   use Ecto.Schema
 
   import Sanbase.DateTimeUtils, only: [str_to_sec: 1]
-  require Sanbase.ClickhouseRepo, as: ClickhouseRepo
+  alias Sanbase.ClickhouseRepo
 
   @type word :: String.t()
   @type slug :: String.t()

--- a/lib/sanbase/utils/error_handling.ex
+++ b/lib/sanbase/utils/error_handling.ex
@@ -32,12 +32,22 @@ defmodule Sanbase.Utils.ErrorHandling do
           {description, identifier}
       end
 
+    # Detect if reason already contains UUID and use it.
+    {uuid, message} =
+      case reason do
+        <<"["::utf8, uuid::binary-size(36), "]"::utf8, message::binary>> ->
+          {uuid, message |> String.trim()}
+
+        _ ->
+          {Ecto.UUID.generate(), reason}
+      end
+
     error_msg =
-      "[#{Ecto.UUID.generate()}] Can't fetch #{metric} for #{target_description}: #{
+      "[#{uuid}] Can't fetch #{metric} for #{target_description}: #{
         identifier_to_string(identifier)
       }"
 
-    error_msg_with_reason = error_msg <> ", Reason: #{inspect(reason)}"
+    error_msg_with_reason = error_msg <> ", Reason: #{inspect(message)}"
 
     Logger.warn(error_msg_with_reason)
 

--- a/lib/sanbase_web/graphql/resolvers/project/project_list_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_list_resolver.ex
@@ -1,8 +1,6 @@
 defmodule SanbaseWeb.Graphql.Resolvers.ProjectListResolver do
   require Logger
 
-  import Sanbase.DateTimeUtils
-
   alias Sanbase.Model.Project
 
   @spec all_projects(any, map, any) :: {:ok, any}

--- a/test/sanbase/clickhouse/api_call_data_test.exs
+++ b/test/sanbase/clickhouse/api_call_data_test.exs
@@ -67,7 +67,7 @@ defmodule Sanbase.Clickhouse.ApiCallDataTest do
 
     Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:error, "Something went wrong"})
     |> Sanbase.Mock.run_with_mocks(fn ->
-      result =
+      {:error, error} =
         ApiCallData.api_call_history(
           context.user.id,
           from_iso8601!(dt1_str),
@@ -75,8 +75,7 @@ defmodule Sanbase.Clickhouse.ApiCallDataTest do
           "1d"
         )
 
-      assert result ==
-               {:error, "Something went wrong"}
+      assert error =~ "Cannot execute database query."
     end)
   end
 end

--- a/test/sanbase/clickhouse/clickhouse_repo_test.exs
+++ b/test/sanbase/clickhouse/clickhouse_repo_test.exs
@@ -1,0 +1,57 @@
+defmodule Sanbase.Clickhouse.ClickhouseRepoTest do
+  use Sanbase.DataCase
+
+  import ExUnit.CaptureLog
+  alias Sanbase.ClickhouseRepo
+
+  test "error handlign when clickhouse repo returns error" do
+    error_msg = "something went wrong with the connection"
+
+    Sanbase.Mock.prepare_mock2(&ClickhouseRepo.query/2, {:error, error_msg})
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      log =
+        capture_log(fn ->
+          {:error, error} = ClickhouseRepo.query_transform("SELECT NOW()", [], & &1)
+
+          assert error =~
+                   "Cannot execute database query. If issue persist please contact Santiment Support"
+
+          # assert returned error message does not contain internal details
+          refute error =~ error_msg
+
+          # assert error starts with UUID
+          assert <<"["::utf8, uuid::binary-size(36), "]"::utf8, message::binary>> = error
+        end)
+
+      # Only the log contains the internal error returned from CH
+      assert log =~ error_msg
+    end)
+  end
+
+  test "error handlign when clickhouse throws exception" do
+    error_msg = "something went wrong with the connection"
+
+    Sanbase.Mock.prepare_mock(ClickhouseRepo, :query, fn _, _ -> raise(error_msg) end)
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      log =
+        capture_log(fn ->
+          {:error, error} = ClickhouseRepo.query_transform("SELECT NOW()", [], & &1)
+
+          assert error =~
+                   "Cannot execute database query. If issue persist please contact Santiment Support"
+
+          # assert returned error message does not contain internal details
+          refute error =~ error_msg
+
+          # assert error starts with UUID
+          assert <<"["::utf8, uuid::binary-size(36), "]"::utf8, message::binary>> = error
+        end)
+
+      # Only the log contains the internal error returned from CH
+      assert log =~ error_msg
+
+      # Log includes stacktrace as well
+      assert log =~ "Stacktrace:"
+    end)
+  end
+end

--- a/test/sanbase/clickhouse/gas_used_test.exs
+++ b/test/sanbase/clickhouse/gas_used_test.exs
@@ -3,7 +3,6 @@ defmodule Sanbase.Clickhouse.GasUsedTest do
   import Sanbase.DateTimeUtils, only: [from_iso8601_to_unix!: 1, from_iso8601!: 1]
 
   alias Sanbase.Clickhouse.GasUsed
-  require Sanbase.ClickhouseRepo
 
   setup do
     [

--- a/test/sanbase/clickhouse/historical_balance/assets_held_by_address_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/assets_held_by_address_test.exs
@@ -6,8 +6,6 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.AssetsHeldByAdderssTest do
 
   alias Sanbase.Clickhouse.HistoricalBalance
 
-  require Sanbase.ClickhouseRepo
-
   setup do
     p1 = insert(:random_erc20_project)
     p2 = insert(:random_erc20_project)

--- a/test/sanbase/clickhouse/historical_balance/erc20_assets_held_by_address_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/erc20_assets_held_by_address_test.exs
@@ -47,7 +47,8 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20AssetsHeldByAdderssTest do
   test "clickhouse returns error", _context do
     Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:error, "error"})
     |> Sanbase.Mock.run_with_mocks(fn ->
-      assert Erc20Balance.assets_held_by_address("0x123") == {:error, "error"}
+      {:error, error} = Erc20Balance.assets_held_by_address("0x123")
+      assert error =~ "Cannot execute database query."
     end)
   end
 end

--- a/test/sanbase/clickhouse/historical_balance/erc20_assets_held_by_address_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/erc20_assets_held_by_address_test.exs
@@ -5,8 +5,6 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20AssetsHeldByAdderssTest do
 
   alias Sanbase.Clickhouse.HistoricalBalance.Erc20Balance
 
-  require Sanbase.ClickhouseRepo
-
   setup do
     p1 = insert(:random_erc20_project)
     p2 = insert(:random_erc20_project)

--- a/test/sanbase/clickhouse/historical_balance/eth_assets_held_by_address_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/eth_assets_held_by_address_test.exs
@@ -31,7 +31,8 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EthAssetsHeldByAdderssTest do
   test "clickhouse returns error", _context do
     Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:error, "error"})
     |> Sanbase.Mock.run_with_mocks(fn ->
-      assert EthBalance.assets_held_by_address("0x123") == {:error, "error"}
+      {:error, error} = EthBalance.assets_held_by_address("0x123")
+      assert error =~ "Cannot execute database query."
     end)
   end
 end

--- a/test/sanbase/clickhouse/historical_balance/eth_assets_held_by_address_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/eth_assets_held_by_address_test.exs
@@ -5,8 +5,6 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.EthAssetsHeldByAdderssTest do
 
   alias Sanbase.Clickhouse.HistoricalBalance.EthBalance
 
-  require Sanbase.ClickhouseRepo
-
   setup do
     project = insert(:project, %{name: "Ethereum", slug: "ethereum", ticker: "ETH"})
 

--- a/test/sanbase/clickhouse/historical_balance/miners_balance_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/miners_balance_test.exs
@@ -5,8 +5,6 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.MinersBalanceTest do
 
   alias Sanbase.Clickhouse.HistoricalBalance.MinersBalance
 
-  require Sanbase.ClickhouseRepo
-
   setup do
     [
       slug: "ethereum",

--- a/test/sanbase/clickhouse/mining_pools_distribution_test.exs
+++ b/test/sanbase/clickhouse/mining_pools_distribution_test.exs
@@ -3,8 +3,6 @@ defmodule Sanbase.Clickhouse.MiningPoolsDistributionTest do
 
   alias Sanbase.Clickhouse.MiningPoolsDistribution
 
-  require Sanbase.ClickhouseRepo
-
   setup do
     [
       slug: "ethereum",

--- a/test/sanbase/clickhouse/top_holders_test.exs
+++ b/test/sanbase/clickhouse/top_holders_test.exs
@@ -6,8 +6,6 @@ defmodule Sanbase.Clickhouse.TopHoldersTest do
 
   alias Sanbase.Clickhouse.TopHolders
 
-  require Sanbase.ClickhouseRepo
-
   setup do
     project = insert(:project, %{slug: "ethereum", ticker: "ETH"})
 

--- a/test/sanbase/social_data/trending_words/trending_words_test.exs
+++ b/test/sanbase/social_data/trending_words/trending_words_test.exs
@@ -53,7 +53,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
 
       Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:error, "error"})
       |> Sanbase.Mock.run_with_mocks(fn ->
-        result =
+        {:error, error} =
           TrendingWords.get_trending_words(
             from_iso8601!(dt1_str),
             from_iso8601!(dt3_str),
@@ -61,7 +61,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
             2
           )
 
-        assert result == {:error, "error"}
+        assert error =~ "Cannot execute database query."
       end)
     end
   end
@@ -82,9 +82,9 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
     test "clickhouse returns error", _context do
       Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:error, "error"})
       |> Sanbase.Mock.run_with_mocks(fn ->
-        result = TrendingWords.get_currently_trending_words()
+        {:error, error} = TrendingWords.get_currently_trending_words()
 
-        assert result == {:error, "error"}
+        assert error =~ "Cannot execute database query."
       end)
     end
   end
@@ -119,7 +119,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
 
       Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:error, "error"})
       |> Sanbase.Mock.run_with_mocks(fn ->
-        result =
+        {:error, error} =
           TrendingWords.get_word_trending_history(
             "word",
             from_iso8601!(dt1_str),
@@ -128,7 +128,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
             10
           )
 
-        assert result == {:error, "error"}
+        assert error =~ "Cannot execute database query."
       end)
     end
   end
@@ -166,7 +166,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
 
       Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:error, "error"})
       |> Sanbase.Mock.run_with_mocks(fn ->
-        result =
+        {:error, error} =
           TrendingWords.get_project_trending_history(
             project.slug,
             from_iso8601!(dt1_str),
@@ -175,7 +175,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
             10
           )
 
-        assert result == {:error, "error"}
+        assert error =~ "Cannot execute database query."
       end)
     end
   end

--- a/test/sanbase_web/graphql/clickhouse/historical_balance/historical_balances_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/historical_balance/historical_balances_test.exs
@@ -6,8 +6,6 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
   import ExUnit.CaptureLog
   import Sanbase.Factory
 
-  require Sanbase.ClickhouseRepo
-
   @eth_decimals 1_000_000_000_000_000_000
   setup do
     project_without_contract = insert(:project, %{slug: "someid1"})

--- a/test/sanbase_web/graphql/clickhouse/historical_balance/historical_balances_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/historical_balance/historical_balances_test.exs
@@ -189,10 +189,10 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
           assert historical_balance == nil
         end)
 
+      assert log =~ inspect(error)
+
       assert log =~
-               "Can't fetch Historical Balances for selector: #{inspect(selector)}, Reason: #{
-                 inspect(error)
-               }"
+               ~s|Can't fetch Historical Balances for selector: #{inspect(selector)}|
     end)
   end
 

--- a/test/sanbase_web/graphql/exchanges/market_depth_test.exs
+++ b/test/sanbase_web/graphql/exchanges/market_depth_test.exs
@@ -26,10 +26,10 @@ defmodule SanbaseWeb.Graphql.Exchanges.MarketDepthTest do
           execute_query_with_error(context.conn, query, "lastExchangeMarketDepth")
         end)
 
+      assert log =~ inspect(error)
+
       assert log =~
-               ~s(Can't fetch Last exchange market depth for exchange and ticker_pair: "Kraken" and "ZEC/BTC", Reason: #{
-                 inspect(error)
-               })
+               ~s(Can't fetch Last exchange market depth for exchange and ticker_pair: "Kraken" and "ZEC/BTC")
     end)
   end
 

--- a/test/sanbase_web/graphql/exchanges/trades_test.exs
+++ b/test/sanbase_web/graphql/exchanges/trades_test.exs
@@ -30,10 +30,10 @@ defmodule SanbaseWeb.Graphql.Exchanges.TradesTest do
           execute_query_with_error(context.conn, query, "lastExchangeTrades")
         end)
 
+      assert log =~ inspect(error)
+
       assert log =~
-               ~s(Can't fetch Last exchange trades for exchange and ticker_pair: "Kraken" and "ETH/EUR", Reason: #{
-                 inspect(error)
-               })
+               ~s(Can't fetch Last exchange trades for exchange and ticker_pair: "Kraken" and "ETH/EUR")
     end)
   end
 
@@ -63,10 +63,10 @@ defmodule SanbaseWeb.Graphql.Exchanges.TradesTest do
           execute_query_with_error(context.conn, query, "exchangeTrades")
         end)
 
+      assert log =~ inspect(error)
+
       assert log =~
-               ~s(Can't fetch Exchange trades for exchange and ticker_pair: "Kraken" and "ETH/EUR", Reason: #{
-                 inspect(error)
-               })
+               ~s(Can't fetch Exchange trades for exchange and ticker_pair: "Kraken" and "ETH/EUR")
     end)
   end
 
@@ -96,10 +96,10 @@ defmodule SanbaseWeb.Graphql.Exchanges.TradesTest do
           execute_query_with_error(context.conn, query, "exchangeTrades")
         end)
 
+      assert log =~ inspect(error)
+
       assert log =~
-               ~s(Can't fetch Aggregated exchange trades for exchange and ticker_pair: "Kraken" and "ETH/EUR", Reason: #{
-                 inspect(error)
-               })
+               ~s(Can't fetch Aggregated exchange trades for exchange and ticker_pair: "Kraken" and "ETH/EUR")
     end)
   end
 


### PR DESCRIPTION
#### Summary
Do not propagate clickhouse internal errors to the API. Reuse the UUID in error messages so all errors and API response contain the same UUID.
![image](https://user-images.githubusercontent.com/6518376/85416535-40bbb300-b577-11ea-8b3f-756a1caa952e.png)

![image](https://user-images.githubusercontent.com/6518376/85416589-4dd8a200-b577-11ea-9c1d-6fdc014eff76.png)

<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
