### PR TITLE
Use eth_labels_final table in labels query

### DIFF
--- a/lib/sanbase/clickhouse/labels.ex
+++ b/lib/sanbase/clickhouse/labels.ex
@@ -91,6 +91,7 @@ defmodule Sanbase.Clickhouse.Label do
                label_owner.2 as owner,
                asset_id,
                multiIf(
+                   address = '0x7a250d5630b4cf539739df2c5dacb4c659f2488d', 'Uniswap Router',
                    label_raw='uniswap_ecosystem', 'Uniswap Ecosystem',
                    label_raw='cex_dex_trader', 'CEX & DEX Trader',
                    label_raw='centralized_exchange', 'CEX',
@@ -110,7 +111,9 @@ defmodule Sanbase.Clickhouse.Label do
                    label_raw='proxy', 'Proxy',
                    label_raw='system', 'System',
                    label_raw='miner', 'Miner',
+                   label_raw='contract_factory', 'Contract Factory',
                    label_raw='derivative_token', 'Derivative Token',
+                   label_raw='eth2stakingcontract', 'ETH2 Staking Contract',
                    label_raw
                ) as label
         FROM (
@@ -121,8 +124,8 @@ defmodule Sanbase.Clickhouse.Label do
                    splitByChar(',', owners) as owner_arr,
                    arrayZip(label_arr, owner_arr) as labels_owners,
                    multiIf(
-                       hasAll(label_arr, ['dex_trader', 'withdrawal']), arrayPushFront(arrayFilter(x -> x.1 NOT IN ['dex_trader', 'withdrawal'], labels_owners), ('cex_dex_trader', arrayFilter(x -> x.1 == 'withdrawal', labels_owners)[1].2)),
                        hasAll(label_arr, ['deposit', 'withdrawal']), arrayFilter(x -> x.1 != 'withdrawal', labels_owners),
+                       hasAll(label_arr, ['dex_trader', 'withdrawal']), arrayPushFront(arrayFilter(x -> x.1 NOT IN ['dex_trader', 'withdrawal'], labels_owners), ('cex_dex_trader', arrayFilter(x -> x.1 == 'withdrawal', labels_owners)[1].2)),
                        hasAll(label_arr, ['dex_trader', 'decentralized_exchange']), arrayFilter(x -> x.1 != 'dex_trader', labels_owners),
                        labels_owners
                    ) as labels_owners_filtered
@@ -131,7 +134,7 @@ defmodule Sanbase.Clickhouse.Label do
                 SELECT cityHash64(address) as address_hash,
                        address
                 FROM (
-                    SELECT arrayJoin([?2]) as address
+                    SELECT lower(arrayJoin([?2])) as address
                 )
             )
             USING address_hash

