### PR TITLE
Run the available metrics recomputation less often

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
@@ -12,8 +12,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver do
 
   require Logger
   @ttl 3600
-  @refresh_time_delta 600
-  @refresh_time_max_offset 120
+  @refresh_time_delta 1200
+  @refresh_time_max_offset 600
 
   def available_metrics(%Project{slug: slug}, _args, _resolution) do
     query = :available_metrics


### PR DESCRIPTION
## Changes
It was determined that the computation of metrics availability takes a lot of resources. 
In order to test the fix, I fired `availableMetrics` request for every of the 1600+ slugs. 
The metrics do not change often at all, but with the current setup, the rehydrating cache would run the recomputation once per 10-12 minutes and that makes on average 140 projects per minute. There is no point in running the calculations so often. Now it will run after 20-25 minutes (with a randomized offset)
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
