### PR TITLE
Use the email from the twitter oauth. Refactor login code

### DIFF
--- a/lib/sanbase/auth/user.ex
+++ b/lib/sanbase/auth/user.ex
@@ -116,22 +116,26 @@ defmodule Sanbase.Auth.User do
 
     user
     |> cast(attrs, [
-      :email,
-      :email_candidate,
-      :email_candidate_token,
+      :avatar_url,
+      :consent_id,
       :email_candidate_token_generated_at,
       :email_candidate_token_validated_at,
-      :username,
-      :salt,
-      :test_san_balance,
-      :privacy_policy_accepted,
-      :marketing_accepted,
-      :stripe_customer_id,
+      :email_candidate_token,
+      :email_candidate,
+      :email_token_generated_at,
+      :email_token_validated_at,
+      :email_token,
+      :email,
       :first_login,
-      :avatar_url,
       :is_registered,
       :is_superuser,
-      :twitter_id
+      :marketing_accepted,
+      :privacy_policy_accepted,
+      :salt,
+      :stripe_customer_id,
+      :test_san_balance,
+      :twitter_id,
+      :username
     ])
     |> normalize_username(attrs)
     |> normalize_email(attrs[:email], :email)
@@ -146,9 +150,11 @@ defmodule Sanbase.Auth.User do
   end
 
   # Twitter functions
-  defdelegate find_or_insert_by_twitter_id(twitter_id, username \\ nil), to: __MODULE__.Twitter
+  defdelegate find_or_insert_by_twitter_id(twitter_id, username \\ %{}), to: __MODULE__.Twitter
+  defdelegate update_twitter_id(user, twitter_id), to: __MODULE__.Twitter
+
   # Email functions
-  defdelegate find_or_insert_by_email(email, username \\ nil), to: __MODULE__.Email
+  defdelegate find_or_insert_by_email(email, username \\ %{}), to: __MODULE__.Email
   defdelegate find_by_email_candidate(candidate, token), to: __MODULE__.Email
   defdelegate update_email_token(user, consent \\ nil), to: __MODULE__.Email
   defdelegate update_email_candidate(user, candidate), to: __MODULE__.Email
@@ -243,6 +249,8 @@ defmodule Sanbase.Auth.User do
       {:error, msg} -> [avatar_url: msg]
     end
   end
+
+  def change_username(%__MODULE__{username: username} = user, username), do: {:ok, user}
 
   def change_username(%__MODULE__{} = user, username) do
     user

--- a/lib/sanbase/auth/user/user_email.ex
+++ b/lib/sanbase/auth/user/user_email.ex
@@ -7,26 +7,6 @@ defmodule Sanbase.Auth.User.Email do
   require Mockery.Macro
   defp mandrill_api(), do: Mockery.Macro.mockable(Sanbase.MandrillApi)
 
-  def find_or_insert_by_email(email, attrs \\ %{}) do
-    email = String.downcase(email)
-
-    case Repo.get_by(User, email: email) do
-      nil ->
-        user_create_attrs =
-          Map.merge(
-            attrs,
-            %{email: email, salt: User.generate_salt(), first_login: true}
-          )
-
-        %User{}
-        |> User.changeset(user_create_attrs)
-        |> Repo.insert()
-
-      user ->
-        {:ok, user}
-    end
-  end
-
   def find_by_email_candidate(email_candidate, email_candidate_token) do
     email_candidate = String.downcase(email_candidate)
 

--- a/lib/sanbase/auth/user/user_twitter.ex
+++ b/lib/sanbase/auth/user/user_twitter.ex
@@ -2,19 +2,29 @@ defmodule Sanbase.Auth.User.Twitter do
   alias Sanbase.Repo
   alias Sanbase.Auth.User
 
-  def find_or_insert_by_twitter_id(twitter_id, username \\ nil) do
+  def find_or_insert_by_twitter_id(twitter_id, attrs \\ %{}) do
     case Repo.get_by(User, twitter_id: twitter_id) do
       nil ->
-        %User{
-          twitter_id: twitter_id,
-          username: username,
-          salt: User.generate_salt(),
-          first_login: true
-        }
+        user_create_attrs =
+          Map.merge(
+            attrs,
+            %{twitter_id: twitter_id, salt: User.generate_salt(), first_login: true}
+          )
+
+        %User{}
+        |> User.changeset(user_create_attrs)
         |> Repo.insert()
 
       user ->
         {:ok, user}
     end
+  end
+
+  def update_twitter_id(%User{twitter_id: twitter_id} = user, twitter_id), do: {:ok, user}
+
+  def update_twitter_id(%User{} = user, twitter_id) do
+    user
+    |> User.changeset(%{twitter_id: twitter_id})
+    |> Sanbase.Repo.update()
   end
 end

