### PR TITLE
Properly use and check for disabled notification channels 

### DIFF
--- a/lib/sanbase/signals/evaluator/scheduler.ex
+++ b/lib/sanbase/signals/evaluator/scheduler.ex
@@ -216,8 +216,13 @@ defmodule Sanbase.Signal.Scheduler do
       Logger.warn("Cannot send a #{type} signal. Reason: #{inspect(error)}")
     end
 
+    disabled_count = Enum.filter(list, &match?({_, :channel_disabled}, &1)) |> Enum.count()
+    verb = if disabled_count == 1, do: "has", else: "have"
+
     Logger.info(
-      "In total #{successful_messages_count}/#{length(list)} #{type} signals were sent successfully."
+      "In total #{successful_messages_count}/#{length(list)} (#{disabled_count} #{verb} disabled channel) #{
+        type
+      } signals were sent successfully."
     )
   end
 

--- a/lib/sanbase/signals/signal.ex
+++ b/lib/sanbase/signals/signal.ex
@@ -178,8 +178,7 @@ defimpl Sanbase.Signal, for: Any do
     # Force the settings to be fetched and not taken from the user struct
     # This is done so while evaluating signals, the signals fired count is
     # properly reflected here.
-
-    user_settings = Sanbase.Auth.UserSettings.settings_for(%Sanbase.Auth.User{id: user.id})
+    user_settings = Sanbase.Auth.UserSettings.settings_for(user, force: true)
 
     %{
       signals_fired: signals_fired,
@@ -262,8 +261,7 @@ defimpl Sanbase.Signal, for: Any do
   end
 
   defp update_user_signals_sent_per_day(user, sent_list_per_channel) do
-    %{signals_fired: signals_fired} =
-      Sanbase.Auth.UserSettings.settings_for(%Sanbase.Auth.User{id: user.id})
+    %{signals_fired: signals_fired} = Sanbase.Auth.UserSettings.settings_for(user, force: true)
 
     map_key = Date.utc_today() |> to_string()
 

--- a/test/sanbase/signals/daily_active_addresses/trigger_daily_active_addresses_absolute_change_test.exs
+++ b/test/sanbase/signals/daily_active_addresses/trigger_daily_active_addresses_absolute_change_test.exs
@@ -13,7 +13,7 @@ defmodule Sanbase.Signal.DailyActiveAddresseAbsoluetChangeTest do
   setup do
     Sanbase.Signal.Evaluator.Cache.clear_all()
 
-    user = insert(:user)
+    user = insert(:user, user_settings: %{settings: %{signal_notify_telegram: true}})
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
 
     Sanbase.Factory.insert(:random_erc20_project, %{

--- a/test/sanbase/signals/daily_active_addresses/trigger_daily_active_addresses_percent_down_change_test.exs
+++ b/test/sanbase/signals/daily_active_addresses/trigger_daily_active_addresses_percent_down_change_test.exs
@@ -13,7 +13,7 @@ defmodule Sanbase.Signal.DailyActiveAddressesPercentDownChangeTest do
   setup do
     Sanbase.Signal.Evaluator.Cache.clear_all()
 
-    user = insert(:user)
+    user = insert(:user, user_settings: %{settings: %{signal_notify_telegram: true}})
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
 
     Sanbase.Factory.insert(:project, %{

--- a/test/sanbase/signals/daily_active_addresses/trigger_daily_active_addresses_percent_up_change_test.exs
+++ b/test/sanbase/signals/daily_active_addresses/trigger_daily_active_addresses_percent_up_change_test.exs
@@ -13,7 +13,7 @@ defmodule Sanbase.Signal.DailyActiveAddressesPercentUpChangeTest do
   setup do
     Sanbase.Signal.Evaluator.Cache.clear_all()
 
-    user = insert(:user)
+    user = insert(:user, user_settings: %{settings: %{signal_notify_telegram: true}})
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
 
     project = insert(:random_erc20_project)

--- a/test/sanbase/signals/max_signals_per_day_test.exs
+++ b/test/sanbase/signals/max_signals_per_day_test.exs
@@ -9,7 +9,7 @@ defmodule Sanbase.Signal.MaxSignalsPerDayTest do
 
   setup do
     project = insert(:random_erc20_project)
-    user = insert(:user)
+    user = insert(:user, user_settings: %{settings: %{signal_notify_telegram: true}})
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
 
     trigger_settings = %{

--- a/test/sanbase/signals/metric/metric_trigger_settings_test.exs
+++ b/test/sanbase/signals/metric/metric_trigger_settings_test.exs
@@ -28,7 +28,7 @@ defmodule Sanbase.Signal.MetricTriggerSettingsTest do
       Sanbase.Signal.Evaluator.Cache.clear_all()
       datetimes = generate_datetimes(~U[2019-01-01 00:00:00Z], "1d", 7)
 
-      user = insert(:user)
+      user = insert(:user, user_settings: %{settings: %{signal_notify_telegram: true}})
       Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
       %{user: user, datetimes: datetimes}
     end

--- a/test/sanbase/signals/price/trigger_price_absolute_change_test.exs
+++ b/test/sanbase/signals/price/trigger_price_absolute_change_test.exs
@@ -12,7 +12,7 @@ defmodule Sanbase.Signal.TriggerPriceAbsoluteChangeTest do
 
     Tesla.Mock.mock(fn %{method: :post} -> %Tesla.Env{status: 200, body: "ok"} end)
 
-    user = insert(:user)
+    user = insert(:user, user_settings: %{settings: %{signal_notify_telegram: true}})
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
 
     [
@@ -143,7 +143,8 @@ defmodule Sanbase.Signal.TriggerPriceAbsoluteChangeTest do
       |> Sanbase.Mock.run_with_mocks(fn ->
         assert capture_log(fn ->
                  Sanbase.Signal.Scheduler.run_signal(PriceAbsoluteChangeSettings)
-               end) =~ "In total 1/1 price_absolute_change signals were sent successfully"
+               end) =~
+                 "In total 1/1 (0 have disabled channel) price_absolute_change signals were sent successfully"
 
         Sanbase.Signal.Evaluator.Cache.clear_all()
 

--- a/test/sanbase/signals/price/trigger_price_percent_change_test.exs
+++ b/test/sanbase/signals/price/trigger_price_percent_change_test.exs
@@ -11,7 +11,7 @@ defmodule Sanbase.Signal.TriggerPricePercentChangeTest do
 
     Tesla.Mock.mock(fn %{method: :post} -> %Tesla.Env{status: 200, body: "ok"} end)
 
-    user = insert(:user)
+    user = insert(:user, user_settings: %{settings: %{signal_notify_telegram: true}})
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
 
     project = insert(:random_erc20_project)

--- a/test/sanbase/signals/price/trigger_price_target_user_list_test.exs
+++ b/test/sanbase/signals/price/trigger_price_target_user_list_test.exs
@@ -11,7 +11,7 @@ defmodule SanbaseWeb.Graphql.TargetUserListTest do
   setup do
     clean_task_supervisor_children()
 
-    user = insert(:user)
+    user = insert(:user, user_settings: %{settings: %{signal_notify_telegram: true}})
 
     p1 =
       insert(:project, %{

--- a/test/sanbase/signals/price/trigger_price_volume_diff_test.exs
+++ b/test/sanbase/signals/price/trigger_price_volume_diff_test.exs
@@ -19,7 +19,7 @@ defmodule Sanbase.Signal.PriceVolumeDiffTest do
         %Tesla.Env{status: 200, body: "ok"}
     end)
 
-    user = insert(:user)
+    user = insert(:user, user_settings: %{settings: %{signal_notify_telegram: true}})
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
 
     Sanbase.Factory.insert(:project, %{

--- a/test/sanbase/signals/scheduler_test.exs
+++ b/test/sanbase/signals/scheduler_test.exs
@@ -14,7 +14,9 @@ defmodule Sanbase.Signal.SchedulerTest do
     Tesla.Mock.mock_global(fn %{method: :post} -> %Tesla.Env{status: 200, body: "ok"} end)
 
     project = insert(:random_erc20_project)
-    user = insert(:user)
+
+    user = insert(:user, user_settings: %{settings: %{signal_notify_telegram: true}})
+
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
 
     trigger_settings = %{
@@ -71,7 +73,8 @@ defmodule Sanbase.Signal.SchedulerTest do
 
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(MetricTriggerSettings)
-             end) =~ "In total 1/1 metric_signal signals were sent successfully"
+             end) =~
+               "In total 1/1 (0 have disabled channel) metric_signal signals were sent successfully"
 
       ut = Sanbase.Repo.get(UserTrigger, trigger.id)
       assert ut.trigger.is_repeating == false
@@ -90,7 +93,8 @@ defmodule Sanbase.Signal.SchedulerTest do
 
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(MetricTriggerSettings)
-             end) =~ "In total 1/1 metric_signal signals were sent successfully"
+             end) =~
+               "In total 1/1 (0 have disabled channel) metric_signal signals were sent successfully"
 
       ut = Sanbase.Repo.get(UserTrigger, trigger.id)
       assert ut.trigger.is_repeating == false

--- a/test/sanbase/signals/screener/screener_trigger_settings_test.exs
+++ b/test/sanbase/signals/screener/screener_trigger_settings_test.exs
@@ -13,7 +13,7 @@ defmodule Sanbase.Signal.ScreenerTriggerSettingsTest do
 
     Sanbase.Signal.Evaluator.Cache.clear_all()
 
-    user = insert(:user)
+    user = insert(:user, user_settings: %{settings: %{signal_notify_telegram: true}})
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
 
     selector = %{
@@ -91,7 +91,8 @@ defmodule Sanbase.Signal.ScreenerTriggerSettingsTest do
       # First run
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(ScreenerTriggerSettings)
-             end) =~ "In total 1/1 screener_signal signals were sent successfully"
+             end) =~
+               "In total 1/1 (0 have disabled channel) screener_signal signals were sent successfully"
 
       # Clear the result of the filter
       Sanbase.Cache.clear_all()
@@ -140,7 +141,8 @@ defmodule Sanbase.Signal.ScreenerTriggerSettingsTest do
       # First run
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(ScreenerTriggerSettings)
-             end) =~ "In total 1/1 screener_signal signals were sent successfully"
+             end) =~
+               "In total 1/1 (0 have disabled channel) screener_signal signals were sent successfully"
 
       # Clear the result of the filter
       Sanbase.Cache.clear_all()

--- a/test/sanbase/signals/trending_words/trigger_trending_watchlist_target_test.exs
+++ b/test/sanbase/signals/trending_words/trigger_trending_watchlist_target_test.exs
@@ -13,7 +13,7 @@ defmodule Sanbase.Signal.TriggerTrendingWordsWatchlistTargetTest do
   setup do
     Sanbase.Signal.Evaluator.Cache.clear_all()
 
-    user = insert(:user)
+    user = insert(:user, user_settings: %{settings: %{signal_notify_telegram: true}})
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
 
     p1 = insert(:random_project)

--- a/test/sanbase/signals/trending_words/trigger_trending_words_send_at_predefiend_time_test.exs
+++ b/test/sanbase/signals/trending_words/trigger_trending_words_send_at_predefiend_time_test.exs
@@ -15,7 +15,7 @@ defmodule Sanbase.Signal.TriggerTrendingWordsSendAtPredefiendTimeTest do
   setup do
     Sanbase.Signal.Evaluator.Cache.clear_all()
 
-    user = insert(:user)
+    user = insert(:user, user_settings: %{settings: %{signal_notify_telegram: true}})
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
 
     send_at = Time.utc_now() |> Time.add(60) |> Time.to_iso8601()
@@ -83,7 +83,8 @@ defmodule Sanbase.Signal.TriggerTrendingWordsSendAtPredefiendTimeTest do
       end do
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(TrendingWordsTriggerSettings)
-             end) =~ "In total 1/1 trending_words signals were sent successfully"
+             end) =~
+               "In total 1/1 (0 have disabled channel) trending_words signals were sent successfully"
 
       user_signal = HistoricalActivity |> Sanbase.Repo.all() |> List.first()
       assert user_signal.user_id == context.user.id
@@ -127,7 +128,8 @@ defmodule Sanbase.Signal.TriggerTrendingWordsSendAtPredefiendTimeTest do
       end do
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(TrendingWordsTriggerSettings)
-             end) =~ "In total 1/1 trending_words signals were sent successfully"
+             end) =~
+               "In total 1/1 (0 have disabled channel) trending_words signals were sent successfully"
 
       {:ok, ut} = UserTrigger.get_trigger_by_id(context.user, context.trigger_trending_words.id)
       refute ut.trigger.is_active

