### PR TITLE
Improve API call limit internals

### DIFF
--- a/lib/sanbase/api_call_limit/api_call_limit.ex
+++ b/lib/sanbase/api_call_limit/api_call_limit.ex
@@ -31,9 +31,6 @@ defmodule Sanbase.ApiCallLimit do
     "sanapi_pro" => 600
   }
 
-  @quota_size 100
-  def quota_size(), do: @quota_size
-
   @product_api_id Product.product_api()
   @product_sanbase_id Product.product_sanbase()
 
@@ -198,8 +195,9 @@ defmodule Sanbase.ApiCallLimit do
     }
 
     min_remaining = api_calls_remaining |> Map.values() |> Enum.min()
+    quota_size = :rand.uniform(100) + 100
 
-    case Enum.min([@quota_size, min_remaining]) do
+    case Enum.min([quota_size, min_remaining]) do
       0 ->
         now = Timex.now()
 

--- a/lib/sanbase/application.ex
+++ b/lib/sanbase/application.ex
@@ -184,6 +184,9 @@ defmodule Sanbase.Application do
       # Start the Task Supervisor
       {Task.Supervisor, [name: Sanbase.TaskSupervisor]},
 
+      # Mutex for forcing sequential execution when updating api call limits
+      {Mutex, name: Sanbase.ApiCallLimitMutex},
+
       # Start telegram rate limiter. Used both in web and signals
       Sanbase.ExternalServices.RateLimiting.Server.child_spec(
         :telegram_bot_rate_limiting_server,

--- a/lib/sanbase/application.ex
+++ b/lib/sanbase/application.ex
@@ -185,7 +185,10 @@ defmodule Sanbase.Application do
       {Task.Supervisor, [name: Sanbase.TaskSupervisor]},
 
       # Mutex for forcing sequential execution when updating api call limits
-      {Mutex, name: Sanbase.ApiCallLimitMutex},
+      Supervisor.child_spec(
+        {Mutex, name: Sanbase.ApiCallLimitMutex},
+        id: Sanbase.ApiCallLimitMutex
+      ),
 
       # Start telegram rate limiter. Used both in web and signals
       Sanbase.ExternalServices.RateLimiting.Server.child_spec(

--- a/lib/sanbase/signals.ex
+++ b/lib/sanbase/signals.ex
@@ -13,7 +13,10 @@ defmodule Sanbase.Application.Signals do
       # Mutex used when sending notifications for triggered signals
       # Guards agains concurrently sending notifications to a single user
       # which can bypass the limit for signals per day
-      {Mutex, name: Sanbase.SignalMutex},
+      Supervisor.child_spec(
+        {Mutex, name: Sanbase.SignalMutex},
+        id: Sanbase.SignalMutex
+      ),
 
       # Start the signal evaluator cache
       Supervisor.child_spec(

--- a/lib/sanbase_web/admin/auth/api_call_limit.ex
+++ b/lib/sanbase_web/admin/auth/api_call_limit.ex
@@ -2,5 +2,23 @@ defmodule SanbaseWeb.ExAdmin.ApiCallLimit do
   use ExAdmin.Register
 
   register_resource Sanbase.ApiCallLimit do
+    index do
+      column(:id)
+      column(:user, link: true)
+      column(:remote_ip)
+      column(:has_limits)
+      column(:api_calls_limit_plan)
+      column(:api_calls)
+    end
+
+    show acl do
+      attributes_table(all: true)
+    end
+
+    form acl do
+      inputs do
+        input(acl, :has_limits)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Changes
1. This is to reduce the risk of updating the DB concurrently by more than 1 node at the same time. This does not prevent issues connected with race conditions, but makes the second part (using mutex) not happen at the same time across all nodes at the same time.

2. Use mutex to force sequential DB updates for an entity key.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
