### PR TITLE
Handle metric aliases

### DIFF
--- a/lib/sanbase/clickhouse/metadata_helper.ex
+++ b/lib/sanbase/clickhouse/metadata_helper.ex
@@ -9,7 +9,9 @@ defmodule Sanbase.Clickhouse.MetadataHelper do
   # Map from the names used in ClickHouse to the publicly exposed ones.
   # Example: stack_circulation_20y -> circulation
   @original_name_to_metric_name Sanbase.Clickhouse.Metric.FileHandler.name_to_metric_map()
-                                |> Enum.into(%{}, fn {k, v} -> {v, k} end)
+                                |> Enum.reduce(%{}, fn {k, v}, acc ->
+                                  Map.update(acc, v, [k], fn list -> [k | list] end)
+                                end)
 
   def slug_to_asset_id_map() do
     cache_key = {__MODULE__, __ENV__.function} |> Sanbase.Cache.hash()
@@ -46,8 +48,12 @@ defmodule Sanbase.Clickhouse.MetadataHelper do
       args = []
 
       ClickhouseRepo.query_reduce(query, args, %{}, fn [metric_id, name], acc ->
-        name = Map.get(@original_name_to_metric_name, name, name)
-        Map.put(acc, name, metric_id)
+        names = Map.get(@original_name_to_metric_name, name, [name])
+
+        names
+        |> Enum.reduce(acc, fn inner_name, inner_acc ->
+          Map.put(inner_acc, inner_name, metric_id)
+        end)
       end)
     end)
   end
@@ -58,7 +64,13 @@ defmodule Sanbase.Clickhouse.MetadataHelper do
     Sanbase.Cache.get_or_store({cache_key, 600}, fn ->
       case metric_name_to_metric_id_map() do
         {:ok, data} ->
-          {:ok, data |> Enum.into(%{}, fn {k, v} -> {v, k} end)}
+          map =
+            data
+            |> Enum.reduce(%{}, fn {name, id}, acc ->
+              Map.update(acc, id, [name], fn list -> [name | list] end)
+            end)
+
+          {:ok, map}
 
         {:error, error} ->
           {:error, error}

--- a/lib/sanbase/clickhouse/metric/metric.ex
+++ b/lib/sanbase/clickhouse/metric/metric.ex
@@ -283,11 +283,15 @@ defmodule Sanbase.Clickhouse.Metric do
     {:ok, metric_map} = metric_id_to_metric_name_map()
 
     ClickhouseRepo.query_reduce(query, args, [], fn [metric_id], acc ->
-      metric = Map.get(metric_map, metric_id |> Sanbase.Math.to_integer())
+      metrics = Map.get(metric_map, metric_id |> Sanbase.Math.to_integer())
 
-      case is_nil(metric) or metric not in @metrics_mapset do
-        true -> acc
-        false -> [metric | acc]
+      case metrics != nil and metrics != [] do
+        true ->
+          metrics = Enum.filter(metrics, &(&1 in @metrics_mapset))
+          metrics ++ acc
+
+        false ->
+          acc
       end
     end)
   end

--- a/test/sanbase_web/graphql/anomaly/api_project_available_metrics_test.exs
+++ b/test/sanbase_web/graphql/anomaly/api_project_available_metrics_test.exs
@@ -26,10 +26,11 @@ defmodule Sanbase.Project.AvailableMetricsApiTest do
     )
     |> Sanbase.Mock.prepare_mock2(
       &Sanbase.Clickhouse.MetadataHelper.metric_id_to_metric_name_map/0,
-      {:ok, %{1 => "dev_activity", 2 => "daily_active_addresses", 3 => "exchange_balance"}}
+      {:ok, %{1 => ["dev_activity"], 2 => ["daily_active_addresses"], 3 => ["exchange_balance"]}}
     )
     |> Sanbase.Mock.run_with_mocks(fn ->
       result = get_available_anomalies(project)
+
       %{"data" => %{"projectBySlug" => %{"availableAnomalies" => available_anomalies}}} = result
 
       assert available_anomalies |> Enum.sort() ==


### PR DESCRIPTION
## Changes
Metric aliases are not properly shown in the available metrics APIs.

The metric_id <-> metric_name is not a one-to-one mapping now. One metric_id can have multiple metric names. This allows introducing aliases for metrics. For example, we can introduce `age_consumed` along `age_destroyed` as we stick to this name in our products.

Anomalies internals use these metric mappings, so some reworks there are needed, too.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
