### PR TITLE
Add defi value locked in API

### DIFF
--- a/lib/sanbase/clickhouse/metric/file_handler.ex
+++ b/lib/sanbase/clickhouse/metric/file_handler.ex
@@ -36,16 +36,19 @@ defmodule Sanbase.Clickhouse.Metric.FileHandler do
   @holders_file "metric_files/holders_metrics.json"
   @makerdao_file "metric_files/makerdao_metrics.json"
   @label_file "metric_files/label_metrics.json"
+  @defi_file "metric_files/defi_metrics.json"
 
   @external_resource metrics_file = Path.join(__DIR__, @metrics_file)
   @external_resource holders_file = Path.join(__DIR__, @holders_file)
   @external_resource makerdao_file = Path.join(__DIR__, @makerdao_file)
   @external_resource label_file = Path.join(__DIR__, @label_file)
+  @external_resource defi_file = Path.join(__DIR__, @defi_file)
 
   @metrics_json (File.read!(metrics_file) |> Jason.decode!()) ++
                   (File.read!(holders_file) |> Jason.decode!()) ++
                   (File.read!(makerdao_file) |> Jason.decode!()) ++
-                  (File.read!(label_file) |> Jason.decode!())
+                  (File.read!(label_file) |> Jason.decode!()) ++
+                  (File.read!(defi_file) |> Jason.decode!())
 
   @aggregations Sanbase.Metric.SqlQuery.Helper.aggregations()
 

--- a/lib/sanbase/clickhouse/metric/metric_files/defi_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/defi_metrics.json
@@ -1,0 +1,40 @@
+[
+  {
+    "human_readable_name": "Total value locked in DeFi projects in ETH",
+    "name": "defi_total_value_locked_eth",
+    "metric": "defipulse_total_value_locked_eth",
+    "version": "2020-05-27",
+    "access": "restricted",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "custom",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "1h",
+    "table": "intraday_metrics",
+    "has_incomplete_data": true,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Total value locked in DeFi projects in USD",
+    "name": "defi_total_value_locked_usd",
+    "metric": "defipulse_total_value_locked_usd",
+    "version": "2020-05-27",
+    "access": "restricted",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "custom",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "1h",
+    "table": "intraday_metrics",
+    "has_incomplete_data": true,
+    "data_type": "timeseries"
+  }
+]

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -287,7 +287,10 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "holders_distribution_0.1_to_1_per_exchange",
         "holders_distribution_1_to_10_per_exchange",
         "holders_distribution_10_100_per_exchange",
-        "withdrawal_transactions_per_exchange"
+        "withdrawal_transactions_per_exchange",
+        # Defi
+        "defi_total_value_locked_eth",
+        "defi_total_value_locked_usd"
       ]
       |> Enum.sort()
 


### PR DESCRIPTION
## Changes

Add defi value locked in ETH and USD into the API

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

## Usage
```graphql
{
  getMetric(metric: "defi_total_value_locked_eth") {
    timeseriesData(
      slug: "ethereum"
      from: "2020-07-01T00:00:00Z"
      to: "2020-07-07T00:00:00Z"
      interval: "1h"
    ) {
      datetime
      value
    }
  }
}
```

```graphql
{
  getMetric(metric: "defi_total_value_locked_usd") {
    timeseriesData(
      slug: "ethereum"
      from: "2020-07-01T00:00:00Z"
      to: "2020-07-07T00:00:00Z"
      interval: "1h"
    ) {
      datetime
      value
    }
  }
}
```
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
