### PR TITLE
Add ignored_slugs to getMetric selector

### DIFF
--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -551,11 +551,13 @@ defmodule Sanbase.Metric do
     }
   end
 
-  defp transform_identifier(%{market_segments: market_segments}) do
+  defp transform_identifier(%{market_segments: market_segments} = selector) do
     slugs =
       Sanbase.Model.Project.List.by_market_segment_all_of(market_segments) |> Enum.map(& &1.slug)
 
-    %{slug: slugs}
+    ignored_slugs = Map.get(selector, :ignored_slugs, [])
+
+    %{slug: slugs -- ignored_slugs}
   end
 
   defp transform_identifier(identifier), do: identifier

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -28,6 +28,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     value(:label)
     value(:holders_count)
     value(:market_segments)
+    value(:ignored_slugs)
   end
 
   input_object :metric_target_selector_input_object do
@@ -37,6 +38,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:label, :string)
     field(:holders_count, :integer)
     field(:market_segments, list_of(:string))
+    field(:ignored_slugs, list_of(:string))
   end
 
   input_object :timeseries_metric_transform_input_object do


### PR DESCRIPTION
## Changes
This will allow to build dashboards where there's separate data for top 3-5 projects and the rest are combined under `Others`. This is done by providing these slugs in the `ignored_slugs` field.
```graphql
{
  getMetric(metric: "holders_distribution_1_to_10"){
    timeseriesData(
      selector: {market_segments: ["Stablecoin"], ignored_slugs: ["dai", "sai"]}
      from: "2020-01-01T00:00:00Z"
      to: "2020-02-01T00:00:00Z"
      interval: "1d"){
        datetime
        value
     }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
