### PR TITLE
Remove invalid labels for DEX & CEX addresses

### DIFF
--- a/lib/sanbase/clickhouse/labels.ex
+++ b/lib/sanbase/clickhouse/labels.ex
@@ -125,8 +125,8 @@ defmodule Sanbase.Clickhouse.Label do
                    arrayZip(label_arr, owner_arr) as labels_owners,
                    multiIf(
                        has(label_arr, 'system'), arrayFilter(x -> x.1 = 'system', labels_owners),
-                       has(label_arr, 'centralized_exchange'), arrayFilter(x -> x.1 NOT IN ('deposit', 'withdrawal'), labels_owners),
-                       has(label_arr, 'decentralized_exchange'), arrayFilter(x -> x.1 != 'dex_trader', labels_owners),
+                       has(label_arr, 'centralized_exchange') AND hasAny(label_arr, ['deposit', 'withdrawal']), arrayFilter(x -> x.1 NOT IN ('deposit', 'withdrawal'), labels_owners),
+                       hasAll(label_arr, ['dex_trader', 'decentralized_exchange']), arrayFilter(x -> x.1 != 'dex_trader', labels_owners),
                        hasAll(label_arr, ['deposit', 'withdrawal']), arrayFilter(x -> x.1 != 'withdrawal', labels_owners),
                        hasAll(label_arr, ['dex_trader', 'withdrawal']), arrayPushFront(arrayFilter(x -> x.1 NOT IN ['dex_trader', 'withdrawal'], labels_owners), ('cex_dex_trader', arrayFilter(x -> x.1 == 'withdrawal', labels_owners)[1].2)),
                        labels_owners

--- a/lib/sanbase/clickhouse/labels.ex
+++ b/lib/sanbase/clickhouse/labels.ex
@@ -125,6 +125,8 @@ defmodule Sanbase.Clickhouse.Label do
                    arrayZip(label_arr, owner_arr) as labels_owners,
                    multiIf(
                        has(label_arr, 'system'), arrayFilter(x -> x.1 = 'system', labels_owners),
+                       has(label_arr, 'centralized_exchange'), arrayFilter(x -> x.1 NOT IN ('deposit', 'withdrawal'), labels_owners),
+                       has(label_arr, 'decentralized_exchange'), arrayFilter(x -> x.1 NOT IN ('dex_trader'), labels_owners),
                        hasAll(label_arr, ['deposit', 'withdrawal']), arrayFilter(x -> x.1 != 'withdrawal', labels_owners),
                        hasAll(label_arr, ['dex_trader', 'withdrawal']), arrayPushFront(arrayFilter(x -> x.1 NOT IN ['dex_trader', 'withdrawal'], labels_owners), ('cex_dex_trader', arrayFilter(x -> x.1 == 'withdrawal', labels_owners)[1].2)),
                        hasAll(label_arr, ['dex_trader', 'decentralized_exchange']), arrayFilter(x -> x.1 != 'dex_trader', labels_owners),

--- a/lib/sanbase/clickhouse/labels.ex
+++ b/lib/sanbase/clickhouse/labels.ex
@@ -126,10 +126,9 @@ defmodule Sanbase.Clickhouse.Label do
                    multiIf(
                        has(label_arr, 'system'), arrayFilter(x -> x.1 = 'system', labels_owners),
                        has(label_arr, 'centralized_exchange'), arrayFilter(x -> x.1 NOT IN ('deposit', 'withdrawal'), labels_owners),
-                       has(label_arr, 'decentralized_exchange'), arrayFilter(x -> x.1 NOT IN ('dex_trader'), labels_owners),
+                       has(label_arr, 'decentralized_exchange'), arrayFilter(x -> x.1 != 'dex_trader', labels_owners),
                        hasAll(label_arr, ['deposit', 'withdrawal']), arrayFilter(x -> x.1 != 'withdrawal', labels_owners),
                        hasAll(label_arr, ['dex_trader', 'withdrawal']), arrayPushFront(arrayFilter(x -> x.1 NOT IN ['dex_trader', 'withdrawal'], labels_owners), ('cex_dex_trader', arrayFilter(x -> x.1 == 'withdrawal', labels_owners)[1].2)),
-                       hasAll(label_arr, ['dex_trader', 'decentralized_exchange']), arrayFilter(x -> x.1 != 'dex_trader', labels_owners),
                        labels_owners
                    ) as labels_owners_filtered
             FROM eth_labels_final


### PR DESCRIPTION
## Changes

Add new rules for addresses with DEX and CEX labels:
* if an address has CEX label - remove `deposit` and `withdrawal` labels
* if an address has DEX label - remove the `dex_trader` label

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works