--- a/lib/sanbase_web/admin/auth/user.ex
+++ b/lib/sanbase_web/admin/auth/user.ex
@@ -9,6 +9,15 @@ defmodule SanbaseWeb.ExAdmin.Auth.User do
       before_filter(:assign_all_user_insights_to_anonymous, only: [:destroy])
     end
 
+    index do
+      column(:id)
+      column(:username)
+      column(:email)
+      column(:twitter_id)
+      column(:is_superuser)
+      column(:san_balance)
+    end
+
     show user do
       attributes_table(all: true)
 

--- a/lib/sanbase_web/controllers/auth_controller.ex
+++ b/lib/sanbase_web/controllers/auth_controller.ex
@@ -29,7 +29,7 @@ defmodule SanbaseWeb.AuthController do
     email = auth.info.email
 
     with true <- is_binary(email),
-         {:ok, user} <- User.find_or_insert_by_email(email, %{is_registered: true}),
+         {:ok, user} <- User.find_or_insert_by(:email, email, %{is_registered: true}),
          {:ok, token, _claims} <- SanbaseWeb.Guardian.encode_and_sign(user, %{salt: user.salt}) do
       conn
       |> put_session(:auth_token, token)
@@ -64,13 +64,13 @@ defmodule SanbaseWeb.AuthController do
   # has that twitter_id set. So this results in a single DB call in all cases
   # except the first time twitter login is used.
   defp twitter_login(email, twitter_id) when is_binary(email) and byte_size(email) > 0 do
-    with {:ok, user} <- User.find_or_insert_by_email(email, %{is_registered: true}),
-         {:ok, user} <- User.update_twitter_id(user, twitter_id) do
+    with {:ok, user} <- User.find_or_insert_by(:email, email, %{is_registered: true}),
+         {:ok, user} <- User.update_field(user, :twitter_id, twitter_id) do
       {:ok, user}
     end
   end
 
   defp twitter_login(_email, twitter_id) do
-    User.find_or_insert_by_twitter_id(twitter_id)
+    User.find_or_insert_by(:twitter_id, twitter_id, %{is_registered: true})
   end
 end

--- a/lib/sanbase_web/controllers/auth_controller.ex
+++ b/lib/sanbase_web/controllers/auth_controller.ex
@@ -7,6 +7,7 @@ defmodule SanbaseWeb.AuthController do
 
   plug(Ueberauth)
 
+  alias Sanbase.Auth.User
   alias Ueberauth.Strategy.Helpers
 
   def request(conn, _params) do
@@ -28,7 +29,7 @@ defmodule SanbaseWeb.AuthController do
     email = auth.info.email
 
     with true <- is_binary(email),
-         {:ok, user} <- Sanbase.Auth.User.find_or_insert_by_email(email),
+         {:ok, user} <- User.find_or_insert_by_email(email, %{is_registered: true}),
          {:ok, token, _claims} <- SanbaseWeb.Guardian.encode_and_sign(user, %{salt: user.salt}) do
       conn
       |> put_session(:auth_token, token)
@@ -41,10 +42,10 @@ defmodule SanbaseWeb.AuthController do
   end
 
   def callback(%{assigns: %{ueberauth_auth: %{provider: :twitter} = auth}} = conn, _params) do
-    twitter_id_str = auth.uid
+    twitter_id = auth.uid
+    email = auth.info.email
 
-    with true <- is_binary(twitter_id_str),
-         {:ok, user} <- Sanbase.Auth.User.find_or_insert_by_twitter_id(twitter_id_str),
+    with {:ok, user} <- twitter_login(email, twitter_id),
          {:ok, token, _claims} <- SanbaseWeb.Guardian.encode_and_sign(user, %{salt: user.salt}) do
       conn
       |> put_session(:auth_token, token)
@@ -54,5 +55,22 @@ defmodule SanbaseWeb.AuthController do
         conn
         |> redirect(external: SanbaseWeb.Endpoint.website_url())
     end
+  end
+
+  # In case the twitter profile has an email address, try fetching the user with
+  # that email and set its twitter_id to the given id. This is done so existing
+  # account can be linked to a twitter account when email addresses match.
+  # The User.update_twitter_id/2 is no-op if the user with that email already exists and
+  # has that twitter_id set. So this results in a single DB call in all cases
+  # except the first time twitter login is used.
+  defp twitter_login(email, twitter_id) when is_binary(email) and byte_size(email) > 0 do
+    with {:ok, user} <- User.find_or_insert_by_email(email, %{is_registered: true}),
+         {:ok, user} <- User.update_twitter_id(user, twitter_id) do
+      {:ok, user}
+    end
+  end
+
+  defp twitter_login(_email, twitter_id) do
+    User.find_or_insert_by_twitter_id(twitter_id)
   end
 end