--- a/test/sanbase/signals/trending_words/trigger_trending_words_trending_project_test.exs
+++ b/test/sanbase/signals/trending_words/trigger_trending_words_trending_project_test.exs
@@ -13,7 +13,7 @@ defmodule Sanbase.Signal.TriggerTrendingWordsTrendingProjectTest do
   setup do
     Sanbase.Signal.Evaluator.Cache.clear_all()
 
-    user = insert(:user)
+    user = insert(:user, user_settings: %{settings: %{signal_notify_telegram: true}})
     project = insert(:project)
 
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
@@ -70,7 +70,8 @@ defmodule Sanbase.Signal.TriggerTrendingWordsTrendingProjectTest do
       end do
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(TrendingWordsTriggerSettings)
-             end) =~ "In total 1/1 trending_words signals were sent successfully"
+             end) =~
+               "In total 1/1 (0 have disabled channel) trending_words signals were sent successfully"
 
       Sanbase.Signal.Evaluator.Cache.clear_all()
 

--- a/test/sanbase/signals/trending_words/trigger_trending_words_trending_word_test.exs
+++ b/test/sanbase/signals/trending_words/trigger_trending_words_trending_word_test.exs
@@ -13,7 +13,7 @@ defmodule Sanbase.Signal.TriggerTrendingWordsTrendingWordTest do
   setup do
     Sanbase.Signal.Evaluator.Cache.clear_all()
 
