### PR TITLE
Add auth method to api_call_history. Add api_call_count aggregated field

### DIFF
--- a/lib/sanbase/clickhouse/api_call_data.ex
+++ b/lib/sanbase/clickhouse/api_call_data.ex
@@ -4,16 +4,19 @@ defmodule Sanbase.Clickhouse.ApiCallData do
   Get data about the API Calls that were made by users
   """
 
+  import Sanbase.Utils.Transform, only: [maybe_unwrap_ok_value: 1]
+
   alias Sanbase.ClickhouseRepo
 
   @doc ~s"""
   Get a timeseries with the total number of api calls made by a user in a given interval
+  and auth method
   """
-  @spec api_call_history(non_neg_integer(), DateTime.t(), DateTime.t(), String.t()) ::
+  @spec api_call_history(non_neg_integer(), DateTime.t(), DateTime.t(), String.t(), Atom.t()) ::
           {:ok, list(%{datetime: DateTime.t(), api_calls_count: non_neg_integer()})}
           | {:error, String.t()}
-  def api_call_history(user_id, from, to, interval) do
-    {query, args} = api_call_history_query(user_id, from, to, interval)
+  def api_call_history(user_id, from, to, interval, auth_method) do
+    {query, args} = api_call_history_query(user_id, from, to, interval, auth_method)
 
     ClickhouseRepo.query_transform(query, args, fn [t, count] ->
       %{
@@ -21,6 +24,19 @@ defmodule Sanbase.Clickhouse.ApiCallData do
         api_calls_count: count
       }
     end)
+  end
+
+  @doc ~s"""
+  Get a timeseries with the total number of api calls made by a user in a given interval
+  and auth method
+  """
+  @spec api_call_count(non_neg_integer(), DateTime.t(), DateTime.t(), Atom.t()) ::
+          {:ok, number()} | {:error, String.t()}
+  def api_call_count(user_id, from, to, auth_method \\ :all) do
+    {query, args} = api_call_count_query(user_id, from, to, auth_method)
+
+    ClickhouseRepo.query_transform(query, args, fn [count] -> count end)
+    |> maybe_unwrap_ok_value()
   end
 
   def active_users_count(from, to) do
@@ -65,7 +81,7 @@ defmodule Sanbase.Clickhouse.ApiCallData do
     end
   end
 
-  defp api_call_history_query(user_id, from, to, interval) do
+  defp api_call_history_query(user_id, from, to, interval, auth_method) do
     interval_sec = Sanbase.DateTimeUtils.str_to_sec(interval)
 
     query = """
@@ -78,6 +94,7 @@ defmodule Sanbase.Clickhouse.ApiCallData do
       dt >= toDateTime(?2) AND
       dt < toDateTime(?3) AND
       user_id = ?4
+      #{maybe_filter_auth_method(auth_method)}
     GROUP BY t
     ORDER BY t
     """
@@ -90,6 +107,34 @@ defmodule Sanbase.Clickhouse.ApiCallData do
     ]
 
     {query, args}
+  end
+
+  defp api_call_count_query(user_id, from, to, auth_method) do
+    query = """
+    SELECT
+      toUInt32(count())
+    FROM
+      #{@table}
+    PREWHERE
+      dt >= toDateTime(?1) AND
+      dt < toDateTime(?2) AND
+      user_id = ?3
+      #{maybe_filter_auth_method(auth_method)}
+    """
+
+    args = [
+      from,
+      to,
+      user_id
+    ]
+
+    {query, args}
+  end
+
+  defp maybe_filter_auth_method(:all), do: ""
+
+  defp maybe_filter_auth_method(method) when method in [:apikey, :jwt, :basic] do
+    "AND auth_method = '#{method}'"
   end
 
   defp active_users_count_query(from, to) do

--- a/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
@@ -45,8 +45,22 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserResolver do
     end
   end
 
-  def api_calls_history(%User{} = user, %{from: from, to: to, interval: interval}, _resolution) do
-    Sanbase.Clickhouse.ApiCallData.api_call_history(user.id, from, to, interval)
+  def api_calls_history(
+        %User{} = user,
+        %{from: from, to: to, interval: interval} = args,
+        _resolution
+      ) do
+    auth_method = Map.get(args, :auth_method, :all)
+    Sanbase.Clickhouse.ApiCallData.api_call_history(user.id, from, to, interval, auth_method)
+  end
+
+  def api_calls_count(
+        %User{} = user,
+        %{from: from, to: to} = args,
+        _resolution
+      ) do
+    auth_method = Map.get(args, :auth_method, :all)
+    Sanbase.Clickhouse.ApiCallData.api_call_count(user.id, from, to, auth_method)
   end
 
   def current_user(_root, _args, %{

--- a/lib/sanbase_web/graphql/schema/types/user_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_types.ex
@@ -18,6 +18,13 @@ defmodule SanbaseWeb.Graphql.UserTypes do
     BillingResolver
   }
 
+  enum :api_call_auth_method do
+    value(:all)
+    value(:apikey)
+    value(:basic)
+    value(:jwt)
+  end
+
   input_object :user_selector_input_object do
     field(:id, :id)
     field(:email, :string)
@@ -150,15 +157,26 @@ defmodule SanbaseWeb.Graphql.UserTypes do
     end
 
     @desc ~s"""