--- a/lib/sanbase/clickhouse/labels.ex
+++ b/lib/sanbase/clickhouse/labels.ex
@@ -85,52 +85,52 @@ defmodule Sanbase.Clickhouse.Label do
        label,
        concat('\{', '"owner": "', owner, '"\}') as metadata
     FROM (
-    SELECT address_hash,
-           asset_id,
-           address,
-           splitByChar(',', labels) as label_arr,
-           splitByChar(',', owners) as owner_arr,
-           arrayZip(label_arr, owner_arr) as labels_owners,
-           multiIf(
-               has(label_arr, 'uniswap_ecosystem'), ('Uniswap Ecosystem', arrayFilter(x -> x.1 = 'uniswap_ecosystem', labels_owners)[1].2),
-               has(label_arr, 'decentralized_exchange'), ('DEX', arrayFilter(x -> x.1 = 'decentralized_exchange', labels_owners)[1].2),
-               has(label_arr, 'defi'), ('DeFi', arrayFilter(x -> x.1 = 'defi', labels_owners)[1].2),
-               has(label_arr, 'deployer'), ('Deployer', arrayFilter(x -> x.1 = 'deployer', labels_owners)[1].2),
-               has(label_arr, 'stablecoin'), ('Stablecoin', arrayFilter(x -> x.1 = 'stablecoin', labels_owners)[1].2),
-               hasAll(label_arr, ['withdrawal', 'dex_trader']), ('CEX & DEX Trader', arrayFilter(x -> x.1 = 'withdrawal', labels_owners)[1].2),
-               hasAll(label_arr, ['withdrawal', 'deposit']), ('CEX Deposit', arrayFilter(x -> x.1 = 'deposit', labels_owners)[1].2),
-               has(label_arr, 'deposit'), ('CEX Deposit', arrayFilter(x -> x.1 = 'deposit', labels_owners)[1].2),
-               has(label_arr, 'withdrawal'), ('CEX Trader', arrayFilter(x -> x.1 = 'withdrawal', labels_owners)[1].2),
-               has(label_arr, 'dex_trader'), ('DEX Trader', arrayFilter(x -> x.1 = 'dex_trader', labels_owners)[1].2),
-               has(label_arr, 'whale') AND asset_id = (SELECT asset_id FROM asset_metadata FINAL PREWHERE name = ?1), ('Whale', arrayFilter(x -> x.1 = 'whale', labels_owners)[1].2),
-               has(label_arr, 'whale') AND asset_id != (SELECT asset_id FROM asset_metadata FINAL PREWHERE name = ?1), ('wrong_whale', ''),
-               has(label_arr, 'centralized_exchange'), ('CEX', arrayFilter(x -> x.1 = 'centralized_exchange', labels_owners)[1].2),
-               has(label_arr, 'makerdao-cdp-owner'), ('MakerDAO CDP Owner', arrayFilter(x -> x.1 = 'makerdao-cdp-owner', labels_owners)[1].2),
-               has(label_arr, 'makerdao-bite-keeper'), ('MakerDAO Bite Keeper', arrayFilter(x -> x.1 = 'makerdao-bite-keeper', labels_owners)[1].2),
-               has(label_arr, 'genesis'), ('Genesis', arrayFilter(x -> x.1 = 'genesis', labels_owners)[1].2),
-               has(label_arr, 'proxy'), ('Proxy', arrayFilter(x -> x.1 = 'proxy', labels_owners)[1].2),
-               has(label_arr, 'system'), ('System', arrayFilter(x -> x.1 = 'system', labels_owners)[1].2),
-               has(label_arr, 'miner'), ('Miner', arrayFilter(x -> x.1 = 'miner', labels_owners)[1].2),
-               (label_arr[1], owner_arr[1])
-            ) as label_owner,
-           label_owner.1 as label,
-           label_owner.2 as owner
-    FROM eth_labels_final
-    ANY INNER JOIN (
-        SELECT cityHash64(address) as address_hash,
-               address
-        FROM (
-            SELECT arrayJoin([?2]) as address
-        )
-    )
-    USING address_hash
-    PREWHERE address_hash IN (
-        SELECT cityHash64(address)
-        FROM (
-            SELECT lower(arrayJoin([?2])) as address
-        )
-    )
-        AND NOT has(label_arr, 'system')
+      SELECT address_hash,
+             asset_id,
+             address,
+             splitByChar(',', labels) as label_arr,
+             splitByChar(',', owners) as owner_arr,
+             arrayZip(label_arr, owner_arr) as labels_owners,
+             multiIf(
+                 has(label_arr, 'uniswap_ecosystem'), ('Uniswap Ecosystem', arrayFilter(x -> x.1 = 'uniswap_ecosystem', labels_owners)[1].2),
+                 has(label_arr, 'decentralized_exchange'), ('DEX', arrayFilter(x -> x.1 = 'decentralized_exchange', labels_owners)[1].2),
+                 has(label_arr, 'defi'), ('DeFi', arrayFilter(x -> x.1 = 'defi', labels_owners)[1].2),
+                 has(label_arr, 'deployer'), ('Deployer', arrayFilter(x -> x.1 = 'deployer', labels_owners)[1].2),
+                 has(label_arr, 'stablecoin'), ('Stablecoin', arrayFilter(x -> x.1 = 'stablecoin', labels_owners)[1].2),
+                 hasAll(label_arr, ['withdrawal', 'dex_trader']), ('CEX & DEX Trader', arrayFilter(x -> x.1 = 'withdrawal', labels_owners)[1].2),
+                 hasAll(label_arr, ['withdrawal', 'deposit']), ('CEX Deposit', arrayFilter(x -> x.1 = 'deposit', labels_owners)[1].2),
+                 has(label_arr, 'deposit'), ('CEX Deposit', arrayFilter(x -> x.1 = 'deposit', labels_owners)[1].2),
+                 has(label_arr, 'withdrawal'), ('CEX Trader', arrayFilter(x -> x.1 = 'withdrawal', labels_owners)[1].2),
+                 has(label_arr, 'dex_trader'), ('DEX Trader', arrayFilter(x -> x.1 = 'dex_trader', labels_owners)[1].2),
+                 has(label_arr, 'whale') AND asset_id = (SELECT asset_id FROM asset_metadata FINAL PREWHERE name = ?1), ('Whale', arrayFilter(x -> x.1 = 'whale', labels_owners)[1].2),
+                 has(label_arr, 'whale') AND asset_id != (SELECT asset_id FROM asset_metadata FINAL PREWHERE name = ?1), ('wrong_whale', ''),
+                 has(label_arr, 'centralized_exchange'), ('CEX', arrayFilter(x -> x.1 = 'centralized_exchange', labels_owners)[1].2),
+                 has(label_arr, 'makerdao-cdp-owner'), ('MakerDAO CDP Owner', arrayFilter(x -> x.1 = 'makerdao-cdp-owner', labels_owners)[1].2),
+                 has(label_arr, 'makerdao-bite-keeper'), ('MakerDAO Bite Keeper', arrayFilter(x -> x.1 = 'makerdao-bite-keeper', labels_owners)[1].2),
+                 has(label_arr, 'genesis'), ('Genesis', arrayFilter(x -> x.1 = 'genesis', labels_owners)[1].2),
+                 has(label_arr, 'proxy'), ('Proxy', arrayFilter(x -> x.1 = 'proxy', labels_owners)[1].2),
+                 has(label_arr, 'system'), ('System', arrayFilter(x -> x.1 = 'system', labels_owners)[1].2),
+                 has(label_arr, 'miner'), ('Miner', arrayFilter(x -> x.1 = 'miner', labels_owners)[1].2),
+                 (label_arr[1], owner_arr[1])
+              ) as label_owner,
+             label_owner.1 as label,
+             label_owner.2 as owner
+      FROM eth_labels_final
+      ANY INNER JOIN (
+          SELECT cityHash64(address) as address_hash,
+                 address
+          FROM (
+              SELECT arrayJoin([?2]) as address
+          )
+      )
+      USING address_hash
+      PREWHERE address_hash IN (
+          SELECT cityHash64(address)
+          FROM (
+              SELECT lower(arrayJoin([?2])) as address
+          )
+      )
+          AND NOT has(label_arr, 'system')
     )
     WHERE label != 'wrong_whale'
     """

--- a/lib/sanbase/clickhouse/labels.ex
+++ b/lib/sanbase/clickhouse/labels.ex
@@ -91,7 +91,7 @@ defmodule Sanbase.Clickhouse.Label do
                label_owner.2 as owner,
                asset_id,
                multiIf(
-                   address = '0x7a250d5630b4cf539739df2c5dacb4c659f2488d', 'Uniswap Router',
+                   owner = 'uniswap router', 'Uniswap Router',
                    label_raw='uniswap_ecosystem', 'Uniswap Ecosystem',
                    label_raw='cex_dex_trader', 'CEX & DEX Trader',
                    label_raw='centralized_exchange', 'CEX',

--- a/lib/sanbase/clickhouse/labels.ex
+++ b/lib/sanbase/clickhouse/labels.ex
@@ -82,57 +82,57 @@ defmodule Sanbase.Clickhouse.Label do
   defp addresses_labels_query(slug, addresses) do
     query = """
     SELECT address,
