### PR TITLE
Add balance in usd in assets_held_by_address

### DIFF
--- a/lib/sanbase_web/graphql/schema/types/historical_balance_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/historical_balance_types.ex
@@ -4,6 +4,7 @@ defmodule SanbaseWeb.Graphql.HistoricalBalanceTypes do
   object :slug_balance do
     field(:slug, non_null(:string))
     field(:balance, non_null(:float))
+    field(:balance_usd, non_null(:float))
   end
 
   object :historical_balance do

--- a/lib/sanbase_web/graphql/schema/types/historical_balance_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/historical_balance_types.ex
@@ -4,6 +4,7 @@ defmodule SanbaseWeb.Graphql.HistoricalBalanceTypes do
   object :slug_balance do
     field(:slug, non_null(:string))
     field(:balance, non_null(:float))
+    # TODO - should be resolved via Dataloader only when it is requested.
     field(:balance_usd, non_null(:float))
   end
 

--- a/test/sanbase/clickhouse/historical_balance/assets_held_by_address_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/assets_held_by_address_test.exs
@@ -9,8 +9,11 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.AssetsHeldByAdderssTest do
   setup do
     p1 = insert(:random_erc20_project)
     p2 = insert(:random_erc20_project)
-
     eth_project = insert(:project, %{name: "Ethereum", slug: "ethereum", ticker: "ETH"})
+
+    insert(:latest_cmc_data, %{coinmarketcap_id: p1.slug, price_usd: 2})
+    insert(:latest_cmc_data, %{coinmarketcap_id: p2.slug, price_usd: 2})
+    insert(:latest_cmc_data, %{coinmarketcap_id: eth_project.slug, price_usd: 2})
 
     {:ok, [p1: p1, p2: p2, eth_project: eth_project]}
   end
@@ -33,9 +36,9 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.AssetsHeldByAdderssTest do
       assert HistoricalBalance.assets_held_by_address(%{address: "0x123", infrastructure: "ETH"}) ==
                {:ok,
                 [
-                  %{slug: context.eth_project.slug, balance: 1000.0},
-                  %{slug: context.p1.slug, balance: 100.0},
-                  %{slug: context.p2.slug, balance: 200.0}
+                  %{slug: context.eth_project.slug, balance: 1000.0, balance_usd: 2000.0},
+                  %{slug: context.p1.slug, balance: 100.0, balance_usd: 200.0},
+                  %{slug: context.p2.slug, balance: 200.0, balance_usd: 400.0}
                 ]}
     end
   end

--- a/test/sanbase_web/graphql/clickhouse/historical_balance/assets_held_by_address_api_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/historical_balance/assets_held_by_address_api_test.exs
@@ -11,6 +11,12 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
     p2 = insert(:random_erc20_project)
 
     eth_project = insert(:project, %{name: "Ethereum", slug: "ethereum", ticker: "ETH"})
+    btc_project = insert(:project, %{name: "Bitcoin", slug: "bitcoin", ticker: "BTC"})
+
+    insert(:latest_cmc_data, %{coinmarketcap_id: p1.slug, price_usd: 2})
+    insert(:latest_cmc_data, %{coinmarketcap_id: p2.slug, price_usd: 2})
+    insert(:latest_cmc_data, %{coinmarketcap_id: eth_project.slug, price_usd: 2})
+    insert(:latest_cmc_data, %{coinmarketcap_id: btc_project.slug, price_usd: 2})
 
     {:ok, [p1: p1, p2: p2, eth_project: eth_project]}
   end
@@ -42,8 +48,12 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
       assert result == %{
                "data" => %{
                  "assetsHeldByAddress" => [
-                   %{"balance" => 1.0e3, "slug" => context.eth_project.slug},
-                   %{"balance" => 200.0, "slug" => context.p2.slug}
+                   %{
+                     "balance" => 1.0e3,
+                     "slug" => context.eth_project.slug,
+                     "balanceUsd" => 2000.0
+                   },
+                   %{"balance" => 200.0, "slug" => context.p2.slug, "balanceUsd" => 400.0}
                  ]
                }
              }
@@ -69,7 +79,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
       assert result == %{
                "data" => %{
                  "assetsHeldByAddress" => [
-                   %{"balance" => 200.0, "slug" => "bitcoin"}
+                   %{"balance" => 200.0, "slug" => "bitcoin", "balanceUsd" => 400.0}
                  ]
                }
              }
@@ -161,6 +171,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
         ){
             slug
             balance
+            balanceUsd
         }
       }
     """


### PR DESCRIPTION
## Changes
Added `balanceUsd` in assets held by address api

```graphql
      {
        assetsHeldByAddress(
          selector: {infrastructure: "#{infrastructure}", address: "#{address}"}
        ){
            slug
            balance
            balanceUsd
        }
      }
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
