### PR TITLE
Do not raise on insert conflicts for contract data

### DIFF
--- a/lib/sanbase/model/project/contract_address.ex
+++ b/lib/sanbase/model/project/contract_address.ex
@@ -44,7 +44,7 @@ defmodule Sanbase.Model.Project.ContractAddress do
 
     %__MODULE__{}
     |> changeset(map)
-    |> Sanbase.Repo.insert()
+    |> Sanbase.Repo.insert(on_conflict: :nothing)
   end
 
   def list_to_main_contract_address(list) when is_list(list) do


### PR DESCRIPTION
Because of other missing data, the scraper can try to insert the
contract address again. The default behaviour is to raise an error in
this case, but it can safely be ignored.

#### Summary
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
