### PR TITLE
Add final and having to label queries

### DIFF
--- a/lib/sanbase/clickhouse/exchange_address.ex
+++ b/lib/sanbase/clickhouse/exchange_address.ex
@@ -54,10 +54,11 @@ defmodule Sanbase.Clickhouse.ExchangeAddress do
   defp exchange_names_query(blockchain, is_dex) do
     query = """
     SELECT DISTINCT JSONExtractString(metadata, 'owner')
-    FROM blockchain_address_labels
+    FROM blockchain_address_labels FINAL
     PREWHERE
       blockchain = ?1 AND
       #{maybe_is_dex(is_dex)}
+    HAVING sign = 1
     """
 
     args = [blockchain |> String.downcase()]
@@ -68,8 +69,9 @@ defmodule Sanbase.Clickhouse.ExchangeAddress do
   defp exchange_addresses_query(blockchain, limit) do
     query = """
     SELECT DISTINCT(address), label, JSONExtractString(metadata, 'owner')
-    FROM blockchain_address_labels
+    FROM blockchain_address_labels FINAL
     PREWHERE blockchain = 'ethereum' AND label in ('centralized_exchange', 'decentralized_exchange')
+    HAVING sign = 1
     LIMIT ?2
     """
 
@@ -81,11 +83,12 @@ defmodule Sanbase.Clickhouse.ExchangeAddress do
   defp exchange_addresses_for_exchange_query(blockchain, owner, limit) do
     query = """
     SELECT DISTINCT(address), label, JSONExtractString(metadata, 'owner')
-    FROM blockchain_address_labels
+    FROM blockchain_address_labels FINAL
     PREWHERE
       blockchain = ?1 AND
       lower(JSONExtractString(metadata, 'owner')) = ?2 AND
       label in ('centralized_exchange', 'decentralized_exchange')
+    HAVING sign = 1
     LIMIT ?3
     """
 

--- a/lib/sanbase/clickhouse/top_holders/top_holders_sql_query.ex
+++ b/lib/sanbase/clickhouse/top_holders/top_holders_sql_query.ex
@@ -86,8 +86,9 @@ defmodule Sanbase.Clickhouse.TopHolders.SqlQuery do
     )
     GLOBAL ANY INNER JOIN (
       SELECT address
-      FROM blockchain_address_labels
+      FROM blockchain_address_labels FINAL
       PREWHERE blockchain = ?6 AND label IN ('centralized_exchange', 'decentralized_exchange')
+      HAVING sign = 1
     ) USING address
     GROUP BY dt
     ORDER BY dt
@@ -130,8 +131,9 @@ defmodule Sanbase.Clickhouse.TopHolders.SqlQuery do
       PREWHERE
         address GLOBAL NOT IN (
           SELECT address
-          FROM blockchain_address_labels
+          FROM blockchain_address_labels FINAL
           PREWHERE blockchain = ?6 AND label IN ('centralized_exchange', 'decentralized_exchange')
+          HAVING sign = 1
         ) AND
         contract = ?2 AND
         dt >= toDateTime(?4) AND

--- a/lib/sanbase/utils/transform.ex
+++ b/lib/sanbase/utils/transform.ex
@@ -80,6 +80,11 @@ defmodule Sanbase.Utils.Transform do
   def maybe_unwrap_ok_value({:ok, []}), do: {:ok, nil}
   def maybe_unwrap_ok_value({:error, error}), do: {:error, error}
 
+  def maybe_apply_function({:ok, list}, fun) when is_list(list) and is_function(fun, 1),
+    do: {:ok, fun.(list)}
+
+  def maybe_apply_function({:error, error}), do: {:error, error}
+
   @doc ~s"""
   Sums the values of all keys with the same datetime
 


### PR DESCRIPTION
## Changes

Adding `FINAL` and `HAVING sign = 1` parts to queries that use `blockchain_address_labels` table. We need these parts to filter out rows that were marked to deletion

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works
