### PR TITLE
Add chart events

### DIFF
--- a/lib/sanbase/chart/configuration.ex
+++ b/lib/sanbase/chart/configuration.ex
@@ -24,6 +24,11 @@ defmodule Sanbase.Chart.Configuration do
     belongs_to(:user, Sanbase.Auth.User)
     belongs_to(:project, Sanbase.Model.Project)
 
+    has_many(:chart_events, Sanbase.Insight.Post,
+      foreign_key: :chart_configuration_for_event_id,
+      where: [is_chart_event: true]
+    )
+
     timestamps()
   end
 
@@ -96,7 +101,7 @@ defmodule Sanbase.Chart.Configuration do
   end
 
   defp get_chart_configuration(config_id, querying_user_id) do
-    case Repo.get(__MODULE__, config_id) do
+    case Repo.one(from(conf in __MODULE__, where: conf.id == ^config_id, preload: :chart_events)) do
       %__MODULE__{user_id: user_id, is_public: is_public} = conf
       when user_id == querying_user_id or is_public == true ->
         {:ok, conf}

--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -393,6 +393,10 @@ defmodule Sanbase.Insight.Post do
           })
         )
         |> Repo.insert()
+        |> case do
+          {:ok, post} -> {:ok, post |> Repo.preload(@preloads)}
+          {:error, changeset} -> {:error, changeset}
+        end
 
       {:error, reason} ->
         {:error, reason}

--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -118,9 +118,9 @@ defmodule Sanbase.Insight.Post do
       :ready_state,
       :is_pulse,
       :is_paywall_required,
-      :is_chart_event,
       :prediction,
       :price_chart_project_id,
+      :is_chart_event,
       :chart_event_datetime
     ])
     |> Tag.put_tags(attrs)
@@ -382,15 +382,21 @@ defmodule Sanbase.Insight.Post do
         user_id,
         %{chart_configuration_id: chart_configuration_for_event_id} = args
       ) do
-    %__MODULE__{user_id: user_id}
-    |> create_changeset(
-      Map.merge(args, %{
-        chart_configuration_for_event_id: chart_configuration_for_event_id,
-        is_chart_event: true,
-        ready_state: @published
-      })
-    )
-    |> Repo.insert()
+    case Configuration.by_id(chart_configuration_for_event_id, user_id) do
+      {:ok, conf} ->
+        %__MODULE__{user_id: user_id}
+        |> create_changeset(
+          Map.merge(args, %{
+            chart_configuration_for_event_id: conf.id,
+            is_chart_event: true,
+            ready_state: @published
+          })
+        )
+        |> Repo.insert()
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   # Helper functions

--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -13,10 +13,11 @@ defmodule Sanbase.Insight.Post do
   alias Sanbase.Insight.{Post, PostImage}
   alias Sanbase.Timeline.TimelineEvent
   alias Sanbase.Metric.MetricPostgresData
+  alias Sanbase.Chart.Configuration
 
   require Logger
 
-  @preloads [:votes, :user, :images, :tags]
+  @preloads [:votes, :user, :images, :tags, :chart_configuration_for_event]
   # state
   @awaiting_approval "awaiting_approval"
   @approved "approved"
@@ -39,11 +40,16 @@ defmodule Sanbase.Insight.Post do
     field(:is_paywall_required, :boolean, default: false)
     field(:prediction, :string, default: "unspecified")
 
+    # Chart events are insights connected to specific chart configuration and datetime
+    field(:is_chart_event, :boolean, default: false)
+    field(:chart_event_datetime, :utc_datetime)
+    belongs_to(:chart_configuration_for_event, Configuration)
+
     belongs_to(:price_chart_project, Project)
 
     has_one(:featured_item, Sanbase.FeaturedItem, on_delete: :delete_all)
 
-    has_many(:chart_configurations, Sanbase.Chart.Configuration)
+    has_many(:chart_configurations, Configuration)
     has_many(:images, PostImage, on_delete: :delete_all)
     has_many(:timeline_events, TimelineEvent, on_delete: :delete_all)
     has_many(:votes, Vote, on_delete: :delete_all)
@@ -82,7 +88,11 @@ defmodule Sanbase.Insight.Post do
       :is_pulse,
       :is_paywall_required,
       :prediction,
-      :price_chart_project_id
+      :price_chart_project_id,
+      :is_chart_event,
+      :chart_event_datetime,
+      :chart_configuration_for_event_id,
+      :ready_state
     ])
     |> Tag.put_tags(attrs)
     |> MetricPostgresData.put_metrics(attrs)
@@ -108,8 +118,10 @@ defmodule Sanbase.Insight.Post do
       :ready_state,
       :is_pulse,
       :is_paywall_required,
+      :is_chart_event,
       :prediction,
-      :price_chart_project_id
+      :price_chart_project_id,
+      :chart_event_datetime
     ])
     |> Tag.put_tags(attrs)
     |> MetricPostgresData.put_metrics(attrs)
