### PR TITLE
Rework webhook so it can send to discord. Renama payload to content

### DIFF
--- a/test/sanbase/signals/trigger_test.exs
+++ b/test/sanbase/signals/trigger_test.exs
@@ -179,7 +179,7 @@ defmodule Sanbase.Signal.TriggersTest do
       })
 
     assert trigger_settings.target == created_trigger.trigger.settings |> Map.get(:target)
-    assert title = created_trigger.trigger.title
+    assert title == created_trigger.trigger.title
   end
 
   test "create trigger with icon and description" do
@@ -209,9 +209,9 @@ defmodule Sanbase.Signal.TriggersTest do
       })
 
     assert trigger_settings.target == created_trigger.trigger.settings |> Map.get(:target)
-    assert title = created_trigger.trigger.title
-    assert description = created_trigger.trigger.description
-    assert icon_url = created_trigger.trigger.icon_url
+    assert title == created_trigger.trigger.title
+    assert description == created_trigger.trigger.description
+    assert icon_url == created_trigger.trigger.icon_url
   end
 
   test "create trigger when there is existing one" do


### PR DESCRIPTION
## Changes
Change `payload` field to `content` and add the proper Content-Type headers so the signals' webhook format is recognized by discord.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
