### PR TITLE
Enter/Exit screener signal

### DIFF
--- a/config/scheduler_config.exs
+++ b/config/scheduler_config.exs
@@ -17,6 +17,10 @@ config :sanbase, Sanbase.Signals.Scheduler,
       task:
         {Sanbase.Signal.Scheduler, :run_signal, [Trigger.PriceVolumeDifferenceTriggerSettings]}
     ],
+    screener_sonar_signal: [
+      schedule: "1-59/5 * * * *",
+      task: {Sanbase.Signal.Scheduler, :run_signal, [Trigger.ScreenerTriggerSettings]}
+    ],
     daily_active_addresses_sonar_signal: [
       schedule: "2-59/5 * * * *",
       task: {Sanbase.Signal.Scheduler, :run_signal, [Trigger.DailyActiveAddressesSettings]}

--- a/docs/user-triggers-api.md
+++ b/docs/user-triggers-api.md
@@ -648,7 +648,7 @@ the same way with the same syntax in this signal
 ```json
 // All projects with DAA > 500.
 {
-  "type": "metric_signal",
+  "type": "screener_signal",
   "metric": "social_volume_total",
   "channel": "telegram",
   "operation": {
@@ -671,7 +671,7 @@ the same way with the same syntax in this signal
 ```json
 // Follow projects entering/exiting a dynamic watchlist.
 {
-  "type": "metric_signal",
+  "type": "screener_signal",
   "metric": "social_volume_total",
   "channel": "telegram",
   "operation": {

--- a/docs/user-triggers-api.md
+++ b/docs/user-triggers-api.md
@@ -12,6 +12,7 @@
     - [Example settings structure for `eth_wallet`](#example-settings-structure-for-eth_wallet)
     - [Example settings structure for `wallet_movement`](#example-settings-structure-for-wallet_movement)
     - [Example settings structure for `metric_signal`](#example-settings-structure-for-metric_signal)
+    - [Example settings structure for `screener_signal`](#example-settings-structure-for-metric_signal)
   - [Create trigger](#create-trigger)
   - [Get all triggers for current user](#get-all-triggers-for-current-user)
   - [Update trigger by id](#update-trigger-by-id)
@@ -630,6 +631,52 @@ For full list check [here](<https://api.santiment.net/graphiql?variables=&query=
   "channel": "telegram",
   "target": { "slug": "santiment" },
   "operation": { "some_of": [{ "percent_up": 10 }, { "above": 10000 }] }
+}
+```
+
+#### Example settings structure for `screener_signal`
+
+Receive a notification every `cooldown` the entering/exiting projects. Entering
+projects are projects that previously did not satisfy the filters, but now do.
+Exiting projects are projects that previously did satisfy the filters, but now
+do not.
+
+All metrics and fields (`"filters"`, `"orderBy"` and `"pagination"`) supported
+in dynamic watchlsits and in the `allProjects` selector are supported in exactly
+the same way with the same syntax in this signal
+
+```json
+// All projects with DAA > 500.
+{
+  "type": "metric_signal",
+  "metric": "social_volume_total",
+  "channel": "telegram",
+  "operation": {
+    "selector": {
+      "filters": [
+        {
+          "metric": "daily_active_addresse",
+          "dynamicFrom": "1d",
+          "dynamicTo": "now",
+          "aggregation": "last",
+          "operation": "greater_than",
+          "threshold": 500
+        }
+      ]
+    }
+  }
+}
+```
+
+```json
+// Follow projects entering/exiting a dynamic watchlist.
+{
+  "type": "metric_signal",
+  "metric": "social_volume_total",
+  "channel": "telegram",
+  "operation": {
+    "selector": { "watchlist_id": 12 }
+  }
 }
 ```
 

--- a/lib/map_utils.ex
+++ b/lib/map_utils.ex
@@ -89,10 +89,8 @@ defmodule Sanbase.MapUtils do
   # Private functions
 
   @compile {:inline, atomize: 1}
-  defp atomize(atom) when is_atom(atom), do: atom
-
-  defp atomize(str) when is_binary(str),
-    do: str |> Inflex.underscore() |> String.to_existing_atom()
+  defp atomize(value) when is_atom(value) or is_binary(value),
+    do: value |> Inflex.underscore() |> String.to_existing_atom()
 
   defp do_find_pair_path(map, key, value, path) when is_map(map) do
     keys = Map.keys(map)

--- a/lib/sanbase/model/project/list/list_selector.ex
+++ b/lib/sanbase/model/project/list/list_selector.ex
@@ -14,6 +14,11 @@ defmodule Sanbase.Model.Project.ListSelector do
     {:ok, Project.List.projects(opts)}
   end
 
+  def slugs(args) do
+    opts = args_to_opts(args)
+    {:ok, Project.List.projects_slugs()}
+  end
+
   @doc ~s"""
   Transform a selector to a keyword list that can be passed to the functions
   in the `Project.List` module to apply filtering/ordering/pagination.

--- a/lib/sanbase/model/project/list/list_selector.ex
+++ b/lib/sanbase/model/project/list/list_selector.ex
@@ -1,7 +1,66 @@
 defmodule Sanbase.Model.Project.ListSelector do
+  import Norm
   import Sanbase.DateTimeUtils
 
   alias Sanbase.Model.Project
+
+  def valid_selector?(args) do
+    args = Sanbase.MapUtils.atomize_keys(args)
+
+    order_by_schema =
+      schema(%{
+        metric: spec(is_binary()),
+        from: spec(&match?(%DateTime{}, &1)),
+        to: spec(&match?(%DateTime{}, &1)),
+        direction: spec(is_atom())
+      })
+
+    pagination_schema =
+      schema(%{
+        page: spec(&(is_integer(&1) and &1 > 0)),
+        page_size: spec(&(is_integer(&1) and &1 > 0))
+      })
+
+    filters = args_to_filters(args)
+    order_by = args_to_order_by(args) || %{}
+    pagination = args_to_pagination(args) || %{}
+
+    with true <- check_filters(filters),
+         {:ok, _} <- conform(order_by, order_by_schema),
+         {:ok, _} <- conform(pagination, pagination_schema) do
+      true
+    end
+  end
+
+  defp check_filters(filters) do
+    filter_schema =
+      schema(%{
+        metric: spec(is_binary()),
+        from: spec(&match?(%DateTime{}, &1)),
+        to: spec(&match?(%DateTime{}, &1)),
+        operator: spec(is_atom()),
+        threshold: spec(is_number()),
+        aggregation: spec(is_atom())
+      })
+
+    Enum.map(filters, &conform(&1, filter_schema))
+    |> Enum.find(&match?({:error, _}, &1))
+    |> case do
+      nil ->
+        Enum.map(
+          filters,
+          &([:metric, :from, :to, :operator, :threshold, :aggregation] -- Map.keys(&1))
+        )
+        |> Enum.find(&(&1 != []))
+        |> case do
+          nil -> true
+          fields -> {:error, "A filter has missing fields: #{inspect(fields)}."}
+        end
+
+      error ->
+        error
+    end
+  end
 
   @doc ~s"""
   Return a list of projects described by the selector object.
@@ -16,7 +75,7 @@ defmodule Sanbase.Model.Project.ListSelector do
 
   def slugs(args) do
     opts = args_to_opts(args)
-    {:ok, Project.List.projects_slugs()}
+    {:ok, Project.List.projects_slugs(opts)}
   end
 
   @doc ~s"""
@@ -48,19 +107,11 @@ defmodule Sanbase.Model.Project.ListSelector do
   }
   """
   def args_to_opts(args) do
-    filters =
-      (get_in(args, [:selector, :filters]) || [])
-      |> Enum.map(&transform_from_to/1)
-      |> Enum.map(&update_dynamic_datetimes/1)
-      |> Enum.map(&atomize_values/1)
+    args = Sanbase.MapUtils.atomize_keys(args)
 
-    order_by =
-      get_in(args, [:selector, :order_by])
-      |> transform_from_to()
-      |> update_dynamic_datetimes()
-      |> atomize_values()
-
-    pagination = get_in(args, [:selector, :pagination])
+    filters = args_to_filters(args)
+    order_by = args_to_order_by(args)
+    pagination = args_to_pagination(args)
 
     included_slugs = filters |> included_slugs_by_filters()
     ordered_slugs = order_by |> ordered_slugs_by_order_by(included_slugs)
@@ -68,13 +119,30 @@ defmodule Sanbase.Model.Project.ListSelector do
     [
       has_selector?: not is_nil(args[:selector]),
       has_order?: not is_nil(order_by),
-      has_filters?: not is_nil(filters),
       has_pagination?: not is_nil(pagination),
       pagination: pagination,
       min_volume: Map.get(args, :min_volume),
       included_slugs: included_slugs,
       ordered_slugs: ordered_slugs
     ]
+  end
+
+  defp args_to_filters(args) do
+    (get_in(args, [:selector, :filters]) || [])
+    |> Enum.map(&transform_from_to/1)
+    |> Enum.map(&update_dynamic_datetimes/1)
+    |> Enum.map(&atomize_values/1)
+  end
+
+  defp args_to_order_by(args) do
+    get_in(args, [:selector, :order_by])
+    |> transform_from_to()
+    |> update_dynamic_datetimes()
+    |> atomize_values()
+  end
+
+  defp args_to_pagination(args) do
+    get_in(args, [:selector, :pagination])
   end
 
   defp atomize_values(nil), do: nil

--- a/lib/sanbase/signals/evaluator/cache.ex
+++ b/lib/sanbase/signals/evaluator/cache.ex
@@ -49,7 +49,7 @@ defmodule Sanbase.Signal.Evaluator.Cache do
     end
   end
 
-  def clear() do
+  def clear_all() do
     @cache_name
     |> ConCache.ets()
     |> :ets.tab2list()

--- a/lib/sanbase/signals/evaluator/evaluator.ex
+++ b/lib/sanbase/signals/evaluator/evaluator.ex
@@ -60,6 +60,17 @@ defmodule Sanbase.Signal.Evaluator do
       [Access.key!(:trigger), Access.key!(:settings), Access.key!(:triggered?)],
       evaluated_trigger.settings.triggered?
     )
+    |> case do
+      %{trigger: %{settings: %{state: _}}} = user_trigger ->
+        user_trigger
+        |> put_in(
+          [Access.key!(:trigger), Access.key!(:settings), Access.key!(:state)],
+          evaluated_trigger.settings.state
+        )
+
+      user_trigger ->
+        user_trigger
+    end
   end
 
   defp filter_triggered(triggers, type) do

--- a/lib/sanbase/signals/evaluator/scheduler.ex
+++ b/lib/sanbase/signals/evaluator/scheduler.ex
@@ -72,7 +72,7 @@ defmodule Sanbase.Signal.Scheduler do
             {user_trigger, []}
 
           list when is_list(list) ->
-            {:ok, updated_user_trigger} = update_last_triggered(user_trigger, list)
+            {:ok, updated_user_trigger} = update_triggered(user_trigger, list)
 
             user_trigger =
               put_in(
@@ -90,8 +90,12 @@ defmodule Sanbase.Signal.Scheduler do
     |> Enum.unzip()
   end
 
-  defp update_last_triggered(
-         %{user: user, id: trigger_id, trigger: %{last_triggered: last_triggered}},
+  defp update_triggered(
+         %{
+           user: user,
+           id: trigger_id,
+           trigger: %{last_triggered: last_triggered, settings: settings}
+         },
          send_results_list
        ) do
     # Round the datetimes to minutes because the `last_triggered` is used as
@@ -115,7 +119,8 @@ defmodule Sanbase.Signal.Scheduler do
 
     UserTrigger.update_user_trigger(user, %{
       id: trigger_id,
-      last_triggered: last_triggered
+      last_triggered: last_triggered,
+      settings: settings
     })
   end
 

--- a/lib/sanbase/signals/signal_list.ex
+++ b/lib/sanbase/signals/signal_list.ex
@@ -4,13 +4,14 @@ defmodule Sanbase.Signal.List do
   def get() do
     [
       Trigger.DailyActiveAddressesSettings,
-      Trigger.PricePercentChangeSettings,
-      Trigger.PriceAbsoluteChangeSettings,
-      Trigger.PriceVolumeDifferenceTriggerSettings,
-      Trigger.TrendingWordsTriggerSettings,
       Trigger.EthWalletTriggerSettings,
-      Trigger.WalletTriggerSettings,
-      Trigger.MetricTriggerSettings
+      Trigger.MetricTriggerSettings,
+      Trigger.PriceAbsoluteChangeSettings,
+      Trigger.PricePercentChangeSettings,
+      Trigger.PriceVolumeDifferenceTriggerSettings,
+      Trigger.ScreenerTriggerSettings,
+      Trigger.TrendingWordsTriggerSettings,
+      Trigger.WalletTriggerSettings
     ]
   end
 end

--- a/lib/sanbase/signals/struct_map_transformation.ex
+++ b/lib/sanbase/signals/struct_map_transformation.ex
@@ -19,6 +19,8 @@ defmodule Sanbase.Signal.StructMapTransformation do
     %{trigger | settings: settings}
   end
 
+  def load_in_struct_if_valid(struct) when is_struct(struct), do: {:ok, struct}
+
   def load_in_struct_if_valid(map) when is_map(map) do
     atomized_map =
       map

--- a/lib/sanbase/signals/trigger/settings/daily_active_addresses_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/daily_active_addresses_settings.ex
@@ -53,6 +53,9 @@ defmodule Sanbase.Signal.Trigger.DailyActiveAddressesSettings do
   @spec type() :: Type.trigger_type()
   def type(), do: @trigger_type
 
+  def post_create_process(_trigger), do: :nochange
+  def post_update_process(_trigger), do: :nochange
+
   def get_data(%__MODULE__{filtered_target: %{list: target_list}} = settings)
       when is_list(target_list) do
     time_window_in_days = Enum.max([str_to_days(settings.time_window), 1])

--- a/lib/sanbase/signals/trigger/settings/eth_wallet_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/eth_wallet_trigger_settings.ex
@@ -60,6 +60,9 @@ defmodule Sanbase.Signal.Trigger.EthWalletTriggerSettings do
   @spec type() :: String.t()
   def type(), do: @trigger_type
 
+  def post_create_process(_trigger), do: :nochange
+  def post_update_process(_trigger), do: :nochange
+
   def get_data(
         %__MODULE__{
           filtered_target: %{list: target_list, type: :eth_address}

--- a/lib/sanbase/signals/trigger/settings/metric_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/metric_trigger_settings.ex
@@ -55,6 +55,9 @@ defmodule Sanbase.Signal.Trigger.MetricTriggerSettings do
   @spec type() :: Type.trigger_type()
   def type(), do: @trigger_type
 
+  def post_create_process(_trigger), do: :nochange
+  def post_update_process(_trigger), do: :nochange
+
   @doc ~s"""
   Return a list of the `settings.metric` values for the necessary time range
   """

--- a/lib/sanbase/signals/trigger/settings/price_absolute_change_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/price_absolute_change_settings.ex
@@ -47,6 +47,9 @@ defmodule Sanbase.Signal.Trigger.PriceAbsoluteChangeSettings do
   @spec type() :: Type.trigger_type()
   def type(), do: @trigger_type
 
+  def post_create_process(_trigger), do: :nochange
+  def post_update_process(_trigger), do: :nochange
+
   def get_data(%__MODULE__{filtered_target: %{list: target_list}}) when is_list(target_list) do
     target_list
     |> Enum.map(fn slug ->

--- a/lib/sanbase/signals/trigger/settings/price_percent_change_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/price_percent_change_settings.ex
@@ -51,6 +51,9 @@ defmodule Sanbase.Signal.Trigger.PricePercentChangeSettings do
   @spec type() :: Type.trigger_type()
   def type(), do: @trigger_type
 
+  def post_create_process(_trigger), do: :nochange
+  def post_update_process(_trigger), do: :nochange
+
   @spec get_data(__MODULE__.t()) :: list({Type.target(), any()})
   def get_data(%__MODULE__{filtered_target: %{list: target_list}} = settings)
       when is_list(target_list) do

--- a/lib/sanbase/signals/trigger/settings/price_volume_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/price_volume_trigger_settings.ex
@@ -65,6 +65,9 @@ defmodule Sanbase.Signal.Trigger.PriceVolumeDifferenceTriggerSettings do
   @spec type() :: Type.trigger_type()
   def type(), do: @trigger_type
 
+  def post_create_process(_trigger), do: :nochange
+  def post_update_process(_trigger), do: :nochange
+
   def get_data(%__MODULE__{filtered_target: %{list: target_list}} = settings)
       when is_list(target_list) do
     target_list

--- a/lib/sanbase/signals/trigger/settings/screener_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/screener_trigger_settings.ex
@@ -1,0 +1,148 @@
+defmodule Sanbase.Signal.Trigger.ScreenerTriggerSettings do
+  @moduledoc ~s"""
+  A signal based on the screener feature.
+
+  When a project fulfills the requirements of a given set of filters, a signal
+  is fired that the project has entered the list. When a project no longer fulfills
+  the filters, a signal is fired that the project exits the list.
+  """
+  use Vex.Struct
+
+  import Sanbase.{Validation, Signal.Validation}
+  import Sanbase.Signal.Utils
+  import Sanbase.DateTimeUtils
+
+  alias __MODULE__
+  alias Sanbase.Signal.Type
+  alias Sanbase.Model.Project
+  alias Sanbase.Metric
+  alias Sanbase.Signal.Evaluator.Cache
+
+  @trigger_type "screener_signal"
+  @derive {Jason.Encoder, except: [:filtered_target, :triggered?, :payload, :template_kv]}
+  @enforce_keys [:type, :channel, :operation]
+  defstruct type: @trigger_type,
+            channel: nil,
+            operation: nil,
+            state: nil,
+            filtered_target: %{list: []},
+            triggered?: false,
+            payload: %{},
+            template_kv: %{}
+
+  validates(:channel, &valid_notification_channel?/1)
+  validates(:operation, &valid_operation?/1)
+
+  @type t :: %__MODULE__{
+          type: Type.trigger_type(),
+          channel: Type.channel(),
+          operation: Type.operation(),
+          state: Map.t(),
+          # Private fields, not stored in DB.
+          filtered_target: Type.filtered_target(),
+          triggered?: boolean(),
+          payload: Type.payload(),
+          template_kv: Type.template_kv()
+        }
+
+  @spec type() :: Type.trigger_type()
+  def type(), do: @trigger_type
+
+  def post_create_process(trigger) do
+    %{settings: %__MODULE__{} = settings} = trigger
+    slugs = get_data(settings)
+    settings = %{settings | state: %{slugs_in_screener: slugs}}
+    %{trigger | settings: settings}
+  end
+
+  def post_update_process(_trigger), do: :nochange
+
+  @doc ~s"""
+  Return a list of the `settings.metric` values for the necessary time range
+  """
+  @spec get_data(ScreenerTriggerSettings.t()) :: list(String.t())
+  def get_data(%__MODULE__{} = settings) do
+    %{operation: %{selector: selector}} = settings
+    {:ok, slugs} = Project.ListSelector.slugs(selector)
+    slugs
+  end
+
+  defimpl Sanbase.Signal.Settings, for: ScreenerTriggerSettings do
+    alias Sanbase.Signal.OperationText
+    alias Sanbase.Signal.Trigger.ScreenerTriggerSettings
+
+    def triggered?(%ScreenerTriggerSettings{triggered?: triggered}), do: triggered
+
+    @spec evaluate(ScreenerTriggerSettings.t(), any) :: ScreenerTriggerSettings.t()
+    def evaluate(%ScreenerTriggerSettings{} = settings, _trigger) do
+      case ScreenerTriggerSettings.get_data(settings) do
+        data when is_list(data) and data != [] ->
+          build_result(data, settings)
+
+        _ ->
+          %ScreenerTriggerSettings{settings | triggered?: false}
+      end
+    end
+
+    def build_result(current_slugs, settings) do
+      %{state: %{slugs_in_screener: previous_slugs}} = settings
+      added_slugs = current_slugs -- previous_slugs
+      removed_slugs = previous_slugs -- current_slugs
+
+      case added_slugs != [] or removed_slugs != [] do
+        true ->
+          template_kv =
+            template_kv(%{added_slugs: added_slugs, removed_slugs: removed_slugs}, settings)
+
+          %ScreenerTriggerSettings{
+            settings
+            | template_kv: %{"screener" => template_kv},
+              triggered?: true
+          }
+
+        false ->
+          %ScreenerTriggerSettings{settings | triggered?: false}
+      end
+    end
+
+    def cache_key(%ScreenerTriggerSettings{}) do
+      # The result heavily depends on the trigger state
+      :nocache
+    end
+
+    defp template_kv(values, settings) do
+      %{added_slugs: added_slugs, removed_slugs: removed_slugs} = values
+
+      kv = %{
+        type: ScreenerTriggerSettings.type(),
+        operation: settings.operation,
+        added_slugs: added_slugs,
+        removed_slugs: removed_slugs
+      }
+
+      template = """
+      🔔Projects' changes in your screener.
+      #{format_enter_exit_slugs(added_slugs, removed_slugs)}
+      """
+
+      {template, kv}
+    end
+
+    defp format_enter_exit_slugs(added_slugs, removed_slugs) do
+      projects_map =
+        Project.List.by_slugs(added_slugs ++ removed_slugs, preload?: false)
+        |> Enum.into(%{}, fn %{slug: slug} = project -> {slug, project} end)
+
+      entering =
+        Enum.map(added_slugs, fn slug ->
+          project = Map.get(projects_map, slug)
+          "[##{project.ticker} | #{project.name}]("
+        end)
+
+      """
+      Entering projects:
+
+      """
+    end
+  end
+end

--- a/lib/sanbase/signals/trigger/settings/trending_words_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/trending_words_trigger_settings.ex
@@ -55,6 +55,9 @@ defmodule Sanbase.Signal.Trigger.TrendingWordsTriggerSettings do
   @spec type() :: String.t()
   def type(), do: @trigger_type
 
+  def post_create_process(_trigger), do: :nochange
+  def post_update_process(_trigger), do: :nochange
+
   @spec get_data(%__MODULE__{}) :: TrendingWords.result()
   def get_data(%__MODULE__{}) do
     TrendingWords.get_currently_trending_words(@trending_words_size)

--- a/lib/sanbase/signals/trigger/settings/wallet_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/wallet_trigger_settings.ex
@@ -57,6 +57,9 @@ defmodule Sanbase.Signal.Trigger.WalletTriggerSettings do
   @spec type() :: String.t()
   def type(), do: @trigger_type
 
+  def post_create_process(_trigger), do: :nochange
+  def post_update_process(_trigger), do: :nochange
+
   @doc ~s"""
   Return a list of the `settings.metric` values for the necessary time range
   """

--- a/lib/sanbase/signals/trigger/validation/operation_validation.ex
+++ b/lib/sanbase/signals/trigger/validation/operation_validation.ex
@@ -90,6 +90,16 @@ defmodule Sanbase.Signal.Validation.Operation do
   def valid_operation?(%{amount_up: value}) when is_number(value), do: :ok
   def valid_operation?(%{amount_down: value}) when is_number(value), do: :ok
 
+  # Validate screener signal
+  def valid_operation?(%{selector: %{watchlist_id: id}}) when is_integer(id) and id > 0, do: :ok
+
+  def valid_operation?(%{selector: _} = selector) do
+    case Sanbase.Model.Project.ListSelector.valid_selector?(selector) do
+      true -> :ok
+      false -> {:error, "The provided selector is not valid."}
+    end
+  end
+
   # All else is invalid operation
   def valid_operation?(op), do: {:error, "#{inspect(op)} is not a valid operation"}
 

--- a/lib/sanbase/signals/user_trigger.ex
+++ b/lib/sanbase/signals/user_trigger.ex
@@ -237,10 +237,8 @@ defmodule Sanbase.Signal.UserTrigger do
   defp post_create_process(%__MODULE__{} = user_trigger) do
     %{trigger: trigger} = user_trigger
 
-    with {:ok, %settings_module{}} <- load_in_struct_if_valid(trigger.settings) do
-      trigger = settings_module.post_create_process(trigger)
-
-      case settings_module.post_update_process(trigger) do
+    with {:ok, %settings_module{} = settings} <- load_in_struct_if_valid(trigger.settings) do
+      case settings_module.post_create_process(%{trigger | settings: settings}) do
         :nochange ->
           {:ok, user_trigger}
 
@@ -255,8 +253,8 @@ defmodule Sanbase.Signal.UserTrigger do
   defp post_update_process(%__MODULE__{} = user_trigger) do
     %{trigger: trigger} = user_trigger
 
-    with {:ok, %settings_module{}} <- load_in_struct_if_valid(trigger.settings) do
-      case settings_module.post_update_process(trigger) do
+    with {:ok, %settings_module{} = settings} <- load_in_struct_if_valid(trigger.settings) do
+      case settings_module.post_update_process(%{trigger | settings: settings}) do
         :nochange ->
           {:ok, user_trigger}
 

--- a/lib/sanbase/telegram/telegram.ex
+++ b/lib/sanbase/telegram/telegram.ex
@@ -85,7 +85,8 @@ defmodule Sanbase.Telegram do
       %{
         parse_mode: "markdown",
         chat_id: chat_id,
-        text: text
+        text: text,
+        disable_web_page_preview: true
       }
       |> Jason.encode!()
 

--- a/lib/sanbase/user_lists/user_list.ex
+++ b/lib/sanbase/user_lists/user_list.ex
@@ -95,18 +95,28 @@ defmodule Sanbase.UserList do
   @doc ~s"""
   Return a list of all projects in a watchlist.
   """
-  def get_projects(%__MODULE__{function: fun} = user_list) do
-    case WatchlistFunction.evaluate(fun) do
+  def get_projects(%__MODULE__{function: function} = watchlist) do
+    case WatchlistFunction.evaluate(function) do
       {:error, error} ->
         {:error, error}
 
       projects ->
         result =
-          (projects ++ ListItem.get_projects(user_list))
+          (projects ++ ListItem.get_projects(watchlist))
           |> Enum.reject(&is_nil(&1.slug))
           |> Enum.uniq_by(& &1.id)
 
         {:ok, result}
+    end
+  end
+
+  def get_slugs(%__MODULE__{function: fun} = watchlist) do
+    case get_projects(watchlist) do
+      {:ok, projects} ->
+        {:ok, Enum.map(projects, & &1.slug)}
+
+      {:error, error} ->
+        {:error, error}
     end
   end
 

--- a/lib/sanbase/user_lists/watchlist_function.ex
+++ b/lib/sanbase/user_lists/watchlist_function.ex
@@ -11,7 +11,6 @@ defmodule Sanbase.WatchlistFunction do
   def evaluate(%__MODULE__{name: "selector", args: args}) do
     case Map.split(args, ["filters", "order", "pagination"]) do
       {selector, empty_map} when map_size(empty_map) == 0 ->
-        selector = Sanbase.MapUtils.atomize_keys(selector)
         {:ok, projects} = Project.ListSelector.projects(%{selector: selector})
         projects
 
@@ -76,7 +75,11 @@ defmodule Sanbase.WatchlistFunction do
   def cast(%{} = function) do
     atomized_fun =
       for {key, val} <- function, into: %{} do
-        {String.to_existing_atom(key), val}
+        if is_binary(key) do
+          {String.to_existing_atom(key), val}
+        else
+          {key, val}
+        end
       end
 
     {:ok, struct!(__MODULE__, atomized_fun)}

--- a/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
@@ -253,6 +253,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   end
 
   defp valid_selector?(_), do: true
+
   defp to_selector(%{slug: slug}), do: %{slug: slug}
   defp to_selector(%{word: word}), do: %{word: word}
 

--- a/mix.exs
+++ b/mix.exs
@@ -91,6 +91,7 @@ defmodule Sanbase.Mixfile do
       {:mock, "~> 0.3"},
       {:mockery, "~> 2.2"},
       {:mogrify, "~> 0.7.2"},
+      {:norm, "~> 0.12"},
       {:number, "~> 1.0"},
       {:observer_cli, "~> 1.3"},
       {:phoenix_ecto, "~> 4.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -81,6 +81,7 @@
   "mockery": {:hex, :mockery, "2.3.1", "a02fd60b10ac9ed37a7a2ecf6786c1f1dd5c75d2b079a60594b089fba32dc087", [:mix], [], "hexpm", "1d0971d88ebf084e962da3f2cfee16f0ea8e04ff73a7710428500d4500b947fa"},
   "mogrify": {:hex, :mogrify, "0.7.3", "1494ee739f6e90de158dec4d4edee2d854d2f2d06a522e943f996ae176bca53d", [:mix], [], "hexpm", "b3e90a87171c23efa6b5910d735dd44f3fda15ba07a57cdb89cdb8ecaf83988d"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm", "5c040b8469c1ff1b10093d3186e2e10dbe483cd73d79ec017993fb3985b8a9b3"},
+  "norm": {:hex, :norm, "0.12.0", "b27a629fea9aaf7757604e9d4ed06cd815c2c5fb335f38b33c1bf17db9b217b0", [:mix], [], "hexpm", "aecd53df72219966d9493e3426a32d83490c822ef618ef442721b1ae68cb6f0c"},
   "number": {:hex, :number, "1.0.1", "a1017dc867a9860b0c261bf9f3ac4990f64589dbbe50260724190c78a0b92104", [:mix], [{:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm", "149c62771306451198b2a044b4f077520c9acf6e69304723b17385257c683b52"},
   "oauther": {:hex, :oauther, "1.1.1", "7d8b16167bb587ecbcddd3f8792beb9ec3e7b65c1f8ebd86b8dd25318d535752", [:mix], [], "hexpm", "9374f4302045321874cccdc57eb975893643bd69c3b22bf1312dab5f06e5788e"},
   "observer_cli": {:hex, :observer_cli, "1.5.4", "e8489b3a7c77c2155c0b67fa9f90d9afa76bf15c24fb7b312addcc117771d154", [:mix, :rebar3], [{:recon, "~>2.5.1", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm", "f4825d374b22f258ad114a74796b79b86e20a03611051719f6062353c05389cb"},

--- a/test/sanbase/signals/daily_active_addresses/trigger_daily_active_addresses_absolute_change_test.exs
+++ b/test/sanbase/signals/daily_active_addresses/trigger_daily_active_addresses_absolute_change_test.exs
@@ -11,7 +11,7 @@ defmodule Sanbase.Signal.DailyActiveAddresseAbsoluetChangeTest do
   alias Sanbase.Signal.Trigger.DailyActiveAddressesSettings
 
   setup do
-    Sanbase.Signal.Evaluator.Cache.clear()
+    Sanbase.Signal.Evaluator.Cache.clear_all()
 
     user = insert(:user)
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)

--- a/test/sanbase/signals/daily_active_addresses/trigger_daily_active_addresses_percent_down_change_test.exs
+++ b/test/sanbase/signals/daily_active_addresses/trigger_daily_active_addresses_percent_down_change_test.exs
@@ -11,7 +11,7 @@ defmodule Sanbase.Signal.DailyActiveAddressesPercentDownChangeTest do
   alias Sanbase.Signal.Trigger.DailyActiveAddressesSettings
 
   setup do
-    Sanbase.Signal.Evaluator.Cache.clear()
+    Sanbase.Signal.Evaluator.Cache.clear_all()
 
     user = insert(:user)
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)

--- a/test/sanbase/signals/daily_active_addresses/trigger_daily_active_addresses_percent_up_change_test.exs
+++ b/test/sanbase/signals/daily_active_addresses/trigger_daily_active_addresses_percent_up_change_test.exs
@@ -11,7 +11,7 @@ defmodule Sanbase.Signal.DailyActiveAddressesPercentUpChangeTest do
   alias Sanbase.Signal.Trigger.DailyActiveAddressesSettings
 
   setup do
-    Sanbase.Signal.Evaluator.Cache.clear()
+    Sanbase.Signal.Evaluator.Cache.clear_all()
 
     user = insert(:user)
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)

--- a/test/sanbase/signals/history/trigger_eth_wallet_history_test.exs
+++ b/test/sanbase/signals/history/trigger_eth_wallet_history_test.exs
@@ -9,7 +9,7 @@ defmodule Sanbase.Signal.EthWalletTriggerHistoryTest do
   alias Sanbase.Clickhouse.HistoricalBalance
 
   setup do
-    Sanbase.Signal.Evaluator.Cache.clear()
+    Sanbase.Signal.Evaluator.Cache.clear_all()
 
     project = Sanbase.Factory.insert(:random_erc20_project)
 

--- a/test/sanbase/signals/history/trigger_price_volume_diff_history_test.exs
+++ b/test/sanbase/signals/history/trigger_price_volume_diff_history_test.exs
@@ -8,7 +8,7 @@ defmodule Sanbase.Signal.PriceVolumeDiffHistoryTest do
   @moduletag capture_log: true
 
   setup do
-    Sanbase.Signal.Evaluator.Cache.clear()
+    Sanbase.Signal.Evaluator.Cache.clear_all()
 
     project =
       insert(:project, %{

--- a/test/sanbase/signals/history/trigger_wallet_history_test.exs
+++ b/test/sanbase/signals/history/trigger_wallet_history_test.exs
@@ -8,7 +8,7 @@ defmodule Sanbase.Signal.WalletTriggerHistoryTest do
   alias Sanbase.Clickhouse.HistoricalBalance
 
   setup do
-    Sanbase.Signal.Evaluator.Cache.clear()
+    Sanbase.Signal.Evaluator.Cache.clear_all()
 
     project = Sanbase.Factory.insert(:random_erc20_project)
 

--- a/test/sanbase/signals/metric/metric_trigger_settings_test.exs
+++ b/test/sanbase/signals/metric/metric_trigger_settings_test.exs
@@ -1,4 +1,4 @@
-defmodule Sanbase.Signal.TriggerMetricTest do
+defmodule Sanbase.Signal.MetricTriggerSettingsTest do
   use Sanbase.DataCase, async: false
 
   import Sanbase.Factory
@@ -26,7 +26,7 @@ defmodule Sanbase.Signal.TriggerMetricTest do
     setup do
       # Clean children on exit, otherwise DB calls from async tasks can be attempted
       clean_task_supervisor_children()
-      Sanbase.Signal.Evaluator.Cache.clear()
+      Sanbase.Signal.Evaluator.Cache.clear_all()
       datetimes = generate_datetimes(~U[2019-01-01 00:00:00Z], "1d", 7)
 
       user = insert(:user)
@@ -79,7 +79,7 @@ defmodule Sanbase.Signal.TriggerMetricTest do
       # Clean children on exit, otherwise DB calls from async tasks can be attempted
       clean_task_supervisor_children()
 
-      Sanbase.Signal.Evaluator.Cache.clear()
+      Sanbase.Signal.Evaluator.Cache.clear_all()
 
       user = insert(:user)
       Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)

--- a/test/sanbase/signals/price/trigger_price_absolute_change_test.exs
+++ b/test/sanbase/signals/price/trigger_price_absolute_change_test.exs
@@ -8,7 +8,7 @@ defmodule Sanbase.Signal.TriggerPriceAbsoluteChangeTest do
   alias Sanbase.Signal.Trigger.PriceAbsoluteChangeSettings
 
   setup do
-    Sanbase.Signal.Evaluator.Cache.clear()
+    Sanbase.Signal.Evaluator.Cache.clear_all()
 
     Tesla.Mock.mock(fn %{method: :post} -> %Tesla.Env{status: 200, body: "ok"} end)
 
@@ -145,7 +145,7 @@ defmodule Sanbase.Signal.TriggerPriceAbsoluteChangeTest do
                  Sanbase.Signal.Scheduler.run_signal(PriceAbsoluteChangeSettings)
                end) =~ "In total 1/1 price_absolute_change signals were sent successfully"
 
-        Sanbase.Signal.Evaluator.Cache.clear()
+        Sanbase.Signal.Evaluator.Cache.clear_all()
 
         assert capture_log(fn ->
                  Sanbase.Signal.Scheduler.run_signal(PriceAbsoluteChangeSettings)

--- a/test/sanbase/signals/price/trigger_price_percent_change_test.exs
+++ b/test/sanbase/signals/price/trigger_price_percent_change_test.exs
@@ -7,7 +7,7 @@ defmodule Sanbase.Signal.TriggerPricePercentChangeTest do
   alias Sanbase.Signal.Trigger.PricePercentChangeSettings
 
   setup do
-    Sanbase.Signal.Evaluator.Cache.clear()
+    Sanbase.Signal.Evaluator.Cache.clear_all()
 
     Tesla.Mock.mock(fn %{method: :post} -> %Tesla.Env{status: 200, body: "ok"} end)
 

--- a/test/sanbase/signals/price/trigger_price_volume_diff_test.exs
+++ b/test/sanbase/signals/price/trigger_price_volume_diff_test.exs
@@ -12,7 +12,7 @@ defmodule Sanbase.Signal.PriceVolumeDiffTest do
   @cmc_id "santiment"
 
   setup do
-    Sanbase.Signal.Evaluator.Cache.clear()
+    Sanbase.Signal.Evaluator.Cache.clear_all()
 
     Tesla.Mock.mock(fn
       %{method: :post} ->

--- a/test/sanbase/signals/scheduler_test.exs
+++ b/test/sanbase/signals/scheduler_test.exs
@@ -9,7 +9,7 @@ defmodule Sanbase.Signal.SchedulerTest do
   alias Sanbase.Signal.Trigger.MetricTriggerSettings
 
   setup do
-    Sanbase.Signal.Evaluator.Cache.clear()
+    Sanbase.Signal.Evaluator.Cache.clear_all()
 
     Tesla.Mock.mock_global(fn %{method: :post} -> %Tesla.Env{status: 200, body: "ok"} end)
 

--- a/test/sanbase/signals/screener/screener_trigger_settings_test.exs
+++ b/test/sanbase/signals/screener/screener_trigger_settings_test.exs
@@ -1,0 +1,155 @@
+defmodule Sanbase.Signal.ScreenerTriggerSettingsTest do
+  use Sanbase.DataCase, async: false
+
+  import Sanbase.Factory
+  import Sanbase.TestHelpers
+  import ExUnit.CaptureLog
+
+  alias Sanbase.Signal.{UserTrigger, Trigger.ScreenerTriggerSettings}
+
+  setup do
+    # Clean children on exit, otherwise DB calls from async tasks can be attempted
+    clean_task_supervisor_children()
+
+    Sanbase.Signal.Evaluator.Cache.clear_all()
+
+    user = insert(:user)
+    Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
+
+    selector = %{
+      filters: [
+        %{
+          metric: "active_addresses_24h",
+          dynamicFrom: "1d",
+          dynamicTo: "now",
+          operator: :greater_than,
+          threshold: 500,
+          aggregation: :last
+        }
+      ]
+    }
+
+    watchlist = insert(:watchlist, %{user: user, function: %{name: "selector", args: selector}})
+
+    settings_selector = %{
+      type: "screener_signal",
+      operation: %{selector: selector},
+      channel: "telegram"
+    }
+
+    settings_watchlist = %{
+      type: "screener_signal",
+      operation: %{selector: %{watchlist_id: watchlist.id}},
+      channel: "telegram"
+    }
+
+    %{
+      user: user,
+      settings_selector: settings_selector,
+      settings_watchlist: settings_watchlist,
+      p1: insert(:random_project),
+      p2: insert(:random_project),
+      p3: insert(:random_project),
+      p4: insert(:random_project),
+      p5: insert(:random_project)
+    }
+  end
+
+  test "enter/exit screener with selector", context do
+    %{user: user, settings_selector: settings_selector, p1: p1, p2: p2, p3: p3, p4: p4, p5: p5} =
+      context
+
+    # On post create processing add p1, p2 and p3.
+    # On the first evaluation the trigger should be fired as there are changes.
+    # On the second evaluation the trigger should not be fired as there are no changes
+    mock_fun =
+      [
+        fn -> {:ok, [p1.slug, p2.slug, p3.slug]} end,
+        fn -> {:ok, [p3.slug, p4.slug, p5.slug]} end,
+        fn -> {:ok, [p3.slug, p4.slug, p5.slug]} end
+      ]
+      |> Sanbase.Mock.wrap_consecutives(arity: 6)
+
+    Sanbase.Mock.prepare_mock(Sanbase.Clickhouse.Metric, :slugs_by_filter, mock_fun)
+    |> Sanbase.Mock.prepare_mock2(&Sanbase.Telegram.send_message/2, :ok)
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      # After creation the post create processing adds p1, p2 and p3 to the state.
+      # 0s cooldown so it can be re-run in order to test the behaviour when
+      # the state did not hange
+      {:ok, _user_trigger} =
+        UserTrigger.create_user_trigger(user, %{
+          title: "Generic title",
+          is_public: true,
+          cooldown: "0s",
+          settings: settings_selector
+        })
+
+      # Clear the result of the filter
+      Sanbase.Cache.clear_all()
+      Sanbase.Signal.Evaluator.Cache.clear_all()
+
+      # First run
+      assert capture_log(fn ->
+               Sanbase.Signal.Scheduler.run_signal(ScreenerTriggerSettings)
+             end) =~ "In total 1/1 screener_signal signals were sent successfully"
+
+      # Clear the result of the filter
+      Sanbase.Cache.clear_all()
+      Sanbase.Signal.Evaluator.Cache.clear_all()
+
+      # Second run
+      assert capture_log(fn ->
+               Sanbase.Signal.Scheduler.run_signal(ScreenerTriggerSettings)
+             end) =~ "There were no signals triggered of type screener_signal"
+    end)
+  end
+
+  test "enter/exit screener with watchlist", context do
+    %{user: user, settings_watchlist: settings_watchlist, p1: p1, p2: p2, p3: p3, p4: p4, p5: p5} =
+      context
+
+    # On post create processing add p1, p2 and p3.
+    # On the first evaluation the trigger should be fired as there are changes.
+    # On the second evaluation the trigger should not be fired as there are no changes
+    mock_fun =
+      [
+        fn -> {:ok, [p1.slug, p2.slug, p3.slug]} end,
+        fn -> {:ok, [p3.slug, p4.slug, p5.slug]} end,
+        fn -> {:ok, [p3.slug, p4.slug, p5.slug]} end
+      ]
+      |> Sanbase.Mock.wrap_consecutives(arity: 6)
+
+    Sanbase.Mock.prepare_mock(Sanbase.Clickhouse.Metric, :slugs_by_filter, mock_fun)
+    |> Sanbase.Mock.prepare_mock2(&Sanbase.Telegram.send_message/2, :ok)
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      # After creation the post create processing adds p1, p2 and p3 to the state.
+      # 0s cooldown so it can be re-run in order to test the behaviour when
+      # the state did not hange
+      {:ok, _user_trigger} =
+        UserTrigger.create_user_trigger(user, %{
+          title: "Generic title",
+          is_public: true,
+          cooldown: "0s",
+          settings: settings_watchlist
+        })
+
+      # Clear the result of the filter
+      Sanbase.Cache.clear_all()
+      Sanbase.Signal.Evaluator.Cache.clear_all()
+
+      # First run
+      assert capture_log(fn ->
+               Sanbase.Signal.Scheduler.run_signal(ScreenerTriggerSettings)
+             end) =~ "In total 1/1 screener_signal signals were sent successfully"
+
+      # Clear the result of the filter
+      Sanbase.Cache.clear_all()
+      Sanbase.Signal.Evaluator.Cache.clear_all()
+
+      # Second run
+      assert capture_log(fn ->
+               Sanbase.Signal.Scheduler.run_signal(ScreenerTriggerSettings)
+             end) =~ "There were no signals triggered of type screener_signal"
+    end)
+  end
+end

--- a/test/sanbase/signals/trending_words/trigger_trending_watchlist_target_test.exs
+++ b/test/sanbase/signals/trending_words/trigger_trending_watchlist_target_test.exs
@@ -11,7 +11,7 @@ defmodule Sanbase.Signal.TriggerTrendingWordsWatchlistTargetTest do
   alias Sanbase.Signal.Trigger.TrendingWordsTriggerSettings
 
   setup do
-    Sanbase.Signal.Evaluator.Cache.clear()
+    Sanbase.Signal.Evaluator.Cache.clear_all()
 
     user = insert(:user)
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)

--- a/test/sanbase/signals/trending_words/trigger_trending_words_send_at_predefiend_time_test.exs
+++ b/test/sanbase/signals/trending_words/trigger_trending_words_send_at_predefiend_time_test.exs
@@ -13,7 +13,7 @@ defmodule Sanbase.Signal.TriggerTrendingWordsSendAtPredefiendTimeTest do
   @moduletag capture_log: true
 
   setup do
-    Sanbase.Signal.Evaluator.Cache.clear()
+    Sanbase.Signal.Evaluator.Cache.clear_all()
 
     user = insert(:user)
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
@@ -91,7 +91,7 @@ defmodule Sanbase.Signal.TriggerTrendingWordsSendAtPredefiendTimeTest do
       payload = user_signal.payload |> Map.values() |> List.first()
       assert String.contains?(payload, "coinbase")
 
-      Sanbase.Signal.Evaluator.Cache.clear()
+      Sanbase.Signal.Evaluator.Cache.clear_all()
 
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(TrendingWordsTriggerSettings)

--- a/test/sanbase/signals/trending_words/trigger_trending_words_trending_project_test.exs
+++ b/test/sanbase/signals/trending_words/trigger_trending_words_trending_project_test.exs
@@ -11,7 +11,7 @@ defmodule Sanbase.Signal.TriggerTrendingWordsTrendingProjectTest do
   alias Sanbase.Signal.Trigger.TrendingWordsTriggerSettings
 
   setup do
-    Sanbase.Signal.Evaluator.Cache.clear()
+    Sanbase.Signal.Evaluator.Cache.clear_all()
 
     user = insert(:user)
     project = insert(:project)
@@ -72,7 +72,7 @@ defmodule Sanbase.Signal.TriggerTrendingWordsTrendingProjectTest do
                Sanbase.Signal.Scheduler.run_signal(TrendingWordsTriggerSettings)
              end) =~ "In total 1/1 trending_words signals were sent successfully"
 
-      Sanbase.Signal.Evaluator.Cache.clear()
+      Sanbase.Signal.Evaluator.Cache.clear_all()
 
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(TrendingWordsTriggerSettings)

--- a/test/sanbase/signals/trending_words/trigger_trending_words_trending_word_test.exs
+++ b/test/sanbase/signals/trending_words/trigger_trending_words_trending_word_test.exs
@@ -11,7 +11,7 @@ defmodule Sanbase.Signal.TriggerTrendingWordsTrendingWordTest do
   alias Sanbase.Signal.Trigger.TrendingWordsTriggerSettings
 
   setup do
-    Sanbase.Signal.Evaluator.Cache.clear()
+    Sanbase.Signal.Evaluator.Cache.clear_all()
 
     user = insert(:user)
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
@@ -67,7 +67,7 @@ defmodule Sanbase.Signal.TriggerTrendingWordsTrendingWordTest do
                Sanbase.Signal.Scheduler.run_signal(TrendingWordsTriggerSettings)
              end) =~ "In total 1/1 trending_words signals were sent successfully"
 
-      Sanbase.Signal.Evaluator.Cache.clear()
+      Sanbase.Signal.Evaluator.Cache.clear_all()
 
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(TrendingWordsTriggerSettings)
@@ -89,7 +89,7 @@ defmodule Sanbase.Signal.TriggerTrendingWordsTrendingWordTest do
                Sanbase.Signal.Scheduler.run_signal(TrendingWordsTriggerSettings)
              end) =~ "In total 1/1 trending_words signals were sent successfully"
 
-      Sanbase.Signal.Evaluator.Cache.clear()
+      Sanbase.Signal.Evaluator.Cache.clear_all()
 
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(TrendingWordsTriggerSettings)

--- a/test/sanbase/signals/trigger_payload_test.exs
+++ b/test/sanbase/signals/trigger_payload_test.exs
@@ -9,7 +9,7 @@ defmodule Sanbase.Signal.TriggerPayloadTest do
   alias Sanbase.Signal.Trigger.DailyActiveAddressesSettings
 
   setup do
-    Sanbase.Signal.Evaluator.Cache.clear()
+    Sanbase.Signal.Evaluator.Cache.clear_all()
     user = insert(:user, email: "test@example.com")
     Sanbase.Auth.UserSettings.update_settings(user, %{signal_notify_email: true})
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)

--- a/test/sanbase/signals/wallet_movement/trigger_eth_wallet_test.exs
+++ b/test/sanbase/signals/wallet_movement/trigger_eth_wallet_test.exs
@@ -15,7 +15,7 @@ defmodule Sanbase.Signal.EthWalletTriggerTest do
   alias Sanbase.Clickhouse.HistoricalBalance
 
   setup do
-    Sanbase.Signal.Evaluator.Cache.clear()
+    Sanbase.Signal.Evaluator.Cache.clear_all()
 
     user = insert(:user)
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)

--- a/test/sanbase/signals/wallet_movement/trigger_wallet_test.exs
+++ b/test/sanbase/signals/wallet_movement/trigger_wallet_test.exs
@@ -15,7 +15,7 @@ defmodule Sanbase.Signal.WalletTriggerTest do
   alias Sanbase.Clickhouse.HistoricalBalance
 
   setup do
-    Sanbase.Signal.Evaluator.Cache.clear()
+    Sanbase.Signal.Evaluator.Cache.clear_all()
 
     user = insert(:user)
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)

--- a/test/support/mock.ex
+++ b/test/support/mock.ex
@@ -62,7 +62,7 @@ defmodule Sanbase.Mock do
         when is_function(captured_fun, unquote(arity)) do
       {:name, name} = Function.info(captured_fun, :name)
       {:module, module} = Function.info(captured_fun, :module)
-      passthrough = if Keyword.get(opts, :passthrough, true) == true, do: [:passthrough], else: []
+      passthrough = if Keyword.get(opts, :passthrough, true), do: [:passthrough], else: []
 
       fun = fn unquote_splicing(Macro.generate_arguments(@arity, __MODULE__)) ->
         data


### PR DESCRIPTION
## Changes
- Implement `screener_signal` which notifies what projects exited or entered the screener.
- In order not to mark all projects as new, when the screener is created or updated, a `post_create_process/1` or `post_update_process/2` function is called. They properly set the state, so only changes in screener are made into signals.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
