### PR TITLE
Add labels to uniswap top claimers result

### DIFF
--- a/lib/sanbase/clickhouse/labels.ex
+++ b/lib/sanbase/clickhouse/labels.ex
@@ -58,6 +58,15 @@ defmodule Sanbase.Clickhouse.Label do
     end
   end
 
+  def get_address_labels(slug, addresses) when is_list(addresses) do
+    {query, args} = addresses_labels_query(slug, addresses)
+
+    Sanbase.ClickhouseRepo.query_reduce(query, args, %{}, fn [address, label, metadata], acc ->
+      label = %{name: label, metadata: metadata}
+      Map.update(acc, address, [label], &[label | &1])
+    end)
+  end
+
   # helpers
   defp addresses_labels_query("bitcoin", addresses) do
     query = """

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -73,12 +73,22 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:value, :float)
   end
 
+  object :object_address_float_value do
+    field(:address, :address)
+    field(:value, :float)
+  end
+
   object :string_address_float_value do
     field(:address, :string)
+    field(:labels, list_of(:string))
     field(:value, :float)
   end
 
   object :string_address_float_value_list do
+    field(:data, list_of(:string_address_float_value))
+  end
+
+  object :object_address_float_value_list do
     field(:data, list_of(:string_address_float_value))
   end
 


### PR DESCRIPTION
## Changes
Add a `labels` field to the following query, which holds a list of strings (labels)
```graphql
{
getMetric(metric: "uniswap_top_claimers"){
  histogramData(
    selector: {slug: "uniswap"}
    from: "2020-09-18T00:00:00Z"
    to:"2020-09-19T00:00:00Z"
    limit: 10){
      values {
        ... on StringAddressFloatValueList{
          data{
            address
            value
            labels
          }
        }
    }
  }
}}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
