### PR TITLE
Improve how data is fetched for the metric signal

### DIFF
--- a/test/sanbase/signals/max_signals_per_day_test.exs
+++ b/test/sanbase/signals/max_signals_per_day_test.exs
@@ -34,14 +34,12 @@ defmodule Sanbase.Signal.MaxSignalsPerDayTest do
     {:ok, _} = create_trigger_fun.()
     {:ok, _} = create_trigger_fun.()
 
-    datetimes = generate_datetimes(~U[2019-01-01 00:00:00Z], "1d", 7)
-
     mock_fun =
       [
-        fn -> {:ok, [%{datetime: datetimes |> List.first(), value: 100}]} end,
-        fn -> {:ok, [%{datetiem: datetimes |> List.last(), value: 500}]} end
+        fn -> {:ok, %{project.slug => 100}} end,
+        fn -> {:ok, %{project.slug => 500}} end
       ]
-      |> Sanbase.Mock.wrap_consecutives(arity: 6)
+      |> Sanbase.Mock.wrap_consecutives(arity: 5)
 
     [
       trigger: trigger,
@@ -60,7 +58,11 @@ defmodule Sanbase.Signal.MaxSignalsPerDayTest do
 
     self_pid = self()
 
-    Sanbase.Mock.prepare_mock(Sanbase.Clickhouse.MetricAdapter, :timeseries_data, mock_fun)
+    Sanbase.Mock.prepare_mock(
+      Sanbase.Clickhouse.MetricAdapter,
+      :aggregated_timeseries_data,
+      mock_fun
+    )
     |> Sanbase.Mock.prepare_mock(Sanbase.Telegram, :send_message, fn _user, text ->
       send(self_pid, {:telegram_to_self, text})
       :ok


### PR DESCRIPTION
## Changes
With the old approach it can happen that the data is split into 2 buckets, so part of the data gets ignored.
With the new approach this is no longer possible, making the signal more correct.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
