### PR TITLE
Improve the speed of erc20 transers queries

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -20,6 +20,10 @@ config :postgrex, :json_library, Jason
 
 config :sanbase, Sanbase, environment: "#{Mix.env()}"
 
+config :sanbase, Sanbase.Clickhouse.Erc20Transfers,
+  dt_ordered_table: {:system, "dt_ordered_table", "erc20_transfers_new"},
+  address_ordered_table: {:system, "address_ordered_table", "erc20_transfers"}
+
 config :sanbase, Sanbase.KafkaExporter,
   supervisor: SanExporterEx.Producer.Supervisor,
   producer: SanExporterEx.Producer,

--- a/lib/sanbase/clickhouse/fees/fees.ex
+++ b/lib/sanbase/clickhouse/fees/fees.ex
@@ -43,14 +43,13 @@ defmodule Sanbase.Clickhouse.Fees do
             (
                 SELECT transactionHash, value
                 FROM eth_transfers FINAL
-                PREWHERE dt >= toDateTime(?1) and dt <= toDateTime(?2)
-                WHERE type = 'fee'
+                PREWHERE dt >= toDateTime(?1) AND dt < toDateTime(?2) AND type = 'fee'
             )
             ANY LEFT JOIN
             (
                 SELECT transactionHash, contract, assetRefId
                 FROM erc20_transfers_union
-                WHERE dt >= toDateTime(?1) and dt <= toDateTime(?2)
+                WHERE dt >= toDateTime(?1) and dt < toDateTime(?2)
             ) USING (transactionHash)
             GROUP BY assetRefId, contract
             ORDER BY fees DESC
@@ -58,8 +57,8 @@ defmodule Sanbase.Clickhouse.Fees do
         )
         ALL LEFT JOIN
         (
-            SELECT name, asset_ref_id AS assetRefId
-            FROM asset_metadata FINAL
+          SELECT name, asset_ref_id AS assetRefId
+          FROM asset_metadata FINAL
         ) USING (assetRefId)
     ) ORDER BY fees DESC
     """

--- a/lib/sanbase/clickhouse/historical_balance/fetchers/erc20_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/fetchers/erc20_balance.ex
@@ -108,7 +108,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20Balance do
     FROM #{@table} FINAL
     PREWHERE
       address IN (?1) AND
-      contract = ?2
+      assetRefId = cityHash64('ETH_' || ?2)
     GROUP BY address
     """
 
@@ -128,7 +128,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20Balance do
     FROM #{@table}
     PREWHERE
       address IN (?1) AND
-      contract = ?2 AND
+      assetRefId = cityHash64('ETH_' || ?2) AND
       dt >= toDateTime(?3) AND
       dt < toDateTime(?4) AND
       sign = 1
@@ -151,7 +151,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20Balance do
     FROM #{@table}
     PREWHERE
       address = ?1 AND
-      contract = ?2 AND
+      assetRefId = cityHash64('ETH_' || ?2) AND
       dt <= toDateTime(?3) AND
       sign = 1
     ORDER BY dt DESC
@@ -195,7 +195,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Erc20Balance do
     FROM #{@table}
     PREWHERE
       address = ?3 AND
-      contract = ?4 AND
+      assetRefId = cityHash64('ETH_' || ?4) AND
       sign = 1 AND
       dt >= toDateTime(?5) AND
       dt < toDateTime(?6)


### PR DESCRIPTION
## Changes
Add usage of erc20 transfers table ordered by dt in some of the queries.
Switch from contract to assetRefId as it is first in the order by, while contract is not present.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