-    The total number of api calls made by the user in a given time range.
-    Counts all API calls made either with JWT or API Key authentication
+    Timeseries data of api calls count per interval in a given time range.
     """
     field :api_calls_history, list_of(:api_call_data) do
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
+      arg(:auth_method, :api_call_auth_method, default_value: :apikey)
       arg(:interval, :interval, default_value: "1d")
 
       cache_resolve(&UserResolver.api_calls_history/3)
+    end
+
+    @desc ~s"""
+    Timeseries data of api calls count per interval in a given time range.
+    """
+    field :api_calls_count, :integer do
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+      arg(:auth_method, :api_call_auth_method, default_value: :apikey)
+
+      cache_resolve(&UserResolver.api_calls_count/3)
     end
   end
 

--- a/test/sanbase_web/graphql/user/user_api_call_data_api_test.exs
+++ b/test/sanbase_web/graphql/user/user_api_call_data_api_test.exs
@@ -18,7 +18,7 @@ defmodule SanbaseWeb.Graphql.UserApiCallDataApiTest do
     dt3_str = "2019-01-03T00:00:00Z"
 
     with_mock Sanbase.Clickhouse.ApiCallData,
-      api_call_history: fn _, _, _, _ ->
+      api_call_history: fn _, _, _, _, _ ->
         {:ok,
          [
            %{datetime: from_iso8601!(dt1_str), api_calls_count: 400},
@@ -64,7 +64,7 @@ defmodule SanbaseWeb.Graphql.UserApiCallDataApiTest do
     dt2_str = "2019-01-03T00:00:00Z"
 
     with_mock Sanbase.Clickhouse.ApiCallData,
-      api_call_history: fn _, _, _, _ ->
+      api_call_history: fn _, _, _, _, _ ->
         {:ok, []}
       end do
       result =
@@ -92,7 +92,7 @@ defmodule SanbaseWeb.Graphql.UserApiCallDataApiTest do
     dt2_str = "2019-01-03T00:00:00Z"
 
     with_mock Sanbase.Clickhouse.ApiCallData,
-      api_call_history: fn _, _, _, _ ->
+      api_call_history: fn _, _, _, _, _ ->
         {:error, "Something went wrong"}
       end do
       result =


### PR DESCRIPTION
## Changes

- Add `apiCallsCount` aggregated field that allows to fetch the total number of API calls in a given period.
- Add `authMethod` that has possible values `ALL`, `APIKEY`, `JWT` (and `BASIC` but this should not be exposed for users) to `apiCallsCount` and `apiCallsHistory`
- 
```graphql
Docs
{
  currentUser {
    apiCallsCount(
      from: "utc_now-30d"
      to: "utc_now"
      authMethod: APIKEY)
    
    apiCallsHistory(
      from: "utc_now-30d"
      to: "utc_now"
      interval: "1d"
      authMethod: APIKEY) {
        datetime
        apiCallsCount
    }
  }
}
​
{
  "data": {
    "currentUser": null
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
