### PR TITLE
Expose caching params in the getMetric API

### DIFF
--- a/lib/sanbase_web/graphql/cache/cache.ex
+++ b/lib/sanbase_web/graphql/cache/cache.ex
@@ -209,8 +209,13 @@ defmodule SanbaseWeb.Graphql.Cache do
   # Helper functions
 
   def cache_key(name, args, opts \\ []) do
-    base_ttl = Keyword.get(opts, :ttl, @ttl)
-    max_ttl_offset = Keyword.get(opts, :max_ttl_offset, @max_ttl_offset)
+    base_ttl = args[:caching_params][:base_ttl] || Keyword.get(opts, :ttl, @ttl)
+
+    max_ttl_offset =
+      args[:caching_params][:max_ttl_offset] ||
+        Keyword.get(opts, :max_ttl_offset, @max_ttl_offset)
+
+    max_ttl_offset = Enum.max([max_ttl_offset, 5])
 
     # Used to randomize the TTL for lists of objects like list of projects
     additional_args = Map.take(args, [:slug, :id])

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -31,6 +31,13 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     value(:ignored_slugs)
     value(:watchlist_id)
     value(:watchlist_slug)
+    value(:base_ttl)
+    value(:max_ttl_offset)
+  end
+
+  input_object :caching_params_input_object do
+    field(:base_ttl, :integer)
+    field(:max_ttl_offset, :integer)
   end
 
   input_object :metric_target_selector_input_object do
@@ -300,6 +307,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       arg(:aggregation, :aggregation, default_value: nil)
       arg(:transform, :timeseries_metric_transform_input_object)
       arg(:include_incomplete_data, :boolean, default_value: false)
+      arg(:caching_params, :caching_params_input_object)
 
       complexity(&Complexity.from_to_interval/3)
       middleware(AccessControl)
@@ -315,6 +323,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       arg(:aggregation, :aggregation, default_value: nil)
       arg(:transform, :timeseries_metric_transform_input_object)
       arg(:include_incomplete_data, :boolean, default_value: false)
+      arg(:caching_params, :caching_params_input_object)
 
       complexity(&Complexity.from_to_interval/3)
       middleware(AccessControl)
@@ -336,6 +345,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
       arg(:aggregation, :aggregation, default_value: nil)
+      arg(:caching_params, :caching_params_input_object)
 
       complexity(&Complexity.from_to_interval/3)
       middleware(AccessControl)

--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -299,6 +299,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       arg(:to, non_null(:datetime))
       arg(:aggregation, :aggregation, default_value: nil)
       arg(:include_incomplete_data, :boolean, default_value: false)
+      arg(:caching_params, :caching_params_input_object)
 
       complexity(&Complexity.from_to_interval/3)
       middleware(AccessControl)


### PR DESCRIPTION
## Changes
> Note: The usage of these options should be **VERY** limited and **VERY** careful.

Expose caching params in case more live data is needed. Exposed only for `timeseriesData`, `timeseriesDataPerSlug` and `aggregatedTimeseriesData` (both on getMetric and project types)

```graphql
{
  getMetric(metric: "price_usd"){
    timeseriesData(
      selector: {slug: "bitcoin"}
      from: "utc_now-7d"
      to: "utc_now"
      cachingParams: {baseTtl: 5, maxTtlOffset: 5}
    ) {
      datetime
      value
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
