### PR TITLE
Add balance to the top claimers

### DIFF
--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -80,6 +80,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
 
   object :string_address_float_value do
     field(:address, :string)
+    field(:balance, :float)
     field(:labels, list_of(:string))
     field(:value, :float)
   end


### PR DESCRIPTION
## Changes
Extend the uniswap top claimers with current balance field:
```graphql
{
getMetric(metric: "uniswap_top_claimers"){
  histogramData(
    selector: {slug: "uniswap"}
    from: "2020-09-18T00:00:00Z"
    to:"2020-09-19T00:00:00Z"
    limit: 10){
      values {
        ... on StringAddressFloatValueList{
          data{
            address
            value
            balance
            labels
          }
        }
    }
  }
}}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
