### PR TITLE
Introduce market_segments_combinator in the market segments filter

### DIFF
--- a/lib/sanbase/model/project/list/selector/list_selector.ex
+++ b/lib/sanbase/model/project/list/selector/list_selector.ex
@@ -127,7 +127,14 @@ defmodule Sanbase.Model.Project.ListSelector do
   end
 
   defp slugs_by_filter(%{name: "market_segments", args: args}) do
-    projects = Project.List.by_market_segment_any_of(args.market_segments)
+    combinator = Map.get(args, :market_segments_combinator, "and")
+
+    projects =
+      case combinator do
+        "and" -> Project.List.by_market_segment_all_of(args.market_segments)
+        "or" -> Project.List.by_market_segment_any_of(args.market_segments)
+      end
+
     slugs = Enum.map(projects, & &1.slug)
     {:ok, slugs}
   end

--- a/lib/sanbase/model/project/list/selector/validator.ex
+++ b/lib/sanbase/model/project/list/selector/validator.ex
@@ -39,8 +39,8 @@ defmodule Sanbase.Model.Project.ListSelector.Validator do
       false ->
         {:error,
          """
-         Unsupported filter combinator #{inspect(filters_combinator)}.
-         Supported filter combinators are 'and' and 'or'
+         Unsupported filter_combinator #{inspect(filters_combinator)}.
+         Supported filter combinators are 'and' and 'or'.
          """}
     end
   end
@@ -87,13 +87,25 @@ defmodule Sanbase.Model.Project.ListSelector.Validator do
     end
   end
 
-  defp valid_filter?(%{name: "market_segments", args: %{market_segments: list}}) do
+  defp valid_filter?(%{name: "market_segments", args: %{market_segments: list} = args}) do
+    combinator = Map.get(args, :market_segments_combinator, "and")
+
     case is_list(list) and list != [] do
       true ->
-        true
+        case combinator in ["and", "or"] do
+          true ->
+            true
+
+          false ->
+            {:error,
+             """
+             Unsupported market_segments_combinator: #{inspect(combinator)}.
+             Supported filter combinators are 'and' and 'or'.
+             """}
+        end
 
       false ->
-        {:error, "Market segments filter must provide a non-empty list of market segments."}
+        {:error, "The market segments filter must provide a non-empty list of 'market_segments'."}
     end
   end
 

--- a/test/sanbase/project/project_list_selector_test.exs
+++ b/test/sanbase/project/project_list_selector_test.exs
@@ -6,6 +6,33 @@ defmodule Sanbase.Model.ProjectListSelectorTest do
   alias Sanbase.Model.Project.ListSelector
 
   describe "validation caughts errors" do
+    test "invalid filters_combinator" do
+      selector = %{
+        filters_combinator: "orr",
+        filters: [
+          %{
+            metric: "nvt",
+            dynamic_from: "1d",
+            dynamic_to: "now",
+            aggregation: :last,
+            operator: :greater_than,
+            threshold: 10
+          },
+          %{
+            metric: "daily_active_addresses",
+            dynamic_from: "1d",
+            dynamic_to: "now",
+            aggregation: :last,
+            operator: :greater_than,
+            threshold: 10
+          }
+        ]
+      }
+
+      {:error, error_msg} = ListSelector.valid_selector?(%{selector: selector})
+      assert error_msg =~ "Unsupported filter_combinator"
+    end
+
     test "filters must be a list of maps" do
       selector = %{
         filters: [
@@ -110,6 +137,62 @@ defmodule Sanbase.Model.ProjectListSelectorTest do
         assert p3.slug in slugs
         assert p4.slug in slugs
       end)
+    end
+
+    test "combine market segments with 'or'" do
+      defi_segment = insert(:market_segment, name: "DeFi")
+      mineable_segment = insert(:market_segment, name: "Mineable")
+
+      p1 = insert(:random_project, market_segments: [defi_segment])
+      p2 = insert(:random_project, market_segments: [mineable_segment])
+      p3 = insert(:random_project, market_segments: [mineable_segment, defi_segment])
+
+      selector = %{
+        filters: [
+          %{
+            name: "market_segments",
+            args: %{
+              market_segments: [defi_segment.name, mineable_segment.name],
+              market_segments_combinator: "or"
+            }
+          }
+        ]
+      }
+
+      {:ok, %{slugs: slugs, total_projects_count: total_projects_count}} =
+        ListSelector.slugs(%{selector: selector})
+
+      assert total_projects_count == 3
+      assert p1.slug in slugs
+      assert p2.slug in slugs
+      assert p3.slug in slugs
+    end
+
+    test "combine market segments with 'and'" do
+      defi_segment = insert(:market_segment, name: "DeFi")
+      mineable_segment = insert(:market_segment, name: "Mineable")
+
+      _p1 = insert(:random_project, market_segments: [defi_segment])
+      _p2 = insert(:random_project, market_segments: [mineable_segment])
+      p3 = insert(:random_project, market_segments: [mineable_segment, defi_segment])
+
+      selector = %{
+        filters: [
+          %{
+            name: "market_segments",
+            args: %{
+              market_segments: [defi_segment.name, mineable_segment.name],
+              market_segments_combinator: "and"
+            }
+          }
+        ]
+      }
+
+      {:ok, %{slugs: slugs, total_projects_count: total_projects_count}} =
+        ListSelector.slugs(%{selector: selector})
+
+      assert total_projects_count == 1
+      assert p3.slug in slugs
     end
 
     test "fetch by metric and market segments" do


### PR DESCRIPTION
## Changes
Introduce `market_segments_combinator` (`"and"` or `"or"`) which controls how the market segments are combined.

```json
{
  "filters": [
    {
      "name": "market_segments",
       "args": {
          "market_segments": ["DeFi", "Ethereum"],
          "market_segments_combinator": "and"
        }
     }
  ]
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
