### PR TITLE
Add eth2 metrics

### DIFF
--- a/lib/sanbase/clickhouse/metric/file_handler.ex
+++ b/lib/sanbase/clickhouse/metric/file_handler.ex
@@ -39,6 +39,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter.FileHandler do
   @external_resource Path.join(__DIR__, "metric_files/derivatives_metrics.json")
   @external_resource Path.join(__DIR__, "metric_files/eth2_metrics.json")
   @external_resource Path.join(__DIR__, "metric_files/exchange_metrics.json")
+  @external_resource Path.join(__DIR__, "metric_files/histogram_metrics.json")
   @external_resource Path.join(__DIR__, "metric_files/holders_metrics.json")
   @external_resource Path.join(__DIR__, "metric_files/label_metrics.json")
   @external_resource Path.join(__DIR__, "metric_files/labeled_balance_metrics.json")

--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -1537,62 +1537,6 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Age Distribution Histogram",
-    "name": "age_distribution",
-    "metric": "age_distribution_5min_delta",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": ["slug"],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "distribution_deltas_5min",
-    "has_incomplete_data": false,
-    "data_type": "histogram"
-  },
-  {
-    "human_readable_name": "Price Histogram",
-    "name": "price_histogram",
-    "metric": "price_histogram",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": ["slug"],
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": ["distribution_deltas_5min", "intraday_metrics"],
-    "has_incomplete_data": false,
-    "data_type": "histogram"
-  },
-  {
-    "human_readable_name": "Spent Coins Cost",
-    "name": "spent_coins_cost",
-    "metric": "spent_coins_cost",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": ["slug"],
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": ["distribution_deltas_5min", "intraday_metrics"],
-    "has_incomplete_data": false,
-    "data_type": "histogram"
-  },
-  {
-    "human_readable_name": "All Spent Coins Cost",
-    "name": "all_spent_coins_cost",
-    "metric": "all_spent_coins_cost",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": ["slug"],
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": ["distribution_deltas_5min", "intraday_metrics"],
-    "has_incomplete_data": false,
-    "data_type": "histogram"
-  },
-  {
     "human_readable_name": "Active Deposits",
     "name": "active_deposits",
     "metric": "active_deposits",

--- a/lib/sanbase/clickhouse/metric/metric_files/histogram_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/histogram_metrics.json
@@ -1,0 +1,126 @@
+[
+  {
+    "human_readable_name": "Price Histogram",
+    "name": "price_histogram",
+    "metric": "price_histogram",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": ["distribution_deltas_5min", "intraday_metrics"],
+    "has_incomplete_data": false,
+    "data_type": "histogram"
+  },
+  {
+    "human_readable_name": "Spent Coins Cost",
+    "name": "spent_coins_cost",
+    "metric": "spent_coins_cost",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": ["distribution_deltas_5min", "intraday_metrics"],
+    "has_incomplete_data": false,
+    "data_type": "histogram"
+  },
+  {
+    "human_readable_name": "All Spent Coins Cost",
+    "name": "all_spent_coins_cost",
+    "metric": "all_spent_coins_cost",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": ["distribution_deltas_5min", "intraday_metrics"],
+    "has_incomplete_data": false,
+    "data_type": "histogram"
+  },
+  {
+    "human_readable_name": "Age Distribution Histogram",
+    "name": "age_distribution",
+    "metric": "age_distribution_5min_delta",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "distribution_deltas_5min",
+    "has_incomplete_data": false,
+    "data_type": "histogram"
+  },
+  {
+    "human_readable_name": "ETH2 Staked Amount",
+    "name": "eth2_staked_amount_per_label",
+    "metric": "eth2_staked_amount_per_label",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "eth2_staking_transfers_mv",
+    "has_incomplete_data": false,
+    "data_type": "histogram"
+  },
+  {
+    "human_readable_name": "ETH2 Staked Amount",
+    "name": "eth2_staked_address_count_per_label",
+    "metric": "eth2_staked_address_count_per_label",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "eth2_staking_transfers_mv",
+    "has_incomplete_data": false,
+    "data_type": "histogram"
+  },
+  {
+    "human_readable_name": "ETH2 Staked Amount",
+    "name": "eth2_unlabeled_staker_inflow_sources",
+    "metric": "eth2_unlabeled_staker_inflow_sources",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "eth2_staking_transfers_mv",
+    "has_incomplete_data": false,
+    "data_type": "histogram"
+  },
+  {
+    "human_readable_name": "ETH2 Staked Amount",
+    "name": "eth2_top_stakers",
+    "metric": "eth2_top_stakers",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "eth2_staking_transfers_mv",
+    "has_incomplete_data": false,
+    "data_type": "histogram"
+  }
+]

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -102,6 +102,23 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:value, :float)
   end
 
