### PR TITLE
AvailableSlugs returns true for TOTAL_MARKET and TOTAL_ERC20 now

### DIFF
--- a/lib/sanbase/available_slugs/available_slugs.ex
+++ b/lib/sanbase/available_slugs/available_slugs.ex
@@ -8,13 +8,17 @@ defmodule Sanbase.AvailableSlugs do
   """
   @behaviour Sanbase.AvailableSlugs.Behaviour
 
+  # There are 2 special cases that are not a project slug but refer to big groups
+  # of projects and there is marketcap and volume data for them
+  @non_project_slugs ["TOTAL_MARKET", "TOTAL_ERC20"]
+
   @ets_table :available_projects_slugs_ets_table
   use GenServer
 
   @impl Sanbase.AvailableSlugs.Behaviour
   def valid_slug?(slug) do
     case :ets.lookup(@ets_table, slug) do
-      [] -> false
+      [] -> slug in @non_project_slugs
       _ -> true
     end
   end


### PR DESCRIPTION
## Changes
```graphql
{getMetric(metric: "marketcap_usd") {
    timeseriesData(slug: "TOTAL_MARKET" ...
```
should not return an error that `TOTAL_MARKET` is not a valid slug.
<!--- Describe your changes --> 

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
