### PR TITLE
Allow whitespace in API dynamic datetimes

### DIFF
--- a/lib/sanbase_web/graphql/schema/custom_types/datetime.ex
+++ b/lib/sanbase_web/graphql/schema/custom_types/datetime.ex
@@ -48,7 +48,7 @@ defmodule SanbaseWeb.Graphql.CustomTypes.DateTime do
   @spec parse_datetime(Absinthe.Blueprint.Input.String.t()) :: {:ok, DateTime.t()} | :error
   @spec parse_datetime(Absinthe.Blueprint.Input.Null.t()) :: {:ok, nil}
   defp parse_datetime(%Absinthe.Blueprint.Input.String{value: "utc_now" <> _rest = value}) do
-    case String.split(value, "-") do
+    case String.split(value, ~r/\s*-\s*/) do
       ["utc_now"] ->
         {:ok, DateTime.utc_now()}
 


### PR DESCRIPTION
## Changes
Allow adding extra whitespaces in dynamic datetimes like so: `utc_now - 1d`
![image](https://user-images.githubusercontent.com/122794/94666443-2895c580-0316-11eb-9c22-ee64a84e3d7d.png)

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