+  object :datetime_range_float_value do
+    field(:range, list_of(:datetime))
+    field(:value, :float)
+  end
+
+  object :string_label_float_value do
+    field(:label, :string)
+    field(:value, :float)
+  end
+
+  object :string_address_string_label_float_value do
+    field(:address, :string)
+    field(:label, :string)
+    field(:value, :float)
+  end
+
+  # List objects
   object :string_address_float_value_list do
     field(:data, list_of(:string_address_float_value))
   end
@@ -114,9 +131,12 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:data, list_of(:datetime_range_float_value))
   end
 
-  object :datetime_range_float_value do
-    field(:range, list_of(:datetime))
-    field(:value, :float)
+  object :string_label_float_value_list do
+    field(:data, list_of(:string_label_float_value))
+  end
+
+  object :string_address_string_label_float_value_list do
+    field(:data, list_of(:string_address_string_label_float_value))
   end
 
   union :value_list do
@@ -127,7 +147,9 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       :float_list,
       :float_range_float_value_list,
       :datetime_range_float_value_list,
-      :string_address_float_value_list
+      :string_address_float_value_list,
+      :string_label_float_value_list,
+      :string_address_string_label_float_value_list
     ])
 
     resolve_type(fn
@@ -137,15 +159,24 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       %{data: [value | _]}, _ when is_binary(value) ->
         :string_list
 
-      %{data: [%{range: [r | _], value: value} | _]}, _ when is_number(r) and is_number(value) ->
+      %{data: [%{range: [r | _], value: value} | _]}, _
+      when is_number(r) and is_number(value) ->
         :float_range_float_value_list
 
       %{data: [%{range: [%DateTime{} | _], value: value} | _]}, _ when is_number(value) ->
         :datetime_range_float_value_list
 
+      %{data: [%{address: address, label: label, value: value} | _]}, _
+      when is_binary(label) and is_binary(address) and is_number(value) ->
+        :string_address_string_label_float_value_list
+
       %{data: [%{address: address, value: value} | _]}, _
       when is_binary(address) and is_number(value) ->
         :string_address_float_value_list
+
+      %{data: [%{label: label, value: value} | _]}, _
+      when is_binary(label) and is_number(value) ->
+        :string_label_float_value_list
 
       %{data: []}, _ ->
         :float_list

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -15,6 +15,7 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
       [
         "active_addresses_24h",
         "active_addresses_1h",
+        "circulation",
         "daily_active_addresses",
         "daily_avg_marketcap_usd",
         "daily_avg_price_usd",
@@ -68,7 +69,11 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "uniswap_total_user_claims_count",
         "uniswap_user_claims_amount",
         "uniswap_user_claims_count",
-        "circulation"
+        # histogram metrics
+        "eth2_staked_amount_per_label",
+        "eth2_staked_address_count_per_label",
+        "eth2_unlabeled_staker_inflow_sources",
+        "eth2_top_stakers"
       ]
       |> Enum.sort()
 

--- a/test/sanbase_web/graphql/metric/api_metric_histogram_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_histogram_data_test.exs
@@ -136,7 +136,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricHistogramDataTest do
     end)
   end
 
-  test "histogram metric different than all_spent_coins_cost without from datetime - returns proper error",
+  test "histogram metric different except without from datetime - returns proper error",
        context do
     %{conn: conn, slug: slug, to: to} = context
     metric = "spent_coins_cost"


