### PR TITLE
Add watchlist_id and watchlist_slug in selector input object

### DIFF
--- a/lib/sanbase/clickhouse/exchanges/exchange_metric.ex
+++ b/lib/sanbase/clickhouse/exchanges/exchange_metric.ex
@@ -1,7 +1,9 @@
 defmodule Sanbase.Clickhouse.Exchanges.ExchangeMetric do
+  import Sanbase.Metric.SqlQuery.Helper, only: [asset_id_filter: 2]
+
   require Sanbase.ClickhouseRepo, as: ClickhouseRepo
 
-  def top_exchanges_by_balance(slug, limit, opts \\ []) do
+  def top_exchanges_by_balance(%{slug: slug_or_slugs}, limit, opts \\ []) do
     filters = Keyword.get(opts, :additional_filters, [])
 
     additional_filters = additional_filters(filters, trailing_and: false)
@@ -9,52 +11,66 @@ defmodule Sanbase.Clickhouse.Exchanges.ExchangeMetric do
     query = """
     SELECT
       owner,
-      label2 AS label,
-      argMaxIf( value2, dt, metric_name = 'labelled_exchange_balance_sum' ) AS balance,
-      sumIf( value2, metric_name = 'labelled_exchange_balance' and dt > now() - INTERVAL 1 DAY ) AS change_1d,
-      sumIf( value2, metric_name = 'labelled_exchange_balance' and dt > now() - INTERVAL 7 DAY ) AS change_1w,
-      sumIf( value2, metric_name = 'labelled_exchange_balance') AS change_1m,
-      toUnixTimestamp(if(
-        minIf( dt, metric_name = 'labelled_exchange_balance' and abs(value2) > 0 ) = 0,
-        NULL,
-        minIf( dt, metric_name = 'labelled_exchange_balance' and abs(value2) > 0 )
-      )) AS unix_ts_of_first_transfer,
-      if(
-          unix_ts_of_first_transfer > 0,
-          intDivOrZero( now() - toDateTime(unix_ts_of_first_transfer), 86400 ),
-          NULL
-     ) AS days_since_first_transfer
+      label,
+      SUM( balance ) AS balance,
+      SUM( change_1d ) AS change_1d,
+      SUM( change_7d ) AS balance_7d,
+      SUM( change_30d ) AS balance_30d,
+      min( unix_ts_of_first_transfer ) AS unix_ts_of_first_transfer,
+      max( days_since_first_transfer ) AS days_since_first_transfer
     FROM (
       SELECT
-        if(
-          label='deposit',
-          'centralized_exchange',
-          label
-        ) AS label2,
         owner,
-        dt,
-        metric_name,
-        argMax( value, computed_at ) AS value2
-      FROM intraday_label_based_metrics FINAL
+        label2 AS label,
+        argMaxIf( value2, dt, metric_name = 'labelled_exchange_balance_sum' ) AS balance,
+        sumIf( value2, metric_name = 'labelled_exchange_balance' and dt > now() - INTERVAL 1 DAY ) AS change_1d,
+        sumIf( value2, metric_name = 'labelled_exchange_balance' and dt > now() - INTERVAL 7 DAY ) AS change_7d,
+        sumIf( value2, metric_name = 'labelled_exchange_balance') AS change_30d,
+        toUnixTimestamp(if(
+          minIf( dt, metric_name = 'labelled_exchange_balance' and abs(value2) > 0 ) = 0,
+          NULL,
+          minIf( dt, metric_name = 'labelled_exchange_balance' and abs(value2) > 0 )
+        )) AS unix_ts_of_first_transfer,
+        if(
+            unix_ts_of_first_transfer > 0,
+            intDivOrZero( now() - toDateTime(unix_ts_of_first_transfer), 86400 ),
+            NULL
+      ) AS days_since_first_transfer
+      FROM (
+        SELECT
+          asset_id,
+          if(
+            label='deposit',
+            'centralized_exchange',
+            label
+          ) AS label2,
+          owner,
+          dt,
+          metric_name,
+          argMax( value, computed_at ) AS value2
 
-      ANY LEFT JOIN (
-        SELECT name AS metric_name, metric_id FROM metric_metadata FINAL
-        ) USING metric_id
-      PREWHERE
-        asset_id = ( SELECT asset_id FROM asset_metadata FINAL PREWHERE name = ?1 LIMIT 1 ) AND
-        metric_id IN ( SELECT metric_id FROM metric_metadata FINAL PREWHERE name IN ('labelled_exchange_balance', 'labelled_exchange_balance_sum') ) AND
-        dt >= now() - INTERVAL 1 MONTH AND
-        dt < now() AND
-        dt != toDateTime('1970-01-01 00:00:00')
-      GROUP BY label2, owner, dt, metric_name
+        FROM intraday_label_based_metrics FINAL
+
+        ANY LEFT JOIN (
+          SELECT name AS metric_name, metric_id FROM metric_metadata FINAL
+          ) USING metric_id
+        PREWHERE
+          #{asset_id_filter(slug_or_slugs, argument_position: 1)} AND
+          metric_id IN ( SELECT metric_id FROM metric_metadata FINAL PREWHERE name IN ('labelled_exchange_balance', 'labelled_exchange_balance_sum') ) AND
+          dt >= now() - INTERVAL 1 MONTH AND
+          dt < now() AND
+          dt != toDateTime('1970-01-01 00:00:00')
+        GROUP BY asset_id, label2, owner, dt, metric_name
+      )
+      #{if(additional_filters != [], do: "WHERE #{additional_filters}")}
+      GROUP BY asset_id, label, owner
     )
-    #{if(additional_filters != [], do: "WHERE #{additional_filters}")}
     GROUP BY label, owner
     ORDER BY balance DESC
     LIMIT ?2
     """
 
