### PR TITLE
Add telegram_channel alert channel

### DIFF
--- a/docs/user-triggers-api.md
+++ b/docs/user-triggers-api.md
@@ -41,7 +41,7 @@ These are the fields describing a trigger.
 
 - **type** Defines the type of the trigger. Can be one of: `["trending_words", "price_volume_difference", "metric_signal", "daily_metric_signal", "wallet_movement"]`
 - **target**: Slug or list of slugs or watchlist or ethereum addresses or list of ethereum addresses - `{"slug": "naga"} | {"slug": ["ethereum", "santiment"]} | {"watchlist_id": watchlsit_id} | {"eth_address": "0x123"} | {"eth_address": ["0x123", "0x234"]}`.
-- **channel**: A channel where the alert is sent. Can be one of `"telegram" | "email" | "web_push" | {"webhook": <webhook_url>}` or a list of any combination.
+- **channel**: A channel where the alert is sent. Can be one of `"telegram" | "email" | "web_push" | {"webhook": <webhook_url>}` | `{"telegram_channel": "@<channel_name>"}` or a list of any combination. In case of telegram_channel, the bot must be an admin that has post messages priviliges.
 - **time_window**: `1d`, `4w`, `1h` - Time string we use throughout the API for `interval`
 - **operation** - A map describing the operation that triggers the alert. Check the examples.
 - **threshold** - Float threshold used in `price_volume_difference`


### PR DESCRIPTION
## Changes

Now the alert channel can be a JSON map like this: `{"telegram_channel": "@san_alerts"}`. The signals bot must be made an admin of the channel with only `Post Messages` privileges: 
![image](https://user-images.githubusercontent.com/6518376/107237569-8c03d280-6a2f-11eb-9d32-5efbb488fa30.png)

All of the existing alerts can be configured to send to a telegram channel. The only difference is the notifications will be seen by many people and not only the alert owner. Because of this, the only difference of the payload is that the link to the alert that fired is omitted at the end.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
