### PR TITLE
Add cursor when get all users because of too much memory allocated

### DIFF
--- a/lib/sanbase/auth/user.ex
+++ b/lib/sanbase/auth/user.ex
@@ -398,11 +398,6 @@ defmodule Sanbase.Auth.User do
     )
   end
 
-  def all() do
-    from(u in User, order_by: u.id, preload: [:eth_accounts])
-    |> Sanbase.Repo.all()
-  end
-
   def by_id(user_id) when is_integer(user_id) do
     case Sanbase.Repo.get_by(User, id: user_id) do
       nil ->


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Selecting all users in production results in too much memory allocated.
Fetch with cursor and use Stream to avoid this.

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
