### PR TITLE
Support CLICKHOUSE_REPO_ENABLED env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,20 @@
 ## In order to start working, copy the needed env vars from this file
 ## in a .env.dev file. There must be DATABASE_URL and CLICKHOUSE_DATABASE_URL
 ## in order to be able to start the application
+## In case you don't want to or cannot connect to a Clickhouse database,
+## setting `CLICKHOUSE_REPO_ENABLED=false` will disable the ClickhouseRepo
+## and some of the services that run in the background
 
-DATABASE_URL="ecto://postgres:postgres@localhost:5432/sanbase_dev"
-CLICKHOUSE_DATABASE_URL="ecto://sanbase@clickhouse-proxy.stage.san:30901/default"
+# DATABASE_URL="ecto://postgres:postgres@localhost:5432/sanbase_dev"
+# CLICKHOUSE_DATABASE_URL="ecto://sanbase@clickhouse-proxy.stage.san:30901/default"
 
-HYDRA_BASE_URL=http://localhost:4444
-HYDRA_TOKEN_URI=/oauth2/token
-HYDRA_CONSENT_URI=/oauth2/consent/requests
-HYDRA_CLIENT_ID=consent-app
-HYDRA_CLIENT_SECRET=consent-secret
-CLIENTS_THAT_REQUIRE_SAN_TOKENS={"grafana": 50}
+# HYDRA_BASE_URL=http://localhost:4444
+# HYDRA_TOKEN_URI=/oauth2/token
+# HYDRA_CONSENT_URI=/oauth2/consent/requests
+# HYDRA_CLIENT_ID=consent-app
+# HYDRA_CLIENT_SECRET=consent-secret
+# CLIENTS_THAT_REQUIRE_SAN_TOKENS={"grafana": 50}
+# CLICKHOUSE_REPO_ENABLED=true
 
 ## To access stage and production services, WireGuard VPN must be on
 ## Apart from the RDS Postgres, the other services do not contain a secret

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,6 +11,7 @@ config :tzdata, :autoupdate, :disabled
 
 # General application configuration
 config :sanbase,
+  env: Mix.env(),
   ecto_repos: [Sanbase.Repo],
   available_slugs_module: Sanbase.AvailableSlugs
 

--- a/lib/sanbase/application.ex
+++ b/lib/sanbase/application.ex
@@ -173,7 +173,10 @@ defmodule Sanbase.Application do
       SanbaseWeb.Telemetry,
 
       # Start the Clickhouse Repo
-      start_in(Sanbase.ClickhouseRepo, [:prod, :dev]),
+      start_if(
+        fn -> start_in(Sanbase.ClickhouseRepo, [:prod, :dev]) end,
+        fn -> System.get_env("CLICKHOUSE_REPO_ENABLED", "true") |> String.to_existing_atom() end
+      ),
 
       # Star the API call service
       Sanbase.ApiCallLimit.ETS,

--- a/lib/sanbase/application.ex
+++ b/lib/sanbase/application.ex
@@ -174,8 +174,11 @@ defmodule Sanbase.Application do
 
       # Start the Clickhouse Repo
       start_if(
-        fn -> start_in(Sanbase.ClickhouseRepo, [:prod, :dev]) end,
-        fn -> System.get_env("CLICKHOUSE_REPO_ENABLED", "true") |> String.to_existing_atom() end
+        fn -> Sanbase.ClickhouseRepo end,
+        fn ->
+          Application.get_env(:sanbase, :env) in [:dev, :prod] and
+            Sanbase.ClickhouseRepo.enabled?()
+        end
       ),
 
       # Star the API call service

--- a/lib/sanbase/clickhouse_repo.ex
+++ b/lib/sanbase/clickhouse_repo.ex
@@ -1,12 +1,16 @@
 defmodule Sanbase.ClickhouseRepo do
   # Clickhouse tests are done only through mocking the results.
-  @env Application.compile_env(:sanbase, [Sanbase, :env])
+  @env Application.compile_env(:sanbase, :env)
   @adapter if @env() == :test, do: Ecto.Adapters.Postgres, else: ClickhouseEcto
 
   use Ecto.Repo, otp_app: :sanbase, adapter: @adapter
 
   require Sanbase.Utils.Config, as: Config
   require Logger
+
+  def enabled?() do
+    System.get_env("CLICKHOUSE_REPO_ENABLED", "true") |> String.to_existing_atom()
+  end
 
   @doc """
   Dynamically loads the repository url from the

--- a/lib/sanbase/mandrill_api.ex
+++ b/lib/sanbase/mandrill_api.ex
@@ -2,7 +2,7 @@ defmodule Sanbase.MandrillApi do
   require Sanbase.Utils.Config, as: Config
 
   @send_email_url "https://mandrillapp.com/api/1.0/messages/send-template.json"
-  @environment Application.compile_env(:sanbase, [Sanbase, :env])
+  @environment Application.compile_env(:sanbase, :env)
 
   @spec send(any, String.t() | nil, any, map) :: {:error, any} | {:ok, any}
   def send(template, recepient, variables, message_opts \\ %{})


### PR DESCRIPTION
## Changes

Support `CLICKHOUSE_REPO_ENABLED` env var that is used in the local development process. Currently, if sanbase is started without a CH connection it just crashes as the CH Ecto Repo cannot be started. The `MarkExchanges` service also needs CH connection in its initiation process.

Now sanbase can be started as `CLICKHOUSE_REPO_ENABLED=false iex -S mix phx.server` and it won't crash.
This can be used while the current task does not make any CH queries - all the postgres related data. This also makes it easy to work on something without internet connection.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
