### PR TITLE
Add recent trxs for address where address is only the sender

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/blockchain_address_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/blockchain_address_resolver.ex
@@ -16,7 +16,13 @@ defmodule SanbaseWeb.Graphql.Resolvers.BlockchainAddressResolver do
 
   def recent_transactions(
         _root,
-        %{address: address, type: type, page: page, page_size: page_size},
+        %{
+          address: address,
+          type: type,
+          page: page,
+          page_size: page_size,
+          only_sender: only_sender
+        },
         _resolution
       ) do
     page_size = Enum.min([page_size, 100])
@@ -26,7 +32,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.BlockchainAddressResolver do
     slug = @recent_transactions_type_map[type].slug
 
     with {:ok, recent_transactions} <-
-           module.recent_transactions(address, page, page_size),
+           module.recent_transactions(address,
+             page: page,
+             page_size: page_size,
+             only_sender: only_sender
+           ),
          {:ok, recent_transactions} <-
            MarkExchanges.mark_exchange_wallets(recent_transactions),
          {:ok, recent_transactions} <-

--- a/lib/sanbase_web/graphql/schema/queries/blockchain_address_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/blockchain_address_queries.ex
@@ -12,6 +12,7 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainAddressQueries do
       arg(:type, non_null(:recent_transactions_type))
       arg(:page, non_null(:integer), default_value: 1)
       arg(:page_size, non_null(:integer), default_value: 10)
+      arg(:only_sender, non_null(:boolean), default_value: true)
 
       cache_resolve(&BlockchainAddressResolver.recent_transactions/3)
     end


### PR DESCRIPTION
## Changes
Add `onlySender` (by default `true` until the query is sped up) to fetch only recent transactions for given address where
the address is only the sender.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

## Usage
<!--- (Mainly graphql snippets that showcase how new API is used) -->
```graphql
    {
      recentTransactions(
        address: "0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8"
        type: ERC20,
        onlySender: false
      ) {
        fromAddress {
          address
          labels {
            name
          }
        }
        toAddress {
          address
          labels {
            name
          }
        }
        trxValue
        trxHash
      }
    }
```
<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
