### PR TITLE
Fix eth price

### DIFF
--- a/lib/sanbase/prices/price.ex
+++ b/lib/sanbase/prices/price.ex
@@ -173,7 +173,9 @@ defmodule Sanbase.Price do
     async with {:ok, prices_slug_usd} <- timeseries_data(slug_or_slugs, from, to, interval, opts),
                {:ok, prices_ethereum_usd} <- timeseries_data("ethereum", from, to, interval, opts) do
       transform_func = fn value1, value2 ->
-        if value2 != 0 && value2 != nil, do: value1 / value2, else: 0
+        IO.inspect(value1)
+        IO.inspect(value2)
+        if value1 != nil && value2 != 0 && value2 != nil, do: value1 / value2, else: 0
       end
 
       {:ok, merge_by_datetime(prices_slug_usd, prices_ethereum_usd, transform_func, :price_usd)}


### PR DESCRIPTION
## Changes
Price for one of the days was `nil` which breaks the calculation.
```
   %{datetime: ~U[2020-09-26 00:00:00Z], value: 2.1501000000000002e-4},
   %{datetime: ~U[2020-09-27 00:00:00Z], value: 2.1549999999999998e-4},
   %{datetime: ~U[2020-09-28 00:00:00Z], value: 3.2129e-4},
   %{datetime: ~U[2020-09-29 00:00:00Z], value: nil},
   %{datetime: ~U[2020-09-30 00:00:00Z], value: 5.3925e-4},
   %{datetime: ~U[2020-10-01 00:00:00Z], value: 4.2478e-4},
   %{datetime: ~U[2020-10-02 00:00:00Z], value: 4.2304e-4},
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
