### PR TITLE
Format the numbers in the signals in more human readable way

### DIFF
--- a/lib/sanbase/signals/operation/operation_text_kv.ex
+++ b/lib/sanbase/signals/operation/operation_text_kv.ex
@@ -9,7 +9,13 @@ defmodule Sanbase.Signal.OperationText.KV do
     transform_fun = Keyword.get(opts, :value_transform, fn x -> x end)
 
     template = "was: #{special_symbol}{{previous}}, now: #{special_symbol}{{value}}"
-    kv = %{value: transform_fun.(value), previous: transform_fun.(previous)}
+
+    kv = %{
+      value: transform_fun.(value),
+      previous: transform_fun.(previous),
+      human_readable: [:value, :previous]
+    }
+
     {template, kv}
   end
 
@@ -18,7 +24,7 @@ defmodule Sanbase.Signal.OperationText.KV do
     transform_fun = Keyword.get(opts, :value_transform, fn x -> x end)
 
     template = "now: #{special_symbol}{{value}}"
-    kv = %{value: transform_fun.(value)}
+    kv = %{value: transform_fun.(value), human_readable: [:value]}
     {template, kv}
   end
 
@@ -39,7 +45,12 @@ defmodule Sanbase.Signal.OperationText.KV do
         false -> "#{form} above #{special_symbol}{{above}}"
       end
 
-    kv = %{above: transform_fun.(above), value: transform_fun.(value)}
+    kv = %{
+      above: transform_fun.(above),
+      value: transform_fun.(value),
+      human_readable: [:above, :value]
+    }
+
     {template, kv}
   end
 
@@ -58,7 +69,12 @@ defmodule Sanbase.Signal.OperationText.KV do
         false -> "#{form} below #{special_symbol}{{below}}"
       end
 
-    kv = %{below: transform_fun.(below), value: transform_fun.(value)}
+    kv = %{
+      below: transform_fun.(below),
+      value: transform_fun.(value),
+      human_readable: [:below, :value]
+    }
+
     {template, kv}
   end
 
@@ -83,7 +99,8 @@ defmodule Sanbase.Signal.OperationText.KV do
     kv = %{
       lower: transform_fun.(lower),
       upper: transform_fun.(upper),
-      value: transform_fun.(value)
+      value: transform_fun.(value),
+      human_readable: [:lower, :upper, :value]
     }
 
     {template, kv}
@@ -110,7 +127,8 @@ defmodule Sanbase.Signal.OperationText.KV do
     kv = %{
       lower: transform_fun.(lower),
       upper: transform_fun.(upper),
-      value: transform_fun.(value)
+      value: transform_fun.(value),
+      human_readable: [:lower, :upper, :value]
     }
 
     {template, kv}
@@ -174,7 +192,8 @@ defmodule Sanbase.Signal.OperationText.KV do
 
     kv = %{
       amount_change_up: transform_fun.(amount_change),
-      amount_change_up_required: transform_fun.(amount_up)
+      amount_change_up_required: transform_fun.(amount_up),
+      human_readable: [:amount_change_up, :amount_change_up_required]
     }
 
     {template, kv}
@@ -196,7 +215,8 @@ defmodule Sanbase.Signal.OperationText.KV do
 
     kv = %{
       amount_down_change: transform_fun.(amount_change) |> abs(),
-      amount_down_change_required: transform_fun.(amount_down)
+      amount_down_change_required: transform_fun.(amount_down),
+      human_readable: [:amount_down_change, :amount_down_change_required]
     }
 
     {template, kv}

--- a/lib/sanbase/template_engine/template_engine.ex
+++ b/lib/sanbase/template_engine/template_engine.ex
@@ -3,8 +3,27 @@ defmodule Sanbase.TemplateEngine do
   """
 
   def run(template, kv) do
+    {human_readable_map, kv} = Map.split(kv, [:human_readable])
+    human_readable = Map.get(human_readable_map, :human_readable, [])
+
     Enum.reduce(kv, template, fn {key, value}, acc ->
-      String.replace(acc, "{{#{key}}}", fn _ -> value |> to_string() end)
+      String.replace(acc, "{{#{key}}}", fn _ ->
+        case key in human_readable do
+          true -> value |> human_readable |> to_string()
+          false -> value |> to_string()
+        end
+      end)
     end)
+  end
+
+  # Numbers below 1000 are not changed
+  # Numbers between 1000 and 1000000 are delimited: 999,523.00, 123,529.12
+  # Number bigger than 1000000 are made human readable: 1.54 Million, 85.00 Billion
+  defp human_readable(data) do
+    case data do
+      num when is_number(num) and num >= 1_000_000 -> Number.Human.number_to_human(num)
+      num when is_number(num) and num >= 1000 -> Number.Delimit.number_to_delimited(num)
+      _ -> data
+    end
   end
 end


### PR DESCRIPTION
<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->

## Changes
Adding some formatting to the numbers in signals payload:
- numbers < 1000 are not touched
- numbers between 1k and 1M are delimited - 123,000 instead of 123000
- numbers > 1M are human readable - 12.58 Million instead of 12580123

The changes are done only in the text representation, the KV stays the same so it is easy to interact with it with code.
<!--- Describe your changes -->

## Ticket
<!--- Issue to which the pull request is related -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->


<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->


<!--- ## Screenshots -->
<!--- (if appropriate) -->
