### PR TITLE
Add Enum.uniq_by/2 to projects in project list resolver

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/project/project_list_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_list_resolver.ex
@@ -28,6 +28,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectListResolver do
         apply(Project.List, fun, [opts])
       end
 
+    projects = Enum.uniq_by(projects, & &1.id)
+
     {:ok, projects}
   end
 
@@ -35,6 +37,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectListResolver do
     with {:ok, function} <- Sanbase.WatchlistFunction.cast(function),
          {:ok, data} <- Sanbase.WatchlistFunction.evaluate(function) do
       %{projects: projects, total_projects_count: total_projects_count} = data
+
+      projects = Enum.uniq_by(projects, & &1.id)
 
       {:ok,
        %{
@@ -47,7 +51,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectListResolver do
   end
 
   def all_projects_by_ticker(_root, %{ticker: ticker}, _resolution) do
-    {:ok, Project.List.projects_by_ticker(ticker)}
+    projects = Project.List.projects_by_ticker(ticker) |> Enum.uniq_by(& &1.id)
+
+    {:ok, projects}
   end
 
   def projects_count(_root, args, _resolution) do


### PR DESCRIPTION
## Changes

This query is used as base for almost all project lists. In some cases
(having more than one contract addresses) leads to duplication of the
project in the end list. Adding distinct(true) solves this issue.


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