-    args = [slug, limit]
+    args = [slug_or_slugs, limit]
 
     ClickhouseRepo.query_transform(
       query,

--- a/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
+++ b/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
@@ -11,7 +11,9 @@ defmodule Sanbase.Clickhouse.Metric.SqlQuery do
   use Ecto.Schema
 
   import Sanbase.DateTimeUtils, only: [str_to_sec: 1]
-  import Sanbase.Metric.SqlQuery.Helper, only: [aggregation: 3, generate_comparison_string: 3]
+
+  import Sanbase.Metric.SqlQuery.Helper,
+    only: [aggregation: 3, generate_comparison_string: 3, asset_id_filter: 2]
 
   alias Sanbase.Clickhouse.Metric.FileHandler
 
@@ -58,24 +60,6 @@ defmodule Sanbase.Clickhouse.Metric.SqlQuery do
     ]
 
     {query, args}
-  end
-
-  defp asset_id_filter(slug, opts) when is_binary(slug) do
-    arg_position = Keyword.fetch!(opts, :argument_position)
-
-    """
-    asset_id = ( SELECT asset_id FROM asset_metadata FINAL PREWHERE name = ?#{arg_position} LIMIT 1 )
-    """
-  end
-
-  defp asset_id_filter(slugs, opts) when is_list(slugs) do
-    arg_position = Keyword.fetch!(opts, :argument_position)
-
-    """
-    asset_id IN ( SELECT DISTINCT(asset_id) FROM asset_metadata FINAL PREWHERE name IN (?#{
-      arg_position
-    }) )
-    """
   end
 
   def aggregated_timeseries_data_query(metric, asset_ids, from, to, aggregation, filters) do

--- a/lib/sanbase/clickhouse_repo.ex
+++ b/lib/sanbase/clickhouse_repo.ex
@@ -21,7 +21,7 @@ defmodule Sanbase.ClickhouseRepo do
     {:ok, opts}
   end
 