-    user = insert(:user)
+    user = insert(:user, user_settings: %{settings: %{signal_notify_telegram: true}})
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
 
     trending_words_settings = %{
@@ -65,7 +65,8 @@ defmodule Sanbase.Signal.TriggerTrendingWordsTrendingWordTest do
       end do
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(TrendingWordsTriggerSettings)
-             end) =~ "In total 1/1 trending_words signals were sent successfully"
+             end) =~
+               "In total 1/1 (0 have disabled channel) trending_words signals were sent successfully"
 
       Sanbase.Signal.Evaluator.Cache.clear_all()
 
@@ -87,7 +88,8 @@ defmodule Sanbase.Signal.TriggerTrendingWordsTrendingWordTest do
       end do
       assert capture_log(fn ->
                Sanbase.Signal.Scheduler.run_signal(TrendingWordsTriggerSettings)
-             end) =~ "In total 1/1 trending_words signals were sent successfully"
+             end) =~
+               "In total 1/1 (0 have disabled channel) trending_words signals were sent successfully"
 
       Sanbase.Signal.Evaluator.Cache.clear_all()
 

--- a/test/sanbase/signals/trigger_payload_test.exs
+++ b/test/sanbase/signals/trigger_payload_test.exs
@@ -10,7 +10,13 @@ defmodule Sanbase.Signal.TriggerPayloadTest do
 
   setup do
     Sanbase.Signal.Evaluator.Cache.clear_all()
