### PR TITLE
Implement APIs for reports

### DIFF
--- a/config/ex_admin_config.exs
+++ b/config/ex_admin_config.exs
@@ -64,7 +64,8 @@ config :ex_admin,
     SanbaseWeb.ExAdmin.Exchanges.MarketPairMapping,
     SanbaseWeb.ExAdmin.Billing.SignUpTrial,
     SanbaseWeb.ExAdmin.Comments.Notification,
-    SanbaseWeb.ExAdmin.Intercom.UserAttributes
+    SanbaseWeb.ExAdmin.Intercom.UserAttributes,
+    SanbaseWeb.ExAdmin.Report
   ],
   basic_auth: [
     username: {:system, "ADMIN_BASIC_AUTH_USERNAME"},

--- a/lib/sanbase/file_store/store.ex
+++ b/lib/sanbase/file_store/store.ex
@@ -3,7 +3,7 @@ defmodule Sanbase.FileStore do
 
   @versions [:original]
   @acl :public_read
-  @extension_whitelist ~w(.jpg .jpeg .gif .png)
+  @extension_whitelist ~w(.jpg .jpeg .gif .png .pdf .csv)
   @max_file_size 5 * 1024 * 1024
 
   @doc ~s"""

--- a/lib/sanbase/report/report.ex
+++ b/lib/sanbase/report/report.ex
@@ -1,9 +1,18 @@
 defmodule Sanbase.Report do
+  @moduledoc """
+  Module that manages .pdf file reports.
+  Files are saved in s3 and the url is stored in database.
+  """
   use Ecto.Schema
+
   import Ecto.Changeset
   import Ecto.Query
 
+  require Logger
+
   alias Sanbase.Repo
+  alias Sanbase.FileStore
+  alias Sanbase.Utils.FileHash
 
   schema "reports" do
     field(:name, :string, null: true)
@@ -28,13 +37,44 @@ defmodule Sanbase.Report do
     |> Repo.insert()
   end
 
+  def save_report(%Plug.Upload{filename: filename} = report) do
+    %{report | filename: milliseconds_str() <> "_" <> filename}
+    |> do_save_report()
+  end
+
   def list_published_reports(nil) do
     from(r in __MODULE__, where: r.is_published == true and r.is_pro == false)
     |> Repo.all()
   end
 
-  def list_published_reports(_) do
+  def list_published_reports(%{plan: %{name: "FREE"}}) do
+    from(r in __MODULE__, where: r.is_published == true and r.is_pro == false)
+    |> Repo.all()
+  end
+
+  def list_published_reports(%{plan: %{name: "PRO"}}) do
     from(r in __MODULE__, where: r.is_published == true)
     |> Repo.all()
+  end
+
+  # Helpers
+
+  defp do_save_report(%{filename: filename, path: filepath} = report) do
+    with {:ok, content_hash} <- FileHash.calculate(filepath),
+         {:ok, local_filepath} <- FileStore.store({report, content_hash}),
+         file_url <- FileStore.url({local_filepath, content_hash}),
+         {:ok, report} <- save(%{url: file_url}) do
+      {:ok, report.url}
+    else
+      {:error, reason} ->
+        Logger.error("Could not save file: #{filename}. Reason: #{inspect(reason)}")
+        {:error, "Could not save file: #{filename}."}
+    end
+  end
+
+  defp milliseconds_str() do
+    DateTime.utc_now()
+    |> DateTime.to_unix(:millisecond)
+    |> Integer.to_string()
   end
 end

--- a/lib/sanbase/report/report.ex
+++ b/lib/sanbase/report/report.ex
@@ -1,0 +1,40 @@
+defmodule Sanbase.Report do
+  use Ecto.Schema
+  import Ecto.Changeset
+  import Ecto.Query
+
+  alias Sanbase.Repo
+
+  schema "reports" do
+    field(:name, :string, null: true)
+    field(:description, :string, null: true)
+    field(:is_pro, :boolean, default: false)
+    field(:is_published, :boolean, default: false)
+    field(:url, :string)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(report, attrs) do
+    report
+    |> cast(attrs, [:name, :description, :url, :is_published, :is_pro])
+    |> validate_required([:url, :is_published, :is_pro])
+  end
+
+  def save(params) do
+    %__MODULE__{}
+    |> changeset(params)
+    |> Repo.insert()
+  end
+
+  def list_published_reports(nil) do
+    from(r in __MODULE__, where: r.is_published == true and r.is_pro == false)
+    |> Repo.all()
+  end
+
+  def list_published_reports(_) do
+    from(r in __MODULE__, where: r.is_published == true)
+    |> Repo.all()
+  end
+end

--- a/lib/sanbase_web/admin/report.ex
+++ b/lib/sanbase_web/admin/report.ex
@@ -1,0 +1,16 @@
+defmodule SanbaseWeb.ExAdmin.Report do
+  use ExAdmin.Register
+
+  register_resource Sanbase.Report do
+    action_items(only: [:show, :edit])
+
+    form report do
+      inputs do
+        input(report, :name)
+        input(report, :description, type: :text)
+        input(report, :is_published)
+        input(report, :is_pro)
+      end
+    end
+  end
+end

--- a/lib/sanbase_web/graphql/resolvers/file_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/file_resolver.ex
@@ -12,7 +12,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.FileResolver do
   """
   def upload_image(_root, %{images: images}, _resolution) do
     # In S3 there are no folders so the file name just contains some random text
-    # and a slash in it. Locally (in test and dev mode) the files are treaded as if
+    # and a slash in it. Locally (in test and dev mode) the files are treated as if
     # they are located in a folder called `scope`
 
     image_data =

--- a/lib/sanbase_web/graphql/resolvers/report_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/report_resolver.ex
@@ -6,14 +6,15 @@ defmodule SanbaseWeb.Graphql.Resolvers.ReportResolver do
 
   @product_sanbase Product.product_sanbase()
 
-  def upload_report(_root, %{report: report}, _resolution) do
-    Report.save_report(report)
+  def upload_report(_root, %{report: report} = args, _resolution) do
+    {params, _} = Map.split(args, [:name, :description])
+    Report.save_report(report, params)
   end
 
-  def list_reports(_root, _args, %{context: %{auth: %{current_user: user}}}) do
+  def get_reports(_root, _args, %{context: %{auth: %{current_user: user}}}) do
     reports =
       Subscription.current_subscription(user, @product_sanbase)
-      |> Report.list_published_reports()
+      |> Report.get_published_reports()
 
     {:ok, reports}
   end

--- a/lib/sanbase_web/graphql/resolvers/report_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/report_resolver.ex
@@ -1,38 +1,20 @@
 defmodule SanbaseWeb.Graphql.Resolvers.ReportResolver do
   require Logger
 
-  alias Sanbase.FileStore
-  alias Sanbase.Utils.FileHash
   alias Sanbase.Report
+  alias Sanbase.Billing.{Subscription, Product}
+
+  @product_sanbase Product.product_sanbase()
 
   def upload_report(_root, %{report: report}, _resolution) do
-    report = %{report | filename: milliseconds_str() <> "_" <> report.filename}
-    save_file(report)
+    Report.save_report(report)
   end
 
-  def list_reports(_root, _args, _resolution) do
-    user = Repo.get(Sanbase.Auth.User, 31)
-    subscription = Sanbase.Billing.Subscription.current_subscription(user, @product_sanbase)
+  def list_reports(_root, _args, %{context: %{auth: %{current_user: user}}}) do
+    reports =
+      Subscription.current_subscription(user, @product_sanbase)
+      |> Report.list_published_reports()
 
-    {:ok, Report.list_published_reports(subscription)}
-  end
-
-  defp save_file(%Plug.Upload{filename: file_name} = arg) do
-    with {:ok, content_hash} <- FileHash.calculate(arg.path),
-         {:ok, file_name} <- FileStore.store({arg, content_hash}),
-         file_url <- FileStore.url({file_name, content_hash}),
-         {:ok, report} <- Report.save(%{url: file_url}) do
-      {:ok, report.url}
-    else
-      {:error, reason} ->
-        Logger.error("Could not save file: #{file_name}. Reason: #{inspect(reason)}")
-        {:error, "Could not save file: #{file_name}."}
-    end
-  end
-
-  defp milliseconds_str() do
-    DateTime.utc_now()
-    |> DateTime.to_unix(:millisecond)
-    |> Integer.to_string()
+    {:ok, reports}
   end
 end

--- a/lib/sanbase_web/graphql/resolvers/report_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/report_resolver.ex
@@ -1,0 +1,38 @@
+defmodule SanbaseWeb.Graphql.Resolvers.ReportResolver do
+  require Logger
+
+  alias Sanbase.FileStore
+  alias Sanbase.Utils.FileHash
+  alias Sanbase.Report
+
+  def upload_report(_root, %{report: report}, _resolution) do
+    report = %{report | filename: milliseconds_str() <> "_" <> report.filename}
+    save_file(report)
+  end
+
+  def list_reports(_root, _args, _resolution) do
+    user = Repo.get(Sanbase.Auth.User, 31)
+    subscription = Sanbase.Billing.Subscription.current_subscription(user, @product_sanbase)
+
+    {:ok, Report.list_published_reports(subscription)}
+  end
+
+  defp save_file(%Plug.Upload{filename: file_name} = arg) do
+    with {:ok, content_hash} <- FileHash.calculate(arg.path),
+         {:ok, file_name} <- FileStore.store({arg, content_hash}),
+         file_url <- FileStore.url({file_name, content_hash}),
+         {:ok, report} <- Report.save(%{url: file_url}) do
+      {:ok, report.url}
+    else
+      {:error, reason} ->
+        Logger.error("Could not save file: #{file_name}. Reason: #{inspect(reason)}")
+        {:error, "Could not save file: #{file_name}."}
+    end
+  end
+
+  defp milliseconds_str() do
+    DateTime.utc_now()
+    |> DateTime.to_unix(:millisecond)
+    |> Integer.to_string()
+  end
+end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -135,6 +135,7 @@ defmodule SanbaseWeb.Graphql.Schema do
     import_fields(:promoter_queries)
     import_fields(:widget_queries)
     import_fields(:table_configuration_queries)
+    import_fields(:report_queries)
   end
 
   mutation do

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -75,6 +75,7 @@ defmodule SanbaseWeb.Graphql.Schema do
   import_types(Graphql.Schema.WidgetQueries)
   import_types(Graphql.Schema.EmailQueries)
   import_types(Graphql.Schema.TableConfigurationQueries)
+  import_types(Graphql.Schema.ReportQueries)
 
   def dataloader() do
     Dataloader.new(timeout: :timer.seconds(20), get_policy: :return_nil_on_error)
@@ -148,6 +149,7 @@ defmodule SanbaseWeb.Graphql.Schema do
     import_fields(:promoter_mutations)
     import_fields(:email_mutations)
     import_fields(:table_configuration_mutations)
+    import_fields(:report_mutations)
   end
 
   subscription do

--- a/lib/sanbase_web/graphql/schema/queries/report_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/report_queries.ex
@@ -1,21 +1,16 @@
 defmodule SanbaseWeb.Graphql.Schema.ReportQueries do
   use Absinthe.Schema.Notation
   alias SanbaseWeb.Graphql.Resolvers.ReportResolver
+  alias SanbaseWeb.Graphql.Middlewares.{BasicAuth, JWTAuth}
 
-  # import_types(SanbaseWeb.Graphql.Schema.ReportTypes)
-
-  object :report_data do
-    field(:url, :string)
-    field(:name, :string)
-    field(:descrption, :string)
-  end
+  import_types(SanbaseWeb.Graphql.ReportTypes)
 
   object :report_queries do
     @desc ~s"""
-
+    List all reports.
     """
-    field :list_reports, :report_data do
-      # middleware(JWTAuth)
+    field :list_reports, list_of(:report) do
+      middleware(JWTAuth)
 
       resolve(&ReportResolver.list_reports/3)
     end
@@ -23,14 +18,12 @@ defmodule SanbaseWeb.Graphql.Schema.ReportQueries do
 
   object :report_mutations do
     @desc ~s"""
-
+    Upload a report file.
     """
     field :upload_report, :string do
       arg(:report, non_null(:upload))
       arg(:name, :string)
-      arg(:descrption, :string)
-
-      # arg :metadata, :upload
+      arg(:description, :string)
 
       middleware(BasicAuth)
 

--- a/lib/sanbase_web/graphql/schema/queries/report_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/report_queries.ex
@@ -1,0 +1,40 @@
+defmodule SanbaseWeb.Graphql.Schema.ReportQueries do
+  use Absinthe.Schema.Notation
+  alias SanbaseWeb.Graphql.Resolvers.ReportResolver
+
+  # import_types(SanbaseWeb.Graphql.Schema.ReportTypes)
+
+  object :report_data do
+    field(:url, :string)
+    field(:name, :string)
+    field(:descrption, :string)
+  end
+
+  object :report_queries do
+    @desc ~s"""
+
+    """
+    field :list_reports, :report_data do
+      # middleware(JWTAuth)
+
+      resolve(&ReportResolver.list_reports/3)
+    end
+  end
+
+  object :report_mutations do
+    @desc ~s"""
+
+    """
+    field :upload_report, :string do
+      arg(:report, non_null(:upload))
+      arg(:name, :string)
+      arg(:descrption, :string)
+
+      # arg :metadata, :upload
+
+      middleware(BasicAuth)
+
+      resolve(&ReportResolver.upload_report/3)
+    end
+  end
+end

--- a/lib/sanbase_web/graphql/schema/queries/report_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/report_queries.ex
@@ -9,10 +9,10 @@ defmodule SanbaseWeb.Graphql.Schema.ReportQueries do
     @desc ~s"""
     List all reports.
     """
-    field :list_reports, list_of(:report) do
+    field :get_reports, list_of(:report) do
       middleware(JWTAuth)
 
-      resolve(&ReportResolver.list_reports/3)
+      resolve(&ReportResolver.get_reports/3)
     end
   end
 
@@ -22,7 +22,7 @@ defmodule SanbaseWeb.Graphql.Schema.ReportQueries do
     """
     field :upload_report, :string do
       arg(:report, non_null(:upload))
-      arg(:name, :string)
+      arg(:name, non_null(:string))
       arg(:description, :string)
 
       middleware(BasicAuth)

--- a/lib/sanbase_web/graphql/schema/types/report_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/report_types.ex
@@ -1,0 +1,9 @@
+defmodule SanbaseWeb.Graphql.ReportTypes do
+  use Absinthe.Schema.Notation
+
+  object :report do
+    field(:url, :string)
+    field(:name, :string)
+    field(:description, :string)
+  end
+end

--- a/lib/sanbase_web/report.ex
+++ b/lib/sanbase_web/report.ex
@@ -1,6 +1,0 @@
-defmodule SanbaseWeb.ExAdmin.Report do
-  use ExAdmin.Register
-
-  register_resource Sanbase.Report do
-  end
-end

--- a/lib/sanbase_web/report.ex
+++ b/lib/sanbase_web/report.ex
@@ -1,0 +1,6 @@
+defmodule SanbaseWeb.ExAdmin.Report do
+  use ExAdmin.Register
+
+  register_resource Sanbase.Report do
+  end
+end

--- a/priv/repo/migrations/20200706070758_create_reports.exs
+++ b/priv/repo/migrations/20200706070758_create_reports.exs
@@ -1,0 +1,15 @@
+defmodule Sanbase.Repo.Migrations.CreateReports do
+  use Ecto.Migration
+
+  def change do
+    create table(:reports) do
+      add(:name, :string)
+      add(:description, :text)
+      add(:url, :string)
+      add(:is_published, :boolean, default: false, null: false)
+      add(:is_pro, :boolean, default: false, null: false)
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20200706070758_create_reports.exs
+++ b/priv/repo/migrations/20200706070758_create_reports.exs
@@ -3,9 +3,9 @@ defmodule Sanbase.Repo.Migrations.CreateReports do
 
   def change do
     create table(:reports) do
-      add(:name, :string)
+      add(:name, :string, null: false)
       add(:description, :text)
-      add(:url, :string)
+      add(:url, :string, null: false)
       add(:is_published, :boolean, default: false, null: false)
       add(:is_pro, :boolean, default: false, null: false)
 

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -73,8 +73,6 @@ CREATE TYPE public.status AS ENUM (
 
 SET default_tablespace = '';
 
-SET default_table_access_method = heap;
-
 --
 -- Name: active_widgets; Type: TABLE; Schema: public; Owner: -
 --

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -1580,9 +1580,9 @@ ALTER SEQUENCE public.promo_trials_id_seq OWNED BY public.promo_trials.id;
 
 CREATE TABLE public.reports (
     id bigint NOT NULL,
-    name character varying(255),
+    name character varying(255) NOT NULL,
     description text,
-    url character varying(255),
+    url character varying(255) NOT NULL,
     is_published boolean DEFAULT false NOT NULL,
     is_pro boolean DEFAULT false NOT NULL,
     inserted_at timestamp without time zone NOT NULL,

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.13
--- Dumped by pg_dump version 11.6
+-- Dumped from database version 12.3
+-- Dumped by pg_dump version 12.3
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -73,7 +73,7 @@ CREATE TYPE public.status AS ENUM (
 
 SET default_tablespace = '';
 
-SET default_with_oids = false;
+SET default_table_access_method = heap;
 
 --
 -- Name: active_widgets; Type: TABLE; Schema: public; Owner: -
@@ -1577,6 +1577,41 @@ ALTER SEQUENCE public.promo_trials_id_seq OWNED BY public.promo_trials.id;
 
 
 --
+-- Name: reports; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.reports (
+    id bigint NOT NULL,
+    name character varying(255),
+    description text,
+    url character varying(255),
+    is_published boolean DEFAULT false NOT NULL,
+    is_pro boolean DEFAULT false NOT NULL,
+    inserted_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: reports_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.reports_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: reports_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.reports_id_seq OWNED BY public.reports.id;
+
+
+--
 -- Name: roles; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2588,6 +2623,13 @@ ALTER TABLE ONLY public.promo_trials ALTER COLUMN id SET DEFAULT nextval('public
 
 
 --
+-- Name: reports id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reports ALTER COLUMN id SET DEFAULT nextval('public.reports_id_seq'::regclass);
+
+
+--
 -- Name: roles id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -3071,6 +3113,14 @@ ALTER TABLE ONLY public.promo_coupons
 
 ALTER TABLE ONLY public.promo_trials
     ADD CONSTRAINT promo_trials_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: reports reports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reports
+    ADD CONSTRAINT reports_pkey PRIMARY KEY (id);
 
 
 --
@@ -4313,6 +4363,14 @@ ALTER TABLE ONLY public.user_intercom_attributes
 
 
 --
+-- Name: user_lists user_lists_table_configuration_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_lists
+    ADD CONSTRAINT user_lists_table_configuration_id_fkey FOREIGN KEY (table_configuration_id) REFERENCES public.table_configurations(id);
+
+
+--
 -- Name: user_lists user_lists_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4658,9 +4716,10 @@ INSERT INTO public."schema_migrations" (version) VALUES (20200601122422);
 INSERT INTO public."schema_migrations" (version) VALUES (20200601142229);
 INSERT INTO public."schema_migrations" (version) VALUES (20200602101130);
 INSERT INTO public."schema_migrations" (version) VALUES (20200611093359);
-INSERT INTO public."schema_migrations" (version) VALUES (20200622093455);
-INSERT INTO public."schema_migrations" (version) VALUES (20200622095648);
-INSERT INTO public."schema_migrations" (version) VALUES (20200622132624);
 INSERT INTO public."schema_migrations" (version) VALUES (20200618135228);
 INSERT INTO public."schema_migrations" (version) VALUES (20200619102126);
 INSERT INTO public."schema_migrations" (version) VALUES (20200622084937);
+INSERT INTO public."schema_migrations" (version) VALUES (20200622093455);
+INSERT INTO public."schema_migrations" (version) VALUES (20200622095648);
+INSERT INTO public."schema_migrations" (version) VALUES (20200622132624);
+INSERT INTO public."schema_migrations" (version) VALUES (20200706070758);

--- a/test/sanbase_web/reports_api_test.exs
+++ b/test/sanbase_web/reports_api_test.exs
@@ -54,31 +54,31 @@ defmodule SanbaseWeb.Graphql.ReportsApiTest do
     end
 
     test "with free sanbase user, list only free published reports", context do
-      res = list_reports(context.free_conn)
+      res = get_reports(context.free_conn)
 
-      assert Enum.map(res["data"]["listReports"], & &1["url"]) == [context.free_report.url]
+      assert Enum.map(res["data"]["getReports"], & &1["url"]) == [context.free_report.url]
     end
 
     test "with pro sanbase user list all published reports", context do
-      res = list_reports(context.pro_conn)
+      res = get_reports(context.pro_conn)
 
-      assert Enum.map(res["data"]["listReports"], & &1["url"]) == [
+      assert Enum.map(res["data"]["getReports"], & &1["url"]) == [
                context.free_report.url,
                context.pro_report.url
              ]
     end
 
     test "with user without auth returns unauthorized" do
-      %{"errors" => [error]} = list_reports(build_conn())
+      %{"errors" => [error]} = get_reports(build_conn())
 
       assert error["message"] =~ "unauthorized"
     end
   end
 
-  def list_reports(conn) do
+  def get_reports(conn) do
     query = """
     {
-      listReports
+      getReports
       {
         url
         name
@@ -95,7 +95,7 @@ defmodule SanbaseWeb.Graphql.ReportsApiTest do
   defp upload_report(conn) do
     mutation = """
       mutation {
-        uploadReport(report: "report")
+        uploadReport(report: "report", name: "New Alpha Report")
       }
     """
 

--- a/test/sanbase_web/reports_api_test.exs
+++ b/test/sanbase_web/reports_api_test.exs
@@ -1,0 +1,112 @@
+defmodule SanbaseWeb.Graphql.ReportsApiTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import Sanbase.Factory
+  import SanbaseWeb.Graphql.TestHelpers
+
+  setup do
+    user = insert(:user)
+
+    conn = setup_jwt_auth(build_conn(), user)
+    basic_auth_conn = setup_basic_auth(conn, "user", "pass")
+
+    {:ok, conn: conn, basic_auth_conn: basic_auth_conn}
+  end
+
+  describe "upload a report" do
+    test "succeeds with basic auth", context do
+      res = upload_report(context.basic_auth_conn)
+      assert res["data"]["uploadReport"] =~ "image.png"
+    end
+
+    test "unauthorized with no auth" do
+      %{"errors" => [error]} = upload_report(build_conn())
+      assert error["message"] =~ "unauthorized"
+    end
+
+    test "unauthorized for jwt auth", context do
+      %{"errors" => [error]} = upload_report(context.conn)
+      assert error["message"] =~ "unauthorized"
+    end
+  end
+
+  describe "list all reports" do
+    setup do
+      not_published = insert(:report, is_published: false)
+      free_report = insert(:report, is_pro: false, is_published: true)
+      pro_report = insert(:report, is_pro: true, is_published: true)
+
+      free_user = insert(:user)
+      free_conn = setup_jwt_auth(build_conn(), free_user)
+
+      pro_user = insert(:user)
+      insert(:subscription_pro_sanbase, user: pro_user)
+      pro_conn = setup_jwt_auth(build_conn(), pro_user)
+
+      {
+        :ok,
+        not_published: not_published,
+        free_report: free_report,
+        pro_report: pro_report,
+        free_conn: free_conn,
+        pro_conn: pro_conn
+      }
+    end
+
+    test "with free sanbase user, list only free published reports", context do
+      res = list_reports(context.free_conn)
+
+      assert Enum.map(res["data"]["listReports"], & &1["url"]) == [context.free_report.url]
+    end
+
+    test "with pro sanbase user list all published reports", context do
+      res = list_reports(context.pro_conn)
+
+      assert Enum.map(res["data"]["listReports"], & &1["url"]) == [
+               context.free_report.url,
+               context.pro_report.url
+             ]
+    end
+
+    test "with user without auth returns unauthorized" do
+      %{"errors" => [error]} = list_reports(build_conn())
+
+      assert error["message"] =~ "unauthorized"
+    end
+  end
+
+  def list_reports(conn) do
+    query = """
+    {
+      listReports
+      {
+        url
+        name
+      }
+    }
+    """
+
+    conn
+    |> post("/graphql", %{"query" => query})
+    |> json_response(200)
+  end
+
+  @test_file_path "#{File.cwd!()}/test/sanbase_web/graphql/assets/image.png"
+  defp upload_report(conn) do
+    mutation = """
+      mutation {
+        uploadReport(report: "report")
+      }
+    """
+
+    upload = %Plug.Upload{
+      content_type: "application/octet-stream",
+      filename: "image.png",
+      path: @test_file_path
+    }
+
+    conn
+    |> post("/graphql", %{"query" => mutation, "report" => upload})
+    |> json_response(200)
+  end
+end

--- a/test/support/sanbase_factory.ex
+++ b/test/support/sanbase_factory.ex
@@ -27,6 +27,7 @@ defmodule Sanbase.Factory do
   alias Sanbase.Chart
   alias Sanbase.TableConfiguration
   alias Sanbase.Email.NewsletterToken
+  alias Sanbase.Report
 
   def user_factory() do
     %User{
@@ -603,6 +604,13 @@ defmodule Sanbase.Factory do
       token: :crypto.strong_rand_bytes(64) |> Base.encode64(),
       email: (:crypto.strong_rand_bytes(16) |> Base.encode16()) <> "@santiment.net",
       email_token_generated_at: DateTime.utc_now()
+    }
+  end
+
+  def report_factory do
+    %Report{
+      url: "https://example.com/#{rand_hex_str()}_report.pdf",
+      name: "Alpha Report"
     }
   end
 


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Added APis to uploading a file report and listing uploaded reports
Admin interface for publishing and controlling if report is only for `PRO` users.

## Ticket

<!--- Issue to which the pull request is related -->
https://www.notion.so/santiment/APIs-to-store-and-retrieve-Alpha-reports-24750f6f15684adba95cc4f3143d0c39

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

## Usage
<!--- (Mainly graphql snippets that showcase how new API is used) -->

### Upload report

```bash
curl -X POST \
-F query="mutation { uploadReport(report: \"report\", name: \"Alpha Report title ...\")}" \
-F report=@report.pdf \
-u "user":"pass" \
http://localhost:4000/graphql
```

### List reports
```graphql
    {
      getReports
      {
        url
        name
        description
      }
    }
```

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
