### PR TITLE
Allow to add list_items in create_watchlist mutation

### DIFF
--- a/lib/sanbase/user_lists/user_list.ex
+++ b/lib/sanbase/user_lists/user_list.ex
@@ -156,10 +156,22 @@ defmodule Sanbase.UserList do
     end
   end
 
-  def create_user_list(%User{id: user_id} = _user, params \\ %{}) do
+  def create_user_list(%User{id: user_id}, params \\ %{}) do
+    params = params |> Map.put(:user_id, user_id)
+
     %__MODULE__{}
-    |> create_changeset(Map.merge(params, %{user_id: user_id}))
+    |> create_changeset(params)
     |> Repo.insert()
+    |> case do
+      {:ok, user_list} ->
+        case Map.has_key?(params, :list_items) do
+          true -> update_user_list(%{id: user_list.id, list_items: params[:list_items]})
+          false -> {:ok, user_list}
+        end
+
+      {:error, error} ->
+        {:error, error}
+    end
   end
 
   def update_user_list(%{id: id} = params) do

--- a/lib/sanbase_web/graphql/resolvers/user/user_list_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/user_list_resolver.ex
@@ -138,7 +138,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserListResolver do
     end
   end
 
-  def update_user_list(_root, %{id: id} = args, %{context: %{auth: %{current_user: current_user}}}) do
+  def update_watchlist(_root, %{id: id} = args, %{context: %{auth: %{current_user: current_user}}}) do
     if has_permissions?(id, current_user) do
       case UserList.update_user_list(args) do
         {:ok, user_list} ->

--- a/lib/sanbase_web/graphql/schema/queries/watchlist_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/watchlist_queries.ex
@@ -111,6 +111,7 @@ defmodule SanbaseWeb.Graphql.Schema.WatchlistQueries do
       arg(:color, :color_enum)
       arg(:function, :json)
       arg(:table_configuration_id, :integer)
+      arg(:list_items, list_of(:input_list_item))
 
       middleware(JWTAuth)
       resolve(&UserListResolver.create_user_list/3)
@@ -130,7 +131,7 @@ defmodule SanbaseWeb.Graphql.Schema.WatchlistQueries do
       arg(:is_monitored, :boolean)
 
       middleware(JWTAuth)
-      resolve(&UserListResolver.update_user_list/3)
+      resolve(&UserListResolver.update_watchlist/3)
     end
 
     @desc """
@@ -148,7 +149,7 @@ defmodule SanbaseWeb.Graphql.Schema.WatchlistQueries do
       arg(:table_configuration_id, :integer)
 
       middleware(JWTAuth)
-      resolve(&UserListResolver.update_user_list/3)
+      resolve(&UserListResolver.update_watchlist/3)
     end
 
     field :update_watchlist_settings, :watchlist_settings do


### PR DESCRIPTION
## Changes
Add the `listItems` argument to the `createWatchlist` mutation, allowing to add projects to watchlist on its creation.
```graphql
mutation {
  createWatchlist(
     ...
     listItems: ....){
        id
     }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
