### PR TITLE
Change order of fields when generating unique user string

### DIFF
--- a/lib/sanbase/auth/user.ex
+++ b/lib/sanbase/auth/user.ex
@@ -91,7 +91,7 @@ defmodule Sanbase.Auth.User do
   end
 
   def get_unique_str(%__MODULE__{} = user) do
-    user.username || user.email || user.twitter_id || "id_#{user.id}"
+    user.email || user.username || user.twitter_id || "id_#{user.id}"
   end
 
   def describe(%__MODULE__{} = user) do


### PR DESCRIPTION
## Changes

This fixes an issue that was introduced for the grafana login. If the
username is first it creates some problems because of the way the
grafana login token is generated.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
