### PR TITLE
Votes now can stack up to 20

### DIFF
--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -17,7 +17,7 @@ defmodule Sanbase.Insight.Post do
 
   require Logger
 
-  @preloads [:votes, :user, :images, :tags, :chart_configuration_for_event]
+  @preloads [:user, :images, :tags, :chart_configuration_for_event]
   # state
   @awaiting_approval "awaiting_approval"
   @approved "approved"

--- a/lib/sanbase/voting/vote.ex
+++ b/lib/sanbase/voting/vote.ex
@@ -51,8 +51,7 @@ defmodule Sanbase.Vote do
   @doc ~s"""
   Create a new vote entity or increases the votes count up to #{@max_votes}.
   """
-  @spec create(vote_params) ::
-          {:ok, %__MODULE__{}} | {:error, Ecto.Changeset.t()}
+  @spec create(vote_params) :: {:ok, %__MODULE__{}} | {:error, Ecto.Changeset.t()}
   def create(attrs) do
     Ecto.Multi.new()
     |> Ecto.Multi.run(:select_if_exists, fn _repo, _changes ->
@@ -86,8 +85,7 @@ defmodule Sanbase.Vote do
   Decreases the votes count for an entityt. If the votes count drops to 0, the vote
   entity is destroyed.
   """
-  @spec downvote(%__MODULE__{}) ::
-          {:ok, %__MODULE__{}} | {:error, Ecto.Changeset.t()}
+  @spec downvote(vote_params) :: {:ok, %__MODULE__{}} | {:error, Ecto.Changeset.t()}
   def downvote(attrs) do
     Ecto.Multi.new()
     |> Ecto.Multi.run(:select_if_exists, fn _repo, _changes ->
@@ -95,6 +93,9 @@ defmodule Sanbase.Vote do
     end)
     |> Ecto.Multi.run(:decrease_count_or_destroy, fn _repo, %{select_if_exists: vote} ->
       case vote do
+        nil ->
+          {:ok, %__MODULE__{}}
+
         %__MODULE__{count: 1} ->
           Repo.delete(vote)
 
@@ -117,9 +118,9 @@ defmodule Sanbase.Vote do
     |> Repo.one()
   end
 
-  def total_votes(entity, user \\ nil)
+  def vote_stats(entity, user \\ nil)
 
-  def total_votes(entity, nil) do
+  def vote_stats(entity, nil) do
     {total_votes, total_voters} =
       total_votes_query(entity)
       |> Repo.one()
@@ -131,7 +132,7 @@ defmodule Sanbase.Vote do
     }
   end
 
-  def total_votes(entity, %User{id: user_id}) do
+  def vote_stats(entity, %User{id: user_id}) do
     {total_votes, total_voters} =
       total_votes_query(entity)
       |> Repo.one()

--- a/lib/sanbase/voting/vote.ex
+++ b/lib/sanbase/voting/vote.ex
@@ -4,6 +4,7 @@ defmodule Sanbase.Vote do
   """
   use Ecto.Schema
 
+  import Ecto.Query
   import Ecto.Changeset
 
   alias Sanbase.Repo
@@ -23,7 +24,11 @@ defmodule Sanbase.Vote do
           post_id: non_neg_integer()
         ]
 
+  @max_votes 20
+
   schema "votes" do
+    field(:count, :integer)
+
     belongs_to(:post, Post)
     belongs_to(:timeline_event, TimelineEvent)
     belongs_to(:user, User)
@@ -33,7 +38,7 @@ defmodule Sanbase.Vote do
 
   def changeset(%__MODULE__{} = vote, attrs \\ %{}) do
     vote
-    |> cast(attrs, [:post_id, :timeline_event_id, :user_id])
+    |> cast(attrs, [:post_id, :timeline_event_id, :user_id, :count])
     |> validate_required([:user_id])
     |> unique_constraint(:post_id,
       name: :votes_post_id_user_id_index
@@ -43,19 +48,80 @@ defmodule Sanbase.Vote do
     )
   end
 
+  @doc ~s"""
+  Create a new vote entity or increases the votes count up to #{@max_votes}.
+  """
   @spec create(vote_params) ::
           {:ok, %__MODULE__{}} | {:error, Ecto.Changeset.t()}
   def create(attrs) do
