### PR TITLE
Rework allProjectsByFunction to return object

### DIFF
--- a/lib/sanbase/signals/trigger/settings/screener_trigger_settings.ex
+++ b/lib/sanbase/signals/trigger/settings/screener_trigger_settings.ex
@@ -72,7 +72,8 @@ defmodule Sanbase.Signal.Trigger.ScreenerTriggerSettings do
   end
 
   def get_data(%__MODULE__{operation: %{selector: _} = selector}) do
-    {:ok, slugs} = Project.ListSelector.slugs(selector)
+    {:ok, %{slugs: slugs}} = Project.ListSelector.slugs(selector)
+
     slugs
   end
 

--- a/lib/sanbase/signals/trigger/trigger.ex
+++ b/lib/sanbase/signals/trigger/trigger.ex
@@ -170,7 +170,7 @@ defmodule Sanbase.Signal.Trigger do
 
       %Sanbase.UserList{} = user_list ->
         case Sanbase.UserList.get_projects(user_list) do
-          {:ok, projects} ->
+          {:ok, %{projects: projects}} ->
             projects
             |> Enum.map(& &1.slug)
             |> remove_targets_on_cooldown(trigger, :slug)

--- a/lib/sanbase/user_lists/watchlist_function.ex
+++ b/lib/sanbase/user_lists/watchlist_function.ex
@@ -3,6 +3,13 @@ defmodule Sanbase.WatchlistFunction do
   @derive Jason.Encoder
   defstruct name: "empty", args: []
 
+  @type result :: %{
+          required(:projects) => list(),
+          required(:total_projects_count) => non_neg_integer(),
+          optional(:has_pagination?) => boolean(),
+          optional(:all_included_slugs) => list(String.t())
+        }
+
   alias Sanbase.Model.Project
 
   @impl Ecto.Type
@@ -56,11 +63,15 @@ defmodule Sanbase.WatchlistFunction do
 
   def valid_function?(%__MODULE__{name: "empty"}), do: true
 
+  @spec evaluate(%__MODULE__{}) :: {:ok, result} | {:error, String.t()}
+  def evaluate(watchlist_function)
+
   def evaluate(%__MODULE__{name: "selector", args: args}) do
-    case Map.split(args, ["filters", "order", "pagination"]) do
+    args = Enum.into(args, %{}, fn {k, v} -> {Inflex.underscore(k), v} end)
+
+    case Map.split(args, ["filters", "order_by", "pagination"]) do
       {selector, empty_map} when map_size(empty_map) == 0 ->
