### PR TITLE
Remove a wrongly defined metric

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -2136,23 +2136,6 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Daily Age Distribution Histogram",
-    "name": "daily_age_distribution",
-    "metric": "age_distribution_1day_delta",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": ["slug"],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "sum",
-    "min_interval": "1d",
-    "table": "distribution_deltas_5min",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
     "human_readable_name": "Average Gas Used in Gwei",
     "name": "avg_gas_used",
     "metric": "avg_gas",

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -185,7 +185,6 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "fees_to_network_circulation_usd_1d",
         "total_supply",
         "avg_gas_used",
-        "daily_age_distribution",
         # social metrics
         "community_messages_count_telegram",
         "community_messages_count_total",


### PR DESCRIPTION
We cannot have a timeseries metric on top of the distributions table as
it does not have a float value column

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
