### PR TITLE
Add new metrics to API

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -2151,5 +2151,56 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Network Realized Profit or Loss in USD",
+    "name": "network_profit_loss",
+    "metric": "network_profit_loss",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "sum",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Network Realized Profit or Loss in USD",
+    "name": "total_supply_in_profit",
+    "metric": "total_supply_in_profit",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Network Realized Profit or Loss in USD",
+    "name": "percent_of_total_supply_in_profit",
+    "metric": "percent_of_total_supply_in_profit",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "daily_metrics_v2",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
   }
 ]

--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -2170,7 +2170,7 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Network Realized Profit or Loss in USD",
+    "human_readable_name": "Total Supply in profit",
     "name": "total_supply_in_profit",
     "metric": "total_supply_in_profit",
     "version": "2019-01-01",
@@ -2187,7 +2187,7 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Network Realized Profit or Loss in USD",
+    "human_readable_name": "Percent of Total Supply in profit",
     "name": "percent_of_total_supply_in_profit",
     "metric": "percent_of_total_supply_in_profit",
     "version": "2019-01-01",

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -185,6 +185,9 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "fees_to_network_circulation_usd_1d",
         "total_supply",
         "avg_gas_used",
+        "network_profit_loss",
+        "total_supply_in_profit",
+        "percent_of_total_supply_in_profit",
         # social metrics
         "community_messages_count_telegram",
         "community_messages_count_total",


### PR DESCRIPTION
## Changes
Adding 3 metrics to API:
- network_profit_loss
- total_supply_in_profit
- percent_of_total_supply_in_profit

Should minimal access plan for api and sabase be "free"?
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
