### PR TITLE
Add addresses and balances to Intercom

### DIFF
--- a/lib/sanbase/auth/user.ex
+++ b/lib/sanbase/auth/user.ex
@@ -399,7 +399,7 @@ defmodule Sanbase.Auth.User do
   end
 
   def all() do
-    from(u in User, order_by: u.id)
+    from(u in User, order_by: u.id, preload: [:eth_accounts])
     |> Sanbase.Repo.all()
   end
 

--- a/lib/sanbase/intercom/intercom.ex
+++ b/lib/sanbase/intercom/intercom.ex
@@ -12,6 +12,7 @@ defmodule Sanbase.Intercom do
   alias Sanbase.Signal.UserTrigger
   alias Sanbase.Clickhouse.ApiCallData
   alias Sanbase.Intercom.UserAttributes
+  alias Sanbase.Auth.EthAccount
 
   @intercom_url "https://api.intercom.io/users"
 
@@ -46,18 +47,13 @@ defmodule Sanbase.Intercom do
     end
   end
 
-  def get_data_for_user(user_id) do
-    Repo.get(User, user_id)
-    |> fetch_stats_for_user(all_users_stats())
-    |> Jason.encode!()
-  end
-
   defp fetch_stats_for_user(
          %User{
            id: id,
            email: email,
            username: username,
            san_balance: san_balance,
+           eth_accounts: eth_accounts,
            stripe_customer_id: stripe_customer_id,
            inserted_at: inserted_at
          } = user,
@@ -78,6 +74,15 @@ defmodule Sanbase.Intercom do
     user_paid_after_trial =
       sanbase_trial_created_at && sanbase_subscription_current_status == "active"
 
+    address_balance_map =
+      eth_accounts
+      |> Enum.into(%{}, fn eth_account ->
+        case EthAccount.san_balance(eth_account) do
+          :error -> {eth_account.address, 0.0}
+          balance -> {eth_account.address, Sanbase.Math.to_float(balance)}
+        end
+      end)
+
     stats = %{
       user_id: id,
       email: email,
@@ -88,7 +93,8 @@ defmodule Sanbase.Intercom do
           all_watchlists_count: Map.get(watchlists_map, id, 0),
           all_triggers_count: Map.get(triggers_map, id, 0),
           all_insights_count: Map.get(insights_map, id, 0),
-          staked_san_tokens: format_balance(san_balance),
+          staked_san_tokens: Sanbase.Math.to_float(san_balance),
+          address_balance_map: address_balance_map,
           sanbase_subscription_current_status: sanbase_subscription_current_status,
           sanbase_trial_created_at: sanbase_trial_created_at,
           user_paid_after_trial: user_paid_after_trial,

--- a/lib/sanbase/intercom/intercom.ex
+++ b/lib/sanbase/intercom/intercom.ex
@@ -230,9 +230,6 @@ defmodule Sanbase.Intercom do
     end)
   end
 
-  defp format_balance(nil), do: 0.0
-  defp format_balance(balance), do: Decimal.to_float(balance)
-
   defp format_dt(nil), do: nil
 
   defp format_dt(unix_dt) do


### PR DESCRIPTION
## Changes

Add addresses and their balances as Intercom property
`"address_balance_map": {"0xf878c003aaddr1": 1008.0, "0xf123addr2": 0.0}`

The total is in `staked_san_tokens` property.

<!--- Describe your changes -->

## Ticket
https://www.notion.so/santiment/Add-Intercom-Properties-for-connected-wallet-and-balance-on-this-wallet-b0214eb858df49f288ab30ef2b61025a

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
