### PR TITLE
Add API specs for social dominance and sentiment balance change metrics

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/change_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/change_metrics.json
@@ -3296,5 +3296,112 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Social Dominance Change (1d)",
+    "name": "social_dominance_total_change_1d",
+    "metric": "social_dominance_change_1d",
+    "version": "2020-07-31",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  }
+,
+  {
+    "human_readable_name": "Social Dominance Change (7d)",
+    "name": "social_dominance_total_change_7d",
+    "metric": "social_dominance_change_7d",
+    "version": "2020-07-31",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  }
+,
+  {
+    "human_readable_name": "Social Dominance Change (30d)",
+    "name": "social_dominance_total_change_30d",
+    "metric": "social_dominance_change_30d",
+    "version": "2020-07-31",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  }
+,
+  {
+    "human_readable_name": "Sentiment Balance Change (1d)",
+    "name": "sentiment_balance_total_change_1d",
+    "metric": "sentiment_balance_change_1d",
+    "version": "2020-07-31",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  }
+,
+  {
+    "human_readable_name": "Sentiment Balance Change (7d)",
+    "name": "sentiment_balance_total_change_7d",
+    "metric": "sentiment_balance_change_7d",
+    "version": "2020-07-31",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  }
+,
+  {
+    "human_readable_name": "Sentiment Balance Change (30d)",
+    "name": "sentiment_balance_total_change_30d",
+    "metric": "sentiment_balance_change_30d",
+    "version": "2020-07-31",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
   }
 ]

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -631,7 +631,13 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "whale_to_traders_flow_change_30d",
         "traders_to_whale_flow_change_1d",
         "traders_to_whale_flow_change_7d",
-        "traders_to_whale_flow_change_30d"
+        "traders_to_whale_flow_change_30d",
+        "social_dominance_total_change_1d",
+        "social_dominance_total_change_7d",
+        "social_dominance_total_change_30d",
+        "sentiment_balance_total_change_1d",
+        "sentiment_balance_total_change_7d",
+        "sentiment_balance_total_change_30d"
       ]
       |> Enum.sort()
 


### PR DESCRIPTION
## Changes

Added API specs for the following CH metrics:

- social_dominance_change_1d
- social_dominance_change_7d
- social_dominance_change_30d
- sentiment_balance_change_1d
- sentiment_balance_change_7d
- sentiment_balance_change_30d

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
