### PR TITLE
Extend aggregated timeseries metric selector

### DIFF
--- a/lib/sanbase_web/graphql/dataloader/clickhouse_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/clickhouse_dataloader.ex
@@ -9,17 +9,15 @@ defmodule SanbaseWeb.Graphql.ClickhouseDataloader do
     args_list = args |> Enum.to_list()
 
     args_list
-    |> Enum.group_by(fn %{metric: metric, from: from, to: to, aggregation: aggregation} ->
-      {metric, from, to, aggregation}
+    |> Enum.group_by(fn %{metric: metric, from: from, to: to, opts: opts} ->
+      {metric, from, to, opts}
     end)
     |> Sanbase.Parallel.map(fn {selector, group} ->
-      {metric, from, to, aggregation} = selector
+      {metric, from, to, opts} = selector
       slugs = Enum.map(group, & &1.slug)
 
       data =
-        case Metric.aggregated_timeseries_data(metric, %{slug: slugs}, from, to,
-               aggregation: aggregation
-             ) do
+        case Metric.aggregated_timeseries_data(metric, %{slug: slugs}, from, to, opts) do
           {:ok, result} -> result
           {:error, error} -> {:error, error}
         end

--- a/lib/sanbase_web/graphql/helpers/utils.ex
+++ b/lib/sanbase_web/graphql/helpers/utils.ex
@@ -154,6 +154,18 @@ defmodule SanbaseWeb.Graphql.Helpers.Utils do
     |> Ecto.Changeset.traverse_errors(&format_error/1)
   end
 
+  def selector_args_to_opts(args) when is_map(args) do
+    opts = [aggregation: Map.get(args, :aggregation, nil)]
+
+    with selector when is_map(selector) <- args[:selector],
+         {map, _rest} when map_size(map) > 0 <- Map.split(selector, [:owner, :label]) do
+      [additional_filters: Keyword.new(map)] ++ opts
+    else
+      _ ->
+        opts
+    end
+  end
+
   @doc ~s"""
   Works when the result is a list of elements that contain a datetime and the query arguments
   have a `from` argument. In that case the first element's `datetime` is update to be

--- a/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
@@ -2,6 +2,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   import SanbaseWeb.Graphql.Helpers.Utils
 
   import Sanbase.Utils.ErrorHandling, only: [handle_graphql_error: 3, handle_graphql_error: 4]
+  import SanbaseWeb.Graphql.Helpers.Utils
 
   alias Sanbase.Metric
   alias Sanbase.Billing.Plan.Restrictions
@@ -84,7 +85,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
 
     selector = to_selector(args)
     metric = maybe_replace_metric(metric, selector)
-    opts = args_to_opts(args)
+    opts = selector_args_to_opts(args)
 
     with true <- valid_selector?(selector),
          {:ok, from, to, interval} <-
@@ -111,7 +112,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
       ) do
     include_incomplete_data = Map.get(args, :include_incomplete_data, false)
     selector = to_selector(args)
-    opts = args_to_opts(args)
+    opts = selector_args_to_opts(args)
 
     with true <- valid_selector?(selector),
          {:ok, from, to} <-
@@ -274,17 +275,4 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   defp to_selector(%{word: word}), do: %{word: word}
   defp to_selector(%{selector: %{} = selector}), do: selector
   defp to_selector(_), do: %{}
-
-  # Convert the args to opts that the Metric module recognizes
-  defp args_to_opts(args) when is_map(args) do
-    opts = [aggregation: Map.get(args, :aggregation, nil)]
-
-    with selector when is_map(selector) <- args[:selector],
-         {map, _rest} when map_size(map) > 0 <- Map.split(selector, [:owner, :label]) do
-      [additional_filters: Keyword.new(map)] ++ opts
-    else
-      _ ->
-        opts
-    end
-  end
 end

--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -76,6 +76,12 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     field(:pagination, :project_pagination_input_object)
   end
 
+  input_object :aggregated_timeseries_data_selector_input_object do
+    field(:label, :string)
+    field(:owner, :string)
+    field(:holders_count, :integer)
+  end
+
   object :metric_anomalies do
     field(:metric, :string)
     field(:anomalies, list_of(:string))
@@ -276,6 +282,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
     end
 
     field :aggregated_timeseries_data, :float do
+      arg(:selector, :aggregated_timeseries_data_selector_input_object)
       arg(:metric, non_null(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
@@ -283,7 +290,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       arg(:include_incomplete_data, :boolean, default_value: false)
 
       complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
+      # middleware(AccessControl)
 
       cache_resolve(&ProjectMetricsResolver.aggregated_timeseries_data/3,
         ttl: 600,


### PR DESCRIPTION
## Changes
Add support the following:
```graphql
{
allProjects{
  slug
  exchange_inflow_centralized: aggregatedTimeseriesData(
    selector: {label: "centralized_exchange"}
    from: "2020-01-14T00:00:00Z"
    to: "2020-01-16T00:00:00Z"
    metric: "exchange_inflow_per_exchange"
    aggregation: SUM)
  
   exchange_inflow_decentralized: aggregatedTimeseriesData(
    selector: {label: "decentralized_exchange"}
    from: "2020-01-14T00:00:00Z"
    to: "2020-01-16T00:00:00Z"
    metric: "exchange_inflow_per_exchange"
    aggregation: SUM)
}
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
