### PR TITLE
Add type to market segments and fill the infrastructure ones

### DIFF
--- a/lib/sanbase/model/market_segment.ex
+++ b/lib/sanbase/model/market_segment.ex
@@ -6,6 +6,7 @@ defmodule Sanbase.Model.MarketSegment do
 
   schema "market_segments" do
     field(:name, :string)
+    field(:type, :string)
 
     many_to_many(
       :projects,
@@ -19,7 +20,7 @@ defmodule Sanbase.Model.MarketSegment do
   @doc false
   def changeset(%MarketSegment{} = market_segment, attrs \\ %{}) do
     market_segment
-    |> cast(attrs, [:name])
+    |> cast(attrs, [:name, :type])
     |> validate_required([:name])
     |> unique_constraint(:name)
   end

--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -81,6 +81,11 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     field(:anomalies, list_of(:string))
   end
 
+  object :project_tag do
+    field(:name, non_null(:string))
+    field(:type, :string)
+  end
+
   object :projects_object_stats do
     field(:projects_count, non_null(:integer))
   end
@@ -383,6 +388,17 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
           end
         ),
         fun_name: :market_segments
+      )
+    end
+
+    field :tags, list_of(:project_tag) do
+      cache_resolve(
+        dataloader(SanbaseRepo, :market_segments,
+          callback: fn query, _project, _args ->
+            {:ok, query}
+          end,
+          fun_name: :project_market_segment_tags
+        )
       )
     end
 

--- a/priv/repo/migrations/20200826101751_add_column_to_market_segments.exs
+++ b/priv/repo/migrations/20200826101751_add_column_to_market_segments.exs
@@ -1,0 +1,9 @@
+defmodule Sanbase.Repo.Migrations.AddColumnToMarketSegments do
+  use Ecto.Migration
+
+  def change do
+    alter table(:market_segments) do
+      add(:type, :string)
+    end
+  end
+end

--- a/priv/repo/migrations/20200826114101_fill_market_segments_type.exs
+++ b/priv/repo/migrations/20200826114101_fill_market_segments_type.exs
@@ -1,0 +1,34 @@
+defmodule Sanbase.Repo.Migrations.FillMarketSegmentsType do
+  use Ecto.Migration
+
+  import Ecto.Query
+
+  alias Sanbase.Model.MarketSegment
+
+  def up do
+    setup()
+
+    infrastructural_market_segments = infrastructural_market_segments()
+
+    from(
+      ms in MarketSegment,
+      where: ms.name in ^infrastructural_market_segments
+    )
+    |> Sanbase.Repo.update_all(set: [type: "Infrastructure"])
+  end
+
+  def down do
+    :ok
+  end
+
+  defp setup() do
+    Application.ensure_all_started(:tzdata)
+    Application.ensure_all_started(:prometheus_ecto)
+    Sanbase.Prometheus.EctoInstrumenter.setup()
+  end
+
+  defp infrastructural_market_segments() do
+    ~w(Bitcoin EOS Ethereum-Classic Ethereum IOTA Neo Nxt Omni Ubiq Waves Counterparty NEM
+    Achain Ardor Binance Bitshares Graphene Komodo Nebulas Qtum Scrypt Steem Stellar Tron)
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 12.3
--- Dumped by pg_dump version 12.3
+-- Dumped from database version 10.13
+-- Dumped by pg_dump version 11.6
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -72,6 +72,8 @@ CREATE TYPE public.status AS ENUM (
 
 
 SET default_tablespace = '';
+
+SET default_with_oids = false;
 
 --
 -- Name: active_widgets; Type: TABLE; Schema: public; Owner: -
@@ -711,7 +713,8 @@ CREATE TABLE public.list_items (
 
 CREATE TABLE public.market_segments (
     id bigint NOT NULL,
-    name character varying(255) NOT NULL
+    name character varying(255) NOT NULL,
+    type character varying(255)
 );
 
 
@@ -4823,3 +4826,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20200728103633);
 INSERT INTO public."schema_migrations" (version) VALUES (20200728105033);
 INSERT INTO public."schema_migrations" (version) VALUES (20200804093238);
 INSERT INTO public."schema_migrations" (version) VALUES (20200813141704);
+INSERT INTO public."schema_migrations" (version) VALUES (20200826101751);

--- a/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
@@ -60,7 +60,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesDataTest do
       assert_called(
         Sanbase.Clickhouse.Metric.timeseries_data(
           "holders_distribution_0.1_to_1",
-          %{slug: [p1.slug, p2.slug, p3.slug]},
+          %{slug: [:_, :_, :_]},
           from,
           to,
           interval,
@@ -107,7 +107,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesDataTest do
       assert_called(
         Sanbase.Clickhouse.Metric.timeseries_data(
           "holders_distribution_0.1_to_1",
-          %{slug: [p1.slug, p2.slug]},
+          %{slug: [:_, :_]},
           from,
           to,
           interval,

--- a/test/support/sanbase_factory.ex
+++ b/test/support/sanbase_factory.ex
@@ -260,7 +260,7 @@ defmodule Sanbase.Factory do
   end
 
   def market_segment_factory() do
-    %MarketSegment{name: rand_str()}
+    %MarketSegment{name: rand_str(), type: rand_str()}
   end
 
   def currency_factory() do


### PR DESCRIPTION
## Changes

Extend the market segments table with a `type` and expose this new data as `tags`, without breaking any existing APIs:
```graphql
{
  allProjects {
    slug
    marketSegments
    tags {
      name
      type
    }
  }
}
```

```json
{
  "data": {
    "allProjects": [
      {
        "marketSegments": [
          "Bitcoin",
          "Minable"
        ],
        "slug": "bitcoin",
        "tags": [
          {
            "name": "Bitcoin",
            "type": "Infrastructure"
          },
          {
            "name": "Minable",
            "type": "Type of Work"
          }
        ]
      }
    ]
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
