### PR TITLE
Stablecoins holders distribution

### DIFF
--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -110,6 +110,7 @@ defmodule Sanbase.Metric do
     def timeseries_data(unquote(metric), identifier, from, to, interval, opts) do
       aggregation = Keyword.get(opts, :aggregation, nil)
       aggregation_valid? = aggregation in Map.get(@aggregations_per_metric, unquote(metric))
+      identifier = transform_identifier(identifier)
 
       case aggregation_valid? do
         true ->
@@ -145,6 +146,7 @@ defmodule Sanbase.Metric do
     def aggregated_timeseries_data(unquote(metric), identifier, from, to, opts) do
       aggregation = Keyword.get(opts, :aggregation, nil)
       aggregation_valid? = aggregation in Map.get(@aggregations_per_metric, unquote(metric))
+      identifier = transform_identifier(identifier)
 
       case aggregation_valid? do
         true ->
@@ -250,6 +252,8 @@ defmodule Sanbase.Metric do
 
   for %{metric: metric, module: module} <- @histogram_metric_module_mapping do
     def histogram_data(unquote(metric), identifier, from, to, interval, limit) do
+      identifier = transform_identifier(identifier)
+
       unquote(module).histogram_data(
         unquote(metric),
         identifier,
@@ -546,4 +550,13 @@ defmodule Sanbase.Metric do
       error_msg: "The histogram metric '#{metric}' is not supported or is mistyped."
     }
   end
+
+  defp transform_identifier(%{market_segments: market_segments}) do
+    slugs =
+      Sanbase.Model.Project.List.by_market_segment_all_of(market_segments) |> Enum.map(& &1.slug)
+
+    %{slug: slugs}
+  end
+
+  defp transform_identifier(identifier), do: identifier
 end

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -27,6 +27,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     value(:owner)
     value(:label)
     value(:holders_count)
+    value(:market_segments)
   end
 
   input_object :metric_target_selector_input_object do
@@ -35,6 +36,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:owner, :string)
     field(:label, :string)
     field(:holders_count, :integer)
+    field(:market_segments, list_of(:string))
   end
 
   input_object :timeseries_metric_transform_input_object do


### PR DESCRIPTION
## Changes

Add support for `market_segments` selector in the `getMetric` API.
Currently, it is implemented for the daily_metrics and intraday_metrics and label metric tables (not supported for price and social data). 
This is done to allow implementing holders distributions for the whole stablecoins market segment.

If more than 1 market segment is provided, only the projects that have all of required segments are included.

NOTE: All slugs in the market segments are used in the database query at the same time. This might cause troubles for segments that contain hundreds or thousands of projects.

Example:
```graphql
{
  getMetric(metric: "holders_distribution_0.1_to_1"){
    timeseriesData(
      selector: {market_segments: ["Stablecoin"]}
      from: "2020-07-07T10:00:00Z"
      to: "2020-08-06T10:00:00Z"
      interval: "12h"){
        datetime
        value
      }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
