### PR TITLE
Implement market segments filter by slugs in screener

### DIFF
--- a/lib/sanbase/model/project/list/list.ex
+++ b/lib/sanbase/model/project/list/list.ex
@@ -316,8 +316,10 @@ defmodule Sanbase.Model.Project.List do
 
     from(
       p in projects_query(opts),
-      inner_join: m in assoc(p, :market_segment),
-      where: m.name in ^segments
+      preload: [:market_segments],
+      left_join: ms in assoc(p, :market_segments),
+      where: ms.name in ^segments,
+      distinct: true
     )
     |> Repo.all()
   end
@@ -332,7 +334,8 @@ defmodule Sanbase.Model.Project.List do
   def by_market_segment_all_of(segments, opts \\ [])
 
   def by_market_segment_all_of(segments, opts) when is_list(segments) do
-    from(p in projects_query(opts),
+    from(
+      p in projects_query(opts),
       preload: [:market_segments],
       left_join: ms in assoc(p, :market_segments),
       where: ms.name in ^segments,

--- a/lib/sanbase/model/project/list/selector/validator.ex
+++ b/lib/sanbase/model/project/list/selector/validator.ex
@@ -79,7 +79,7 @@ defmodule Sanbase.Model.Project.ListSelector.Validator do
         |> Enum.find(&(&1 != true))
         |> case do
           nil -> true
-          error -> error |> IO.inspect(label: "FOUND THIS")
+          error -> error
         end
 
       false ->
@@ -110,7 +110,7 @@ defmodule Sanbase.Model.Project.ListSelector.Validator do
         aggregation: spec(is_atom())
       })
 
-    with {:ok, _} <- conform(filter, filter_schema) |> IO.inspect(label: "111", limit: :infinity),
+    with {:ok, _} <- conform(filter, filter_schema),
          true <- Sanbase.Metric.has_metric?(metric) do
       missing_fields =
         [:metric, :from, :to, :operator, :threshold, :aggregation] -- Map.keys(filter)
@@ -120,7 +120,6 @@ defmodule Sanbase.Model.Project.ListSelector.Validator do
         _ -> {:error, "A metric filter has missing fields: #{inspect(missing_fields)}."}
       end
     end
-    |> IO.inspect(label: "VALID IFLER")
   end
 
   defp valid_filter?(_), do: {:error, "Filter is wrongly configured."}

--- a/test/sanbase/project/project_list_selector_test.exs
+++ b/test/sanbase/project/project_list_selector_test.exs
@@ -1,39 +1,157 @@
 defmodule Sanbase.Model.ProjectListSelectorTest do
   use Sanbase.DataCase, async: false
 
+  import Sanbase.Factory
+
   alias Sanbase.Model.Project.ListSelector
 
-  test "filters must be a list of maps" do
-    selector = %{
-      filters: [
-        metric: "nvt",
-        from_dynamic: "1d",
-        to_dynamic: "now",
-        aggregation: :last,
-        operation: :greater_than,
-        threshold: 10
-      ]
-    }
+  describe "validation caughts errors" do
+    test "filters must be a list of maps" do
+      selector = %{
+        filters: [
+          metric: "nvt",
+          dynamic_from: "1d",
+          dynamic_to: "now",
+          aggregation: :last,
+          operator: :greater_than,
+          threshold: 10
+        ]
+      }
 
-    {:error, error_msg} = ListSelector.valid_selector?(%{selector: selector})
-    assert error_msg =~ "must be a map"
+      {:error, error_msg} = ListSelector.valid_selector?(%{selector: selector})
+      assert error_msg =~ "must be a map"
+    end
+
+    test "invalid metric is caught" do
+      selector = %{
+        filters: [
+          %{
+            metric: "nvtt",
+            dynamic_from: "1d",
+            dynamic_to: "now",
+            aggregation: :last,
+            operator: :greater_than,
+            threshold: 10
+          }
+        ]
+      }
+
+      {:error, error_msg} = ListSelector.valid_selector?(%{selector: selector})
+      assert error_msg =~ "The metric 'nvtt' is not supported or is mistyped. Did you mean 'nvt'?"
+    end
   end
 
-  test "invalid metric is caught" do
-    selector = %{
-      filters: [
-        %{
-          metric: "nvtt",
-          from_dynamic: "1d",
-          to_dynamic: "now",
-          aggregation: :last,
-          operation: :greater_than,
-          threshold: 10
-        }
-      ]
-    }
+  describe "fetching projects" do
+    test "fetch by market segment" do
+      insert(:random_project)
+      insert(:random_project)
 