-        {:ok, projects} = Project.ListSelector.projects(%{selector: selector})
-        projects
+        Project.ListSelector.projects(%{selector: selector})
 
       {_selector, unsupported_keys_map} ->
         {:error,
@@ -72,12 +83,24 @@ defmodule Sanbase.WatchlistFunction do
 
   def evaluate(%__MODULE__{name: "market_segment", args: args}) do
     market_segment = Map.get(args, "market_segment") || Map.fetch!(args, :market_segment)
-    Project.List.by_market_segment_any_of(market_segment)
+    projects = Project.List.by_market_segment_any_of(market_segment)
+
+    {:ok,
+     %{
+       projects: projects,
+       total_projects_count: length(projects)
+     }}
   end
 
   def evaluate(%__MODULE__{name: "market_segments", args: args}) do
     market_segments = Map.get(args, "market_segments") || Map.fetch!(args, :market_segments)
-    Project.List.by_market_segment_all_of(market_segments)
+    projects = Project.List.by_market_segment_all_of(market_segments)
+
+    {:ok,
+     %{
+       projects: projects,
+       total_projects_count: length(projects)
+     }}
   end
 
   def evaluate(%__MODULE__{name: "top_erc20_projects", args: args}) do
@@ -85,9 +108,16 @@ defmodule Sanbase.WatchlistFunction do
     ignored_projects = Map.get(args, "ignored_projects") || Map.get(args, :ignored_projects) || []
     ignored_projects_mapset = MapSet.new(ignored_projects)
 
-    Project.List.erc20_projects_page(1, size + length(ignored_projects))
-    |> Enum.reject(fn %Project{slug: slug} -> slug in ignored_projects_mapset end)
-    |> Enum.take(size)
+    projects =
+      Project.List.erc20_projects_page(1, size + length(ignored_projects))
+      |> Enum.reject(fn %Project{slug: slug} -> slug in ignored_projects_mapset end)
+      |> Enum.take(size)
+
+    {:ok,
+     %{
+       projects: projects,
+       total_projects_count: length(projects)
+     }}
   end
 
   def evaluate(%__MODULE__{name: "top_all_projects", args: args}) do
@@ -95,26 +125,57 @@ defmodule Sanbase.WatchlistFunction do
     ignored_projects = Map.get(args, "ignored_projects") || Map.get(args, :ignored_projects) || []
     ignored_projects_mapset = MapSet.new(ignored_projects)
 
-    Project.List.projects_page(1, size + length(ignored_projects))
-    |> Enum.reject(fn %Project{slug: slug} -> slug in ignored_projects_mapset end)
-    |> Enum.take(size)
+    projects =
+      Project.List.projects_page(1, size + length(ignored_projects))
+      |> Enum.reject(fn %Project{slug: slug} -> slug in ignored_projects_mapset end)
+      |> Enum.take(size)
+
+    {:ok,
+     %{
+       projects: projects,
+       total_projects_count: length(projects)
+     }}
   end
 
   def evaluate(%__MODULE__{name: "min_volume", args: args}) do
     min_volume = Map.get(args, "min_volume") || Map.fetch!(args, :min_volume)
-    Project.List.projects(min_volume: min_volume)
+    projects = Project.List.projects(min_volume: min_volume)
+
+    {:ok,
+     %{
+       projects: projects,
+       total_projects_count: length(projects)
+     }}
   end
 
   def evaluate(%__MODULE__{name: "slugs", args: args}) do
     slugs = Map.get(args, "slugs") || Map.fetch!(args, :slugs)
-    Project.List.by_slugs(slugs)
+    projects = Project.List.by_slugs(slugs)
+
+    {:ok,
+     %{
+       projects: projects,
+       total_projects_count: length(projects)
+     }}
   end
 
   def evaluate(%__MODULE__{name: "trending_projects"}) do
-    Project.List.currently_trending_projects()
+    projects = Project.List.currently_trending_projects()
+
+    {:ok,
+     %{
+       projects: projects,
+       total_projects_count: length(projects)
+     }}
   end
 
-  def evaluate(%__MODULE__{name: "empty"}), do: []
+  def evaluate(%__MODULE__{name: "empty"}) do
+    {:ok,
+     %{
+       projects: [],
+       total_projects_count: 0
+     }}
+  end
 
   def empty(), do: %__MODULE__{name: "empty", args: []}
 

--- a/lib/sanbase_web/graphql/resolvers/project/project_list_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_list_resolver.ex
@@ -33,8 +33,16 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectListResolver do
 
   def all_projects_by_function(_root, %{function: function}, _resolution) do
     with {:ok, function} <- Sanbase.WatchlistFunction.cast(function),
-         projects when is_list(projects) <- Sanbase.WatchlistFunction.evaluate(function) do
-      {:ok, projects}
+         {:ok, data} <- Sanbase.WatchlistFunction.evaluate(function) do
+      %{projects: projects, total_projects_count: total_projects_count} = data
+
+      {:ok,
+       %{
+         projects: projects,
+         stats: %{projects_count: total_projects_count}
+       }}
+    else
+      error -> error
     end
   end
 

--- a/lib/sanbase_web/graphql/resolvers/user/user_list_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/user_list_resolver.ex
@@ -28,7 +28,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserListResolver do
         _args,
         resolution
       ) do
-    with {:ok, projects} <- UserList.get_projects(user_list) do
+    with {:ok, %{projects: projects}} <- UserList.get_projects(user_list) do
       trending_words_stats = trending_words_stats(projects, resolution)
       result = Map.merge(trending_words_stats, %{projects_count: length(projects)})
       {:ok, result}
@@ -97,7 +97,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserListResolver do
         %{from: from, to: to, interval: interval},
         _resolution
       ) do
-    with {:ok, projects} <- UserList.get_projects(user_list),
+    with {:ok, %{projects: projects}} <- UserList.get_projects(user_list),
          slugs when is_list(slugs) <- Enum.map(projects, & &1.slug),
          {:ok, result} <- Sanbase.Price.combined_marketcap_and_volume(slugs, from, to, interval) do
       {:ok, result}
@@ -112,7 +112,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserListResolver do
 
   def list_items(%UserList{} = user_list, _args, _resolution) do
     case UserList.get_projects(user_list) do
-      {:ok, projects} ->
+      {:ok, %{projects: projects}} ->
         result =
           projects
           |> Project.preload_assocs()

