### PR TITLE
Add new metrics to API

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -2236,5 +2236,56 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Network Growth Change (1d)",
+    "name": "network_growth_change_1d",
+    "metric": "network_growth_change_1d",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Network Growth Change (7d)",
+    "name": "network_growth_change_7d",
+    "metric": "network_growth_change_7d",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Network Growth Change (30d)",
+    "name": "network_growth_change_30d",
+    "metric": "network_growth_change_30d",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
   }
 ]

--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -2242,7 +2242,7 @@
     "name": "network_growth_change_1d",
     "metric": "network_growth_change_1d",
     "version": "2019-01-01",
-    "access": "free",
+    "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
@@ -2259,7 +2259,7 @@
     "name": "network_growth_change_7d",
     "metric": "network_growth_change_7d",
     "version": "2019-01-01",
-    "access": "free",
+    "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
@@ -2276,7 +2276,7 @@
     "name": "network_growth_change_30d",
     "metric": "network_growth_change_30d",
     "version": "2019-01-01",
-    "access": "free",
+    "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -51,10 +51,7 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "dev_activity_change_30d",
         "marketcap_usd_change_1d",
         "marketcap_usd_change_7d",
-        "marketcap_usd_change_30d",
-        "network_growth_change_1d",
-        "network_growth_change_7d",
-        "network_growth_change_30d"
+        "marketcap_usd_change_30d"
       ]
       |> Enum.sort()
 
@@ -289,7 +286,11 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "withdrawal_transactions_per_exchange",
         # Defi
         "defi_total_value_locked_eth",
-        "defi_total_value_locked_usd"
+        "defi_total_value_locked_usd",
+        # Change metrics
+        "network_growth_change_1d",
+        "network_growth_change_7d",
+        "network_growth_change_30d"
       ]
       |> Enum.sort()
 

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -51,7 +51,10 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "dev_activity_change_30d",
         "marketcap_usd_change_1d",
         "marketcap_usd_change_7d",
-        "marketcap_usd_change_30d"
+        "marketcap_usd_change_30d",
+        "network_growth_change_1d",
+        "network_growth_change_7d",
+        "network_growth_change_30d"
       ]
       |> Enum.sort()
 


### PR DESCRIPTION
## Changes

Add new metrics to API: network_growth_change_1d/7d/30d

## [Ticket](https://www.notion.so/santiment/Implement-metric-differences-for-all-metrics-c8005ed76f60458e8cafcae525b5e093)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