@@ -364,6 +376,21 @@ defmodule Sanbase.Insight.Post do
 
     from(p in Post, where: p.user_id == ^user_id)
     |> Repo.update_all(set: [user_id: anon_user_id])
+  end
+
+  def create_chart_event(
+        user_id,
+        %{chart_configuration_id: chart_configuration_for_event_id} = args
+      ) do
+    %__MODULE__{user_id: user_id}
+    |> create_changeset(
+      Map.merge(args, %{
+        chart_configuration_for_event_id: chart_configuration_for_event_id,
+        is_chart_event: true,
+        ready_state: @published
+      })
+    )
+    |> Repo.insert()
   end
 
   # Helper functions

--- a/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
@@ -227,4 +227,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.InsightResolver do
       {:ok, Dataloader.get(loader, SanbaseDataloader, :insights_comments_count, id) || 0}
     end)
   end
+
+  def create_chart_event(_root, args, %{context: %{auth: %{current_user: user}}}) do
+    Post.create_chart_event(user.id, args)
+  end
 end

--- a/lib/sanbase_web/graphql/schema/queries/insight_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/insight_queries.ex
@@ -272,7 +272,7 @@ defmodule SanbaseWeb.Graphql.Schema.InsightQueries do
     end
 
     @desc """
-    Create and insight connected to particular chart configuration
+    Create an insight connected to particular chart configuration
     """
     field :create_chart_event, :post do
       arg(:chart_configuration_id, non_null(:id))

--- a/lib/sanbase_web/graphql/schema/queries/insight_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/insight_queries.ex
@@ -270,5 +270,18 @@ defmodule SanbaseWeb.Graphql.Schema.InsightQueries do
       middleware(JWTAuth)
       resolve(&InsightResolver.unvote/3)
     end
+
+    @desc """
+    Create and insight connected to particular chart configuration
+    """
+    field :create_chart_event, :post do
+      arg(:chart_configuration_id, non_null(:id))
+      arg(:chart_event_datetime, non_null(:datetime))
+      arg(:title, non_null(:string))
+      arg(:text, non_null(:string))
+
+      middleware(JWTAuth)
+      resolve(&InsightResolver.create_chart_event/3)
+    end
   end
 end

--- a/lib/sanbase_web/graphql/schema/types/chart_configuration_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/chart_configuration_types.ex
@@ -30,6 +30,8 @@ defmodule SanbaseWeb.Graphql.ProjectChartTypes do
     field(:project, :project, resolve: dataloader(SanbaseRepo))
     field(:post, :post, resolve: dataloader(SanbaseRepo))
 
+    field(:chart_events, list_of(:post))
+
     field(:inserted_at, :datetime)
     field(:updated_at, :datetime)
   end

--- a/lib/sanbase_web/graphql/schema/types/insight_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/insight_types.ex
@@ -31,6 +31,9 @@ defmodule SanbaseWeb.Graphql.InsightTypes do
     field(:prediction, :string)
     field(:is_pulse, :boolean)
     field(:is_paywall_required, :boolean)
+    field(:is_chart_event, :boolean)
+    field(:chart_event_datetime, :datetime)
+    field(:chart_configuration_for_event, :chart_configuration)
 
     field :comments_count, :integer do
       resolve(&InsightResolver.comments_count/3)

--- a/priv/repo/migrations/20200727113432_add_is_chart_event_to_insights.exs
+++ b/priv/repo/migrations/20200727113432_add_is_chart_event_to_insights.exs
@@ -1,0 +1,16 @@
+defmodule Sanbase.Repo.Migrations.AddIsChartEventToInsights do
+  use Ecto.Migration
+
+  def change do
+    alter table("posts") do
+      add(:is_chart_event, :boolean, default: false)
+      add(:chart_event_datetime, :utc_datetime)
+
+      add(
+        :chart_configuration_for_event_id,
+        references(:chart_configurations),
+        null: true
+      )
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -1055,7 +1055,10 @@ CREATE TABLE public.posts (
     metrics character varying(255)[] DEFAULT ARRAY[]::character varying[],
     prediction character varying(255) DEFAULT NULL::character varying,
     price_chart_project_id bigint,
-    document_tokens tsvector
+    document_tokens tsvector,
+    is_chart_event boolean DEFAULT false,
+    chart_event_datetime timestamp(0) without time zone,
+    chart_configuration_for_event_id bigint
 );
 
 
@@ -4066,6 +4069,14 @@ ALTER TABLE ONLY public.post_images
 
 
 --
+-- Name: posts posts_chart_configuration_for_event_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.posts
+    ADD CONSTRAINT posts_chart_configuration_for_event_id_fkey FOREIGN KEY (chart_configuration_for_event_id) REFERENCES public.chart_configurations(id);
+
+
+--
 -- Name: posts_metrics posts_metrics_metric_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4733,3 +4744,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20200706070758);
 INSERT INTO public."schema_migrations" (version) VALUES (20200707142725);
 INSERT INTO public."schema_migrations" (version) VALUES (20200707155254);
 INSERT INTO public."schema_migrations" (version) VALUES (20200716074754);