-    %__MODULE__{}
-    |> changeset(attrs)
-    # Voting is idempotent - this fixes voting again due to caching
-    |> Repo.insert(on_conflict: :nothing)
+    case get_by_opts(attrs |> Keyword.new()) do
+      nil ->
+        attrs = Map.put(attrs, :count, 1)
+
+        %__MODULE__{}
+        |> changeset(attrs)
+        |> Repo.insert()
+
+      %__MODULE__{count: @max_votes} = vote ->
+        {:ok, vote}
+
+      %__MODULE__{count: count} = vote ->
+        changeset(vote, %{count: count + 1})
+        |> Repo.update()
+    end
   end
 
+  @doc ~s"""
+  Decreases the votes count for an entityt. If the votes count drops to 0, the vote
+  entity is destroyed.
+  """
   @spec remove(%__MODULE__{}) ::
           {:ok, %__MODULE__{}} | {:error, Ecto.Changeset.t()}
   def remove(%__MODULE__{} = vote) do
-    Repo.delete(vote)
+    case vote do
+      %__MODULE__{count: 1} ->
+        Repo.delete(vote)
+
+      %__MODULE__{count: count} ->
+        changeset(vote, %{count: count - 1})
+        |> Repo.update()
+    end
+  end
+
+  def voted_at(%Post{id: post_id}, %User{id: user_id}) do
+    from(
+      v in __MODULE__,
+      select: v.inserted_at,
+      where: v.post_id == ^post_id and v.user_id == ^user_id
+    )
+    |> Repo.one()
+  end
+
+  def voted_at(%TimelineEvent{id: timeline_event_id}, %User{id: user_id}) do
+    from(
+      v in __MODULE__,
+      select: v.inserted_at,
+      where: v.timeline_event_id == ^timeline_event_id and v.user_id == ^user_id
+    )
+    |> Repo.one()
+  end
+
+  def total_votes(%Post{id: post_id}) do
+    from(
+      v in __MODULE__,
+      select: coalesce(sum(v.count), 0),
+      where: v.post_id == ^post_id
+    )
+    |> Repo.one()
+  end
+
+  def total_votes(%TimelineEvent{id: timeline_event_id}) do
+    from(
+      v in __MODULE__,
+      select: coalesce(sum(v.count), 0),
+      where: v.timeline_event_id == ^timeline_event_id
+    )
+    |> Repo.one()
   end
 
   @spec get_by_opts(vote_kw_list_params) :: %__MODULE__{} | nil

--- a/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
@@ -140,8 +140,20 @@ defmodule SanbaseWeb.Graphql.Resolvers.InsightResolver do
     - `total_san_votes` represents the number of votes where each vote's weight is
     equal to the san balance of the voter
   """
+  def votes(%Post{} = post, _args, %{context: %{auth: %{current_user: user}}}) do
+    {:ok,
+     %{
+       total_votes: Vote.total_votes(post),
+       current_user_votes: Vote.total_votes_of_user(post, user)
+     }}
+  end
+
   def votes(%Post{} = post, _args, _context) do
-    {:ok, %{total_votes: Vote.total_votes(post)}}
+    {:ok,
+     %{
+       total_votes: Vote.total_votes(post),
+       current_user_votes: nil
+     }}
   end
 
   def voted_at(%Post{} = post, _args, %{context: %{auth: %{current_user: user}}}) do

--- a/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
@@ -141,11 +141,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.InsightResolver do
     equal to the san balance of the voter
   """
   def votes(%Post{} = post, _args, %{context: %{auth: %{current_user: user}}}) do
-    {:ok, Vote.total_votes(post, user)}
+    {:ok, Vote.vote_stats(post, user)}
   end
 
   def votes(%Post{} = post, _args, _context) do
-    {:ok, Vote.total_votes(post)}
+    {:ok, Vote.vote_stats(post)}
   end
 
   def voted_at(%Post{} = post, _args, %{context: %{auth: %{current_user: user}}}) do