--- a/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
@@ -104,7 +104,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserResolver do
   def email_login(%{email: email} = args, %{
         context: %{origin_url: origin_url}
       }) do
-    with {:ok, user} <- User.find_or_insert_by_email(email, args[:username]),
+    with {:ok, user} <- User.find_or_insert_by_email(email, %{username: args[:username]}),
          {:ok, user} <- User.update_email_token(user, args[:consent]),
          {:ok, _user} <- User.send_login_email(user, origin_url, args) do
       {:ok, %{success: true, first_login: user.first_login}}

--- a/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
@@ -104,7 +104,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserResolver do
   def email_login(%{email: email} = args, %{
         context: %{origin_url: origin_url}
       }) do
-    with {:ok, user} <- User.find_or_insert_by_email(email, %{username: args[:username]}),
+    with {:ok, user} <- User.find_or_insert_by(:email, email, %{username: args[:username]}),
          {:ok, user} <- User.update_email_token(user, args[:consent]),
          {:ok, _user} <- User.send_login_email(user, origin_url, args) do
       {:ok, %{success: true, first_login: user.first_login}}
@@ -114,7 +114,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserResolver do
   end
 
   def email_login_verify(%{token: token, email: email}, _resolution) do
-    with {:ok, user} <- User.find_or_insert_by_email(email),
+    with {:ok, user} <- User.find_or_insert_by(:email, email),
          true <- User.email_token_valid?(user, token),
          _ <- create_free_trial_on_signup(user),
          {:ok, token, _claims} <- SanbaseWeb.Guardian.encode_and_sign(user, %{salt: user.salt}),

--- a/test/sanbase/auth/apikey/apikey_test.exs
+++ b/test/sanbase/auth/apikey/apikey_test.exs
@@ -7,7 +7,7 @@ defmodule Sanbase.Auth.ApiKeyTest do
   }
 
   setup do
-    {:ok, user} = User.find_or_insert_by_email("as819asdnmaso1011@santiment.net")
+    {:ok, user} = User.find_or_insert_by(:email, "as819asdnmaso1011@santiment.net")
 
     %{
       user: user

--- a/test/sanbase/auth/user_test.exs
+++ b/test/sanbase/auth/user_test.exs
@@ -230,7 +230,7 @@ defmodule Sanbase.Auth.UserTest do
   end
 
   test "find_or_insert_by_email when the user does not exist" do
-    {:ok, user} = User.find_or_insert_by_email("test@example.com", %{username: "john_snow"})
+    {:ok, user} = User.find_or_insert_by(:email, "test@example.com", %{username: "john_snow"})
 
     assert user.email == "test@example.com"
     assert user.username == "john_snow"
@@ -245,7 +245,7 @@ defmodule Sanbase.Auth.UserTest do
         privacy_policy_accepted: true
       )
 
-    {:ok, user} = User.find_or_insert_by_email(existing_user.email, %{username: "john_snow"})
+    {:ok, user} = User.find_or_insert_by(:email, existing_user.email, %{username: "john_snow"})
 
     assert user.id == existing_user.id
     assert user.email == existing_user.email

--- a/test/sanbase/auth/user_test.exs
+++ b/test/sanbase/auth/user_test.exs
@@ -230,7 +230,7 @@ defmodule Sanbase.Auth.UserTest do
   end
 
   test "find_or_insert_by_email when the user does not exist" do
-    {:ok, user} = User.find_or_insert_by_email("test@example.com", "john_snow")
+    {:ok, user} = User.find_or_insert_by_email("test@example.com", %{username: "john_snow"})
 
     assert user.email == "test@example.com"
     assert user.username == "john_snow"
@@ -245,7 +245,7 @@ defmodule Sanbase.Auth.UserTest do
         privacy_policy_accepted: true
       )
 
-    {:ok, user} = User.find_or_insert_by_email(existing_user.email, "john_snow")
+    {:ok, user} = User.find_or_insert_by_email(existing_user.email, %{username: "john_snow"})
 
     assert user.id == existing_user.id
     assert user.email == existing_user.email

--- a/test/sanbase_web/graphql/user/user_api_test.exs
+++ b/test/sanbase_web/graphql/user/user_api_test.exs
@@ -390,7 +390,7 @@ defmodule SanbaseWeb.Graphql.UserApiTest do
 
     login_data = json_response(result, 200)["data"]["emailLoginVerify"]
 
-    {:ok, user} = User.find_or_insert_by_email(user.email)
+    {:ok, user} = User.find_or_insert_by(:email, user.email)
 
     assert login_data["token"] != nil
     assert login_data["user"]["email"] == user.email


### PR DESCRIPTION
## Changes
- Link the twitter account to an existing account if the email addresses match
- Rework the `find_or_insert_by_*` user functions to accept a map of attributes. This is mainly used to properly set `is_registered` when using twitter/google oauth as it does not need a second verification step.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
