### PR TITLE
Fix earmark parallel map timeout

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -93,6 +93,10 @@ config :sentry,
   included_environments: [:prod],
   environment_name: Mix.env()
 
+config :earmark,
+  # disable using parallel map die to timeout errors
+  mapper: &Enum.map/2
+
 config :hammer,
   backend: {Hammer.Backend.ETS, [expiry_ms: 60_000 * 60 * 4, cleanup_interval_ms: 60_000 * 10]}
 


### PR DESCRIPTION
## Changes
Fix Earmark.pmap timeout by using serial Enum.map. Pmap not needed in our case.

sentry error: https://sentry.production.internal.santiment.net/sentry/sanbase-backend/issues/80423/
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
