### PR TITLE
Switch to using the newer ETH top holders table

### DIFF
--- a/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
@@ -18,7 +18,7 @@ defmodule Sanbase.Clickhouse.TopHolders.MetricAdapter do
   def supported_infrastructures(), do: @supported_infrastructures
 
   @infrastructure_to_table %{
-    "ETH" => "eth_top_holders",
+    "ETH" => "eth_top_holders_daily_union",
     "BNB" => "bnb_top_holders",
     "BEP2" => "bnb_top_holders"
   }


### PR DESCRIPTION
The new tables properly use the contract addresses that are introduced
internaly by santiment. For example the SNX contract is now snx_contract
as it is combining data for mulitple contracts

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