+INSERT INTO public."schema_migrations" (version) VALUES (20200727113432);

--- a/test/sanbase_web/graphql/chart/chart_configuration_api_test.exs
+++ b/test/sanbase_web/graphql/chart/chart_configuration_api_test.exs
@@ -427,6 +427,23 @@ defmodule SanbaseWeb.Graphql.ChartConfigurationApiTest do
     end
   end
 
+  test "get chart events", context do
+    conf = insert(:chart_configuration, is_public: true)
+
+    args = %{
+      is_chart_event: true,
+      chart_configuration_for_event_id: conf.id,
+      chart_event_datetime: DateTime.utc_now(),
+      title: "chart event"
+    }
+
+    insert(:post, args)
+    insert(:post, args)
+
+    res = get_chart_configuration(context.conn, conf.id) |> get_in(["data", "chartConfiguration"])
+    assert length(res["chartEvents"]) == 2
+  end
+
   # Private functions
 
   defp create_chart_configuration(conn, settings) do
@@ -515,6 +532,12 @@ defmodule SanbaseWeb.Graphql.ChartConfigurationApiTest do
         metrics
         anomalies
         drawings
+        chartEvents {
+          id
+          isChartEvent
+          chartEventDatetime
+          title
+        }
       }
     }
     """

--- a/test/sanbase_web/graphql/insight/insight_api_test.exs
+++ b/test/sanbase_web/graphql/insight/insight_api_test.exs
@@ -1000,6 +1000,7 @@ defmodule SanbaseWeb.Graphql.InsightApiTest do
 
       assert res["isChartEvent"]
       assert res["chartEventDatetime"] != nil
+      assert res["chartConfigurationForEvent"]["id"] == conf.id
 
       {:ok, new_conf} = Sanbase.Chart.Configuration.by_id(conf.id, context.user)
 

--- a/test/sanbase_web/graphql/insight/insight_api_test.exs
+++ b/test/sanbase_web/graphql/insight/insight_api_test.exs
@@ -983,7 +983,64 @@ defmodule SanbaseWeb.Graphql.InsightApiTest do
            )
   end
 
+  describe "create chart event" do
+    test "successfully creates chart event", context do
+      conf = insert(:chart_configuration, is_public: true)
+
+      args = %{
+        title: "test chart event title",
+        text: "test chart event text",
+        chart_event_datetime: DateTime.utc_now() |> DateTime.to_iso8601(),
+        chart_configuration_id: conf.id
+      }
+
+      query = create_chart_event(args)
+
+      res = execute_mutation_with_success(query, "createChartEvent", context.conn)
+
+      assert res["isChartEvent"]
+      assert res["chartEventDatetime"] != nil
+
+      {:ok, new_conf} = Sanbase.Chart.Configuration.by_id(conf.id, context.user)
+
+      assert length(new_conf.chart_events) == 1
+    end
+
+    test "chart configuration doesn't exist", context do
+      query =
+        create_chart_event(%{
+          title: "test chart event title",
+          text: "test chart event text",
+          chart_event_datetime: DateTime.utc_now() |> DateTime.to_iso8601(),
+          chart_configuration_id: 123
+        })
+
+      res = execute_mutation_with_errors(query, context.conn)
+      assert res["message"] == "Chart configuration with id 123 does not exist."
+    end
+  end
+
   # Helper functions
+
+  defp create_chart_event(args) do
+    """
+    mutation {
+      createChartEvent(
+        title: "#{args.title}",
+        text: "#{args.text}",
+        chartConfigurationId: #{args.chart_configuration_id},
+        chartEventDatetime: "#{args.chart_event_datetime}"
+      ) {
+        id
+        isChartEvent
+        chartEventDatetime
+        chartConfigurationForEvent {
+          id
+        }
+      }
+    }
+    """
+  end
 
   defp publish_insight_mutation(post) do
     """


### PR DESCRIPTION
## Changes
Adding mini insights connected to a specific chart configuration and datetime.

<!--- Describe your changes -->

## Ticket
https://www.notion.so/santiment/ChartEvent-insights-2a46a995d22743559e5cdc493a724819
<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

## Usage

* Create chart event

```graphql
    mutation {
      createChartEvent(
        title: "#{args.title}",
        text: "#{args.text}",
        chartConfigurationId: #{args.chart_configuration_id},
        chartEventDatetime: "#{args.chart_event_datetime}"
      ) {
        id
        isChartEvent
        chartEventDatetime
        chartConfigurationForEvent {
          id
        }
      }
    }
```
* Get chart events

```graphql
    {
      chartConfiguration(id: #{config_id}) {
        id
        title
        isPublic
        description
        user{ id email }
        project{ id slug }
        post{ id title }
        metrics
        anomalies
        drawings
        chartEvents {
          id
          isChartEvent
          chartEventDatetime
          title
          text
        }
      }
    }
```

<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
