### PR TITLE
Add restriction for sansheets

### DIFF
--- a/lib/sanbase_web/graphql/context_plug.ex
+++ b/lib/sanbase_web/graphql/context_plug.ex
@@ -62,6 +62,7 @@ defmodule SanbaseWeb.Graphql.ContextPlug do
       context
       |> Map.put(:remote_ip, conn.remote_ip)
       |> Map.put(:origin_url, Plug.Conn.get_req_header(conn, "origin") |> List.first())
+      |> Map.put(:is_sansheets_request, is_sansheets_request(conn))
 
     conn
     |> put_private(:absinthe, %{context: context})
@@ -292,6 +293,13 @@ defmodule SanbaseWeb.Graphql.ContextPlug do
   end
 
   defp get_no_auth_product_id(_), do: @product_id_api
+
+  defp is_sansheets_request(conn) do
+    case Plug.Conn.get_req_header(conn, "user-agent") do
+      [user_agent] -> String.contains?(user_agent, "Google-Apps-Script")
+      _ -> false
+    end
+  end
 
   defp get_apikey_product_id([user_agent]) do
     case String.contains?(user_agent, "Google-Apps-Script") do


### PR DESCRIPTION
## Changes

Adding a restriction to sanbase, so that SanSheets is a PRO-only exclusive.

## Ticket

https://www.notion.so/santiment/9b1939e0ccb9494db3b074a6b74787e0?v=e9a9914a6279477981f54dcb3f011320&p=111707de0dd64073968283f9e5aeed5c

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
