### PR TITLE
Fix deleting already cancelled trial

### DIFF
--- a/lib/sanbase/billing/subscription/sign_up_trial.ex
+++ b/lib/sanbase/billing/subscription/sign_up_trial.ex
@@ -128,10 +128,14 @@ defmodule Sanbase.Billing.Subscription.SignUpTrial do
           {:ok, _} ->
             update_trial(sign_up_trial, %{is_finished: true})
 
-          {:error, reason} ->
+          # Subscription is already cancelled - update locally
+          {:error, %Stripe.Error{extra: %{http_status: 404}}} ->
+            update_trial(sign_up_trial, %{is_finished: true})
+
+          {:error, other} ->
             Logger.error(
               "Can't delete the subscription for: #{inspect(sign_up_trial)}, reason: #{
-                inspect(reason)
+                inspect(other)
               }"
             )
         end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

When 404 is encountered from Stripe for deleting subscription - we can update the trial locally as finished.

```
%Stripe.Error{code: :invalid_request_error, extra: %{card_code: :resource_missing, http_status: 404, param: :id, raw_error: %{\"code\" => \"resource_missing\", \"doc_url\" => \"https://stripe.com/docs/error-codes/resource-missing\", \"message\" => \"No such subscription: ....
```

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
