### PR TITLE
Improve GraphQL caching

### DIFF
--- a/lib/sanbase/alerts/trigger/settings/eth_wallet_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/eth_wallet_trigger_settings.ex
@@ -14,7 +14,7 @@ defmodule Sanbase.Alert.Trigger.EthWalletTriggerSettings do
   import Sanbase.Validation
   import Sanbase.Alert.Validation
   import Sanbase.Alert.OperationEvaluation
-  import Sanbase.DateTimeUtils, only: [str_to_sec: 1, round_datetime: 2]
+  import Sanbase.DateTimeUtils, only: [str_to_sec: 1, round_datetime: 1]
 
   alias __MODULE__
   alias Sanbase.Alert.Type
@@ -125,7 +125,7 @@ defmodule Sanbase.Alert.Trigger.EthWalletTriggerSettings do
 
   defp balance_change(addresses, slug, from, to) do
     cache_key =
-      {:balance_change, addresses, slug, round_datetime(from, 300), round_datetime(to, 300)}
+      {:balance_change, addresses, slug, round_datetime(from), round_datetime(to)}
       |> Sanbase.Cache.hash()
 
     Cache.get_or_store(

--- a/lib/sanbase/alerts/trigger/settings/metric/metric_trigger_helper.ex
+++ b/lib/sanbase/alerts/trigger/settings/metric/metric_trigger_helper.ex
@@ -66,7 +66,7 @@ defmodule Sanbase.Alert.Trigger.MetricTriggerHelper do
     %{metric: metric, time_window: time_window} = settings
 
     cache_key =
-      {:metric_alert, metric, selector, time_window, round_datetime(Timex.now(), 300)}
+      {:metric_alert, metric, selector, time_window, round_datetime(Timex.now())}
       |> Sanbase.Cache.hash()
 
     %{

--- a/lib/sanbase/alerts/trigger/settings/wallet_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/wallet_trigger_settings.ex
@@ -12,7 +12,7 @@ defmodule Sanbase.Alert.Trigger.WalletTriggerSettings do
   use Vex.Struct
 
   import Sanbase.{Validation, Alert.Validation}
-  import Sanbase.DateTimeUtils, only: [round_datetime: 2, str_to_sec: 1]
+  import Sanbase.DateTimeUtils, only: [round_datetime: 1, str_to_sec: 1]
 
   alias __MODULE__
   alias Sanbase.Model.Project
@@ -130,7 +130,7 @@ defmodule Sanbase.Alert.Trigger.WalletTriggerSettings do
 
   defp balance_change(selector, address, from, to) do
     cache_key =
-      {:wallet_signal, selector, address, round_datetime(from, 300), round_datetime(to, 300)}
+      {:wallet_signal, selector, address, round_datetime(from), round_datetime(to)}
       |> Sanbase.Cache.hash()
 
     Sanbase.Alert.Evaluator.Cache.get_or_store(cache_key, fn ->

--- a/lib/sanbase/model/project/list/selector/transform.ex
+++ b/lib/sanbase/model/project/list/selector/transform.ex
@@ -54,8 +54,9 @@ defmodule Sanbase.Model.Project.ListSelector.Transform do
   def transform_from_to(%{from: from, to: to} = map) do
     %{
       map
-      | from: if(is_binary(from), do: from_iso8601!(from) |> round_datetime(), else: from),
-        to: if(is_binary(to), do: from_iso8601!(to) |> round_datetime(), else: to)
+      | from:
+          if(is_binary(from), do: from_iso8601!(from) |> DateTime.truncate(:second), else: from),
+        to: if(is_binary(to), do: from_iso8601!(to) |> DateTime.truncate(:second), else: to)
     }
   end
 
@@ -99,8 +100,8 @@ defmodule Sanbase.Model.Project.ListSelector.Transform do
         to = Timex.shift(now, seconds: -shift_to_by)
 
         map
-        |> Map.put(:from, from |> round_datetime())
-        |> Map.put(:to, to |> round_datetime())
+        |> Map.put(:from, from |> DateTime.truncate(:second))
+        |> Map.put(:to, to |> DateTime.truncate(:second))
     end
   end
 

--- a/lib/sanbase/model/project/list/selector/transform.ex
+++ b/lib/sanbase/model/project/list/selector/transform.ex
@@ -55,8 +55,8 @@ defmodule Sanbase.Model.Project.ListSelector.Transform do
     %{
       map
       | from:
-          if(is_binary(from), do: from_iso8601!(from) |> DateTime.truncate(:second), else: from),
-        to: if(is_binary(to), do: from_iso8601!(to) |> DateTime.truncate(:second), else: to)
+          if(is_binary(from), do: from_iso8601!(from) |> round_datetime(rounding: :up), else: from),
+        to: if(is_binary(to), do: from_iso8601!(to) |> round_datetime(rounding: :up), else: to)
     }
   end
 
@@ -100,8 +100,8 @@ defmodule Sanbase.Model.Project.ListSelector.Transform do
         to = Timex.shift(now, seconds: -shift_to_by)
 
         map
-        |> Map.put(:from, from |> DateTime.truncate(:second))
-        |> Map.put(:to, to |> DateTime.truncate(:second))
+        |> Map.put(:from, from |> round_datetime(rounding: :up))
+        |> Map.put(:to, to |> round_datetime(rounding: :up))
     end
   end
 

--- a/lib/sanbase/scrapers/kaiko.ex
+++ b/lib/sanbase/scrapers/kaiko.ex
@@ -1,7 +1,6 @@
 defmodule Sanbase.Kaiko do
   alias Sanbase.ExternalServices.Coinmarketcap.PriceScrapingProgress, as: Progress
 
-  import Sanbase.DateTimeUtils, only: [round_datetime: 2]
   require Logger
   require Sanbase.Utils.Config, as: Config
 
@@ -10,7 +9,6 @@ defmodule Sanbase.Kaiko do
   @url "https://eu.market-api.kaiko.io"
   @recv_timeout 30_000
   @interval "1s"
-  @interval_sec 1
   @rounds_per_minute 12
 
   # Scraping is started every round minute. We want to scrape every 5 seconds.
@@ -90,7 +88,7 @@ defmodule Sanbase.Kaiko do
           datetime:
             elem["timestamp"]
             |> DateTime.from_unix!(:millisecond)
-            |> round_datetime(@interval_sec)
+            |> DateTime.truncate(:second)
         }
       end)
     else

--- a/lib/sanbase/utils/datetime/utils.ex
+++ b/lib/sanbase/utils/datetime/utils.ex
@@ -189,8 +189,18 @@ defmodule Sanbase.DateTimeUtils do
   This function is used to bucket all datetimes in a given interval to a single
   datetime, usable in cache key construction
   """
-  def round_datetime(datetime, seconds \\ 300) do
-    DateTime.to_unix(datetime)
+  def round_datetime(datetime, opts \\ []) do
+    seconds = Keyword.get(opts, :second, 300)
+    rounding = Keyword.get(opts, :rounding, :down)
+    datetime_unix = DateTime.to_unix(datetime)
+
+    datetime_unix =
+      case rounding do
+        :up -> datetime_unix + seconds
+        :down -> datetime_unix
+      end
+
+    datetime_unix
     |> div(seconds)
     |> Kernel.*(seconds)
     |> DateTime.from_unix!()

--- a/lib/sanbase_web/graphql/cache/cache.ex
+++ b/lib/sanbase_web/graphql/cache/cache.ex
@@ -226,6 +226,7 @@ defmodule SanbaseWeb.Graphql.Cache do
     ttl = base_ttl + ({name, additional_args} |> :erlang.phash2(max_ttl_offset))
 
     if args[:caching_params] do
+      # This is used in the Absinthe's before_send function
       Process.put(:__change_absinthe_before_send_caching_ttl__, ttl)
     end
 

--- a/lib/sanbase_web/graphql/document/document_provider.ex
+++ b/lib/sanbase_web/graphql/document/document_provider.ex
@@ -86,6 +86,8 @@ defmodule SanbaseWeb.Graphql.Phase.Document.Execution.CacheDocument do
            context.auth.auth_method}
           |> Sanbase.Cache.hash()
 
+        # The ttl/max_ttl_offset might be rewritten in case `caching_params`
+        # are provided. The rewriting happens in the absinthe before_send function
         cache_key =
           SanbaseWeb.Graphql.Cache.cache_key(
             {"bp_root", additional_keys_hash},

--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -4,7 +4,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
   alias Sanbase.Model.Project
 
   import Absinthe.Resolution.Helpers, only: [on_load: 2]
-  import Sanbase.DateTimeUtils, only: [round_datetime: 2]
+  import Sanbase.DateTimeUtils, only: [round_datetime: 1]
   import Sanbase.Utils.ErrorHandling, only: [handle_graphql_error: 3]
 
   alias SanbaseWeb.Graphql.SanbaseDataloader
@@ -163,8 +163,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
         args,
         %{context: %{loader: loader}}
       ) do
-    to = Map.get(args, :to, Timex.now()) |> round_datetime(300)
-    from = Map.get(args, :from, Timex.shift(to, days: -30)) |> round_datetime(300)
+    to = Map.get(args, :to, Timex.now()) |> round_datetime()
+    from = Map.get(args, :from, Timex.shift(to, days: -30)) |> round_datetime()
 
     data = %{project: project, from: from, to: to}
 

--- a/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
@@ -56,8 +56,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver do
         {:ok, from, to} =
           calibrate_incomplete_data_params(include_incomplete_data, Metric, metric, from, to)
 
-        from = from |> Sanbase.DateTimeUtils.round_datetime(300)
-        to = to |> Sanbase.DateTimeUtils.round_datetime(300)
+        from = from |> DateTime.truncate(:second)
+        to = to |> DateTime.truncate(:second)
         {:ok, opts} = selector_args_to_opts(args)
 
         data = %{


### PR DESCRIPTION
## Changes

A few changes:
- If there are `cachingParams` - propagate them (not in the nicest way right now) to the Absinthe before_send function.
- Do not round datetimes that much, only truncate seconds.  This will improve the time new data appears in the API. With the old implementation, if the provided `to` datetime is 17:34:50, it will be rounded down to 17:30:00 and the fact that now the price updates much more is not visible in the API even if there is no caching.
  - This might have some slight negative effects in some computations (in the dataloader) but this should occur rarely and have no negative effects.
 
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
