### PR TITLE
Handle atom values in dynamic watchlist and support dynamic datetimes

### DIFF
--- a/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
+++ b/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
@@ -144,7 +144,7 @@ defmodule Sanbase.Clickhouse.Metric.SqlQuery do
     query =
       query <>
         """
-        ORDER BY value #{direction |> Atom.to_string() |> String.upcase()}
+        ORDER BY a.value #{direction |> Atom.to_string() |> String.upcase()}
         """
 
     {query, args}
@@ -170,12 +170,12 @@ defmodule Sanbase.Clickhouse.Metric.SqlQuery do
         GROUP BY dt, asset_id
       )
       GROUP BY asset_id
-    )
+    ) AS a
     ALL LEFT JOIN
     (
       SELECT asset_id, name
       FROM asset_metadata FINAL
-    ) USING (asset_id)
+    ) AS b USING (asset_id)
     """
 
     args = [

--- a/lib/sanbase/user_lists/watchlist_function.ex
+++ b/lib/sanbase/user_lists/watchlist_function.ex
@@ -12,6 +12,7 @@ defmodule Sanbase.WatchlistFunction do
   def evaluate(%__MODULE__{name: "selector", args: args}) do
     case Map.split(args, ["filters", "order", "pagination"]) do
       {selector, empty_map} when map_size(empty_map) == 0 ->
+        selector = Sanbase.MapUtils.atomize_keys(selector)
         {:ok, projects} = Project.ListSelector.projects(%{selector: selector})
         projects
 

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -28,6 +28,7 @@ defmodule SanbaseWeb.Graphql.Schema do
   import_types(Graphql.CustomTypes.Date)
   import_types(Graphql.CustomTypes.JSON)
   import_types(Graphql.CustomTypes.Interval)
+  import_types(Graphql.CustomTypes.IntervalOrNow)
   import_types(Absinthe.Plug.Types)
   import_types(Graphql.TagTypes)
   import_types(Graphql.UserTypes)

--- a/lib/sanbase_web/graphql/schema/custom_types/interval_or_now.ex
+++ b/lib/sanbase_web/graphql/schema/custom_types/interval_or_now.ex
@@ -1,0 +1,36 @@
+defmodule SanbaseWeb.Graphql.CustomTypes.IntervalOrNow do
+  @moduledoc """
+  The interval scalar type allows arbitrary interval values to be passed in and out.
+  """
+  use Absinthe.Schema.Notation
+
+  scalar :interval_or_now, name: "interval_or_now" do
+    description("""
+    The input is either a valid `interval` type or the string `now`
+    """)
+
+    serialize(&encode/1)
+    parse(&decode/1)
+  end
+
+  @spec decode(Absinthe.Blueprint.Input.String.t()) :: {:ok, term()} | :error
+  @spec decode(Absinthe.Blueprint.Input.Null.t()) :: {:ok, nil}
+  defp decode(%Absinthe.Blueprint.Input.String{value: "now"}), do: {:ok, "now"}
+
+  defp decode(%Absinthe.Blueprint.Input.String{value: value}) do
+    case Sanbase.DateTimeUtils.valid_compound_duration?(value) do
+      true -> {:ok, value}
+      _ -> :error
+    end
+  end
+
+  defp decode(%Absinthe.Blueprint.Input.Null{}) do
+    {:ok, nil}
+  end
+
+  defp decode(_) do
+    :error
+  end
+
+  defp encode(value), do: value
+end

--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -40,8 +40,10 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
 
   input_object :project_filter_input_object do
     field(:metric, non_null(:string))
-    field(:from, non_null(:datetime))
-    field(:to, non_null(:datetime))
+    field(:from, :datetime)
+    field(:to, :datetime)
+    field(:dynamic_from, :interval_or_now)
+    field(:dynamic_to, :interval_or_now)
     field(:aggregation, :aggregation, default_value: nil)
     field(:operator, non_null(:operator_name))
     field(:threshold, non_null(:float))

--- a/test/sanbase_web/graphql/user/dynamic_watchlist_test.exs
+++ b/test/sanbase_web/graphql/user/dynamic_watchlist_test.exs
@@ -59,6 +59,9 @@ defmodule SanbaseWeb.Graphql.DynamicWatchlistTest do
   end
 
   test "dynamic watchlist for selector", %{conn: conn, user: user} do
+    # Have at least 1 project that is not included in the result
+    insert(:random_erc20_project)
+
     function = %{
       "name" => "selector",
       "args" => %{
@@ -88,6 +91,47 @@ defmodule SanbaseWeb.Graphql.DynamicWatchlistTest do
       assert user_list["isPublic"] == false
       assert user_list["user"]["id"] == user.id |> to_string()
 
+      assert length(user_list["listItems"]) == 3
+      assert %{"project" => %{"slug" => "dai"}} in user_list["listItems"]
+      assert %{"project" => %{"slug" => "bitcoin"}} in user_list["listItems"]
+      assert %{"project" => %{"slug" => "ethereum"}} in user_list["listItems"]
+    end)
+  end
+
+  test "dynamic watchlist for selector - dynamic datetimes", %{conn: conn, user: user} do
+    # Have at least 1 project that is not included in the result
+    insert(:random_erc20_project)
+
+    function = %{
+      "name" => "selector",
+      "args" => %{
+        "filters" => [
+          %{
+            "metric" => "daily_active_addresses",
+            "dynamicFrom" => "7d",
+            "dynamicTo" => "now",
+            "aggregation" => "#{:last}",
+            "operator" => "#{:greater_than_or_equal_to}",
+            "threshold" => 10
+          }
+        ]
+      }
+    }
+
+    Sanbase.Mock.prepare_mock2(
+      &Sanbase.Metric.slugs_by_filter/6,
+      {:ok, ["ethereum", "dai", "bitcoin"]}
+    )
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      result = execute_mutation(conn, query(function))
+      user_list = result["data"]["createWatchlist"]
+
+      assert user_list["name"] == "My list"
+      assert user_list["color"] == "BLACK"
+      assert user_list["isPublic"] == false
+      assert user_list["user"]["id"] == user.id |> to_string()
+
+      assert length(user_list["listItems"]) == 3
       assert %{"project" => %{"slug" => "dai"}} in user_list["listItems"]
       assert %{"project" => %{"slug" => "bitcoin"}} in user_list["listItems"]
       assert %{"project" => %{"slug" => "ethereum"}} in user_list["listItems"]


### PR DESCRIPTION
#### Summary
- When watchlist arguments are fetched from the DB some values are
transformed from atoms to strings as json does not have the notion of
atom.

- Watchlist settings are stored in DB and are reused. This means that
static from/to datetimes are not going to work. For this, it now
supports 'dynamic_from|to' which accepts either an interval (1d) or the
string 'now'. This data is used to rewrite the from/to dynamically

Now supported:
```graphql
{
  allProjects(selector: {
    filters: [
      {
        aggregation: LAST,
        dynamicFrom: "1d",
        metric: "daily_active_addresses",
        dynamicTo: "now",
      	operator: GREATER_THAN_OR_EQUAL_TO,
      	threshold: 10000}]}) {
    slug
  }
}
```

These new arguments are usable in the dynamic watchlists as well
<!-- (What does this pull request do in general terms?) -->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->
