### PR TITLE
Add API specs for social metrics precomputed in CH

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -15,7 +15,7 @@ config :sanbase, SanbaseWeb.Endpoint,
 # Print only warnings and errors during test. Do not log JSON in tests.
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
-  level: :debug
+  level: :warn
 
 # Test adapter that allows mocking
 config :tesla, adapter: Tesla.Mock

--- a/lib/sanbase/clickhouse/metric/file_handler.ex
+++ b/lib/sanbase/clickhouse/metric/file_handler.ex
@@ -44,6 +44,7 @@ defmodule Sanbase.Clickhouse.Metric.FileHandler do
   @external_resource Path.join(__DIR__, "metric_files/uniswap_metrics.json")
   @external_resource Path.join(__DIR__, "metric_files/change_metrics.json")
   @external_resource Path.join(__DIR__, "metric_files/table_structured_metrics.json")
+  @external_resource Path.join(__DIR__, "metric_files/social_metrics.json")
 
   @metrics_json Enum.reduce(@external_resource, [], fn file, acc ->
                   (File.read!(file) |> Jason.decode!()) ++ acc

--- a/lib/sanbase/clickhouse/metric/metric_files/social_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/social_metrics.json
@@ -1,0 +1,116 @@
+[
+  {
+    "human_readable_name": "Social Volume Total",
+    "name": "social_volume_total",
+    "metric": "social_volume",
+    "version": "2020-07-31",
+    "access": "restricted",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "sum",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Social Dominance Total",
+    "name": "social_dominance_total",
+    "metric": "social_dominance",
+    "version": "2020-07-31",
+    "access": "restricted",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "sum",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Sentiment Volume Consumed Total",
+    "name": "sentiment_volume_consumed_total",
+    "metric": "sentiment_volume_consumed",
+    "version": "2020-07-31",
+    "access": "restricted",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "sum",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Sentiment Positive Total",
+    "name": "sentiment_positive_total",
+    "metric": "sentiment_positive",
+    "version": "2020-07-31",
+    "access": "restricted",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "sum",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Sentiment Negative Total",
+    "name": "sentiment_negative_total",
+    "metric": "sentiment_negative",
+    "version": "2020-07-31",
+    "access": "restricted",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "sum",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Sentiment Balance Total",
+    "name": "sentiment_balance_total",
+    "metric": "sentiment_balance",
+    "version": "2020-07-31",
+    "access": "restricted",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "sum",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  }
+]

--- a/lib/sanbase/clickhouse/metric/metric_files/social_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/social_metrics.json
@@ -9,7 +9,7 @@
       "slug"
     ],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "sum",
@@ -28,7 +28,7 @@
       "slug"
     ],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "sum",
@@ -47,7 +47,7 @@
       "slug"
     ],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "sum",
@@ -66,7 +66,7 @@
       "slug"
     ],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "sum",
@@ -85,7 +85,7 @@
       "slug"
     ],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "sum",
@@ -104,7 +104,7 @@
       "slug"
     ],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "sum",

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -17,8 +17,7 @@ defmodule Sanbase.SocialData.MetricAdapter do
     "social_volume_reddit",
     "social_volume_professional_traders_chat",
     "social_volume_twitter",
-    "social_volume_bitcointalk",
-    "social_volume_total"
+    "social_volume_bitcointalk"
   ]
 
   @community_messages_count_timeseries_metrics [
@@ -32,14 +31,13 @@ defmodule Sanbase.SocialData.MetricAdapter do
     "social_dominance_telegram",
     "social_dominance_discord",
     "social_dominance_reddit",
-    "social_dominance_professional_traders_chat",
-    "social_dominance_total"
+    "social_dominance_professional_traders_chat"
   ]
 
   @sentiment_timeseries_metrics for name <- ["sentiment"],
                                     type <- ["positive", "negative", "balance", "volume_consumed"],
                                     source <-
-                                      ["total"] ++ Sanbase.SocialData.SocialHelper.sources(),
+                                      Sanbase.SocialData.SocialHelper.sources(),
                                     do: "#{name}_#{type}_#{source}"
 
   @active_users_timeseries_metrics ["social_active_users"]

--- a/test/sanbase/signals/metric/metric_trigger_settings_test.exs
+++ b/test/sanbase/signals/metric/metric_trigger_settings_test.exs
@@ -61,7 +61,7 @@ defmodule Sanbase.Signal.MetricTriggerSettingsTest do
         ]
         |> Sanbase.Mock.wrap_consecutives(arity: 6)
 
-      Sanbase.Mock.prepare_mock(Sanbase.SocialData.MetricAdapter, :timeseries_data, mock_fun)
+      Sanbase.Mock.prepare_mock(Sanbase.Clickhouse.Metric, :timeseries_data, mock_fun)
       |> Sanbase.Mock.run_with_mocks(fn ->
         [triggered] =
           MetricTriggerSettings.type()


### PR DESCRIPTION
## Changes

Added API specs for social metrics precomputed in CH:

1. social_volume_total
2. social_dominance_total
3. sentiment_volume_consumed_total
4. sentiment_positive_total
5. sentiment_negative_total
6. sentiment_balance_total

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