--- a/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
@@ -141,19 +141,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.InsightResolver do
     equal to the san balance of the voter
   """
   def votes(%Post{} = post, _args, %{context: %{auth: %{current_user: user}}}) do
-    {:ok,
-     %{
-       total_votes: Vote.total_votes(post),
-       current_user_votes: Vote.total_votes_of_user(post, user)
-     }}
+    {:ok, Vote.total_votes(post, user)}
   end
 
   def votes(%Post{} = post, _args, _context) do
-    {:ok,
-     %{
-       total_votes: Vote.total_votes(post),
-       current_user_votes: nil
-     }}
+    {:ok, Vote.total_votes(post)}
   end
 
   def voted_at(%Post{} = post, _args, %{context: %{auth: %{current_user: user}}}) do

--- a/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
@@ -174,12 +174,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.InsightResolver do
   def unvote(_root, args, %{context: %{auth: %{current_user: user}}}) do
     insight_id = Map.get(args, :insight_id) || Map.fetch!(args, :post_id)
 
-    with %Vote{} = vote <- Vote.get_by_opts(post_id: insight_id, user_id: user.id),
-         {:ok, _vote} <- Vote.remove(vote) do
-      Post.by_id(insight_id)
-    else
-      _error ->
-        {:error, "Can't remove vote for post with id #{insight_id}"}
+    case Vote.downvote(%{post_id: insight_id, user_id: user.id}) do
+      {:ok, _vote} -> Post.by_id(insight_id)
+      {:error, _error} -> {:error, "Can't remove vote for post with id #{insight_id}"}
     end
   end
 

--- a/lib/sanbase_web/graphql/resolvers/timeline/timeline_event_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/timeline/timeline_event_resolver.ex
@@ -50,12 +50,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.TimelineEventResolver do
   def downvote_timeline_event(_root, %{timeline_event_id: timeline_event_id}, %{
         context: %{auth: %{current_user: current_user}}
       }) do
-    with %Vote{} = vote <-
-           Vote.get_by_opts(timeline_event_id: timeline_event_id, user_id: current_user.id),
-         {:ok, _vote} <- Vote.remove(vote) do
-      {:ok, TimelineEvent.by_id(timeline_event_id)}
-    else
-      _error ->
+    case Vote.downvote(%{timeline_event_id: timeline_event_id, user_id: current_user.id}) do
+      {:ok, _} ->
+        {:ok, TimelineEvent.by_id(timeline_event_id)}
+
+      {:error, _} ->
         {:error, "Can't remove vote for event with id #{timeline_event_id}"}
     end
   end

--- a/lib/sanbase_web/graphql/schema/types/insight_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/insight_types.ex
@@ -8,6 +8,7 @@ defmodule SanbaseWeb.Graphql.InsightTypes do
 
   object :vote do
     field(:total_votes, non_null(:integer))
+    field(:total_voters, non_null(:integer))
     field(:current_user_votes, :integer)
   end
 

--- a/lib/sanbase_web/graphql/schema/types/insight_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/insight_types.ex
@@ -8,7 +8,6 @@ defmodule SanbaseWeb.Graphql.InsightTypes do
 
   object :vote do
     field(:total_votes, non_null(:integer))
-    field(:total_san_votes, non_null(:integer))
   end
 
   object :metric_short_description do

--- a/lib/sanbase_web/graphql/schema/types/insight_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/insight_types.ex
@@ -8,6 +8,7 @@ defmodule SanbaseWeb.Graphql.InsightTypes do
 
   object :vote do
     field(:total_votes, non_null(:integer))
+    field(:current_user_votes, :integer)
   end
 
   object :metric_short_description do

--- a/priv/repo/migrations/20200728103633_add_field_to_votes.exs
+++ b/priv/repo/migrations/20200728103633_add_field_to_votes.exs
@@ -1,0 +1,9 @@
+defmodule Sanbase.Repo.Migrations.AddFieldToVotes do
+  use Ecto.Migration
+
+  def change do
+    alter table(:votes) do
+      add(:count, :integer, default: 1)
+    end
+  end
+end

--- a/priv/repo/migrations/20200728105033_fill_votes_count_field.exs
+++ b/priv/repo/migrations/20200728105033_fill_votes_count_field.exs
@@ -1,0 +1,29 @@
+defmodule Sanbase.Repo.Migrations.FillVotesCountField do
+  use Ecto.Migration
+
+  def change do
+  end
+end
+
+defmodule Sanbase.Repo.Migrations.FillVotesCountField do
+  use Ecto.Migration
+
+  def up do
+    setup()
+    fill_count()
+  end
+
+  def down do
+    :ok
+  end
+
+  defp fill_count() do
+    Sanbase.Repo.update_all(Sanbase.Vote, set: [count: 1])
+  end
+
+  defp setup() do
+    Application.ensure_all_started(:tzdata)
+    Application.ensure_all_started(:prometheus_ecto)
+    Sanbase.Prometheus.EctoInstrumenter.setup()
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 12.3
--- Dumped by pg_dump version 12.3
+-- Dumped from database version 10.13
+-- Dumped by pg_dump version 11.6
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -72,6 +72,8 @@ CREATE TYPE public.status AS ENUM (
 
 
 SET default_tablespace = '';
+
+SET default_with_oids = false;
 
 --
 -- Name: active_widgets; Type: TABLE; Schema: public; Owner: -
@@ -2282,6 +2284,7 @@ CREATE TABLE public.votes (
     inserted_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     timeline_event_id bigint,
+    count integer DEFAULT 1,
     CONSTRAINT only_one_fk CHECK (((
 CASE
     WHEN (post_id IS NULL) THEN 0
@@ -4744,4 +4747,9 @@ INSERT INTO public."schema_migrations" (version) VALUES (20200706070758);
 INSERT INTO public."schema_migrations" (version) VALUES (20200707142725);
 INSERT INTO public."schema_migrations" (version) VALUES (20200707155254);
 INSERT INTO public."schema_migrations" (version) VALUES (20200716074754);
+<<<<<<< HEAD
 INSERT INTO public."schema_migrations" (version) VALUES (20200727113432);
+=======
+INSERT INTO public."schema_migrations" (version) VALUES (20200728103633);
+INSERT INTO public."schema_migrations" (version) VALUES (20200728105033);
+>>>>>>> Votes now can stack up to 20

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -4747,9 +4747,6 @@ INSERT INTO public."schema_migrations" (version) VALUES (20200706070758);
 INSERT INTO public."schema_migrations" (version) VALUES (20200707142725);
 INSERT INTO public."schema_migrations" (version) VALUES (20200707155254);
 INSERT INTO public."schema_migrations" (version) VALUES (20200716074754);
-<<<<<<< HEAD
 INSERT INTO public."schema_migrations" (version) VALUES (20200727113432);
-=======
 INSERT INTO public."schema_migrations" (version) VALUES (20200728103633);
 INSERT INTO public."schema_migrations" (version) VALUES (20200728105033);
->>>>>>> Votes now can stack up to 20

--- a/test/sanbase_web/graphql/insight/insight_voting_api_test.exs
+++ b/test/sanbase_web/graphql/insight/insight_voting_api_test.exs
@@ -61,6 +61,16 @@ defmodule Sanbase.InsihgtVotingApiTest do
     assert user_votes_2 == 2
   end
 
+  test "total voters", context do
+    %{conn: conn, conn2: conn2, insight: insight} = context
+    for _ <- 1..2, do: vote(conn, insight)
+    for _ <- 1..3, do: vote(conn2, insight)
+
+    %{"votes" => %{"totalVoters" => total_voters}} = vote(conn, insight)
+
+    assert total_voters == 2
+  end
+
   test "downvoting an insight", context do
     %{conn: conn, insight: insight} = context
 
@@ -78,7 +88,7 @@ defmodule Sanbase.InsihgtVotingApiTest do
     mutation = """
     mutation {
       vote(insightId: #{insight_id}){
-        votes{ totalVotes currentUserVotes }
+        votes{ totalVotes currentUserVotes totalVoters }
         votedAt
       }
     }
