### PR TITLE
Add filters_combinator in the projects' selector

### DIFF
--- a/lib/sanbase/user_lists/user_list.ex
+++ b/lib/sanbase/user_lists/user_list.ex
@@ -89,7 +89,7 @@ defmodule Sanbase.UserList do
 
     case function |> WatchlistFunction.valid_function?() do
       true -> []
-      false -> [function: "Provided watchlist function is not valid."]
+      {:error, error} -> [function: "Provided watchlist function is not valid. Reason: #{error}"]
     end
   end
 

--- a/lib/sanbase/user_lists/watchlist_function.ex
+++ b/lib/sanbase/user_lists/watchlist_function.ex
@@ -16,47 +16,90 @@ defmodule Sanbase.WatchlistFunction do
   def type, do: :map
 
   def valid_function?(%__MODULE__{name: "selector", args: args}) do
+    args = Enum.into(args, %{}, fn {k, v} -> {Inflex.underscore(k), v} end)
+
     with {selector, empty_map} when map_size(empty_map) == 0 <-
-           Map.split(args, ["filters", "order", "pagination"]),
+           Map.split(args, ["filters", "order_by", "pagination", "filters_combinator"]),
          true <- Project.ListSelector.valid_selector?(%{selector: selector}) do
       true
     else
-      _ ->
-        false
+      {%{}, %{} = unsupported_keys_map} ->
+        {:error,
+         "Dynamic watchlist 'selector' has unsupported fields: #{
+           inspect(Map.keys(unsupported_keys_map))
+         }"}
+
+      {:error, error} ->
+        {:error, error}
     end
   end
 
   def valid_function?(%__MODULE__{name: "market_segment", args: args}) do
     market_segment = Map.get(args, "market_segment") || Map.fetch!(args, :market_segment)
-    is_binary(market_segment)
+
+    case is_binary(market_segment) do
+      true -> true
+      false -> {:error, "The market_segment argument must be a string."}
+    end
   end
 
   def valid_function?(%__MODULE__{name: "market_segments", args: args}) do
     market_segment = Map.get(args, "market_segments") || Map.fetch!(args, :market_segments)
-    is_list(market_segment) and market_segment != []
+
+    case is_list(market_segment) and market_segment != [] do
+      true -> true
+      false -> {:error, "The market_segments argument must be a non-empty list."}
+    end
   end
 
   def valid_function?(%__MODULE__{name: "top_erc20_projects", args: args}) do
     size = Map.get(args, "size") || Map.fetch!(args, :size)
     ignored_projects = Map.get(args, "ignored_projects") || Map.get(args, :ignored_projects) || []
-    is_list(ignored_projects) and is_integer(size) and size > 0
+
+    case is_integer(size) and size > 0 do
+      false ->
+        {:error, "The size argument must be a positive integer."}
+
+      true ->
+        case is_list(ignored_projects) do
+          true -> true
+          false -> {:error, "The ignored projects argument must be a list."}
+        end
+    end
   end
 
   def valid_function?(%__MODULE__{name: "top_all_projects", args: args}) do
     size = Map.get(args, "size") || Map.fetch!(args, :size)
     ignored_projects = Map.get(args, "ignored_projects") || Map.get(args, :ignored_projects) || []
 
-    is_list(ignored_projects) and is_integer(size) and size > 0
+    case is_integer(size) and size > 0 do
+      false ->
+        {:error, "The size argument must be a positive integer."}
+
+      true ->
+        case is_list(ignored_projects) do
+          true -> true
+          false -> {:error, "The ignored projects argument must be a list."}
+        end
+    end
   end
 
   def valid_function?(%__MODULE__{name: "min_volume", args: args}) do
     min_volume = Map.get(args, "min_volume") || Map.fetch!(args, :min_volume)
-    is_number(min_volume) and min_volume >= 0
+
+    case is_number(min_volume) and min_volume >= 0 do
+      true -> true
+      false -> {:error, "The min volume argument must be a non-negative number."}
+    end
   end
 
   def valid_function?(%__MODULE__{name: "slugs", args: args}) do
     slugs = Map.get(args, "slugs") || Map.fetch!(args, :slugs)
-    is_list(slugs)
+
+    case is_list(slugs) and slugs != [] do
+      true -> true
+      false -> {:error, "The slugs argument must be a non-empty list."}
+    end
   end
 
   def valid_function?(%__MODULE__{name: "trending_projects"}), do: true
@@ -69,7 +112,7 @@ defmodule Sanbase.WatchlistFunction do
   def evaluate(%__MODULE__{name: "selector", args: args}) do
     args = Enum.into(args, %{}, fn {k, v} -> {Inflex.underscore(k), v} end)
 
-    case Map.split(args, ["filters", "order_by", "pagination"]) do
+    case Map.split(args, ["filters", "order_by", "pagination", "filters_combinator"]) do
       {selector, empty_map} when map_size(empty_map) == 0 ->
         Project.ListSelector.projects(%{selector: selector})
 
@@ -180,9 +223,7 @@ defmodule Sanbase.WatchlistFunction do
   def empty(), do: %__MODULE__{name: "empty", args: []}
 
   @impl Ecto.Type
-  def cast(function) when is_binary(function) do
-    parse(function)
-  end
+  def cast(function) when is_binary(function), do: parse(function)
 
   @impl Ecto.Type
   def cast(%__MODULE__{} = function), do: {:ok, function}

--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -33,6 +33,11 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     value(:desc)
   end
 
+  enum :filters_combinator do
+    value(:and)
+    value(:or)
+  end
+
   input_object :project_pagination_input_object do
     field(:page, non_null(:integer))
     field(:page_size, non_null(:integer))
@@ -59,6 +64,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
 
   input_object :projects_selector_input_object do
     field(:filters, list_of(:project_filter_input_object))
+    field(:filters_combinator, :filters_combinator, default_value: :and)
     field(:order_by, :project_order_input_object)
     field(:pagination, :project_pagination_input_object)
   end


### PR DESCRIPTION
## Changes

The `selector` used in `allProjects` and in `function` in dynamic watchlist and `allProjectsByFunction` now has an additional `filtersCombinator: AND | OR` field. It controls how the different filters are combined. The old behavior (and current default) is `AND` - the projects in the result must satisfy **all** filters. The `OR` combination returns the projects that satisfy at least one of the filters. This is used to implement outside channel logic (price less than $1 or more than $10, etc.)

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