-    user = insert(:user, email: "test@example.com")
+
+    user =
+      insert(:user,
+        email: "test@example.com",
+        user_settings: %{settings: %{signal_notify_telegram: true}}
+      )
+
     Sanbase.Auth.UserSettings.update_settings(user, %{signal_notify_email: true})
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
 

--- a/test/sanbase/signals/wallet_movement/trigger_eth_wallet_test.exs
+++ b/test/sanbase/signals/wallet_movement/trigger_eth_wallet_test.exs
@@ -17,7 +17,7 @@ defmodule Sanbase.Signal.EthWalletTriggerTest do
   setup do
     Sanbase.Signal.Evaluator.Cache.clear_all()
 
-    user = insert(:user)
+    user = insert(:user, user_settings: %{settings: %{signal_notify_telegram: true}})
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
 
     project = Sanbase.Factory.insert(:random_erc20_project)

--- a/test/sanbase/signals/wallet_movement/trigger_wallet_test.exs
+++ b/test/sanbase/signals/wallet_movement/trigger_wallet_test.exs
@@ -17,7 +17,7 @@ defmodule Sanbase.Signal.WalletTriggerTest do
   setup do
     Sanbase.Signal.Evaluator.Cache.clear_all()
 
-    user = insert(:user)
+    user = insert(:user, user_settings: %{settings: %{signal_notify_telegram: true}})
     Sanbase.Auth.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
 
     project = Sanbase.Factory.insert(:random_erc20_project)

--- a/test/sanbase/telegram/telegram_test.exs
+++ b/test/sanbase/telegram/telegram_test.exs
@@ -41,12 +41,12 @@ defmodule Sanbase.TelegramTest do
     %Telegram.UserToken{token: user_token} = Telegram.UserToken.by_user_id(context.user.id)
 
     # There are no settings before
-    assert nil == UserSettings.settings_for(context.user).telegram_chat_id
+    assert nil == UserSettings.settings_for(context.user, force: true).telegram_chat_id
 
     simulate_telegram_deep_link_follow(context, user_token)
 
     # Now there is a telegram chat id