@@ -94,7 +104,7 @@ defmodule Sanbase.InsihgtVotingApiTest do
     mutation = """
     mutation {
       unvote(insightId: #{insight_id}){
-        votes{ totalVotes currentUserVotes }
+        votes{ totalVotes currentUserVotes totalVoters }
         votedAt
       }
     }

--- a/test/sanbase_web/graphql/insight/insight_voting_api_test.exs
+++ b/test/sanbase_web/graphql/insight/insight_voting_api_test.exs
@@ -1,0 +1,88 @@
+defmodule Sanbase.InsihgtVotingApiTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import Sanbase.Factory
+  import SanbaseWeb.Graphql.TestHelpers
+
+  alias Sanbase.Insight.Post
+
+  setup do
+    insight = insert(:post, state: Post.approved_state(), ready_state: Post.published())
+
+    %{user: user} = insert(:subscription_pro_sanbase, user: insert(:user))
+    conn = setup_jwt_auth(build_conn(), user)
+
+    {:ok, %{insight: insight, user: user, conn: conn}}
+  end
+
+  test "voting for an insight", context do
+    %{conn: conn, insight: insight} = context
+
+    %{"votes" => %{"totalVotes" => total_votes_1}} = vote(conn, insight)
+
+    for _ <- 1..15, do: vote(conn, insight)
+
+    %{"votes" => %{"totalVotes" => total_votes_17}} = vote(conn, insight)
+
+    for _ <- 1..5, do: vote(conn, insight)
+
+    # This is over the 20th vote but the vote cannot be bumped to more than 20
+    %{"votedAt" => voted_at, "votes" => %{"totalVotes" => total_votes_20}} = vote(conn, insight)
+
+    assert total_votes_1 == 1
+    assert total_votes_17 == 17
+    assert total_votes_20 == 20
+
+    assert Sanbase.TestUtils.datetime_close_to(
+             Timex.now(),
+             voted_at |> Sanbase.DateTimeUtils.from_iso8601!(),
+             5,
+             :seconds
+           )
+  end
+
+  test "downvoting an insight", context do
+    %{conn: conn, insight: insight} = context
+
+    vote(conn, insight)
+    vote(conn, insight)
+
+    downvote(conn, insight)
+    %{"votedAt" => voted_at, "votes" => %{"totalVotes" => total_votes}} = downvote(conn, insight)
+
+    assert voted_at == nil
+    assert total_votes == 0
+  end
+
+  defp vote(conn, %{id: insight_id}) do
+    mutation = """
+    mutation {
+      vote(insightId: #{insight_id}){
+        votes{ totalVotes }
+        votedAt
+      }
+    }
+    """
+
+    conn
+    |> post("/graphql", mutation_skeleton(mutation))
+    |> json_response(200)
+    |> get_in(["data", "vote"])
+  end
+
+  defp downvote(conn, %{id: insight_id}) do
+    mutation = """
+    mutation {
+      unvote(insightId: #{insight_id}){
+        votes{ totalVotes }
+        votedAt
+      }
+    }
+    """
+
+    conn
+    |> post("/graphql", mutation_skeleton(mutation))
+    |> json_response(200)
+    |> get_in(["data", "unvote"])
+  end
+end

--- a/test/sanbase_web/graphql/insight/pulse_insight_api_test.exs
+++ b/test/sanbase_web/graphql/insight/pulse_insight_api_test.exs
@@ -270,11 +270,8 @@ defmodule SanbaseWeb.Graphql.PulseInsightApiTest do
         state: Post.approved_state()
       )
 
-    %Vote{post_id: post.id, user_id: user.id}
-    |> Repo.insert!()
-
-    %Vote{post_id: post2.id, user_id: staked_user.id}
-    |> Repo.insert!()
+    Vote.create(%{post_id: post.id, user_id: user.id})
+    Vote.create(%{post_id: post2.id, user_id: staked_user.id})
 
     query = """
     {
@@ -339,7 +336,7 @@ defmodule SanbaseWeb.Graphql.PulseInsightApiTest do
           title
           text
           user { id }
-          votes{ totalSanVotes }
+          votes{ totalVotes }
           state
           createdAt
           publishedAt
@@ -357,7 +354,7 @@ defmodule SanbaseWeb.Graphql.PulseInsightApiTest do
       assert insight["title"] == "Awesome post"
       assert insight["state"] == Post.approved_state()
       assert insight["user"]["id"] == user.id |> Integer.to_string()
-      assert insight["votes"]["totalSanVotes"] == 0
+      assert insight["votes"]["totalVotes"] == 0
       assert insight["publishedAt"] == nil
 
       created_at = Timex.parse!(insight["createdAt"], "{ISO:Extended}")

--- a/test/sanbase_web/graphql/timeline/timeline_event_api_test.exs
+++ b/test/sanbase_web/graphql/timeline/timeline_event_api_test.exs
@@ -356,12 +356,12 @@ defmodule SanbaseWeb.Graphql.TimelineEventApiTest do
       assert result2["votes"] == []
     end
 
-    test "when user has not upvoted, he can't downvote", context do
+    test "when user has not upvoted, downvoting does nothing", context do
       user = insert(:user)
       {timeline_event, _user_trigger} = create_timeline_event(user)
       mutation = downvote_timeline_event_mutation(timeline_event.id)
-      error = execute_mutation_with_error(context.conn, mutation)
-      assert error == "Can't remove vote for event with id #{timeline_event.id}"
+      result = execute_mutation(context.conn, mutation, "downvoteTimelineEvent")
+      assert result["votes"] == []
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,5 @@
 {:ok, _} = Application.ensure_all_started(:ex_machina)
+:erlang.system_flag(:backtrace_depth, 20)
 
 ExUnit.start()
 Faker.start()


### PR DESCRIPTION
## Changes

Rework voting:
- one user can cast between 0 and 20 votes
- remove `totalSanVotes` field from the `votes` field
- introduce `totalVoters` and `currentUserVotes` fields to the `votes` field

```graphql
mutation{
  vote(insightId: 1){
    votes{
      currentUserVotes
      totalVoters
      totalVotes
    }
  }
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