-  @error_message "Cannot execute database query. If issue persist please contact Santiment Support."
+  @error_message "Cannot execute database query. If issue persists please contact Santiment Support."
   def query_transform(query, args, transform_fn) do
     try do
       ordered_params = order_params(query, args)

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -7,11 +7,7 @@ defmodule Sanbase.Metric do
   @metric_modules list and everything else happens automatically.
   """
   @compile :inline_list_funcs
-  @compile inline: [
-             transform_identifier: 1,
-             execute_if_aggregation_valid: 3,
-             metric_not_available_error: 2
-           ]
+  @compile inline: [execute_if_aggregation_valid: 3]
 
   @access_map Sanbase.Metric.Helper.access_map()
   @aggregations Sanbase.Metric.Helper.aggregations()
@@ -61,23 +57,20 @@ defmodule Sanbase.Metric do
         metric_not_available_error(metric, type: :timeseries)
 
       module when is_atom(module) ->
-        with {:ok, identifier} <- transform_identifier(identifier),
-             {:ok, identifier} <- maybe_ignore_slugs(identifier) do
-          aggregation = Keyword.get(opts, :aggregation, nil)
+        aggregation = Keyword.get(opts, :aggregation, nil)
 
-          fun = fn ->
-            module.timeseries_data(
-              metric,
-              identifier,
-              from,
-              to,
-              interval,
-              opts
-            )
-          end
-
-          execute_if_aggregation_valid(fun, metric, aggregation)
+        fun = fn ->
+          module.timeseries_data(
+            metric,
+            identifier,
+            from,
+            to,
+            interval,
+            opts
+          )
         end
+
+        execute_if_aggregation_valid(fun, metric, aggregation)
     end
   end
 
@@ -97,20 +90,17 @@ defmodule Sanbase.Metric do
       module when is_atom(module) ->
         aggregation = Keyword.get(opts, :aggregation, nil)
 
-        with {:ok, identifier} <- transform_identifier(identifier),
-             {:ok, identifier} <- maybe_ignore_slugs(identifier) do
-          fun = fn ->
-            module.aggregated_timeseries_data(
-              metric,
-              identifier,
-              from,
-              to,
-              opts
-            )
-          end
-
-          execute_if_aggregation_valid(fun, metric, aggregation)
+        fun = fn ->
+          module.aggregated_timeseries_data(
+            metric,
+            identifier,
+            from,
+            to,
+            opts
+          )
         end
+
+        execute_if_aggregation_valid(fun, metric, aggregation)
     end
   end
 
@@ -193,17 +183,14 @@ defmodule Sanbase.Metric do
         metric_not_available_error(metric, type: :timeseries)
 
       module when is_atom(module) ->
-        with {:ok, identifier} <- transform_identifier(identifier),
-             {:ok, identifier} <- maybe_ignore_slugs(identifier) do
-          module.histogram_data(
-            metric,
-            identifier,
-            from,
-            to,
-            interval,
-            limit
-          )
-        end
+        module.histogram_data(
+          metric,
+          identifier,
+          from,
+          to,
+          interval,
+          limit
+        )
     end
   end
 
@@ -219,22 +206,19 @@ defmodule Sanbase.Metric do
         metric_not_available_error(metric, type: :table)
 
       module when is_atom(module) ->
-        with {:ok, identifier} <- transform_identifier(identifier),
-             {:ok, identifier} <- maybe_ignore_slugs(identifier) do
-          aggregation = Keyword.get(opts, :aggregation, nil)
+        aggregation = Keyword.get(opts, :aggregation, nil)
 
-          fun = fn ->
-            module.table_data(
-              metric,
-              identifier,
-              from,
-              to,
-              opts
-            )
-          end
-
-          execute_if_aggregation_valid(fun, metric, aggregation)
+        fun = fn ->
+          module.table_data(
+            metric,
+            identifier,
+            from,
+            to,
+            opts
+          )
         end
+
+        execute_if_aggregation_valid(fun, metric, aggregation)
     end
   end
 
@@ -557,57 +541,6 @@ defmodule Sanbase.Metric do
       error_msg: "The histogram metric '#{metric}' is not supported or is mistyped."
     }
   end
-
-  defp transform_identifier(%{market_segments: market_segments} = selector) do
-    slugs =
-      Sanbase.Model.Project.List.by_market_segment_all_of(market_segments)
-      |> Enum.map(& &1.slug)
-
-    {:ok, Map.put(selector, :slug, slugs)}
-  end
-
-  defp transform_identifier(%{watchlist_id: watchlist_id} = selector)
-       when is_integer(watchlist_id) do
-    case Sanbase.UserList.by_id(watchlist_id) do
-      nil ->
-        {:error, "Watchlist with id #{watchlist_id} does not exist."}
-
-      watchlist ->
-        case watchlist |> Sanbase.UserList.get_slugs() do
-          {:ok, slugs} ->
-            {:ok, Map.put(selector, :slug, slugs)}
-
-          {:error, _error} ->
-            {:error, "Cannot fetch slugs for watchlist with id #{watchlist_id}"}
-        end
-    end
-  end
-
-  defp transform_identifier(%{watchlist_slug: watchlist_slug} = selector)
-       when is_binary(watchlist_slug) do
-    case Sanbase.UserList.by_slug(watchlist_slug) do
-      nil ->
-        {:error, "Watchlist with slug #{watchlist_slug} does not exist."}
-
-      watchlist ->
-        case watchlist |> Sanbase.UserList.get_slugs() do
-          {:ok, slugs} ->
-            {:ok, Map.put(selector, :slug, slugs)}
-
-          {:error, _error} ->
-            {:error, "Cannot fetch slugs for watchlist with slug #{watchlist_slug}"}
-        end
-    end
-  end
-
-  defp transform_identifier(identifier), do: {:ok, identifier}
-
-  defp maybe_ignore_slugs(%{ignored_slugs: [_ | _] = ignored_slugs, slug: slugs} = selector) do
-    slugs = List.wrap(slugs) -- ignored_slugs
-    {:ok, Map.put(selector, :slug, slugs)}
-  end
-
-  defp maybe_ignore_slugs(selector), do: {:ok, selector}
 
   defp execute_if_aggregation_valid(fun, metric, aggregation) do
     aggregation_valid? = aggregation in Map.get(@aggregations_per_metric, metric)

--- a/lib/sanbase/metric/selector.ex
+++ b/lib/sanbase/metric/selector.ex
@@ -1,0 +1,88 @@
+defmodule Sanbase.Metric.Selector do
+  @available_slugs_module Application.compile_env(:sanbase, :available_slugs_module)
+
+  def args_to_raw_selector(%{slug: slug}), do: %{slug: slug}
+  def args_to_raw_selector(%{slugs: slugs}), do: %{slug: slugs}
+  def args_to_raw_selector(%{word: word}), do: %{word: word}
+  def args_to_raw_selector(%{selector: %{slugs: slugs}}), do: %{slug: slugs}
+  def args_to_raw_selector(%{selector: %{} = selector}), do: selector
+  def args_to_raw_selector(_), do: %{}
+
+  def args_to_selector(args) do
+    selector = args |> args_to_raw_selector()
+
+    with {:ok, selector} <- transform_selector(selector),
+         {:ok, selector} <- maybe_ignore_slugs(selector),
+         true <- valid_selector?(selector) do
+      {:ok, selector}
+    end
+  end
+
+  # Private functions
+
+  defp valid_selector?(%{slug: slug}) when is_binary(slug) do
+    case @available_slugs_module.valid_slug?(slug) do
+      true -> true
+      false -> {:error, "The slug #{inspect(slug)} is not an existing slug."}
+    end
+  end
+
+  defp valid_selector?(%{} = map) when map_size(map) == 0,
+    do:
+      {:error,
+       "The selector must have at least one field provided." <>
+         "The available selector fields for a metric are listed in the metadata's availableSelectors field."}
+
+  defp valid_selector?(_), do: true
+
+  defp transform_selector(%{market_segments: market_segments} = selector) do
+    slugs =
+      Sanbase.Model.Project.List.by_market_segment_all_of(market_segments)
+      |> Enum.map(& &1.slug)
+
+    {:ok, Map.put(selector, :slug, slugs)}
+  end
+
+  defp transform_selector(%{watchlist_id: watchlist_id} = selector)
+       when is_integer(watchlist_id) do
+    case Sanbase.UserList.by_id(watchlist_id) do
+      nil ->
+        {:error, "Watchlist with id #{watchlist_id} does not exist."}
+
+      watchlist ->
+        case watchlist |> Sanbase.UserList.get_slugs() do
+          {:ok, slugs} ->
+            {:ok, Map.put(selector, :slug, slugs)}
+
+          {:error, _error} ->
+            {:error, "Cannot fetch slugs for watchlist with id #{watchlist_id}"}
+        end
+    end
+  end
+
+  defp transform_selector(%{watchlist_slug: watchlist_slug} = selector)
+       when is_binary(watchlist_slug) do
+    case Sanbase.UserList.by_slug(watchlist_slug) do
+      nil ->
+        {:error, "Watchlist with slug #{watchlist_slug} does not exist."}
+
+      watchlist ->
+        case watchlist |> Sanbase.UserList.get_slugs() do
+          {:ok, slugs} ->
+            {:ok, Map.put(selector, :slug, slugs)}
+
+          {:error, _error} ->
+            {:error, "Cannot fetch slugs for watchlist with slug #{watchlist_slug}"}
+        end
+    end
+  end
+
+  defp transform_selector(identifier), do: {:ok, identifier}
+
+  defp maybe_ignore_slugs(%{ignored_slugs: [_ | _] = ignored_slugs, slug: slugs} = selector) do
+    slugs = List.wrap(slugs) -- ignored_slugs
+    {:ok, Map.put(selector, :slug, slugs)}
+  end
+
+  defp maybe_ignore_slugs(selector), do: {:ok, selector}
+end

--- a/lib/sanbase/metric/sql_query_helper.ex
+++ b/lib/sanbase/metric/sql_query_helper.ex
@@ -34,4 +34,22 @@ defmodule Sanbase.Metric.SqlQuery.Helper do
 
   def generate_comparison_string(column, :outside_channel_exclusive, [low, high]),
     do: "#{column} < #{low} OR #{column} > #{high}"
+
+  def asset_id_filter(slug, opts) when is_binary(slug) do
+    arg_position = Keyword.fetch!(opts, :argument_position)
+
+    """
+    asset_id = ( SELECT asset_id FROM asset_metadata FINAL PREWHERE name = ?#{arg_position} LIMIT 1 )
+    """
+  end
+
+  def asset_id_filter(slugs, opts) when is_list(slugs) do
+    arg_position = Keyword.fetch!(opts, :argument_position)
+
+    """
+    asset_id IN ( SELECT DISTINCT(asset_id) FROM asset_metadata FINAL PREWHERE name IN (?#{
+      arg_position
+    }) )
+    """
+  end
 end

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -118,7 +118,8 @@ defmodule Sanbase.SocialData.MetricAdapter do
              metric in @community_messages_count_timeseries_metrics do
     case timeseries_data(metric, selector, from, to, "1h", opts) do
       {:ok, result} ->
-        {:ok, Enum.reduce(result, 0, &(&1.value + &2))}
+        value = Enum.reduce(result, 0, &(&1.value + &2))
+        {:ok, [%{value: value}]}
 
       {:error, error} ->
         {:error, error}
@@ -129,11 +130,11 @@ defmodule Sanbase.SocialData.MetricAdapter do
       when metric in @social_dominance_timeseries_metrics do
     case timeseries_data(metric, selector, from, to, "1h", opts) do
       {:ok, result} ->
-        result =
+        value =
           Enum.reduce(result, 0, &(&1.value + &2))
           |> Sanbase.Math.average()
 
-        {:ok, result}
+        {:ok, [%{value: value}]}
 
       {:error, error} ->
         {:error, error}

--- a/lib/sanbase/utils/error_handling.ex
+++ b/lib/sanbase/utils/error_handling.ex
@@ -80,6 +80,9 @@ defmodule Sanbase.Utils.ErrorHandling do
           slug when is_binary(slug) ->
             {"project with slug", slug}
 
+          %{} = selector when map_size(selector) > 0 ->
+            {"selector", selector}
+
           %{} ->
             {"an empty selector", "{}"}
         end

--- a/lib/sanbase/utils/error_handling.ex
+++ b/lib/sanbase/utils/error_handling.ex
@@ -38,7 +38,7 @@ defmodule Sanbase.Utils.ErrorHandling do
       end
 
     error_msg =
-      "[#{uuid}] Can't fetch #{metric} for #{target_description}: #{
+      "[#{uuid}] Can't fetch #{metric} for #{target_description} #{
         identifier_to_string(identifier)
       }"
 
@@ -65,10 +65,23 @@ defmodule Sanbase.Utils.ErrorHandling do
     case Keyword.get(opts, :description) do
       nil ->
         case identifier do
-          %{slug: slug} -> {"project with slug", slug}
-          %{text: text} -> {"search term", text}
-          slug when is_binary(slug) -> {"project with slug", slug}
-          %{} -> {"an empty selector", ""}
+          %{metric: metric, selector: selector} ->
+            {"selector #{inspect(selector)} and metric #{metric}", ""}
+
+          %{slug: slug} ->
+            {"project with slug", slug}
+
+          %{text: text} ->
+            {"search term", text}
+
+          %{metric: metric} ->
+            {"metric", metric}
+
+          slug when is_binary(slug) ->
+            {"project with slug", slug}
+
+          %{} ->
+            {"an empty selector", "{}"}
         end
 
       description ->

--- a/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
@@ -2,7 +2,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   import SanbaseWeb.Graphql.Helpers.Utils
   import SanbaseWeb.Graphql.Helpers.CalibrateInterval
 
-  import Sanbase.Utils.ErrorHandling, only: [handle_graphql_error: 3, handle_graphql_error: 4]
+  import Sanbase.Utils.ErrorHandling,
+    only: [handle_graphql_error: 3, handle_graphql_error: 4, maybe_handle_graphql_error: 2]
+
+  import Sanbase.Metric.Selector, only: [args_to_selector: 1, args_to_raw_selector: 1]
   import SanbaseWeb.Graphql.Helpers.Utils
 
   alias Sanbase.Metric
@@ -12,7 +15,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   require Logger
 
   @datapoints 300
-  @available_slugs_module Application.compile_env(:sanbase, :available_slugs_module)
 
   def get_metric(_root, %{metric: metric}, _resolution) do
     case Metric.has_metric?(metric) do
@@ -47,7 +49,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
         {:ok, Map.merge(access_restrictions, metadata)}
 
       {:error, error} ->
-        {:error, handle_graphql_error("metadata", metric, error, description: "metric")}
+        {:error, handle_graphql_error("metadata", %{metric: metric}, error)}
     end
   end
 
@@ -57,21 +59,30 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   end
 
   def available_since(_root, args, %{source: %{metric: metric}}) do
-    selector = to_selector(args)
-
-    case valid_selector?(selector) do
-      true -> Metric.first_datetime(metric, selector)
-      {:error, error} -> {:error, error}
+    with {:ok, selector} <- args_to_selector(args),
+         {:ok, first_datetime} <- Metric.first_datetime(metric, selector) do
+      {:ok, first_datetime}
     end
+    |> maybe_handle_graphql_error(fn error ->
+      handle_graphql_error(
+        "Available Since",
+        %{metric: metric, selector: args_to_raw_selector(args)},
+        error
+      )
+    end)
   end
 
   def last_datetime_computed_at(_root, args, %{source: %{metric: metric}}) do
-    selector = to_selector(args)
-
-    case valid_selector?(selector) do
-      true -> Metric.last_datetime_computed_at(metric, selector)
-      {:error, error} -> {:error, error}
+    with {:ok, selector} <- args_to_selector(args) do
+      Metric.last_datetime_computed_at(metric, selector)
     end
+    |> maybe_handle_graphql_error(fn error ->
+      handle_graphql_error(
+        "Last Datetime Computed At",
+        %{metric: metric, selector: args_to_raw_selector(args)},
+        error
+      )
+    end)
   end
 
   def timeseries_data(
@@ -84,11 +95,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     transform =
       Map.get(args, :transform, %{type: "none"}) |> Map.update!(:type, &Inflex.underscore/1)
 
-    selector = to_selector(args)
-    metric = maybe_replace_metric(metric, selector)
-    opts = selector_args_to_opts(args)
-
-    with true <- valid_selector?(selector),
+    with {:ok, selector} <- args_to_selector(args),
+         metric = maybe_replace_metric(metric, selector),
+         opts = selector_args_to_opts(args),
          {:ok, from, to, interval} <-
            calibrate(Metric, metric, selector, from, to, interval, 86_400, @datapoints),
          {:ok, from, to} <-
@@ -100,10 +109,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
          {:ok, result} <- apply_transform(transform, result),
          {:ok, result} <- fit_from_datetime(result, args) do
       {:ok, result |> Enum.reject(&is_nil/1)}
-    else
-      {:error, error} ->
-        {:error, handle_graphql_error(metric, selector, error)}
     end
+    |> maybe_handle_graphql_error(fn error ->
+      handle_graphql_error(metric, args_to_raw_selector(args), error)
+    end)
   end
 
   def aggregated_timeseries_data(
@@ -112,33 +121,18 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
         %{source: %{metric: metric}}
       ) do
     include_incomplete_data = Map.get(args, :include_incomplete_data, false)
-    selector = to_selector(args)
-    opts = selector_args_to_opts(args)
 
-    with true <- valid_selector?(selector),
+    with {:ok, selector} <- args_to_selector(args),
+         opts = selector_args_to_opts(args),
          {:ok, from, to} <-
            calibrate_incomplete_data_params(include_incomplete_data, Metric, metric, from, to),
-         {:ok, result} <-
-           Metric.aggregated_timeseries_data(metric, selector, from, to, opts) do
-      # This requires internal rework - all aggregated_timeseries_data queries must return the same format
-      case result do
-        value when is_number(value) ->
-          {:ok, value}
-
-        [%{value: value}] ->
-          {:ok, value}
-
-        %{} = map ->
-          value = Map.values(map) |> hd
-          {:ok, value}
-
-        _ ->
-          {:ok, nil}
-      end
-    else
-      {:error, error} ->
-        {:error, handle_graphql_error(metric, selector, error)}
+         {:ok, result} <- Metric.aggregated_timeseries_data(metric, selector, from, to, opts) do
+      [%{value: value} | _] = result
+      {:ok, value}
     end
+    |> maybe_handle_graphql_error(fn error ->
+      handle_graphql_error(metric, args_to_raw_selector(args), error)
+    end)
   end
 
   def histogram_data(
@@ -151,17 +145,16 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     # the histogram for all time.
     from = Map.get(args, :from, nil)
     interval = transform_interval(metric, interval)
-    selector = to_selector(args)
 
-    with true <- valid_selector?(selector),
+    with {:ok, selector} <- args_to_selector(args),
          true <- valid_histogram_args?(metric, args),
          {:ok, data} <- Metric.histogram_data(metric, selector, from, to, interval, limit),
          {:ok, data} <- maybe_enrich_with_labels(metric, data) do
       {:ok, %{values: %{data: data}}}
-    else
-      {:error, error} ->
-        {:error, handle_graphql_error(metric, selector, error)}
     end
+    |> maybe_handle_graphql_error(fn error ->
+      handle_graphql_error(metric, args_to_raw_selector(args), error)
+    end)
   end
 
   def table_data(
@@ -169,20 +162,16 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
         %{from: from, to: to} = args,
         %{source: %{metric: metric}}
       ) do
-    selector = to_selector(args)
-
-    with true <- valid_selector?(selector),
+    with {:ok, selector} <- args_to_selector(args),
          {:ok, data} <- Metric.table_data(metric, selector, from, to) do
       {:ok, data}
-    else
-      {:error, error} ->
-        {:error, handle_graphql_error(metric, selector, error)}
     end
+    |> maybe_handle_graphql_error(fn error ->
+      handle_graphql_error(metric, args_to_raw_selector(args), error)
+    end)
   end
 
   # Private functions
-
-  # gold and s-and-p-500 are present only in the intrday metrics table, not in asset_prices
 
   defp maybe_enrich_with_labels(_metric, [%{address: address} | _] = data)
        when is_binary(address) do
@@ -200,6 +189,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
 
   defp maybe_enrich_with_labels(_metric, data), do: {:ok, data}
 
+  # gold and s-and-p-500 are present only in the intrday metrics table, not in asset_prices
   defp maybe_replace_metric("price_usd", %{slug: slug})
        when slug in ["gold", "s-and-p-500", "crude-oil"],
        do: "price_usd_5m"
@@ -290,26 +280,4 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
       true
     end
   end
-
-  defp valid_selector?(%{slug: slug}) when is_binary(slug) do
-    case @available_slugs_module.valid_slug?(slug) do
-      true -> true
-      false -> {:error, "The slug #{inspect(slug)} is not an existing slug."}
-    end
-  end
-
-  defp valid_selector?(%{} = map) when map_size(map) == 0,
-    do:
-      {:error,
-       "The selector must have at least one field provided." <>
-         "The available selector fields for a metric are listed in the metadata's availableSelectors field."}
-
-  defp valid_selector?(_), do: true
-
-  defp to_selector(%{slug: slug}), do: %{slug: slug}
-  defp to_selector(%{slugs: slugs}), do: %{slug: slugs}
-  defp to_selector(%{word: word}), do: %{word: word}
-  defp to_selector(%{selector: %{slugs: slugs}}), do: %{slug: slugs}
-  defp to_selector(%{selector: %{} = selector}), do: selector
-  defp to_selector(_), do: %{}
 end

--- a/lib/sanbase_web/graphql/schema/queries/exchange_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/exchange_queries.ex
@@ -10,7 +10,8 @@ defmodule SanbaseWeb.Graphql.Schema.ExchangeQueries do
     field :top_exchanges_by_balance, list_of(:top_exchange_balance) do
       meta(access: :restricted)
 
-      arg(:slug, non_null(:string))
+      arg(:slug, :string)
+      arg(:selector, :metric_target_selector_input_object)
       arg(:label, list_of(:string))
       arg(:owner, list_of(:string))
       arg(:limit, :integer, default_value: 100)

--- a/lib/sanbase_web/graphql/schema/queries/exchange_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/exchange_queries.ex
@@ -49,7 +49,8 @@ defmodule SanbaseWeb.Graphql.Schema.ExchangeQueries do
 
     @desc ~s"""
     Returns trades for given exchange and ticker pair between start and end datetime.
