### PR TITLE
Rework base_projects to be a list of maps, not a single map

### DIFF
--- a/lib/sanbase/model/project/list/selector/list_selector.ex
+++ b/lib/sanbase/model/project/list/selector/list_selector.ex
@@ -140,20 +140,26 @@ defmodule Sanbase.Model.Project.ListSelector do
 
   defp base_slugs(:all), do: :all
 
-  defp base_slugs(args) do
-    detect_cycles!(args)
-    {:ok, slugs} = get_base_slugs(args)
-    slugs
+  defp base_slugs(args_list) do
+    Enum.flat_map(args_list, fn args ->
+      {:ok, slugs} = get_base_slugs(args)
+      slugs
+    end)
   end
 
-  defp get_base_slugs(%{watchlist_id: id}),
-    do: id |> Sanbase.UserList.by_id() |> Sanbase.UserList.get_slugs()
+  defp get_base_slugs(%{watchlist_id: id} = map) do
+    detect_cycles!(map)
+    id |> Sanbase.UserList.by_id() |> Sanbase.UserList.get_slugs()
+  end
 
-  defp get_base_slugs(%{watchlist_slug: slug}),
-    do: slug |> Sanbase.UserList.by_slug() |> Sanbase.UserList.get_slugs()
+  defp get_base_slugs(%{watchlist_slug: slug} = map) do
+    detect_cycles!(map)
+    slug |> Sanbase.UserList.by_slug() |> Sanbase.UserList.get_slugs()
+  end
 
-  defp get_base_slugs(%{slugs: slugs}) when is_list(slugs),
-    do: {:ok, slugs}
+  defp get_base_slugs(%{slugs: slugs}) when is_list(slugs) do
+    {:ok, slugs}
+  end
 
   defp included_slugs_by_filters([], _filters_combinator), do: :all
 

--- a/lib/sanbase/model/project/list/selector/transform.ex
+++ b/lib/sanbase/model/project/list/selector/transform.ex
@@ -10,7 +10,6 @@ defmodule Sanbase.Model.Project.ListSelector.Transform do
   def args_to_base_projects(args) do
     case get_in(args, [:selector, :base_projects]) do
       nil -> :all
-      "all" -> :all
       data -> data
     end
   end

--- a/lib/sanbase/model/project/list/selector/validator.ex
+++ b/lib/sanbase/model/project/list/selector/validator.ex
@@ -47,29 +47,33 @@ defmodule Sanbase.Model.Project.ListSelector.Validator do
   end
 
   defp valid_base_projects?(args) do
-    base_projects = get_in(args, [:selector, :base_projects]) || :all
+    base_projects_list = get_in(args, [:selector, :base_projects]) || [:all]
 
-    case base_projects do
-      :all ->
-        true
+    base_projects_list
+    |> Enum.map(fn base_projects ->
+      case base_projects do
+        :all ->
+          true
 
-      %{watchlist_id: id} when is_integer(id) ->
-        true
+        %{watchlist_id: id} when is_integer(id) ->
+          true
 
-      %{watchlist_slug: slug} when is_binary(slug) ->
-        true
+        %{watchlist_slug: slug} when is_binary(slug) ->
+          true
 
-      %{slugs: [_ | _]} ->
-        true
+        %{slugs: [_ | _]} ->
+          true
 
-      _ ->
-        {:error,
-         """
-         Unsupported base_projects #{inspect(base_projects)}.
-         Supported base projects are '{"watchlist_id": <integer>}',
-         '{"watchlsit_slug": "<string>"}' or '{"slugs": [<list of strings>]}'.
-         """}
-    end
+        _ ->
+          {:error,
+           """
+           Unsupported base_projects #{inspect(base_projects)}.
+           Supported base projects are '{"watchlist_id": <integer>}',
+           '{"watchlsit_slug": "<string>"}' or '{"slugs": [<list of strings>]}'.
+           """}
+      end
+    end)
+    |> Enum.find(true, &match?({:error, _}, &1))
   end
 
   defp valid_order_by?(order_by) do

--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -76,7 +76,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
   end
 
   input_object :projects_selector_input_object do
-    field(:base_projects, :base_projects_input_object)
+    field(:base_projects, list_of(:base_projects_input_object))
     field(:filters, list_of(:project_filter_input_object))
     field(:filters_combinator, :filters_combinator, default_value: :and)
     field(:order_by, :project_order_input_object)


### PR DESCRIPTION
## Changes

Improve the base_projects argument from this PR: https://github.com/santiment/sanbase2/pull/2404
Now, instead of a map, base_projects is a list of maps, so many watchlists/slug lists can be used together:
```graphql
{
  allProjects(
    selector: {
      baseProjects: [{ watchlistSlug: "stablecoins" }, { slugs: ["santiment", "bitcoin", "ethereum"]}]
      filters: [
        {
          metric: "daily_active_addresses"
          from: "utc_now-7d"
          to: "utc_now"
          aggregation: AVG
          operator: GREATER_THAN
          threshold: 1000
        }
      ]
      orderBy: {
        metric: "transaction_volume"
        from: "utc_now-7d"
        to: "utc_now"
        aggregation: SUM
        direction: DESC
      }
      pagination: { page: 1, pageSize: 100 }
    }
  ) {
    slug
    avgDaa7d: aggregatedTimeseriesData(
      metric: "daily_active_addresses"
      from: "utc_now-7d"
      to: "utc_now"
      aggregation: AVG
    )
  }
}
```

```json
{
  "data": {
    "allProjects": [
      {
        "avgDaa7d": 101091.875,
        "slug": "tether"
      },
      {
        "avgDaa7d": 25489.25,
        "slug": "usd-coin"
      },
      {
        "avgDaa7d": 7252.75,
        "slug": "multi-collateral-dai"
      },
      {
        "avgDaa7d": 1466.625,
        "slug": "paxos-standard"
      },
      {
        "avgDaa7d": 390301.625,
        "slug": "ethereum"
      },
      {
        "avgDaa7d": 949284.375,
        "slug": "bitcoin"
      }
    ]
  }
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