-    {:error, error_msg} = ListSelector.valid_selector?(%{selector: selector})
-    assert error_msg =~ "The metric 'nvtt' is not supported or is mistyped. Did you mean 'nvt'?"
+      defi_segment = insert(:market_segment, name: "DeFi")
+
+      p1 = insert(:random_project, market_segments: [defi_segment])
+
+      p2 =
+        insert(:random_project,
+          market_segments: [
+            defi_segment,
+            build(:market_segment, name: "Ethereum")
+          ]
+        )
+
+      selector = %{
+        filters: [
+          %{
+            name: "market_segments",
+            args: %{market_segments: ["DeFi"]}
+          }
+        ]
+      }
+
+      {:ok, %{slugs: slugs, total_projects_count: total_projects_count}} =
+        ListSelector.slugs(%{selector: selector})
+
+      assert total_projects_count == 2
+      assert p1.slug in slugs
+      assert p2.slug in slugs
+    end
+
+    test "fetch by metric" do
+      p1 = insert(:random_project)
+      _p2 = insert(:random_project)
+      p3 = insert(:random_project)
+      p4 = insert(:random_project)
+
+      selector = %{
+        filters: [
+          %{
+            name: "metric",
+            args: %{
+              metric: "active_addresses_24h",
+              dynamic_from: "1d",
+              dynamic_to: "now",
+              aggregation: :last,
+              operator: :greater_than,
+              threshold: 100
+            }
+          }
+        ]
+      }
+
+      Sanbase.Mock.prepare_mock2(
+        &Sanbase.Clickhouse.Metric.slugs_by_filter/6,
+        {:ok, [p1.slug, p3.slug, p4.slug]}
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        {:ok, %{slugs: slugs, total_projects_count: total_projects_count}} =
+          ListSelector.slugs(%{selector: selector})
+
+        assert total_projects_count == 3
+        assert p1.slug in slugs
+        assert p3.slug in slugs
+        assert p4.slug in slugs
+      end)
+    end
+
+    test "fetch by metric and market segments" do
+      defi_segment = insert(:market_segment, name: "DeFi")
+
+      p1 = insert(:random_project)
+      p2 = insert(:random_project, market_segments: [defi_segment])
+      p3 = insert(:random_project, market_segments: [defi_segment])
+      _p4 = insert(:random_project, market_segments: [defi_segment])
+
+      selector = %{
+        filters: [
+          %{
+            name: "market_segments",
+            args: %{market_segments: ["DeFi"]}
+          },
+          %{
+            name: "metric",
+            args: %{
+              metric: "daily_active_addresses",
+              dynamic_from: "1d",
+              dynamic_to: "now",
+              aggregation: :last,
+              operator: :greater_than,
+              threshold: 10
+            }
+          }
+        ]
+      }
+
+      Sanbase.Mock.prepare_mock2(
+        &Sanbase.Clickhouse.Metric.slugs_by_filter/6,
+        {:ok, [p1.slug, p2.slug, p3.slug]}
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        {:ok, %{slugs: slugs, total_projects_count: total_projects_count}} =
+          ListSelector.slugs(%{selector: selector})
+
+        assert total_projects_count == 2
+        assert p2.slug in slugs
+        assert p3.slug in slugs
+      end)
+    end
   end
 end

--- a/test/sanbase_web/graphql/projects/projects_by_function_test.exs
+++ b/test/sanbase_web/graphql/projects/projects_by_function_test.exs
@@ -11,31 +11,31 @@ defmodule SanbaseWeb.Graphql.ProjectsByFunctionTest do
     coin = insert(:market_segment, %{name: "coin"})
     mineable = insert(:market_segment, %{name: "mineable"})
 
-    p1 = insert(:project, %{ticker: "TUSD", slug: "tether", market_segment: stablecoin})
+    p1 = insert(:project, %{ticker: "TUSD", slug: "tether", market_segments: [stablecoin]})
     insert(:latest_cmc_data, %{coinmarketcap_id: "tether", rank: 4, volume_usd: 3_000_000_000})
 
     insert(:random_erc20_project, %{
       ticker: "DAI",
       slug: "dai",
-      market_segment: stablecoin,
+      market_segments: [stablecoin],
       infrastructure: infr_eth
     })
 
     insert(:latest_cmc_data, %{coinmarketcap_id: "dai", rank: 40, volume_usd: 15_000_000})
 
-    p2 = insert(:project, %{ticker: "ETH", slug: "ethereum", market_segment: mineable})
+    p2 = insert(:project, %{ticker: "ETH", slug: "ethereum", market_segments: [mineable]})
     insert(:latest_cmc_data, %{coinmarketcap_id: "ethereum", rank: 2, volume_usd: 3_000_000_000})
 
