### PR TITLE
Add new change metrics

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -3463,7 +3463,7 @@
   },
   {
     "human_readable_name": "Social Volume Change (1d)",
-    "name": "social_volume_change_1d",
+    "name": "social_volume_total_change_1d",
     "metric": "social_volume_change_1d",
     "version": "2019-01-01",
     "access": "restricted",
@@ -3480,7 +3480,7 @@
   },
   {
     "human_readable_name": "Social Volume Change (7d)",
-    "name": "social_volume_change_7d",
+    "name": "social_volume_total_change_7d",
     "metric": "social_volume_change_7d",
     "version": "2019-01-01",
     "access": "restricted",
@@ -3497,7 +3497,7 @@
   },
   {
     "human_readable_name": "Social Volume Change (30d)",
-    "name": "social_volume_change_30d",
+    "name": "social_volume_total_change_30d",
     "metric": "social_volume_change_30d",
     "version": "2019-01-01",
     "access": "restricted",

--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -3530,6 +3530,23 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Sentiment Balance Total Change (1d)",
+    "name": "sentiment_balance_total_change_1d",
+    "metric": "sentiment_balance_change_1d",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
     "human_readable_name": "Adjusted Price - DAA divergence",
     "name": "adjusted_price_daa_divergence",
     "metric": "adjusted_daa_divergence",
@@ -3543,6 +3560,91 @@
     "aggregation": "last",
     "min_interval": "1d",
     "table": "daily_metrics_v2",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Sentiment Balance Total Change (7d)",
+    "name": "sentiment_balance_total_change_7d",
+    "metric": "sentiment_balance_change_7d",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Sentiment Balance Total Change (30d)",
+    "name": "sentiment_balance_total_change_30d",
+    "metric": "sentiment_balance_change_30d",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Social Dominance Change (1d)",
+    "name": "social_dominance_total_change_1d",
+    "metric": "social_dominance_change_1d",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Social Dominance Change (7d)",
+    "name": "social_dominance_total_change_7d",
+    "metric": "social_dominance_change_7d",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Social Dominance Change (30d)",
+    "name": "social_dominance_total_change_30d",
+    "metric": "social_dominance_change_30d",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries"
   }

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -476,11 +476,11 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "exchange_outflow_usd_change_1d",
         "exchange_outflow_usd_change_7d",
         "exchange_outflow_usd_change_30d",
-        "social_volume_change_1d",
-        "social_volume_change_7d",
-        "social_volume_change_30d",
         "price_daa_divergence",
-        "adjusted_price_daa_divergence"
+        "adjusted_price_daa_divergence",
+        "social_volume_total_change_1d",
+        "social_volume_total_change_7d",
+        "social_volume_total_change_30d"
       ]
       |> Enum.sort()
 

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -480,7 +480,13 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "adjusted_price_daa_divergence",
         "social_volume_total_change_1d",
         "social_volume_total_change_7d",
-        "social_volume_total_change_30d"
+        "social_volume_total_change_30d",
+        "sentiment_balance_total_change_1d",
+        "sentiment_balance_total_change_7d",
+        "sentiment_balance_total_change_30d",
+        "social_dominance_total_change_1d",
+        "social_dominance_total_change_7d",
+        "social_dominance_total_change_30d"
       ]
       |> Enum.sort()
 


### PR DESCRIPTION
## Changes

Add new metrics to API: 

1. sentiment_balance_change_1d
2. sentiment_balance_change_7d
3. sentiment_balance_change_30d
4. social_dominance_change_1d
5. social_dominance_change_7d
6. social_dominance_change_30d

Renamed social_volume change metrics according to the previous naming convention when we specify total or exact data source, such as `twitter`, `telegram`..


## [Ticket](https://www.notion.so/santiment/Implement-metric-differences-for-all-metrics-c8005ed76f60458e8cafcae525b5e093)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
