### PR TITLE
Reduce the projects_number scraped from CMC from 10k to 5k

### DIFF
--- a/config/scheduler_config.exs
+++ b/config/scheduler_config.exs
@@ -131,6 +131,6 @@ config :sanbase, Sanbase.Scrapers.Scheduler,
       # integer ids.
       schedule: "@daily",
       task:
-        {Sanbase.ExternalServices.Coinmarketcap.TickerFetcher, :work, [projects_number: 10_000]}
+        {Sanbase.ExternalServices.Coinmarketcap.TickerFetcher, :work, [projects_number: 5_000]}
     ]
   ]


### PR DESCRIPTION
With 10k the API returns HTTP 400 and does not work. It also does not
work with 6k, but works fine with 5k.

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
