### PR TITLE
Fix word context to work within get_trending_words query

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -152,7 +152,7 @@ config :sanbase, Sanbase.TechIndicators,
 config :sanbase, Sanbase.SocialData, metricshub_url: {:system, "METRICS_HUB_URL"}
 
 config :sanbase, Sanbase.SocialData.TrendingWords,
-  trending_words_table: {:system, "TRENDING_WORDS_TABLE", "trending_words_top_500"}
+  trending_words_table: {:system, "TRENDING_WORDS_TABLE", "trending_words_v4_top_500"}
 
 config :waffle,
   storage: Waffle.Storage.S3,

--- a/lib/sanbase_web/graphql/resolvers/social_data_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/social_data_resolver.ex
@@ -130,11 +130,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.SocialDataResolver do
   end
 
   def word_context(%{word: word}, _args, resolution) do
-    %{source: source, from: from, to: to} =
-      Utils.extract_root_query_args(resolution, "trending_words")
+    %{from: from, to: to} = Utils.extract_root_query_args(resolution, "get_trending_words")
 
     async(fn ->
-      SocialData.word_context(word, source, @context_words_default_size, from, to)
+      SocialData.word_context(word, :all, @context_words_default_size, from, to)
     end)
   end
 

--- a/lib/sanbase_web/graphql/schema/queries/social_data_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/social_data_queries.ex
@@ -52,34 +52,6 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
     @desc ~s"""
     Returns lists with trending words and their corresponding trend score.
 
-    Arguments description:
-      * source - one of the following:
-        1. TELEGRAM
-        2. PROFESSIONAL_TRADERS_CHAT
-        3. REDDIT
-        4. ALL
-      * size - an integer showing how many words should be included in the top list (max 30)
-      * hour - an integer from 0 to 23 showing the hour of the day when the calculation was executed
-      * from - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
-      * to - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
-    """
-    field :trending_words, list_of(:trending_words) do
-      meta(access: :restricted)
-
-      arg(:source, non_null(:trending_words_sources))
-      arg(:size, non_null(:integer))
-      arg(:hour, non_null(:integer))
-      arg(:from, non_null(:datetime))
-      arg(:to, non_null(:datetime))
-
-      complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl, %{allow_realtime_data: true})
-      cache_resolve(&SocialDataResolver.trending_words/3, ttl: 600, max_ttl_offset: 240)
-    end
-
-    @desc ~s"""
-    Returns lists with trending words and their corresponding trend score.
-
     * from - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
     * to - a string representation of datetime value according to the iso8601 standard, e.g. "2018-04-16T10:02:19Z"
     * interval - a string representing at what interval the words are returned

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -139,7 +139,6 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           :top_social_gainers_losers,
           :topic_search,
           :transaction_volume,
-          :trending_words,
           :word_context,
           :word_trend_score
         ]

--- a/test/sanbase_web/graphql/social_data/social_data_api_test.exs
+++ b/test/sanbase_web/graphql/social_data/social_data_api_test.exs
@@ -17,63 +17,6 @@ defmodule SanbaseWeb.Graphql.SocialDataApiTest do
     %{conn: conn}
   end
 
-  describe "trending words" do
-    test "successfully fetch trending words", context do
-      success_response = [
-        %{
-          datetime: DateTimeUtils.from_iso8601!("2018-11-10T00:00:00Z"),
-          top_words: [
-            %{score: 167.74716011726295, word: "pele"},
-            %{score: 137.61557511242117, word: "people"}
-          ]
-        }
-      ]
-
-      with_mock SocialData, trending_words: fn _, _, _, _, _ -> {:ok, success_response} end do
-        args = %{
-          source: "TELEGRAM",
-          from: "2018-01-09T00:00:00Z",
-          to: "2018-01-10T00:00:00Z",
-          size: 1,
-          hour: 8
-        }
-
-        query = trending_words_query(args)
-        result = execute_and_parse_success_response(context.conn, query, "trendingWords")
-
-        assert result == %{
-                 "data" => %{
-                   "trendingWords" => [
-                     %{
-                       "datetime" => "2018-11-10T00:00:00Z",
-                       "topWords" => [
-                         %{"score" => 167.74716011726295, "word" => "pele"},
-                         %{"score" => 137.61557511242117, "word" => "people"}
-                       ]
-                     }
-                   ]
-                 }
-               }
-      end
-    end
-
-    test "fetch trending words - proper error is returned", context do
-      with_mock SocialData, trending_words: fn _, _, _, _, _ -> {:error, @error_response} end do
-        args = %{
-          source: "TELEGRAM",
-          from: "2018-01-09T00:00:00Z",
-          to: "2018-01-10T00:00:00Z",
-          size: 1,
-          hour: 8
-        }
-
-        query = trending_words_query(args)
-        error = execute_and_parse_error_response(context.conn, query, "trendingWords")
-        assert error =~ @error_response
-      end
-    end
-  end
-
   describe "word context" do
     test "successfully fetch word context", context do
       success_response = [
@@ -378,26 +321,6 @@ defmodule SanbaseWeb.Graphql.SocialDataApiTest do
         assert error =~ @error_response
       end
     end
-  end
-
-  defp trending_words_query(args) do
-    """
-    {
-      trendingWords(
-        source: #{args.source},
-        from: "#{args.from}",
-        to: "#{args.to}",
-        size: 5,
-        hour: 8
-        ){
-          datetime
-          topWords{
-            word
-            score
-          }
-        }
-      }
-    """
   end
 
   defp word_context_query(args) do


### PR DESCRIPTION
## Changes

- Fix how word context is fetched when it's part of get_trending_words query
- Remove the old trending_words query as they cannot easily work in parallel. It is not used.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
