### PR TITLE
Deleting user cascades properly

### DIFF
--- a/lib/sanbase/auth/user.ex
+++ b/lib/sanbase/auth/user.ex
@@ -80,6 +80,7 @@ defmodule Sanbase.Auth.User do
 
     has_one(:telegram_user_tokens, Telegram.UserToken, on_delete: :delete_all)
     has_one(:sign_up_trial, Sanbase.Billing.Subscription.SignUpTrial, on_delete: :delete_all)
+    has_many(:timeline_events, Sanbase.Timeline.TimelineEvent, on_delete: :delete_all)
     has_many(:eth_accounts, EthAccount, on_delete: :delete_all)
     has_many(:votes, Vote, on_delete: :delete_all)
     has_many(:apikey_tokens, UserApikeyToken, on_delete: :delete_all)

--- a/lib/sanbase/signals/historical_activity.ex
+++ b/lib/sanbase/signals/historical_activity.ex
@@ -29,6 +29,12 @@ defmodule Sanbase.Signal.HistoricalActivity do
     |> validate_required([:user_id, :user_trigger_id, :payload, :triggered_at])
   end
 
+  def create(attrs) do
+    %HistoricalActivity{}
+    |> changeset(attrs)
+    |> Repo.insert()
+  end
+
   @doc """
   Fetch signal historical activity for user with cursor ordered by triggered_at descending.
   Cursor is a map with `type` (one of `:before` and `:after`) and `datetime`.

--- a/priv/repo/migrations/20201109091755_add_on_delete_posts_metrics.exs
+++ b/priv/repo/migrations/20201109091755_add_on_delete_posts_metrics.exs
@@ -1,0 +1,27 @@
+defmodule Sanbase.Repo.Migrations.AddOnDeletePostsMetrics do
+  use Ecto.Migration
+
+  @table "posts_metrics"
+  def up do
+    drop(constraint(@table, "posts_metrics_post_id_fkey"))
+    drop(constraint(@table, "posts_metrics_metric_id_fkey"))
+
+    alter table(@table) do
+      modify(:post_id, references(:posts, on_delete: :delete_all))
+      modify(:metric_id, references(:metrics, on_delete: :delete_all))
+    end
+
+    create(unique_index(@table, [:post_id, :metric_id]))
+  end
+
+  def down do
+    drop(unique_index(@table, [:post_id, :metric_id]))
+    drop(constraint(@table, "posts_metrics_post_id_fkey"))
+    drop(constraint(@table, "posts_metrics_metric_id_fkey"))
+
+    alter table(@table) do
+      modify(:post_id, references(:posts))
+      modify(:metric_id, references(:metrics))
+    end
+  end
+end

--- a/priv/repo/migrations/20201109092655_add_on_delete_posts_tags.exs
+++ b/priv/repo/migrations/20201109092655_add_on_delete_posts_tags.exs
@@ -1,0 +1,28 @@
+defmodule Sanbase.Repo.Migrations.AddOnDeletePostsTags do
+  use Ecto.Migration
+
+  @table "posts_tags"
+
+  def up do
+    drop(unique_index(@table, [:post_id, :tag_id]))
+    drop(constraint(@table, "posts_tags_post_id_fkey"))
+    drop(constraint(@table, "posts_tags_tag_id_fkey"))
+
+    alter table(@table) do
+      modify(:post_id, references(:posts, on_delete: :delete_all))
+      modify(:tag_id, references(:tags, on_delete: :delete_all))
+    end
+  end
+
+  def down do
+    drop(constraint(@table, "posts_tags_post_id_fkey"))
+    drop(constraint(@table, "posts_tags_tag_id_fkey"))
+
+    alter table(@table) do
+      modify(:post_id, references(:posts))
+      modify(:tag_id, references(:tags))
+    end
+
+    create(unique_index(@table, [:post_id, :tag_id]))
+  end
+end

--- a/priv/repo/migrations/20201109112004_add_on_delete_timeline_events.exs
+++ b/priv/repo/migrations/20201109112004_add_on_delete_timeline_events.exs
@@ -1,0 +1,32 @@
+defmodule Sanbase.Repo.Migrations.AddOnDeleteTimelineEvents do
+  use Ecto.Migration
+
+  @table "timeline_events"
+  def up do
+    drop(constraint(@table, "timeline_events_post_id_fkey"))
+    drop(constraint(@table, "timeline_events_user_id_fkey"))
+    drop(constraint(@table, "timeline_events_user_list_id_fkey"))
+    drop(constraint(@table, "timeline_events_user_trigger_id_fkey"))
+
+    alter table(@table) do
+      modify(:user_id, references(:users, on_delete: :delete_all))
+      modify(:post_id, references(:posts, on_delete: :delete_all))
+      modify(:user_list_id, references(:user_lists, on_delete: :delete_all))
+      modify(:user_trigger_id, references(:user_triggers, on_delete: :delete_all))
+    end
+  end
+
+  def down do
+    drop(constraint(@table, "timeline_events_post_id_fkey"))
+    drop(constraint(@table, "timeline_events_user_id_fkey"))
+    drop(constraint(@table, "timeline_events_user_list_id_fkey"))
+    drop(constraint(@table, "timeline_events_user_trigger_id_fkey"))
+
+    alter table(@table) do
+      modify(:user_id, references(:users))
+      modify(:post_id, references(:posts))
+      modify(:user_list_id, references(:user_lists))
+      modify(:user_trigger_id, references(:user_triggers))
+    end
+  end
+end

--- a/priv/repo/migrations/20201109124013_add_on_delete_featured_items.exs
+++ b/priv/repo/migrations/20201109124013_add_on_delete_featured_items.exs
@@ -1,0 +1,37 @@
+defmodule Sanbase.Repo.Migrations.AddOnDeleteFeaturedItems do
+  use Ecto.Migration
+
+  @table "featured_items"
+
+  def up do
+    drop(constraint(@table, "featured_items_post_id_fkey"))
+    drop(constraint(@table, "featured_items_table_configuration_id_fkey"))
+    drop(constraint(@table, "featured_items_chart_configuration_id_fkey"))
+    drop(constraint(@table, "featured_items_user_list_id_fkey"))
+    drop(constraint(@table, "featured_items_user_trigger_id_fkey"))
+
+    alter table(@table) do
+      modify(:post_id, references(:posts, on_delete: :delete_all))
+      modify(:user_list_id, references(:user_lists, on_delete: :delete_all))
+      modify(:chart_configuration_id, references(:chart_configurations, on_delete: :delete_all))
+      modify(:table_configuration_id, references(:table_configurations, on_delete: :delete_all))
+      modify(:user_trigger_id, references(:user_triggers, on_delete: :delete_all))
+    end
+  end
+
+  def down do
+    drop(constraint(@table, "featured_items_post_id_fkey"))
+    drop(constraint(@table, "featured_items_table_configuration_id_fkey"))
+    drop(constraint(@table, "featured_items_chart_configuration_id_fkey"))
+    drop(constraint(@table, "featured_items_user_list_id_fkey"))
+    drop(constraint(@table, "featured_items_user_trigger_id_fkey"))
+
+    alter table(@table) do
+      modify(:post_id, references(:posts))
+      modify(:user_list_id, references(:user_lists))
+      modify(:chart_configuration_id, references(:chart_configurations))
+      modify(:table_configuration_id, references(:table_configurations))
+      modify(:user_trigger_id, references(:user_triggers))
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -3684,17 +3684,17 @@ CREATE UNIQUE INDEX post_images_image_url_index ON public.post_images USING btre
 
 
 --
+-- Name: posts_metrics_post_id_metric_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX posts_metrics_post_id_metric_id_index ON public.posts_metrics USING btree (post_id, metric_id);
+
+
+--
 -- Name: posts_projects_post_id_project_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX posts_projects_post_id_project_id_index ON public.posts_projects USING btree (post_id, project_id);
-
-
---
--- Name: posts_tags_post_id_tag_id_index; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX posts_tags_post_id_tag_id_index ON public.posts_tags USING btree (post_id, tag_id);
 
 
 --
@@ -4096,7 +4096,7 @@ ALTER TABLE ONLY public.exchange_addresses
 --
 
 ALTER TABLE ONLY public.featured_items
-    ADD CONSTRAINT featured_items_chart_configuration_id_fkey FOREIGN KEY (chart_configuration_id) REFERENCES public.chart_configurations(id);
+    ADD CONSTRAINT featured_items_chart_configuration_id_fkey FOREIGN KEY (chart_configuration_id) REFERENCES public.chart_configurations(id) ON DELETE CASCADE;
 
 
 --
@@ -4104,7 +4104,7 @@ ALTER TABLE ONLY public.featured_items
 --
 
 ALTER TABLE ONLY public.featured_items
-    ADD CONSTRAINT featured_items_post_id_fkey FOREIGN KEY (post_id) REFERENCES public.posts(id);
+    ADD CONSTRAINT featured_items_post_id_fkey FOREIGN KEY (post_id) REFERENCES public.posts(id) ON DELETE CASCADE;
 
 
 --
@@ -4112,7 +4112,7 @@ ALTER TABLE ONLY public.featured_items
 --
 
 ALTER TABLE ONLY public.featured_items
-    ADD CONSTRAINT featured_items_table_configuration_id_fkey FOREIGN KEY (table_configuration_id) REFERENCES public.table_configurations(id);
+    ADD CONSTRAINT featured_items_table_configuration_id_fkey FOREIGN KEY (table_configuration_id) REFERENCES public.table_configurations(id) ON DELETE CASCADE;
 
 
 --
@@ -4120,7 +4120,7 @@ ALTER TABLE ONLY public.featured_items
 --
 
 ALTER TABLE ONLY public.featured_items
-    ADD CONSTRAINT featured_items_user_list_id_fkey FOREIGN KEY (user_list_id) REFERENCES public.user_lists(id);
+    ADD CONSTRAINT featured_items_user_list_id_fkey FOREIGN KEY (user_list_id) REFERENCES public.user_lists(id) ON DELETE CASCADE;
 
 
 --
@@ -4128,7 +4128,7 @@ ALTER TABLE ONLY public.featured_items
 --
 
 ALTER TABLE ONLY public.featured_items
-    ADD CONSTRAINT featured_items_user_trigger_id_fkey FOREIGN KEY (user_trigger_id) REFERENCES public.user_triggers(id);
+    ADD CONSTRAINT featured_items_user_trigger_id_fkey FOREIGN KEY (user_trigger_id) REFERENCES public.user_triggers(id) ON DELETE CASCADE;
 
 
 --
@@ -4264,7 +4264,7 @@ ALTER TABLE ONLY public.posts
 --
 
 ALTER TABLE ONLY public.posts_metrics
-    ADD CONSTRAINT posts_metrics_metric_id_fkey FOREIGN KEY (metric_id) REFERENCES public.metrics(id);
+    ADD CONSTRAINT posts_metrics_metric_id_fkey FOREIGN KEY (metric_id) REFERENCES public.metrics(id) ON DELETE CASCADE;
 
 
 --
@@ -4272,7 +4272,7 @@ ALTER TABLE ONLY public.posts_metrics
 --
 
 ALTER TABLE ONLY public.posts_metrics
-    ADD CONSTRAINT posts_metrics_post_id_fkey FOREIGN KEY (post_id) REFERENCES public.posts(id);
+    ADD CONSTRAINT posts_metrics_post_id_fkey FOREIGN KEY (post_id) REFERENCES public.posts(id) ON DELETE CASCADE;
 
 
 --
@@ -4304,7 +4304,7 @@ ALTER TABLE ONLY public.posts_projects
 --
 
 ALTER TABLE ONLY public.posts_tags
-    ADD CONSTRAINT posts_tags_post_id_fkey FOREIGN KEY (post_id) REFERENCES public.posts(id);
+    ADD CONSTRAINT posts_tags_post_id_fkey FOREIGN KEY (post_id) REFERENCES public.posts(id) ON DELETE CASCADE;
 
 
 --
@@ -4312,7 +4312,7 @@ ALTER TABLE ONLY public.posts_tags
 --
 
 ALTER TABLE ONLY public.posts_tags
-    ADD CONSTRAINT posts_tags_tag_id_fkey FOREIGN KEY (tag_id) REFERENCES public.tags(id);
+    ADD CONSTRAINT posts_tags_tag_id_fkey FOREIGN KEY (tag_id) REFERENCES public.tags(id) ON DELETE CASCADE;
 
 
 --
@@ -4528,7 +4528,7 @@ ALTER TABLE ONLY public.timeline_event_comments_mapping
 --
 
 ALTER TABLE ONLY public.timeline_events
-    ADD CONSTRAINT timeline_events_post_id_fkey FOREIGN KEY (post_id) REFERENCES public.posts(id);
+    ADD CONSTRAINT timeline_events_post_id_fkey FOREIGN KEY (post_id) REFERENCES public.posts(id) ON DELETE CASCADE;
 
 
 --
@@ -4536,7 +4536,7 @@ ALTER TABLE ONLY public.timeline_events
 --
 
 ALTER TABLE ONLY public.timeline_events
-    ADD CONSTRAINT timeline_events_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
+    ADD CONSTRAINT timeline_events_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
 
 --
@@ -4544,7 +4544,7 @@ ALTER TABLE ONLY public.timeline_events
 --
 
 ALTER TABLE ONLY public.timeline_events
-    ADD CONSTRAINT timeline_events_user_list_id_fkey FOREIGN KEY (user_list_id) REFERENCES public.user_lists(id);
+    ADD CONSTRAINT timeline_events_user_list_id_fkey FOREIGN KEY (user_list_id) REFERENCES public.user_lists(id) ON DELETE CASCADE;
 
 
 --
@@ -4552,7 +4552,7 @@ ALTER TABLE ONLY public.timeline_events
 --
 
 ALTER TABLE ONLY public.timeline_events
-    ADD CONSTRAINT timeline_events_user_trigger_id_fkey FOREIGN KEY (user_trigger_id) REFERENCES public.user_triggers(id);
+    ADD CONSTRAINT timeline_events_user_trigger_id_fkey FOREIGN KEY (user_trigger_id) REFERENCES public.user_triggers(id) ON DELETE CASCADE;
 
 
 --
@@ -4971,3 +4971,7 @@ INSERT INTO public."schema_migrations" (version) VALUES (20200923090710);
 INSERT INTO public."schema_migrations" (version) VALUES (20201016091443);
 INSERT INTO public."schema_migrations" (version) VALUES (20201016105225);
 INSERT INTO public."schema_migrations" (version) VALUES (20201016124426);
+INSERT INTO public."schema_migrations" (version) VALUES (20201109091755);
+INSERT INTO public."schema_migrations" (version) VALUES (20201109092655);
+INSERT INTO public."schema_migrations" (version) VALUES (20201109112004);
+INSERT INTO public."schema_migrations" (version) VALUES (20201109124013);


### PR DESCRIPTION
## Changes
`on_delete: :delete_all` option in schema works for deleting one record of entity and its associations.
But if you want to delete many records of one entity and its associations `ON DELETE CASCADE` to db is needed.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