-    p3 = insert(:project, %{ticker: "BTC", slug: "bitcoin", market_segment: mineable})
+    p3 = insert(:project, %{ticker: "BTC", slug: "bitcoin", market_segments: [mineable]})
     insert(:latest_cmc_data, %{coinmarketcap_id: "bitcoin", rank: 1, volume_usd: 15_000_000_000})
 
-    p4 = insert(:project, %{ticker: "XRP", slug: "ripple", market_segment: mineable})
+    p4 = insert(:project, %{ticker: "XRP", slug: "ripple", market_segments: [mineable]})
     insert(:latest_cmc_data, %{coinmarketcap_id: "ripple", rank: 3, volume_usd: 1_000_000_000})
 
     insert(:random_erc20_project, %{
       ticker: "MKR",
       slug: "maker",
-      market_segment: coin,
+      market_segments: [coin],
       infrastructure: infr_eth
     })
 
@@ -44,7 +44,7 @@ defmodule SanbaseWeb.Graphql.ProjectsByFunctionTest do
     insert(:random_erc20_project, %{
       ticker: "SAN",
       slug: "santiment",
-      market_segment: coin,
+      market_segments: [coin],
       infrastructure: infr_eth
     })
 

--- a/test/sanbase_web/graphql/watchlist/dynamic_watchlist_test.exs
+++ b/test/sanbase_web/graphql/watchlist/dynamic_watchlist_test.exs
@@ -14,33 +14,33 @@ defmodule SanbaseWeb.Graphql.DynamicWatchlistTest do
     coin = insert(:market_segment, %{name: "coin"})
     mineable = insert(:market_segment, %{name: "mineable"})
 
-    p1 = insert(:project, %{ticker: "TUSD", slug: "tether", market_segment: stablecoin})
+    p1 = insert(:project, %{ticker: "TUSD", slug: "tether", market_segments: [stablecoin]})
     insert(:latest_cmc_data, %{coinmarketcap_id: "tether", rank: 4, volume_usd: 3_000_000_000})
 
     p2 =
       insert(:project, %{
         ticker: "DAI",
         slug: "dai",
-        market_segment: stablecoin,
+        market_segments: [stablecoin],
         infrastructure: infr_eth
       })
 
     insert(:latest_cmc_data, %{coinmarketcap_id: "dai", rank: 40, volume_usd: 15_000_000})
 
-    p3 = insert(:project, %{ticker: "ETH", slug: "ethereum", market_segment: mineable})
+    p3 = insert(:project, %{ticker: "ETH", slug: "ethereum", market_segments: [mineable]})
     insert(:latest_cmc_data, %{coinmarketcap_id: "ethereum", rank: 2, volume_usd: 3_000_000_000})
 
-    p4 = insert(:project, %{ticker: "BTC", slug: "bitcoin", market_segment: mineable})
+    p4 = insert(:project, %{ticker: "BTC", slug: "bitcoin", market_segments: [mineable]})
     insert(:latest_cmc_data, %{coinmarketcap_id: "bitcoin", rank: 1, volume_usd: 15_000_000_000})
 
-    p5 = insert(:project, %{ticker: "XRP", slug: "ripple", market_segment: mineable})
+    p5 = insert(:project, %{ticker: "XRP", slug: "ripple", market_segments: [mineable]})
     insert(:latest_cmc_data, %{coinmarketcap_id: "ripple", rank: 3, volume_usd: 1_000_000_000})
 
     p6 =
       insert(:project, %{
         ticker: "MKR",
         slug: "maker",
-        market_segment: coin,
+        market_segments: [coin],
         infrastructure: infr_eth
       })
 
@@ -50,7 +50,7 @@ defmodule SanbaseWeb.Graphql.DynamicWatchlistTest do
       insert(:project, %{
         ticker: "SAN",
         slug: "santiment",
-        market_segment: coin,
+        market_segments: [coin],
         infrastructure: infr_eth
       })
 


### PR DESCRIPTION
## Changes
Introduce the following filter in the selector/screener that can be combined with the metrics' filters.
```json
{
  "name": "market_segments",
  "args": {
     "market_segments": ["DeFi", "Ethereum"]
  }
}
```
Currently, it works by selecting the projects that have at least one of the market segments.

To match this format, there is an alternative to the existing metric filters. It looks like:
```json
{
  "name": "metric",
  "args": {
     "metric": "nvt",
     "dynamic_from": "1d",
     ...
  }
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