-           label_owner_final.1 as label,
-           concat('\{', '"owner": "', label_owner_final.2, '"\}') as metadata
+       label,
+       concat('\{', '"owner": "', owner, '"\}') as metadata
     FROM (
-            SELECT address_hash,
-                   asset_id,
-                   address,
-                   splitByChar(',', labels) as label_arr,
-                   splitByChar(',', owners) as owner_arr,
-                   arrayZip(label_arr, owner_arr) as labels_owners,
-                   multiIf(
-                       has(label_arr, 'uniswap_ecosystem'), ('Uniswap Ecosystem', arrayFilter(x -> x.1 = 'uniswap_ecosystem', labels_owners)[1].2),
-                       has(label_arr, 'decentralized_exchange'), ('DEX', arrayFilter(x -> x.1 = 'decentralized_exchange', labels_owners)[1].2),
-                       has(label_arr, 'defi'), ('DeFi', arrayFilter(x -> x.1 = 'defi', labels_owners)[1].2),
-                       has(label_arr, 'deployer'), ('Deployer', arrayFilter(x -> x.1 = 'deployer', labels_owners)[1].2),
-                       has(label_arr, 'stablecoin'), ('Stablecoin', arrayFilter(x -> x.1 = 'stablecoin', labels_owners)[1].2),
-                       has(label_arr, 'deposit'), ('CEX Deposit', arrayFilter(x -> x.1 = 'deposit', labels_owners)[1].2),
-                       has(label_arr, 'withdrawal'), ('CEX Trader', arrayFilter(x -> x.1 = 'withdrawal', labels_owners)[1].2),
-                       has(label_arr, 'dex_trader'), ('DEX Trader', arrayFilter(x -> x.1 = 'dex_trader', labels_owners)[1].2),
-                       has(label_arr, 'whale') AND asset_id = (SELECT asset_id FROM asset_metadata FINAL PREWHERE name = ?1), ('Whale', arrayFilter(x -> x.1 = 'whale', labels_owners)[1].2),
-                       has(label_arr, 'whale') AND asset_id != (SELECT asset_id FROM asset_metadata FINAL PREWHERE name = ?1), ('wrong_whale', ''),
-                       has(label_arr, 'centralized_exchange'), ('CEX', arrayFilter(x -> x.1 = 'centralized_exchange', labels_owners)[1].2),
-                       has(label_arr, 'makerdao-cdp-owner'), ('MakerDAO CDP Owner', arrayFilter(x -> x.1 = 'makerdao-cdp-owner', labels_owners)[1].2),
-                       has(label_arr, 'makerdao-bite-keeper'), ('MakerDAO Bite Keeper', arrayFilter(x -> x.1 = 'makerdao-bite-keeper', labels_owners)[1].2),
-                       has(label_arr, 'genesis'), ('Genesis', arrayFilter(x -> x.1 = 'genesis', labels_owners)[1].2),
-                       has(label_arr, 'proxy'), ('Proxy', arrayFilter(x -> x.1 = 'proxy', labels_owners)[1].2),
-                       has(label_arr, 'system'), ('System', arrayFilter(x -> x.1 = 'system', labels_owners)[1].2),
-                       has(label_arr, 'miner'), ('Miner', arrayFilter(x -> x.1 = 'miner', labels_owners)[1].2),
-                       (label_arr[1], owner_arr[1])
-                   ) as label_owner,
-                   label_owner.1 as label,
-                   label_owner.2 as owner
-            FROM eth_labels_final
-            ANY INNER JOIN (
-                SELECT cityHash64(address) as address_hash,
-                       address
-                FROM (
-                    SELECT arrayJoin([?2]) as address
-                )
-            )
-            USING address_hash
-            PREWHERE address_hash IN (
-                SELECT cityHash64(address)
-                FROM (
-                    SELECT lower(arrayJoin([?2])) as address
-                )
-            )
-                AND NOT has(label_arr, 'system')
+    SELECT address_hash,
+           asset_id,
+           address,
+           splitByChar(',', labels) as label_arr,
+           splitByChar(',', owners) as owner_arr,
+           arrayZip(label_arr, owner_arr) as labels_owners,
+           multiIf(
+               has(label_arr, 'uniswap_ecosystem'), ('Uniswap Ecosystem', arrayFilter(x -> x.1 = 'uniswap_ecosystem', labels_owners)[1].2),
+               has(label_arr, 'decentralized_exchange'), ('DEX', arrayFilter(x -> x.1 = 'decentralized_exchange', labels_owners)[1].2),
+               has(label_arr, 'defi'), ('DeFi', arrayFilter(x -> x.1 = 'defi', labels_owners)[1].2),
+               has(label_arr, 'deployer'), ('Deployer', arrayFilter(x -> x.1 = 'deployer', labels_owners)[1].2),
+               has(label_arr, 'stablecoin'), ('Stablecoin', arrayFilter(x -> x.1 = 'stablecoin', labels_owners)[1].2),
+               hasAll(label_arr, ['withdrawal', 'dex_trader']), ('CEX & DEX Trader', arrayFilter(x -> x.1 = 'withdrawal', labels_owners)[1].2),
+               hasAll(label_arr, ['withdrawal', 'deposit']), ('CEX Deposit', arrayFilter(x -> x.1 = 'deposit', labels_owners)[1].2),
+               has(label_arr, 'deposit'), ('CEX Deposit', arrayFilter(x -> x.1 = 'deposit', labels_owners)[1].2),
+               has(label_arr, 'withdrawal'), ('CEX Trader', arrayFilter(x -> x.1 = 'withdrawal', labels_owners)[1].2),
+               has(label_arr, 'dex_trader'), ('DEX Trader', arrayFilter(x -> x.1 = 'dex_trader', labels_owners)[1].2),
+               has(label_arr, 'whale') AND asset_id = (SELECT asset_id FROM asset_metadata FINAL PREWHERE name = ?1), ('Whale', arrayFilter(x -> x.1 = 'whale', labels_owners)[1].2),
+               has(label_arr, 'whale') AND asset_id != (SELECT asset_id FROM asset_metadata FINAL PREWHERE name = ?1), ('wrong_whale', ''),
+               has(label_arr, 'centralized_exchange'), ('CEX', arrayFilter(x -> x.1 = 'centralized_exchange', labels_owners)[1].2),
+               has(label_arr, 'makerdao-cdp-owner'), ('MakerDAO CDP Owner', arrayFilter(x -> x.1 = 'makerdao-cdp-owner', labels_owners)[1].2),
+               has(label_arr, 'makerdao-bite-keeper'), ('MakerDAO Bite Keeper', arrayFilter(x -> x.1 = 'makerdao-bite-keeper', labels_owners)[1].2),
+               has(label_arr, 'genesis'), ('Genesis', arrayFilter(x -> x.1 = 'genesis', labels_owners)[1].2),
+               has(label_arr, 'proxy'), ('Proxy', arrayFilter(x -> x.1 = 'proxy', labels_owners)[1].2),
+               has(label_arr, 'system'), ('System', arrayFilter(x -> x.1 = 'system', labels_owners)[1].2),
+               has(label_arr, 'miner'), ('Miner', arrayFilter(x -> x.1 = 'miner', labels_owners)[1].2),
+               (label_arr[1], owner_arr[1])
+            ) as label_owner,
+           label_owner.1 as label,
+           label_owner.2 as owner
+    FROM eth_labels_final
+    ANY INNER JOIN (
+        SELECT cityHash64(address) as address_hash,
+               address
+        FROM (
+            SELECT arrayJoin([?2]) as address
         )
-        WHERE label != 'wrong_whale'
-        GROUP BY address
     )
+    USING address_hash
+    PREWHERE address_hash IN (
+        SELECT cityHash64(address)
+        FROM (
+            SELECT lower(arrayJoin([?2])) as address
+        )
+    )
+        AND NOT has(label_arr, 'system')
+    )
+    WHERE label != 'wrong_whale'
     """
 
     {query, [slug, addresses]}

--- a/lib/sanbase/clickhouse/labels.ex
+++ b/lib/sanbase/clickhouse/labels.ex
@@ -85,13 +85,6 @@ defmodule Sanbase.Clickhouse.Label do
            label_owner_final.1 as label,
            concat('\{', '"owner": "', label_owner_final.2, '"\}') as metadata
     FROM (
-        SELECT address,
-               groupArray(label_owner) as labels_owners,
-               multiIf(
-                   length(labels_owners) > 1, arrayFilter(x -> x.1 != 'Whale', labels_owners)[1],
-                   labels_owners[1]
-               ) as label_owner_final
-        FROM (
             SELECT address_hash,
                    asset_id,
                    address,

--- a/lib/sanbase/clickhouse/labels.ex
+++ b/lib/sanbase/clickhouse/labels.ex
@@ -127,6 +127,7 @@ defmodule Sanbase.Clickhouse.Label do
                        hasAll(label_arr, ['deposit', 'withdrawal']), arrayFilter(x -> x.1 != 'withdrawal', labels_owners),
                        hasAll(label_arr, ['dex_trader', 'withdrawal']), arrayPushFront(arrayFilter(x -> x.1 NOT IN ['dex_trader', 'withdrawal'], labels_owners), ('cex_dex_trader', arrayFilter(x -> x.1 == 'withdrawal', labels_owners)[1].2)),
                        hasAll(label_arr, ['dex_trader', 'decentralized_exchange']), arrayFilter(x -> x.1 != 'dex_trader', labels_owners),
+                       has(label_arr, 'system'), arrayFilter(x -> x.1 = 'system', labels_owners),
                        labels_owners
                    ) as labels_owners_filtered
             FROM eth_labels_final
@@ -144,7 +145,6 @@ defmodule Sanbase.Clickhouse.Label do
                     SELECT lower(arrayJoin([?2])) as address
                 )
             )
-                AND NOT has(label_arr, 'system')
         )
     )
     WHERE label != 'whale_wrong'

--- a/lib/sanbase/clickhouse/labels.ex
+++ b/lib/sanbase/clickhouse/labels.ex
@@ -124,10 +124,10 @@ defmodule Sanbase.Clickhouse.Label do
                    splitByChar(',', owners) as owner_arr,
                    arrayZip(label_arr, owner_arr) as labels_owners,
                    multiIf(
+                       has(label_arr, 'system'), arrayFilter(x -> x.1 = 'system', labels_owners),
                        hasAll(label_arr, ['deposit', 'withdrawal']), arrayFilter(x -> x.1 != 'withdrawal', labels_owners),
                        hasAll(label_arr, ['dex_trader', 'withdrawal']), arrayPushFront(arrayFilter(x -> x.1 NOT IN ['dex_trader', 'withdrawal'], labels_owners), ('cex_dex_trader', arrayFilter(x -> x.1 == 'withdrawal', labels_owners)[1].2)),
                        hasAll(label_arr, ['dex_trader', 'decentralized_exchange']), arrayFilter(x -> x.1 != 'dex_trader', labels_owners),
-                       has(label_arr, 'system'), arrayFilter(x -> x.1 = 'system', labels_owners),
                        labels_owners
                    ) as labels_owners_filtered
             FROM eth_labels_final

--- a/lib/sanbase/clickhouse/metric/file_handler.ex
+++ b/lib/sanbase/clickhouse/metric/file_handler.ex
@@ -45,6 +45,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter.FileHandler do
   @external_resource Path.join(__DIR__, "metric_files/change_metrics.json")
   @external_resource Path.join(__DIR__, "metric_files/table_structured_metrics.json")
   @external_resource Path.join(__DIR__, "metric_files/social_metrics.json")
+  @external_resource Path.join(__DIR__, "metric_files/eth2_metrics.json")
 
   @metrics_json Enum.reduce(@external_resource, [], fn file, acc ->
                   (File.read!(file) |> Jason.decode!()) ++ acc

--- a/lib/sanbase/clickhouse/metric/metric_files/eth2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/eth2_metrics.json
@@ -1,7 +1,7 @@
 [
   {
-    "human_readable_name": "ETH2.0 Staker Count",
-    "name": "eth2_staker_count",
+    "human_readable_name": "ETH 2.0 Stakers Count",
+    "name": "eth2_stakers_count",
     "metric": "eth2_staker_count",
     "version": "2019-01-01",
     "access": "restricted",

--- a/lib/sanbase/clickhouse/metric/metric_files/eth2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/eth2_metrics.json
@@ -1,0 +1,19 @@
+[
+  {
+    "human_readable_name": "ETH2.0 Staker Count",
+    "name": "eth2_staker_count",
+    "metric": "eth2_staker_count",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  }
+]

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -453,7 +453,7 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "traders_to_other_flow",
         "other_traders_balance",
         # ETH2 metrics
-        "eth2_staker_count",
+        "eth2_stakers_count",
         # Defi
         "defi_total_value_locked_eth",
         "defi_total_value_locked_usd",

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -452,6 +452,8 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "other_to_traders_flow",
         "traders_to_other_flow",
         "other_traders_balance",
+        # ETH2 metrics
+        "eth2_staker_count",
         # Defi
         "defi_total_value_locked_eth",
         "defi_total_value_locked_usd",


### PR DESCRIPTION
## Changes

Use `eth_labels_final` table instead of `blockchain_address_labels` to obtain address labels. This will allow to speed up query

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

