### PR TITLE
Add DatabaseSafety Mix Task

### DIFF
--- a/lib/mix/tasks/database_safety.ex
+++ b/lib/mix/tasks/database_safety.ex
@@ -1,0 +1,49 @@
+defmodule Mix.Tasks.DatabaseSafety do
+  @shortdoc "Make sure the destructive operations are not executed on production databases"
+
+  @moduledoc """
+  #{@shortdoc}
+
+  Check the MIX_ENV environment variable, the DATABASE_URL environment variable and
+  the database configuration to determine if the operation is executed in dev
+  or test environment against a production database.
+  """
+
+  use Mix.Task
+  require Sanbase.Utils.Config, as: Config
+
+  @prod_db_patterns ["amazonaws"]
+
+  @impl Mix.Task
+  def run(_args) do
+    env = Config.module_get(Sanbase, :environment)
+    database_url = System.get_env("DATABASE_URL")
+    database_hostname = Config.module_get(Sanbase.Repo, :hostname)
+
+    prod_db_url? =
+      not is_nil(database_url) and
+        Enum.any?(@prod_db_patterns, &String.contains?(database_url, &1))
+
+    prod_db_config? =
+      not is_nil(database_hostname) and
+        Enum.any?(@prod_db_patterns, &String.contains?(database_hostname, &1))
+
+    case env != "prod" and (prod_db_url? or prod_db_config?) do
+      true ->
+        raise(Mix.Error, """
+        Migration execution was stopped due to safety concerns!
+
+        Trying to execute a migration against a production database while not in
+        production environment is prohibited. Either the DATABASE_URL or the
+        Sanbase.Repo config value for :hostname is pointing to a production database.
+
+        DATABASE_URL takes precedence over the config file but even if the config
+        file points to production and the DATABASE_URL env var does not, this would
+        still raise an error
+        """)
+
+      false ->
+        :ok
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -139,12 +139,14 @@ defmodule Sanbase.Mixfile do
     [
       "ecto.setup": [
         "load_dotenv",
+        "database_safety",
         "ecto.drop -r Sanbase.Repo",
         "ecto.create -r Sanbase.Repo",
         "ecto.load -r Sanbase.Repo"
       ],
       "ecto.migrate": [
         "load_dotenv",
+        "database_safety",
         "ecto.migrate -r Sanbase.Repo",
         "ecto.dump -r Sanbase.Repo"
       ],
@@ -153,11 +155,13 @@ defmodule Sanbase.Mixfile do
       ],
       "ecto.rollback": [
         "load_dotenv",
+        "database_safety",
         "ecto.rollback -r Sanbase.Repo",
         "ecto.dump -r Sanbase.Repo"
       ],
       test: [
         "load_dotenv",
+        "database_safety",
         "ecto.create -r Sanbase.Repo --quiet",
         "ecto.load -r Sanbase.Repo --skip-if-loaded",
         "test"
@@ -167,27 +171,32 @@ defmodule Sanbase.Mixfile do
       # and run all tests
       "ecto.setup_all": [
         "load_dotenv",
+        "database_safety",
         "ecto.drop",
         "ecto.create",
         "ecto.load"
       ],
       "ecto.load_all": [
         "load_dotenv",
+        "database_safety",
         "ecto.create --quiet",
         "ecto.load"
       ],
       "ecto.reset_all": [
         "load_dotenv",
+        "database_safety",
         "ecto.drop",
         "ecto.setup_all"
       ],
       "ecto.migrate_all": [
         "load_dotenv",
+        "database_safety",
         "ecto.migrate",
         "ecto.dump"
       ],
       "ecto.rollback_all": [
         "load_dotenv",
+        "database_safety",
         "ecto.rollback",
         "ecto.dump"
       ]


### PR DESCRIPTION
## Changes

Guard against executing (destructive) DB operations (migration, rollback, create, drop, load, etc.) against a production database while working locally.

This is done by adding a Mix.Task that breaks if it finds out that the MIX_ENV is not prod (the actual prod migrations should pass) and the database url/config points to production.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

## Screenshots 
`DATABASE_URL` points to the stage RDS:
![image](https://user-images.githubusercontent.com/6518376/103994279-6f118080-519f-11eb-9a2a-d41d112d179e.png)

`DATABASE_URL` is commented in the env file so the config is used that points to localhost:
![image](https://user-images.githubusercontent.com/6518376/103994699-0545a680-51a0-11eb-9d25-57ff7bb48efe.png)

<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
