### PR TITLE
Fix projects_count when slugs is not list. Introduce erc20 filter

### DIFF
--- a/lib/sanbase/model/project/list/list.ex
+++ b/lib/sanbase/model/project/list/list.ex
@@ -168,6 +168,8 @@ defmodule Sanbase.Model.Project.List do
     |> Enum.filter(fn project -> source in Enum.map(project.source_slug_mappings, & &1.source) end)
   end
 
+  def projects_count(opts \\ [])
+
   def projects_count(opts) do
     projects_query(opts)
     |> select([p], fragment("count(*)"))

--- a/lib/sanbase/model/project/list/selector/list_selector.ex
+++ b/lib/sanbase/model/project/list/selector/list_selector.ex
@@ -124,6 +124,8 @@ defmodule Sanbase.Model.Project.ListSelector do
          slugs when is_list(slugs) <- Keyword.get(opts, :included_slugs) do
       length(slugs)
     else
+      :all -> Project.List.projects_count()
+      :erc20 -> Project.List.erc20_projects_count()
       _ -> length(list)
     end
   end
@@ -190,6 +192,7 @@ defmodule Sanbase.Model.Project.ListSelector do
   end
 
   defp included_slugs_by_filters([], _filters_combinator), do: :all
+  defp included_slugs_by_filters([%{name: "erc20"}], _filters_combinator), do: :erc20
 
   defp included_slugs_by_filters(filters, filters_combinator) when is_list(filters) do
     slug_mapsets =
@@ -265,6 +268,10 @@ defmodule Sanbase.Model.Project.ListSelector do
     case slugs do
       :all ->
         ordered_slugs
+
+      :erc20 ->
+        slugs_mapset = Project.List.erc20_projects_slugs() |> MapSet.new()
+        Enum.filter(ordered_slugs, &(&1 in slugs_mapset))
 
       ^slugs when is_list(slugs) ->
         slugs_mapset = slugs |> MapSet.new()


### PR DESCRIPTION
## Changes

- Introduce a new selector filter that is simply: `{"name": "erc20"}`
- Handle `projects_count` properly when there are no filters (all projects) or there is a single filter `erc20`

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
