### PR TITLE
Add sent signals per day limit for users

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -34,8 +34,7 @@ config :sanbase, Sanbase.ExternalServices.RateLimiting.Server,
 config :sanbase, Sanbase.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,
   database: "sanbase_test",
-  pool_size: 5,
-  ownership_timeout: 200_000
+  pool_size: 5
 
 config :sanbase, Sanbase.ClickhouseRepo,
   pool: Ecto.Adapters.SQL.Sandbox,

--- a/lib/sanbase/auth/settings.ex
+++ b/lib/sanbase/auth/settings.ex
@@ -18,6 +18,8 @@ defmodule Sanbase.Auth.Settings do
     field(:newsletter_subscription_updated_at_unix, :integer, default: nil)
     field(:is_promoter, :boolean, default: false)
     field(:paid_with, :string, default: nil)
+    field(:signals_per_day, :integer, default: 100)
+    field(:signals_fired, :map, default: %{})
   end
 
   def changeset(schema, params) do
@@ -32,7 +34,8 @@ defmodule Sanbase.Auth.Settings do
       :telegram_chat_id,
       :hide_privacy_data,
       :is_promoter,
-      :paid_with
+      :paid_with,
+      :signals_per_day
     ])
     |> normalize_newsletter_subscription(
       :newsletter_subscription,

--- a/lib/sanbase/auth/settings.ex
+++ b/lib/sanbase/auth/settings.ex
@@ -18,7 +18,7 @@ defmodule Sanbase.Auth.Settings do
     field(:newsletter_subscription_updated_at_unix, :integer, default: nil)
     field(:is_promoter, :boolean, default: false)
     field(:paid_with, :string, default: nil)
-    field(:signals_per_day, :integer, default: 100)
+    field(:signals_per_day_limit, :map, default: %{})
     field(:signals_fired, :map, default: %{})
   end
 
@@ -35,7 +35,7 @@ defmodule Sanbase.Auth.Settings do
       :hide_privacy_data,
       :is_promoter,
       :paid_with,
-      :signals_per_day,
+      :signals_per_day_limit,
       :signals_fired
     ])
     |> normalize_newsletter_subscription(

--- a/lib/sanbase/auth/settings.ex
+++ b/lib/sanbase/auth/settings.ex
@@ -35,7 +35,8 @@ defmodule Sanbase.Auth.Settings do
       :hide_privacy_data,
       :is_promoter,
       :paid_with,
-      :signals_per_day
+      :signals_per_day,
+      :signals_fired
     ])
     |> normalize_newsletter_subscription(
       :newsletter_subscription,

--- a/lib/sanbase/signals.ex
+++ b/lib/sanbase/signals.ex
@@ -10,6 +10,11 @@ defmodule Sanbase.Application.Signals do
   """
   def children() do
     children = [
+      # Mutex used when sending notifications for triggered signals
+      # Guards agains concurrently sending notifications to a single user
+      # which can bypass the limit for signals per day
+      {Mutex, name: Sanbase.SignalMutex},
+
       # Start the signal evaluator cache
       Supervisor.child_spec(
         {ConCache,

--- a/lib/sanbase/signals/evaluator/scheduler.ex
+++ b/lib/sanbase/signals/evaluator/scheduler.ex
@@ -21,7 +21,7 @@ defmodule Sanbase.Signal.Scheduler do
   defguard is_non_empty_map(map) when is_map(map) and map != %{}
 
   @doc ~s"""
-  Processfor all active signals with the given type. The processing
+  Process for all active signals with the given type. The processing
    includes the following steps:
    1. Fetch the active signals with the given type.
    2. Evaluate the signals
@@ -97,7 +97,7 @@ defmodule Sanbase.Signal.Scheduler do
   end
 
   # Note that the `user_trigger` that came as an argument is returned with
-  # modofied `last_triggered`.
+  # modified `last_triggered`.
   # TODO: Research if this is really needed
   defp update_trigger_last_triggered(user_trigger, last_triggered) do
     {:ok, updated_user_trigger} =

--- a/lib/sanbase/signals/signal.ex
+++ b/lib/sanbase/signals/signal.ex
@@ -5,15 +5,15 @@ end
 defimpl Sanbase.Signal, for: Any do
   require Logger
 
-  def send(%{
-        trigger: %{settings: %{triggered?: false}}
-      }) do
+  def send(%{trigger: %{settings: %{triggered?: false}}}) do
     warn_msg = "Trying to send an alert that is not triggered."
     Logger.warn(warn_msg)
     {:error, warn_msg}
   end
 
   def send(%{trigger: %{settings: %{channel: channel}}} = user_trigger) do
+    max_signals_to_send = max_signals_to_send(user_trigger)
+
     # This will return a list of `{identifier, telegram_sent_status}` or `{:error, error}`
     # If a signal is sent to more than 1 channel this is handled properly by
     # the caller that puts the triggered identifiers in a map, so duplicates
@@ -21,100 +21,90 @@ defimpl Sanbase.Signal, for: Any do
     channel
     |> List.wrap()
     |> Enum.map(fn
-      "telegram" -> send_telegram(user_trigger)
-      "email" -> send_email(user_trigger)
-      %{webhook: webhook_url} -> send_webhook(user_trigger, webhook_url)
+      "telegram" -> send_telegram(user_trigger, max_signals_to_send)
+      "email" -> send_email(user_trigger, max_signals_to_send)
+      %{webhook: webhook_url} -> send_webhook(user_trigger, webhook_url, max_signals_to_send)
       "web_push" -> []
     end)
     |> List.flatten()
   end
 
-  def send_webhook(
-        %{
-          id: user_trigger_id,
-          trigger: %{
-            settings: %{
-              payload: payload_map
-            }
-          }
-        },
-        webhook_url
-      ) do
-    Enum.map(payload_map, fn {identifier, payload} ->
-      encoded_json_payload =
-        %{
-          timestamp: DateTime.utc_now() |> DateTime.to_unix(),
-          identifier: identifier,
-          content: payload,
-          trigger_id: user_trigger_id,
-          trigger_url: SanbaseWeb.Endpoint.show_signal_url(user_trigger_id)
-        }
-        |> Jason.encode!()
+  defp send_webhook(
+         %{
+           id: user_trigger_id,
+           trigger: %{settings: %{payload: payload_map}}
+         },
+         webhook_url,
+         max_signals_to_send
+       ) do
+    fun = fn identifier, payload ->
+      do_send_webhook(webhook_url, identifier, payload, user_trigger_id)
+    end
 
-      case HTTPoison.post(webhook_url, encoded_json_payload, [
-             {"Content-Type", "application/json"}
-           ]) do
-        {:ok, %HTTPoison.Response{status_code: status_code}} when status_code in 200..299 ->
-          {identifier, :ok}
-
-        {:ok, %HTTPoison.Response{status_code: code}} ->
-          {identifier, {:error, "Error sending webhook alert. Status code: #{code}."}}
-
-        {:error, reason} ->
-          {identifier, {:error, "Error sending webhook alert. Reason: #{inspect(reason)}"}}
-      end
-    end)
+    send_or_limit(payload_map, max_signals_to_send, fun)
   end
 
-  def send_email(%{
-        id: id,
-        user: %Sanbase.Auth.User{
-          email: email,
-          user_settings: %{settings: %{signal_notify_email: true}}
-        },
-        trigger: %{
-          settings: %{payload: payload_map}
-        }
-      })
-      when is_binary(email) and is_map(payload_map) do
-    payload_map
-    |> Enum.map(fn {identifier, payload} ->
-      {identifier, do_send_email(email, payload, id)}
-    end)
+  defp send_email(
+         %{
+           id: id,
+           user: %Sanbase.Auth.User{
+             email: email,
+             user_settings: %{settings: %{signal_notify_email: true}}
+           },
+           trigger: %{settings: %{payload: payload_map}}
+         },
+         max_signals_to_send
+       )
+       when is_binary(email) and is_map(payload_map) do
+    fun = fn _identifier, payload ->
+      do_send_email(email, payload, id)
+    end
+
+    send_or_limit(payload_map, max_signals_to_send, fun)
   end
 
-  def send_email(%{
-        user: %Sanbase.Auth.User{id: id},
-        trigger: %{settings: %{payload: payload_map}}
-      }) do
+  defp send_email(
+         %{
+           user: %Sanbase.Auth.User{id: user_id},
+           trigger: %{settings: %{payload: payload_map}}
+         },
+         _max_signals_to_send
+       ) do
     Logger.warn(
-      "User with id #{id} does not have an email linked or the email notifications are disabled, so an alert cannot be sent."
+      "User with id #{user_id} does not have an email linked or the email notifications are disabled, so an alert cannot be sent."
     )
 
     payload_map
     |> Enum.map(fn {identifier, _payload} ->
-      {identifier, {:error, "No email linked for user with id #{id}"}}
+      {identifier, {:error, "No email linked for user with id #{user_id}"}}
     end)
   end
 
-  def send_telegram(%{
-        id: id,
-        user: %{user_settings: %{settings: %{telegram_chat_id: telegram_chat_id}}} = user,
-        trigger: %{
-          settings: %{payload: payload_map}
-        }
-      })
-      when is_integer(telegram_chat_id) and telegram_chat_id > 0 and is_map(payload_map) do
-    payload_map
-    |> Enum.map(fn {identifier, payload} ->
-      {identifier, Sanbase.Telegram.send_message(user, extend_payload(payload, id))}
-    end)
+  defp send_telegram(
+         %{
+           id: user_trigger_id,
+           user: %{user_settings: %{settings: %{telegram_chat_id: telegram_chat_id}}} = user,
+           trigger: %{
+             settings: %{payload: payload_map}
+           }
+         },
+         max_signals_to_send
+       )
+       when is_integer(telegram_chat_id) and telegram_chat_id > 0 and is_map(payload_map) do
+    fun = fn _identifier, payload ->
+      Sanbase.Telegram.send_message(user, extend_payload(payload, user_trigger_id))
+    end
+
+    send_or_limit(payload_map, max_signals_to_send, fun)
   end
 
-  def send_telegram(%{
-        user: %Sanbase.Auth.User{id: id},
-        trigger: %{settings: %{payload: payload_map}}
-      }) do
+  defp send_telegram(
+         %{
+           user: %Sanbase.Auth.User{id: id},
+           trigger: %{settings: %{payload: payload_map}}
+         },
+         _max_signals_to_send
+       ) do
     Logger.warn("User with id #{id} does not have a telegram linked, so an alert cannot be sent.")
 
     payload_map
@@ -130,6 +120,18 @@ defimpl Sanbase.Signal, for: Any do
     """
   end
 
+  defp max_signals_to_send(%{user: user}) do
+    user_settings = Sanbase.Auth.UserSettings.settings_for(user)
+
+    %{
+      signals_fired: signals_fired,
+      signals_per_day: signals_per_day
+    } = user_settings
+
+    notifications_sent_today = Map.get(signals_fired, Date.utc_today(), 0)
+    Enum.max([signals_per_day - notifications_sent_today, 0])
+  end
+
   defp do_send_email(email, payload, trigger_id) do
     Sanbase.MandrillApi.send("signals", email, %{
       payload: extend_payload(payload, trigger_id) |> Earmark.as_html!(breaks: true)
@@ -138,5 +140,48 @@ defimpl Sanbase.Signal, for: Any do
       {:ok, _} -> :ok
       {:error, reason} -> {:error, reason}
     end
+  end
+
+  defp do_send_webhook(webhook_url, identifier, payload, user_trigger_id) do
+    encoded_json_payload =
+      %{
+        timestamp: DateTime.utc_now() |> DateTime.to_unix(),
+        identifier: identifier,
+        content: payload,
+        trigger_id: user_trigger_id,
+        trigger_url: SanbaseWeb.Endpoint.show_signal_url(user_trigger_id)
+      }
+      |> Jason.encode!()
+
+    case HTTPoison.post(webhook_url, encoded_json_payload, [
+           {"Content-Type", "application/json"}
+         ]) do
+      {:ok, %HTTPoison.Response{status_code: status_code}} when status_code in 200..299 ->
+        {identifier, :ok}
+
+      {:ok, %HTTPoison.Response{status_code: code}} ->
+        {identifier, {:error, "Error sending webhook alert. Status code: #{code}."}}
+
+      {:error, reason} ->
+        {identifier, {:error, "Error sending webhook alert. Reason: #{inspect(reason)}"}}
+    end
+  end
+
+  defp send_or_limit(payload_map, limit, fun) when is_function(fun, 2) do
+    {result, _} =
+      payload_map
+      |> Enum.reduce({[], limit}, fn {identifier, payload}, {list, remaining} ->
+        case remaining do
+          0 ->
+            elem = {identifier, :signals_limit_reached}
+            {[elem | list], 0}
+
+          remaining ->
+            elem = {identifier, fun.(identifier, payload)}
+            {[elem | list], remaining - 1}
+        end
+      end)
+
+    result
   end
 end

--- a/lib/sanbase_web/endpoint.ex
+++ b/lib/sanbase_web/endpoint.ex
@@ -126,6 +126,11 @@ defmodule SanbaseWeb.Endpoint do
     frontend_url() <> "/labs/balance?address=#{address}&assets[]=#{asset}"
   end
 
+  def feed_url() do
+    Config.get(:website_url)
+    |> Path.join("feed")
+  end
+
   def user_account_url() do
     Config.get(:website_url)
     |> Path.join("account")

--- a/lib/sanbase_web/graphql/schema/types/user_settings_type.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_settings_type.ex
@@ -19,7 +19,7 @@ defmodule SanbaseWeb.Graphql.UserSettingsTypes do
     field(:signal_notify_email, :boolean)
     field(:newsletter_subscription, :newsletter_subscription_type)
     field(:paid_with, :string)
-    field(:signals_per_day, :integer)
+    field(:signals_per_day_limit, :json)
   end
 
   input_object :user_settings_input_object do
@@ -32,6 +32,6 @@ defmodule SanbaseWeb.Graphql.UserSettingsTypes do
     field(:signal_notify_telegram, :boolean)
     field(:signal_notify_email, :boolean)
     field(:newsletter_subscription, :newsletter_subscription_type)
-    field(:signals_per_day, :integer)
+    field(:signals_per_day_limit, :json)
   end
 end

--- a/lib/sanbase_web/graphql/schema/types/user_settings_type.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_settings_type.ex
@@ -19,6 +19,7 @@ defmodule SanbaseWeb.Graphql.UserSettingsTypes do
     field(:signal_notify_email, :boolean)
     field(:newsletter_subscription, :newsletter_subscription_type)
     field(:paid_with, :string)
+    field(:signals_per_day, :integer)
   end
 
   input_object :user_settings_input_object do
@@ -31,5 +32,6 @@ defmodule SanbaseWeb.Graphql.UserSettingsTypes do
     field(:signal_notify_telegram, :boolean)
     field(:signal_notify_email, :boolean)
     field(:newsletter_subscription, :newsletter_subscription_type)
+    field(:signals_per_day, :integer)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -110,6 +110,7 @@ defmodule Sanbase.Mixfile do
       {:rexbug, ">= 1.0.0"},
       {:san_exporter_ex, github: "santiment/san-exporter-ex"},
       {:sentry, "~> 7.0"},
+      {:mutex, "~> 1.1"},
       {:stream_data, "~> 0.4.2", only: :test},
       {:stripity_stripe, git: "https://github.com/code-corps/stripity_stripe"},
       {:sweet_xml, "~> 0.6"},

--- a/mix.lock
+++ b/mix.lock
@@ -78,6 +78,7 @@
   "mock": {:hex, :mock, "0.3.4", "c5862eb3b8c64237f45f586cf00c9d892ba07bb48305a43319d428ce3c2897dd", [:mix], [{:meck, "~> 0.8.13", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm", "e6d886252f1a41f4ba06ecf2b4c8d38760b34b1c08a11c28f7397b2e03995964"},
   "mockery": {:hex, :mockery, "2.3.1", "a02fd60b10ac9ed37a7a2ecf6786c1f1dd5c75d2b079a60594b089fba32dc087", [:mix], [], "hexpm", "1d0971d88ebf084e962da3f2cfee16f0ea8e04ff73a7710428500d4500b947fa"},
   "mogrify": {:hex, :mogrify, "0.7.3", "1494ee739f6e90de158dec4d4edee2d854d2f2d06a522e943f996ae176bca53d", [:mix], [], "hexpm", "b3e90a87171c23efa6b5910d735dd44f3fda15ba07a57cdb89cdb8ecaf83988d"},
+  "mutex": {:hex, :mutex, "1.1.3", "d7e19f96fe19d6d97583bf12ca1ec182bbf14619b7568592cc461135de1c3b81", [:mix], [], "hexpm", "2b83b92784add2611c23dd527073b5e8dfe3c9c6c94c5bf9e3081b5c41c3ff3e"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm", "5c040b8469c1ff1b10093d3186e2e10dbe483cd73d79ec017993fb3985b8a9b3"},
   "norm": {:hex, :norm, "0.12.0", "b27a629fea9aaf7757604e9d4ed06cd815c2c5fb335f38b33c1bf17db9b217b0", [:mix], [], "hexpm", "aecd53df72219966d9493e3426a32d83490c822ef618ef442721b1ae68cb6f0c"},
   "number": {:hex, :number, "1.0.1", "a1017dc867a9860b0c261bf9f3ac4990f64589dbbe50260724190c78a0b92104", [:mix], [{:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm", "149c62771306451198b2a044b4f077520c9acf6e69304723b17385257c683b52"},

--- a/test/sanbase/signals/max_signals_per_day_test.exs
+++ b/test/sanbase/signals/max_signals_per_day_test.exs
@@ -53,7 +53,10 @@ defmodule Sanbase.Signal.MaxSignalsPerDayTest do
 
   test "does not send notifications after limit is reached", context do
     %{user: user, mock_fun: mock_fun} = context
-    Sanbase.Auth.UserSettings.update_settings(user, %{signals_per_day: 1})
+
+    Sanbase.Auth.UserSettings.update_settings(user, %{
+      signals_per_day_limit: %{"email" => 1, "telegram" => 1}
+    })
 
     self_pid = self()
 
@@ -76,7 +79,7 @@ defmodule Sanbase.Signal.MaxSignalsPerDayTest do
       assert_receive({:telegram_to_self, limit_reached_msg})
 
       assert limit_reached_msg =~
-               "The allowed number of signal notifications per day has been reached"
+               "Your maximum amount of telegram alert notifications per day has been reached"
 
       refute_receive({:telegram_to_self, _}, 1000)
     end)

--- a/test/sanbase/signals/max_signals_per_day_test.exs
+++ b/test/sanbase/signals/max_signals_per_day_test.exs
@@ -1,0 +1,84 @@
+defmodule Sanbase.Signal.MaxSignalsPerDayTest do
+  use Sanbase.DataCase, async: false
+
+  import Sanbase.Factory
+  import Sanbase.TestHelpers
+
+  alias Sanbase.Signal.UserTrigger
+  alias Sanbase.Signal.Trigger.MetricTriggerSettings
+
+  setup do
+    project = insert(:random_erc20_project)
+    user = insert(:user)
+    Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
+
+    trigger_settings = %{
+      type: "metric_signal",
+      metric: "active_addresses_24h",
+      target: %{slug: project.slug},
+      channel: "telegram",
+      operation: %{above: 300}
+    }
+
+    create_trigger_fun = fn ->
+      UserTrigger.create_user_trigger(user, %{
+        title: "Generic title",
+        is_public: true,
+        cooldown: "12h",
+        settings: trigger_settings
+      })
+    end
+
+    # Create
+    {:ok, trigger} = create_trigger_fun.()
+    {:ok, _} = create_trigger_fun.()
+    {:ok, _} = create_trigger_fun.()
+
+    datetimes = generate_datetimes(~U[2019-01-01 00:00:00Z], "1d", 7)
+
+    mock_fun =
+      [
+        fn -> {:ok, [%{datetime: datetimes |> List.first(), value: 100}]} end,
+        fn -> {:ok, [%{datetiem: datetimes |> List.last(), value: 500}]} end
+      ]
+      |> Sanbase.Mock.wrap_consecutives(arity: 6)
+
+    [
+      trigger: trigger,
+      project: project,
+      user: user,
+      mock_fun: mock_fun
+    ]
+  end
+
+  test "does not send notifications after limit is reached", context do
+    %{user: user, mock_fun: mock_fun} = context
+    Sanbase.Auth.UserSettings.update_settings(user, %{signals_per_day: 1})
+
+    self_pid = self()
+
+    Sanbase.Mock.prepare_mock(Sanbase.Clickhouse.Metric, :timeseries_data, mock_fun)
+    |> Sanbase.Mock.prepare_mock(Sanbase.Telegram, :send_message, fn _user, text ->
+      send(self_pid, {:telegram_to_self, text})
+      :ok
+    end)
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      Sanbase.Signal.Scheduler.run_signal(MetricTriggerSettings)
+
+      # Three triggers have been evaluted with the limit of signals per day being 3
+      # One trigger succesfully sends
+      # The second trigger fires the limit reached notification
+      # The third trigger neither sends a notification nor re-sends the limit
+      # reached notification
+      assert_receive({:telegram_to_self, triggered_msg})
+      assert triggered_msg =~ "Active Addresses for the last 24 hours is above 300"
+
+      assert_receive({:telegram_to_self, limit_reached_msg})
+
+      assert limit_reached_msg =~
+               "The allowed number of signal notifications per day has been reached"
+
+      refute_receive({:telegram_to_self, _}, 1000)
+    end)
+  end
+end

--- a/test/sanbase/signals/price/trigger_price_absolute_change_test.exs
+++ b/test/sanbase/signals/price/trigger_price_absolute_change_test.exs
@@ -149,7 +149,7 @@ defmodule Sanbase.Signal.TriggerPriceAbsoluteChangeTest do
 
         assert capture_log(fn ->
                  Sanbase.Signal.Scheduler.run_signal(PriceAbsoluteChangeSettings)
-               end) =~ "There were no signals triggered of type"
+               end) =~ "There were no price_absolute_change signals triggered"
       end)
     end
   end

--- a/test/sanbase/signals/screener/screener_trigger_settings_test.exs
+++ b/test/sanbase/signals/screener/screener_trigger_settings_test.exs
@@ -100,7 +100,7 @@ defmodule Sanbase.Signal.ScreenerTriggerSettingsTest do
       # Second run
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(ScreenerTriggerSettings)
-             end) =~ "There were no signals triggered of type screener_signal"
+             end) =~ "There were no screener_signal signals triggered"
     end)
   end
 
@@ -149,7 +149,7 @@ defmodule Sanbase.Signal.ScreenerTriggerSettingsTest do
       # Second run
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(ScreenerTriggerSettings)
-             end) =~ "There were no signals triggered of type screener_signal"
+             end) =~ "There were no screener_signal signals triggered"
     end)
   end
 end

--- a/test/sanbase/signals/trending_words/trigger_trending_words_send_at_predefiend_time_test.exs
+++ b/test/sanbase/signals/trending_words/trigger_trending_words_send_at_predefiend_time_test.exs
@@ -95,7 +95,7 @@ defmodule Sanbase.Signal.TriggerTrendingWordsSendAtPredefiendTimeTest do
 
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(TrendingWordsTriggerSettings)
-             end) =~ "There were no signals triggered of type"
+             end) =~ "There were no trending_words signals triggered"
     end
   end
 
@@ -107,7 +107,7 @@ defmodule Sanbase.Signal.TriggerTrendingWordsSendAtPredefiendTimeTest do
 
     assert capture_log(fn ->
              Sanbase.Signal.Scheduler.run_signal(TrendingWordsTriggerSettings)
-           end) =~ "There were no signals triggered of type"
+           end) =~ "There were no trending_words signals triggered"
   end
 
   test "Non repeating signals are deactivated", context do

--- a/test/sanbase/signals/trending_words/trigger_trending_words_trending_project_test.exs
+++ b/test/sanbase/signals/trending_words/trigger_trending_words_trending_project_test.exs
@@ -76,7 +76,7 @@ defmodule Sanbase.Signal.TriggerTrendingWordsTrendingProjectTest do
 
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(TrendingWordsTriggerSettings)
-             end) =~ "There were no signals triggered of type"
+             end) =~ "There were no trending_words signals triggered"
     end
   end
 

--- a/test/sanbase/signals/trending_words/trigger_trending_words_trending_word_test.exs
+++ b/test/sanbase/signals/trending_words/trigger_trending_words_trending_word_test.exs
@@ -71,7 +71,7 @@ defmodule Sanbase.Signal.TriggerTrendingWordsTrendingWordTest do
 
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(TrendingWordsTriggerSettings)
-             end) =~ "There were no signals triggered of type"
+             end) =~ "There were no trending_words signals triggered"
     end
   end
 
@@ -93,7 +93,7 @@ defmodule Sanbase.Signal.TriggerTrendingWordsTrendingWordTest do
 
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(TrendingWordsTriggerSettings)
-             end) =~ "There were no signals triggered of type"
+             end) =~ "There were no trending_words signals triggered"
     end
   end
 


### PR DESCRIPTION
## Changes
Limit the number of signal notifications one user can receive per calendar day. This is done to restrict an accidental spammy signal. The number of notifications is configured in the user settings and can be changed.
API for changing:
```graphql
mutation{
  updateUserSettings(settings: {signalsPerDayLimit: "{\"email\": 100, \"telegram\": 200}"}){
    signalsPerDay
  }
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
