### PR TITLE
Add excluded_addresses to token top transactions API

### DIFF
--- a/lib/sanbase/clickhouse/historical_balance/fetchers/btc_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/fetchers/btc_balance.ex
@@ -114,8 +114,8 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.BtcBalance do
   @doc false
   @spec top_transactions(%DateTime{}, %DateTime{}, integer) ::
           {:ok, nil} | {:ok, list(transaction)} | {:error, String.t()}
-  def top_transactions(from, to, limit) do
-    {query, args} = btc_top_transactions_query(from, to, limit)
+  def top_transactions(from, to, limit, excluded_addresses \\ []) do
+    {query, args} = btc_top_transactions_query(from, to, limit, excluded_addresses)
 
     ClickhouseRepo.query_transform(
       query,

--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -608,6 +608,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:limit, :integer, default_value: 10)
+      arg(:excluded_addresses, list_of(:string))
 
       complexity(&Complexity.from_to_interval/3)
       cache_resolve(&ProjectTransactionsResolver.token_top_transactions/3)

--- a/test/sanbase_web/graphql/projects/project_api_token_top_transfers_test.exs
+++ b/test/sanbase_web/graphql/projects/project_api_token_top_transfers_test.exs
@@ -15,7 +15,7 @@ defmodule SanbaseWeb.Graphql.ProjectApiTokenTopTransactionsTest do
 
   test "top token transactons for a project", %{conn: conn, project: project} do
     Sanbase.Mock.prepare_mock2(
-      &Sanbase.Clickhouse.Erc20Transfers.token_top_transfers/5,
+      &Sanbase.Clickhouse.Erc20Transfers.token_top_transfers/6,
       transactions()
     )
     |> Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:ok, %{rows: labels_rows()}})


### PR DESCRIPTION
## Changes
In some cases all of the top transactions come from some initial distribution, minting from 0x000... or some other similar event that does not represent "real" transaction between 2 parties. For this (and many other cases) we now allow the tokenTopTransactions to accept a list of addresses and all transactions in which these addresses participate (either as sender or receiver) will not be included in the list.
Request:
```graphql
{
  projectBySlug(slug: "santiment") {
    tokenTopTransactions(
      from: "2020-05-10T00:00:00Z"
      to: "2020-09-19T00:00:00Z"
      limit: 10
    	excludedAddresses: ["0xa9742ee9a5407f4c2f8a49f65e3a440f3694960a"]) {
        datetime
        trxValue
        fromAddress{address}
        toAddress{address}
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