### PR DESCRIPTION
## Changes

Note: The `from` argument is *optional*. If it is not provided or if it's set to `null`, then the values will include the staked amount from the beginning up to `to`.

### Staked amount per label

#### Request:
```graphql
{
  getMetric(metric: "eth2_staked_amount_per_label") {
    histogramData(
      selector: {slug: "ethereum"}
      from: "utc_now-70d"
      to:"utc_now"
    ){
      values{
        __typename
        ... on StringLabelFloatValueList{
        data{
            label
            value
          }
      	}
      }
    }
  }
}
```

#### Response:
```json
{
  "data": {
    "getMetric": {
      "histogramData": {
        "values": {
          "__typename": "StringLabelFloatValueList",
          "data": [
            {
              "label": "Genesis",
              "value": 32
            },
            {
              "label": "CEX",
              "value": 64
            },
            {
              "label": "DEX Trader",
              "value": 3072
            },
            {
              "label": "CEX Trader",
              "value": 7040
            },
            {
              "label": "DEX & CEX Trader",
              "value": 15104
            },
            {
              "label": "Unlabeled",
              "value": 25377
            }
          ]
        }
      }
    }
  }
}
```

---

### Count of addresses that staked:

#### Request:
```graphql
{
	getMetric(metric: "eth2_staked_address_count_per_label"){
          histogramData(
            selector: {slug: "ethereum"}
            from: "utc_now-10d"
            to: "utc_now"
          ){
			values{
         
        ... on StringLabelFloatValueList{
          data{
            label
            value
          }
        }
      }
    }
  }
}
```

#### Response:
```json
{
  "data": {
    "getMetric": {
      "histogramData": {
        "values": {
          "data": [
            {
              "label": "Unlabeled",
              "value": 510
            },
            {
              "label": "CEX Trader",
              "value": 210
            },
            {
              "label": "DEX & CEX Trader",
              "value": 86
            },
            {
              "label": "DEX Trader",
              "value": 21
            }
          ]
        }
      }
    }
  }
}
```

---

### Sources for the unlabelled stakes source
#### Request:
```graphql
{
	getMetric(metric: "eth2_unlabeled_staker_inflow_sources"){
    histogramData(
      selector: {slug: "ethereum"}
      from: "utc_now-10d"
      to: "utc_now"
    ){
			values{
         
        ... on StringLabelFloatValueList{
          data{
            label
            value
          }
        }
      }
    }
  }
}
```

#### Response:
```json
{
  "data": {
    "getMetric": {
      "histogramData": {
        "values": {
          "data": [
            {
              "label": "CEX Trader",
              "value": 334428.26722876506
            },
            {
              "label": "Unlabeled",
              "value": 209238.07683600686
            },
            {
              "label": "DEX & CEX Trader",
              "value": 104924.2321883901
            },
            {
              "label": "DEX Trader",
              "value": 12205.778627752865
            },
            {
              "label": "CEX",
              "value": 788.43947558
            },
            {
              "label": "DeFi",
              "value": 100.1
            },
            {
              "label": "Genesis",
              "value": 99.99981099099999
            },
            {
              "label": "Mining Pool",
              "value": 32
            }
          ]
        }
      }
    }
  }
}
```

---

### Top stakers

#### Request
```graphql
{
	getMetric(metric: "eth2_top_stakers"){
    histogramData(
      selector: {slug: "ethereum"}
      from: "utc_now-10d"
      to: "utc_now"
      limit: 2
    ){
			values{
         
        ... on StringAddressStringLabelFloatValueList{
          data{
            address
            label
            value
          }
        }
      }
    }
  }
}
```

#### Response:
```json
{
  "data": {
    "getMetric": {
      "histogramData": {
        "values": {
          "data": [
            {
              "address": "0xd4039ecc40aeda0582036437cf3ec02845da4c13",
              "label": "Other",
              "value": 72064
            },
            {
              "address": "0x194bd70b59491ce1310ea0bceabdb6c23ac9d5b2",
              "label": "CEX Trader",
              "value": 39776
            }
          ]
        }
      }
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