-    %Settings{telegram_chat_id: chat_id} = UserSettings.settings_for(context.user)
+    %Settings{telegram_chat_id: chat_id} = UserSettings.settings_for(context.user, force: true)
     assert chat_id == @telegram_chat_id
   end
 
@@ -69,7 +69,7 @@ defmodule Sanbase.TelegramTest do
     # Simulate a call after the revoke
     simulate_telegram_deep_link_follow(context, user_token)
     # There is no telegram chat id
-    assert nil == UserSettings.settings_for(context.user).telegram_chat_id
+    assert nil == UserSettings.settings_for(context.user, force: true).telegram_chat_id
   end
 
   test "following the telegram deep link sets the `hasTelegramConnected` setting", context do

--- a/test/sanbase_web/graphql/user/user_settings_test.exs
+++ b/test/sanbase_web/graphql/user/user_settings_test.exs
@@ -26,13 +26,13 @@ defmodule SanbaseWeb.Graphql.UserSettingsTest do
     result = conn |> execute(query, "updateUserSettings")
 
     assert result == %{"isBetaMode" => true}
-    assert UserSettings.settings_for(user) |> Map.get(:is_beta_mode) == true
+    assert UserSettings.settings_for(user, force: true) |> Map.get(:is_beta_mode) == true
 
     query = toggle_beta_mode_query(false)
     result = conn |> execute(query, "updateUserSettings")
 
     assert result == %{"isBetaMode" => false}
-    assert UserSettings.settings_for(user) |> Map.get(:is_beta_mode) == false
+    assert UserSettings.settings_for(user, force: true) |> Map.get(:is_beta_mode) == false
   end
 
   test "change theme", %{user: user, conn: conn} do
@@ -40,13 +40,13 @@ defmodule SanbaseWeb.Graphql.UserSettingsTest do
     result = conn |> execute(query, "updateUserSettings")
 
     assert result == %{"theme" => "nightmode"}
-    assert UserSettings.settings_for(user) |> Map.get(:theme) == "nightmode"
+    assert UserSettings.settings_for(user, force: true) |> Map.get(:theme) == "nightmode"
 
     query = change_theme_query("default")
     result = conn |> execute(query, "updateUserSettings")
 
     assert result == %{"theme" => "default"}
-    assert UserSettings.settings_for(user) |> Map.get(:theme) == "default"
+    assert UserSettings.settings_for(user, force: true) |> Map.get(:theme) == "default"
   end
 
   test "change page size", %{user: user, conn: conn} do
@@ -54,13 +54,13 @@ defmodule SanbaseWeb.Graphql.UserSettingsTest do
     result = conn |> execute(query, "updateUserSettings")
 
     assert result == %{"pageSize" => 100}
-    assert UserSettings.settings_for(user) |> Map.get(:page_size) == 100
+    assert UserSettings.settings_for(user, force: true) |> Map.get(:page_size) == 100
 
     query = change_page_size_query(50)
     result = conn |> execute(query, "updateUserSettings")
 
     assert result == %{"pageSize" => 50}
-    assert UserSettings.settings_for(user) |> Map.get(:page_size) == 50
+    assert UserSettings.settings_for(user, force: true) |> Map.get(:page_size) == 50
   end
 
   test "change table columns", %{user: user, conn: conn} do
@@ -69,7 +69,7 @@ defmodule SanbaseWeb.Graphql.UserSettingsTest do
 
     assert result == %{"tableColumns" => %{"shown" => ["price", "volume", "devActivity"]}}
 
