### PR TITLE
Move comment pointing to original PR template to the end

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,15 @@
-<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
-
 ## Changes
+
 <!--- Describe your changes -->
 
 ## Ticket
+
 <!--- Issue to which the pull request is related -->
 
 ## Checklist:
+
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+
 - [ ] I have performed a self-review of my own code
 - [ ] I have made corresponding changes to the documentation
 - [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
@@ -16,10 +18,10 @@
 <!--- ## Deployment steps -->
 <!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->
 
-
 <!--- ## Usage -->
 <!--- (Mainly graphql snippets that showcase how new API is used) -->
 
-
 <!--- ## Screenshots -->
 <!--- (if appropriate) -->
+
+<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


### PR DESCRIPTION
<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->

## Changes
It is clearer to see `Changes` as the first thing in the template, not some comment pointing to the original PR template 
<!--- Describe your changes -->

## Ticket
<!--- Issue to which the pull request is related -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->


<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->


<!--- ## Screenshots -->
<!--- (if appropriate) -->