-    Optionally the data can be aggregated and put into interval length buckets if `interval` arg is used.
+    Optionally the data can be aggregated and put into interval length buckets if
+    `interval` arg is used.
     """
     field :exchange_trades, list_of(:exchange_trade) do
       meta(access: :free)

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -29,6 +29,8 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     value(:holders_count)
     value(:market_segments)
     value(:ignored_slugs)
+    value(:watchlist_id)
+    value(:watchlist_slug)
   end
 
   input_object :metric_target_selector_input_object do
@@ -41,6 +43,8 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:holders_count, :integer)
     field(:market_segments, list_of(:string))
     field(:ignored_slugs, list_of(:string))
+    field(:watchlist_id, :integer)
+    field(:watchlist_slug, :string)
   end
 
   input_object :timeseries_metric_transform_input_object do

--- a/test/sanbase/clickhouse/clickhouse_repo_test.exs
+++ b/test/sanbase/clickhouse/clickhouse_repo_test.exs
@@ -14,7 +14,7 @@ defmodule Sanbase.Clickhouse.ClickhouseRepoTest do
           {:error, error} = ClickhouseRepo.query_transform("SELECT NOW()", [], & &1)
 
           assert error =~
-                   "Cannot execute database query. If issue persist please contact Santiment Support"
+                   "Cannot execute database query. If issue persists please contact Santiment Support"
 
           # assert returned error message does not contain internal details
           refute error =~ error_msg
@@ -38,7 +38,7 @@ defmodule Sanbase.Clickhouse.ClickhouseRepoTest do
           {:error, error} = ClickhouseRepo.query_transform("SELECT NOW()", [], & &1)
 
           assert error =~
-                   "Cannot execute database query. If issue persist please contact Santiment Support"
+                   "Cannot execute database query. If issue persists please contact Santiment Support"
 
           # assert returned error message does not contain internal details
           refute error =~ error_msg

--- a/test/sanbase_web/graphql/clickhouse/exchange_metrics_api_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/exchange_metrics_api_test.exs
@@ -27,6 +27,7 @@ defmodule SanbaseWeb.Graphql.ExchangeMetricsApiTest do
   setup do
     user = insert(:user)
     conn = setup_jwt_auth(build_conn(), user)
+    project = insert(:random_project)
 
     insert(:exchange_market_pair_mappings, %{
       exchange: "Bitfinex",
@@ -40,6 +41,7 @@ defmodule SanbaseWeb.Graphql.ExchangeMetricsApiTest do
 
     [
       exchange: "Binance",
+      project: project,
       conn: conn,
       from: Timex.shift(Timex.now(), days: -10),
       to: Timex.now()
@@ -95,7 +97,7 @@ defmodule SanbaseWeb.Graphql.ExchangeMetricsApiTest do
 
   describe "top exchanges api" do
     test "get top exchanges by balance", context do
-      query = top_exchanges_by_balance("ethereum", 10)
+      query = top_exchanges_by_balance(context.project.slug, 10)
 
       data = [
         %{

--- a/test/sanbase_web/graphql/clickhouse/historical_balance/assets_held_by_address_api_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/historical_balance/assets_held_by_address_api_test.exs
@@ -120,8 +120,8 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
                error = result["errors"] |> List.first()
 
                assert error["message"] =~
-                        "Can't fetch Assets held by address for address: #{address}"
-             end) =~ "Can't fetch Assets held by address for address: #{address}"
+                        "Can't fetch Assets held by address for address #{address}"
+             end) =~ "Can't fetch Assets held by address for address #{address}"
     end
   end
 

--- a/test/sanbase_web/graphql/clickhouse/historical_balance/historical_balances_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/historical_balance/historical_balances_test.exs
@@ -192,7 +192,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
       assert log =~ inspect(error)
 
       assert log =~
-               ~s|Can't fetch Historical Balances for selector: #{inspect(selector)}|
+               ~s|Can't fetch Historical Balances for selector #{inspect(selector)}|
     end)
   end
 
@@ -297,7 +297,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
         error = result["errors"] |> List.first()
 
         assert error["message"] =~
-                 "Can't fetch Historical Balances for selector: #{inspect(selector)}"
+                 "Can't fetch Historical Balances for selector #{inspect(selector)}"
       end)
 
     assert log =~ "Can't find contract address of project with slug: someid1"
@@ -329,7 +329,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
           error = result["errors"] |> List.first()
 
           assert error["message"] =~
-                   "Can't fetch Historical Balances for selector: #{inspect(selector)}"
+                   "Can't fetch Historical Balances for selector #{inspect(selector)}"
         end)
 
       assert log =~ "Can't fetch Historical Balances for selector"

--- a/test/sanbase_web/graphql/exchanges/market_depth_test.exs
+++ b/test/sanbase_web/graphql/exchanges/market_depth_test.exs
@@ -29,7 +29,7 @@ defmodule SanbaseWeb.Graphql.Exchanges.MarketDepthTest do
       assert log =~ inspect(error)
 
       assert log =~
-               ~s(Can't fetch Last exchange market depth for exchange and ticker_pair: "Kraken" and "ZEC/BTC")
+               ~s(Can't fetch Last exchange market depth for exchange and ticker_pair "Kraken" and "ZEC/BTC")
     end)
   end
 

--- a/test/sanbase_web/graphql/exchanges/trades_test.exs
+++ b/test/sanbase_web/graphql/exchanges/trades_test.exs
@@ -33,7 +33,7 @@ defmodule SanbaseWeb.Graphql.Exchanges.TradesTest do
       assert log =~ inspect(error)
 
       assert log =~
-               ~s(Can't fetch Last exchange trades for exchange and ticker_pair: "Kraken" and "ETH/EUR")
+               ~s(Can't fetch Last exchange trades for exchange and ticker_pair "Kraken" and "ETH/EUR")
     end)
   end
 
@@ -66,7 +66,7 @@ defmodule SanbaseWeb.Graphql.Exchanges.TradesTest do
       assert log =~ inspect(error)
 
       assert log =~
-               ~s(Can't fetch Exchange trades for exchange and ticker_pair: "Kraken" and "ETH/EUR")
+               ~s(Can't fetch Exchange trades for exchange and ticker_pair "Kraken" and "ETH/EUR")
     end)
   end
 
@@ -99,7 +99,7 @@ defmodule SanbaseWeb.Graphql.Exchanges.TradesTest do
       assert log =~ inspect(error)
 
       assert log =~
-               ~s(Can't fetch Aggregated exchange trades for exchange and ticker_pair: "Kraken" and "ETH/EUR")
+               ~s(Can't fetch Aggregated exchange trades for exchange and ticker_pair "Kraken" and "ETH/EUR")
     end)
   end
 

--- a/test/sanbase_web/graphql/metric/api_metric_aggregated_timeseries_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_aggregated_timeseries_data_test.exs
@@ -121,7 +121,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricAggregatedTimeseriesDataTest do
                get_aggregated_timeseries_metric(conn, metric, from, to, aggregation)
 
              assert error_message =~
-                      "Can't fetch #{metric} for an empty selector: , Reason: \"The selector must have at least one field provided." <>
+                      "Can't fetch #{metric} for an empty selector {}, Reason: \"The selector must have at least one field provided." <>
                         "The available selector fields for a metric are listed in the metadata's availableSelectors field.\""
            end) =~ "Can't fetch #{metric} for an empty selector"
   end

--- a/test/sanbase_web/graphql/metric/api_metric_histogram_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_histogram_data_test.exs
@@ -104,7 +104,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricHistogramDataTest do
                get_histogram_metric_without_slug(conn, metric, from, to, interval, limit)
 
              assert error_message =~
-                      "Can't fetch #{metric} for an empty selector: , Reason: \"The selector must have at least one field provided." <>
+                      "Can't fetch #{metric} for an empty selector {}, Reason: \"The selector must have at least one field provided." <>
                         "The available selector fields for a metric are listed in the metadata's availableSelectors field.\""
            end) =~ "Can't fetch #{metric} for an empty selector"
   end

--- a/test/sanbase_web/graphql/metric/api_metric_table_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_table_data_test.exs
@@ -186,7 +186,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricTableDataTest do
                get_table_metric_without_slug(conn, metric, from, to)
 
              assert error_message =~
-                      "Can't fetch #{metric} for an empty selector: , Reason: \"The selector must have at least one field provided." <>
+                      "Can't fetch #{metric} for an empty selector {}, Reason: \"The selector must have at least one field provided." <>
                         "The available selector fields for a metric are listed in the metadata's availableSelectors field.\""
            end) =~ "Can't fetch #{metric} for an empty selector"
   end

--- a/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
@@ -331,7 +331,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesDataTest do
                )
 
              assert error_message =~
-                      "Can't fetch #{metric} for an empty selector: , Reason: \"The selector must have at least one field provided." <>
+                      "Can't fetch #{metric} for an empty selector {}, Reason: \"The selector must have at least one field provided." <>
                         "The available selector fields for a metric are listed in the metadata's availableSelectors field.\""
            end) =~ "Can't fetch #{metric} for an empty selector"
   end

--- a/test/support/graphql_test_helpers.ex
+++ b/test/support/graphql_test_helpers.ex
@@ -152,6 +152,6 @@ defmodule SanbaseWeb.Graphql.TestHelpers do
   end
 
   def graphql_error_msg(metric_name, slug, error) do
-    "Can't fetch #{metric_name} for project with slug: #{slug}, Reason: \"#{error}\""
+    "Can't fetch #{metric_name} for project with slug #{slug}, Reason: \"#{error}\""
   end
 end


### PR DESCRIPTION
## Changes
- Add `watchlist_id` and `watchlist_slug` to the selector object that is used in getMetric.
- Support the same selector in `topExchangesByBalance` API, too:
```graphql
{
  topExchangesByBalance(selector: {watchlistId: 415}, limit: 10) {
    owner
    label
    balance
    balanceChange1d
    balanceChange7d
    balanceChange30d
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