-    assert UserSettings.settings_for(user) |> Map.get(:table_columns) == %{
+    assert UserSettings.settings_for(user, force: true) |> Map.get(:table_columns) == %{
              "shown" => ["price", "volume", "devActivity"]
            }
 
@@ -78,7 +78,9 @@ defmodule SanbaseWeb.Graphql.UserSettingsTest do
 
     assert result == %{"tableColumns" => %{"shown" => ["price"]}}
 
-    assert UserSettings.settings_for(user) |> Map.get(:table_columns) == %{"shown" => ["price"]}
+    assert UserSettings.settings_for(user, force: true) |> Map.get(:table_columns) == %{
+             "shown" => ["price"]
+           }
   end
 
   test "toggle telegram notification channel", %{user: user, conn: conn} do
@@ -86,13 +88,17 @@ defmodule SanbaseWeb.Graphql.UserSettingsTest do
     result = conn |> execute(query, "settingsToggleChannel")
 
     assert result == %{"signalNotifyTelegram" => true}
-    assert UserSettings.settings_for(user) |> Map.get(:signal_notify_telegram) == true
+
+    assert UserSettings.settings_for(user, force: true) |> Map.get(:signal_notify_telegram) ==
+             true
 
     query = toggle_telegram_channel_query(false)
     result = conn |> execute(query, "settingsToggleChannel")
 
     assert result == %{"signalNotifyTelegram" => false}
-    assert UserSettings.settings_for(user) |> Map.get(:signal_notify_telegram) == false
+
+    assert UserSettings.settings_for(user, force: true) |> Map.get(:signal_notify_telegram) ==
+             false
   end
 
   test "toggle email notification channel", %{user: user, conn: conn} do
@@ -100,13 +106,13 @@ defmodule SanbaseWeb.Graphql.UserSettingsTest do
     result = conn |> execute(query, "settingsToggleChannel")
 
     assert result == %{"signalNotifyEmail" => true}
-    assert UserSettings.settings_for(user) |> Map.get(:signal_notify_email) == true
+    assert UserSettings.settings_for(user, force: true) |> Map.get(:signal_notify_email) == true
 
     query = toggle_email_channel_query(false)
     result = conn |> execute(query, "settingsToggleChannel")
 
     assert result == %{"signalNotifyEmail" => false}
-    assert UserSettings.settings_for(user) |> Map.get(:signal_notify_email) == false
+    assert UserSettings.settings_for(user, force: true) |> Map.get(:signal_notify_email) == false
   end
 
   test "toggle on existing record", %{user: user, conn: conn} do
@@ -116,7 +122,9 @@ defmodule SanbaseWeb.Graphql.UserSettingsTest do
     result = conn |> execute(query, "settingsToggleChannel")
 
     assert result == %{"signalNotifyTelegram" => true}
-    assert UserSettings.settings_for(user) |> Map.get(:signal_notify_telegram) == true
+
+    assert UserSettings.settings_for(user, force: true) |> Map.get(:signal_notify_telegram) ==
+             true
   end
 
   test "fetches settings for current user", %{user: user, conn: conn} do
@@ -168,7 +176,9 @@ defmodule SanbaseWeb.Graphql.UserSettingsTest do
       result = conn |> execute(query, "changeNewsletterSubscription")
 
       assert result["newsletterSubscription"] == "DAILY"
-      assert UserSettings.settings_for(user) |> Map.get(:newsletter_subscription) == :daily
+
+      assert UserSettings.settings_for(user, force: true) |> Map.get(:newsletter_subscription) ==
+               :daily
     end
 
     test "changes subscription to weekly", %{conn: conn, user: user} do
@@ -177,7 +187,9 @@ defmodule SanbaseWeb.Graphql.UserSettingsTest do
       result = conn |> execute(query, "changeNewsletterSubscription")
 
       assert result["newsletterSubscription"] == "WEEKLY"
-      assert UserSettings.settings_for(user) |> Map.get(:newsletter_subscription) == :weekly
+
+      assert UserSettings.settings_for(user, force: true) |> Map.get(:newsletter_subscription) ==
+               :weekly
     end
 
     test "can turn off subscription", %{conn: conn, user: user} do
@@ -186,7 +198,9 @@ defmodule SanbaseWeb.Graphql.UserSettingsTest do
       result = conn |> execute(query, "changeNewsletterSubscription")
 
       assert result["newsletterSubscription"] == "OFF"
-      assert UserSettings.settings_for(user) |> Map.get(:newsletter_subscription) == :off
+
+      assert UserSettings.settings_for(user, force: true) |> Map.get(:newsletter_subscription) ==
+               :off
     end
 
     test "can handle unknown subscription types", %{conn: conn, user: user} do
@@ -195,7 +209,9 @@ defmodule SanbaseWeb.Graphql.UserSettingsTest do
       result = conn |> execute(query, "changeNewsletterSubscription")
 
       assert result["newsletterSubscription"] == nil
-      assert UserSettings.settings_for(user) |> Map.get(:newsletter_subscription) == :weekly
+
+      assert UserSettings.settings_for(user, force: true) |> Map.get(:newsletter_subscription) ==
+               :weekly
     end
   end
 


### PR DESCRIPTION
## Changes

- When sending signals the `signal_notify_telegram` setting was not checked at all.
- Fix how sending to telegram/email is handled when the channel is disabled and properly log that data.
- Introduce `force: true` option to `UserSettings.settings_for/2` function and use it in tests so when settings are updated we compare the last true settings in the DB.
- Enable the telegram signals in the tests as now this option is checked when sending.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
