### PR TITLE
Rework Kaiko price scraping

### DIFF
--- a/config/scheduler_config.exs
+++ b/config/scheduler_config.exs
@@ -109,6 +109,11 @@ config :sanbase, Sanbase.Scrapers.Scheduler,
       schedule: "7-59/30 * * * *",
       task: {Sanbase.Billing, :sync_liquidity_subscriptions_staked_users, []}
     ],
+    get_kaiko_realtime_prices: [
+      # Start scraping at every round minute
+      schedule: "* * * * *",
+      task: {Sanbase.Kaiko, :run, []}
+    ],
     sync_coinmarketcap_projects: [
       # When a new project gets a coinmarketcap string slug associated with it,
       # it is not until the first scrape which includes it, that it also gets the

--- a/lib/sanbase/external_services/coinmarketcap/price_scraping_progress.ex
+++ b/lib/sanbase/external_services/coinmarketcap/price_scraping_progress.ex
@@ -31,6 +31,15 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.PriceScrapingProgress do
     end
   end
 
+  def last_scraped_all_source(source) do
+    from(progress in __MODULE__,
+      where: progress.source == ^source,
+      select: {progress.identifier, progress.datetime}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
   def store_progress(identifier, source, datetime) do
     (Repo.get_by(__MODULE__, identifier: identifier, source: source) || %__MODULE__{})
     |> changeset(%{identifier: identifier, source: source, datetime: datetime})

--- a/lib/sanbase/scrapers/kaiko.ex
+++ b/lib/sanbase/scrapers/kaiko.ex
@@ -9,38 +9,69 @@ defmodule Sanbase.Kaiko do
   @source "kaiko"
   @url "https://eu.market-api.kaiko.io"
   @recv_timeout 30_000
-  @interval "10s"
-  @interval_sec 10
+  @interval "1s"
+  @interval_sec 1
+  @rounds_per_minute 12
 
+  # Scraping is started every round minute. We want to scrape every 5 seconds.
+  # Because of this, every minute scrape consists of many scrapres.
   def run(opts \\ []) do
-    # cronjobs cannot use sub-minute intervals.
-    # The cronjob runs every 30 seconds by starting it twice, the second time
-    # with a sleep: 30_000 argument, so it sleeps for 30 seconds before running
-    if milliseconds = Keyword.get(opts, :sleep), do: Process.sleep(milliseconds)
+    rounds = Keyword.get(opts, :rounds_per_minute, @rounds_per_minute)
+    sleep_seconds = div(60, rounds)
 
+    for i <- 1..rounds do
+      do_run()
+      # The last time there's no need for sleeping after the scraping
+      if i != rounds, do: Process.sleep(sleep_seconds * 1000)
+    end
+  end
+
+  defp do_run() do
     Logger.info("Scraping Kaiko prices for #{length(pairs())} pairs")
 
     now = Timex.now()
+    naive_now = DateTime.to_naive(now) |> NaiveDateTime.truncate(:second)
+    last_dt_map = Progress.last_scraped_all_source("kaiko")
 
-    Sanbase.Parallel.map(
-      pairs(),
-      fn {base_asset, slug} ->
-        # Build the timerange params. All `end_time` params are matching
-        usd_timerange = get_timerange_params(base_asset, "usd", now)
-        btc_timerange = get_timerange_params(base_asset, "btc", now)
+    data =
+      Sanbase.Parallel.map(
+        pairs(),
+        fn {base_asset, slug} ->
+          # Build the timerange params. All `end_time` params are matching
+          usd_timerange = get_timerange_params(base_asset, "usd", now, last_dt_map)
+          btc_timerange = get_timerange_params(base_asset, "btc", now, last_dt_map)
 
-        # Fetch the USD and BTC prices and combine them based on
-        # the datetime. The datetime is rounded to `@interval_sec` buckets
-        # so this combination can be done in more cases
-        usd_prices = current_prices(base_asset, "usd", usd_timerange)
-        btc_prices = current_prices(base_asset, "btc", btc_timerange)
-        prices = combine_prices(usd_prices, btc_prices)
+          # Fetch the USD and BTC prices and combine them based on
+          # the datetime. The datetime is rounded to `@interval_sec` buckets
+          # so this combination can be done in more cases
+          usd_prices = current_prices(base_asset, "usd", usd_timerange)
+          btc_prices = current_prices(base_asset, "btc", btc_timerange)
+          prices = combine_prices(usd_prices, btc_prices)
 
-        :ok = export_to_kafka(prices, slug)
+          :ok = export_to_kafka(prices, slug)
 
-        :ok = store_last_datetime(usd_prices, base_asset, "usd")
-        :ok = store_last_datetime(btc_prices, base_asset, "btc")
-      end
+          [
+            get_last_datetime(usd_prices, base_asset, "usd"),
+            get_last_datetime(btc_prices, base_asset, "btc")
+          ]
+        end,
+        max_concurrency: 50,
+        map_type: :flat_map
+      )
+      |> Enum.reject(&is_nil/1)
+      |> Enum.map(fn {identifier, dt} ->
+        %{
+          identifier: identifier,
+          datetime: DateTime.to_naive(dt) |> NaiveDateTime.truncate(:second),
+          source: @source,
+          updated_at: naive_now,
+          inserted_at: naive_now
+        }
+      end)
+
+    Sanbase.Repo.insert_all(Progress, data,
+      on_conflict: :replace_all,
+      conflict_target: [:identifier, :source]
     )
   end
 
@@ -91,14 +122,14 @@ defmodule Sanbase.Kaiko do
       URI.encode_query(opts)
   end
 
-  defp last_datetime_scraped(slug) do
-    case Progress.last_scraped(slug, @source) do
-      nil -> Timex.shift(Timex.now(), minutes: -10)
-      %DateTime{} = dt -> dt
+  defp last_datetime_scraped(slug, last_dt_map) do
+    case Map.get(last_dt_map, slug) do
+      nil -> Timex.shift(Timex.now(), minutes: -1)
+      %NaiveDateTime{} = ndt -> DateTime.from_naive!(ndt, "Etc/UTC")
     end
   end
 
-  def store_last_datetime(prices, base_asset, quote_asset) do
+  def get_last_datetime(prices, base_asset, quote_asset) do
     identifier = identifier(base_asset, quote_asset)
 
     prices
@@ -106,17 +137,18 @@ defmodule Sanbase.Kaiko do
     |> Enum.max_by(fn elem -> elem.datetime end, DateTime, fn -> nil end)
     |> case do
       %{datetime: %DateTime{} = dt} ->
-        {:ok, _} = Progress.store_progress(identifier, @source, dt)
-        :ok
+        {identifier, dt}
 
       _ ->
-        :ok
+        nil
     end
   end
 
-  defp get_timerange_params(base_asset, quote_asset, end_time) do
+  defp get_timerange_params(base_asset, quote_asset, end_time, last_dt_map) do
+    identifier = identifier(base_asset, quote_asset)
+
     %{
-      start_time: identifier(base_asset, quote_asset) |> last_datetime_scraped(),
+      start_time: last_datetime_scraped(identifier, last_dt_map),
       end_time: end_time,
       interval: @interval
     }

--- a/test/sanbase/scrapers/kaiko_scraping_test.exs
+++ b/test/sanbase/scrapers/kaiko_scraping_test.exs
@@ -39,7 +39,7 @@ defmodule Sanbase.KaikoTest do
 
     Sanbase.Mock.prepare_mock(HTTPoison, :get, mock_fun)
     |> Sanbase.Mock.run_with_mocks(fn ->
-      Sanbase.Kaiko.run()
+      Sanbase.Kaiko.run(rounds_per_minute: 1)
 
       prices =
         Sanbase.InMemoryKafka.Producer.get_state()


### PR DESCRIPTION
## Changes

- Run the Kaiko price scraping more often with higher granularity (every 5 seconds and get the data with 1 second granularity)
- Rework the postgres communication and reduce it to 2 queries - fetch all `last_scraped` with 1 query and record back all the new last scraped with a single query as well.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