--- a/lib/sanbase_web/graphql/schema/queries/project_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/project_queries.ex
@@ -59,7 +59,7 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
       cache_resolve(&ProjectListResolver.all_currency_projects/3)
     end
 
-    field :all_projects_by_function, list_of(:project) do
+    field :all_projects_by_function, :projects_object do
       meta(access: :free)
 
       arg(:function, :json)

--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -68,6 +68,15 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     field(:anomalies, list_of(:string))
   end
 
+  object :projects_object_stats do
+    field(:projects_count, non_null(:integer))
+  end
+
+  object :projects_object do
+    field(:projects, list_of(:project))
+    field(:stats, :projects_object_stats)
+  end
+
   # Includes all available fields
   @desc ~s"""
   A type fully describing a project.

--- a/test/sanbase_web/graphql/projects/projects_by_function_test.exs
+++ b/test/sanbase_web/graphql/projects/projects_by_function_test.exs
@@ -11,7 +11,7 @@ defmodule SanbaseWeb.Graphql.ProjectsByFunctionTest do
     coin = insert(:market_segment, %{name: "coin"})
     mineable = insert(:market_segment, %{name: "mineable"})
 
-    insert(:project, %{ticker: "TUSD", slug: "tether", market_segment: stablecoin})
+    p1 = insert(:project, %{ticker: "TUSD", slug: "tether", market_segment: stablecoin})
     insert(:latest_cmc_data, %{coinmarketcap_id: "tether", rank: 4, volume_usd: 3_000_000_000})
 
     insert(:random_erc20_project, %{
@@ -23,13 +23,13 @@ defmodule SanbaseWeb.Graphql.ProjectsByFunctionTest do
 
     insert(:latest_cmc_data, %{coinmarketcap_id: "dai", rank: 40, volume_usd: 15_000_000})
 
-    insert(:project, %{ticker: "ETH", slug: "ethereum", market_segment: mineable})
+    p2 = insert(:project, %{ticker: "ETH", slug: "ethereum", market_segment: mineable})
     insert(:latest_cmc_data, %{coinmarketcap_id: "ethereum", rank: 2, volume_usd: 3_000_000_000})
 
-    insert(:project, %{ticker: "BTC", slug: "bitcoin", market_segment: mineable})
+    p3 = insert(:project, %{ticker: "BTC", slug: "bitcoin", market_segment: mineable})
     insert(:latest_cmc_data, %{coinmarketcap_id: "bitcoin", rank: 1, volume_usd: 15_000_000_000})
 
-    insert(:project, %{ticker: "XRP", slug: "ripple", market_segment: mineable})
+    p4 = insert(:project, %{ticker: "XRP", slug: "ripple", market_segment: mineable})
     insert(:latest_cmc_data, %{coinmarketcap_id: "ripple", rank: 3, volume_usd: 1_000_000_000})
 
     insert(:random_erc20_project, %{
@@ -52,23 +52,74 @@ defmodule SanbaseWeb.Graphql.ProjectsByFunctionTest do
 
     conn = build_conn()
 
-    {:ok, conn: conn}
+    {:ok, conn: conn, p1: p1, p2: p2, p3: p3, p4: p4}
   end
 
-  test "dynamic watchlist for market segments", %{conn: conn} do
+  test "projects by function for selector", context do
+    %{conn: conn, p1: p1, p2: p2, p3: p3, p4: p4} = context
+
+    function = %{
+      "name" => "selector",
+      "args" => %{
+        "pagination" => %{"page" => 1, "pageSize" => 2},
+        "orderBy" => %{
+          "metric" => "daily_active_addresses",
+          "from" => "#{Timex.shift(Timex.now(), days: -7)}",
+          "to" => "#{Timex.now()}",
+          "aggregation" => "#{:last}",
+          "direction" => :asc
+        },
+        "filters" => [
+          %{
+            "metric" => "daily_active_addresses",
+            "from" => "#{Timex.shift(Timex.now(), days: -7)}",
+            "to" => "#{Timex.now()}",
+            "aggregation" => "#{:last}",
+            "operator" => "#{:greater_than_or_equal_to}",
+            "threshold" => 10
+          }
+        ]
+      }
+    }
+
+    Sanbase.Mock.prepare_mock2(
+      &Sanbase.Metric.slugs_by_filter/6,
+      {:ok, [p1.slug, p2.slug, p3.slug, p4.slug]}
+    )
+    |> Sanbase.Mock.prepare_mock2(
+      &Sanbase.Metric.slugs_order/5,
+      {:ok, [p1.slug, p2.slug, p3.slug, p4.slug]}
+    )
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      result =
+        execute_query(conn, query(function))
+        |> get_in(["data", "allProjectsByFunction"])
+
+      projects = result["projects"]
+      stats = result["stats"]
+
+      assert stats == %{"projectsCount" => 4}
+      assert length(projects) == 2
+      slugs = Enum.map(projects, & &1["slug"])
+
+      assert slugs == [p1.slug, p2.slug]
+    end)
+  end
+
+  test "projects by function for market segments", %{conn: conn} do
     function = %{"name" => "market_segment", "args" => %{"market_segment" => "stablecoin"}}
 
     result = execute_query(conn, query(function))
-    projects = result["data"]["allProjectsByFunction"]
+    projects = result["data"]["allProjectsByFunction"]["projects"]
     slugs = Enum.map(projects, & &1["slug"]) |> Enum.sort()
 
     assert slugs == ["dai", "tether"]
   end
 
-  test "dynamic watchlist for top erc20 projects", %{conn: conn} do
+  test "projects by function for top erc20 projects", %{conn: conn} do
     function = %{"name" => "top_erc20_projects", "args" => %{"size" => 2}}
     result = execute_query(conn, query(function))
-    projects = result["data"]["allProjectsByFunction"]
+    projects = result["data"]["allProjectsByFunction"]["projects"]
 
     assert projects == [
              %{"slug" => "maker"},
@@ -76,10 +127,10 @@ defmodule SanbaseWeb.Graphql.ProjectsByFunctionTest do
            ]
   end
 
-  test "dynamic watchlist for top all projects", %{conn: conn} do
+  test "projects by function for top all projects", %{conn: conn} do
     function = %{"name" => "top_all_projects", "args" => %{"size" => 3}}
     result = execute_query(conn, query(function))
-    projects = result["data"]["allProjectsByFunction"]
+    projects = result["data"]["allProjectsByFunction"]["projects"]
 
     assert projects == [
              %{"slug" => "bitcoin"},
@@ -88,10 +139,10 @@ defmodule SanbaseWeb.Graphql.ProjectsByFunctionTest do
            ]
   end
 
-  test "dynamic watchlist for min volume", %{conn: conn} do
+  test "projects by function for min volume", %{conn: conn} do
     function = %{"name" => "min_volume", "args" => %{"min_volume" => 1_000_000_000}}
     result = execute_query(conn, query(function, [:volume_usd]))
-    projects = result["data"]["allProjectsByFunction"]
+    projects = result["data"]["allProjectsByFunction"]["projects"]
 
     slugs = projects |> Enum.map(& &1["slug"])
     volumes = projects |> Enum.map(& &1["volumeUsd"])
@@ -100,10 +151,10 @@ defmodule SanbaseWeb.Graphql.ProjectsByFunctionTest do
     assert Enum.all?(volumes, &Kernel.>=(&1, 1_000_000_000))
   end
 
-  test "dynamic watchlist for slug list", %{conn: conn} do
+  test "projects by function for slug list", %{conn: conn} do
     function = %{"name" => "slugs", "args" => %{"slugs" => ["bitcoin", "santiment"]}}
     result = execute_query(conn, query(function))
-    projects = result["data"]["allProjectsByFunction"]
+    projects = result["data"]["allProjectsByFunction"]["projects"]
 
     assert projects == [
              %{"slug" => "bitcoin"},
@@ -118,8 +169,13 @@ defmodule SanbaseWeb.Graphql.ProjectsByFunctionTest do
       allProjectsByFunction(
         function: '#{function}'
         ) {
-         slug
-         #{additional_fields |> Enum.join(" ")}
+         projects{
+           slug
+           #{additional_fields |> Enum.join(" ")}
+         }
+         stats{
+           projectsCount
+         }
       }
     } | |> String.replace(~r|\"|, ~S|\\"|) |> String.replace(~r|'|, ~S|"|)
   end


### PR DESCRIPTION
## Changes

- The returned object contains the projects and some stats.
- Rework the return type of the watchlist function to also return the
number of projects that are in the watchlist. In case of present
pagination (the selector function) the total number of projects is
returned so the client knows the right amuount of pages that it can
show.

```graphql
{
  allProjectsByFunction(function: ....) {
    projects {
       slug
    }
   stats {
      projectsCount
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
