### PR TITLE
Add new metrics to api

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -1899,7 +1899,7 @@
   },
   {
     "human_readable_name": "30 Days Moving Average Of Development Activity 1 Day Change",
-    "name": "30_day_moving_avg_dev_activity_change_1d",
+    "name": "30d_moving_avg_dev_activity_change_1d",
     "metric": "30_day_moving_avg_dev_activity_change_1d",
     "version": "2019-01-01",
     "access": "free",

--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -2149,7 +2149,7 @@
     "aggregation": "last",
     "min_interval": "1d",
     "table": "intraday_metrics",
-    "has_incomplete_data": false,
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -2166,7 +2166,7 @@
     "aggregation": "last",
     "min_interval": "1d",
     "table": "intraday_metrics",
-    "has_incomplete_data": false,
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {
@@ -2183,7 +2183,7 @@
     "aggregation": "last",
     "min_interval": "1d",
     "table": "intraday_metrics",
-    "has_incomplete_data": false,
+    "has_incomplete_data": true,
     "data_type": "timeseries"
   },
   {

--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -1898,9 +1898,9 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Development Activity 30 Days Change",
-    "name": "dev_activity_change_30d",
-    "metric": "dev_activity_change_30d",
+    "human_readable_name": "30 Days Moving Average Of Development Activity 1 Day Change",
+    "name": "30_day_moving_avg_dev_activity_change_1d",
+    "metric": "30_day_moving_avg_dev_activity_change_1d",
     "version": "2019-01-01",
     "access": "free",
     "selectors": ["slug"],
@@ -2133,6 +2133,108 @@
     "min_interval": "1d",
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Development activity Change (1d)",
+    "name": "dev_activity_change_1d",
+    "metric": "dev_activity_change_1d",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Development activity Change (7d)",
+    "name": "dev_activity_change_7d",
+    "metric": "dev_activity_change_7d",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Development activity Change (30d)",
+    "name": "dev_activity_change_30d",
+    "metric": "dev_activity_change_30d",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Market Capitalization Change (1d)",
+    "name": "marketcap_usd_change_1d",
+    "metric": "marketcap_usd_change_1d",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Market Capitalization Change (7d)",
+    "name": "marketcap_usd_change_7d",
+    "metric": "marketcap_usd_change_7d",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Market Capitalization Change (30d)",
+    "name": "marketcap_usd_change_30d",
+    "metric": "marketcap_usd_change_30d",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
     "data_type": "timeseries"
   }
 ]

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -52,7 +52,6 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "marketcap_usd_change_1d",
         "marketcap_usd_change_7d",
         "marketcap_usd_change_30d"
-
       ]
       |> Enum.sort()
 

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -25,7 +25,7 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "daily_trading_volume_usd",
         "dev_activity",
         "dev_activity_1d",
-        "dev_activity_change_30d",
+        "30_day_moving_avg_dev_activity_change_1d",
         "github_activity",
         "dev_activity_contributors_count",
         "github_activity_contributors_count",
@@ -45,7 +45,14 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "price_usd_change_30d",
         "active_addresses_24h_change_1d",
         "active_addresses_24h_change_7d",
-        "active_addresses_24h_change_30d"
+        "active_addresses_24h_change_30d",
+        "dev_activity_change_1d",
+        "dev_activity_change_7d",
+        "dev_activity_change_30d",
+        "marketcap_usd_change_1d",
+        "marketcap_usd_change_7d",
+        "marketcap_usd_change_30d"
+
       ]
       |> Enum.sort()
 

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -25,7 +25,7 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "daily_trading_volume_usd",
         "dev_activity",
         "dev_activity_1d",
-        "30_day_moving_avg_dev_activity_change_1d",
+        "30d_moving_avg_dev_activity_change_1d",
         "github_activity",
         "dev_activity_contributors_count",
         "github_activity_contributors_count",


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

Adding new metrics to API:

- `dev_activity_change_1/7/30d`
- `marketcap_usd_change_1/7/30d`
- `30_day_moving_avg_dev_activity_change_1d` - this metric was initially named `dev_activity_change_30d`, but since it represents a change from yesterday's 30-day moving average, this should be a more appropriate name. 

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
