### PR TITLE
Rework contract addresses handling

### DIFF
--- a/lib/sanbase/model/project/contract_address.ex
+++ b/lib/sanbase/model/project/contract_address.ex
@@ -50,4 +50,10 @@ defmodule Sanbase.Model.Project.ContractAddress do
   def list_to_main_contract_address(list) when is_list(list) do
     Enum.find(list, &(&1.label == "main")) || List.first(list)
   end
+
+  def list_to_latest_onchain_contract_address(list) when is_list(list) do
+    Enum.find(list, &(&1.label == "latest_onchain_contract")) ||
+      Enum.find(list, &(&1.label == "main")) ||
+      List.first(list)
+  end
 end

--- a/lib/sanbase/model/project/project.ex
+++ b/lib/sanbase/model/project/project.ex
@@ -134,14 +134,13 @@ defmodule Sanbase.Model.Project do
 
   defdelegate describe(project), to: Project.Description
 
-  defdelegate contract_info_infrastructure_by_slug(slug), to: Project.ContractData
+  defdelegate contract_info_infrastructure_by_slug(slug, opts \\ []), to: Project.ContractData
 
-  defdelegate contract_info_by_slug(slug), to: Project.ContractData
+  defdelegate contract_info_by_slug(slug, opts \\ []), to: Project.ContractData
 
-  defdelegate contract_info(project), to: Project.ContractData
+  defdelegate contract_info(project, opts \\ []), to: Project.ContractData
 
-  defdelegate contract_address(project), to: Project.ContractData
-  defdelegate contract_addresses(project), to: Project.ContractData
+  defdelegate contract_address(project, opts \\ []), to: Project.ContractData
 
   defdelegate has_contract_address?(project), to: Project.ContractData
 

--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -25,7 +25,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
         },
         _resolution
       ) do
-    with {:ok, contract, token_decimals} <- Project.contract_info_by_slug(slug),
+    with {:ok, contract, token_decimals} <-
+           Project.contract_info_by_slug(slug, contract_type: :latest_onchain_contract),
          {:ok, top_holders} <-
            TopHolders.top_holders(
              slug,
@@ -53,7 +54,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
         },
         _resolution
       ) do
-    with {:ok, contract, token_decimals} <- Project.contract_info_by_slug(slug),
+    with {:ok, contract, token_decimals} <-
+           Project.contract_info_by_slug(slug, contract_type: :latest_onchain_contract),
          {:ok, percent_of_total_supply} <-
            TopHolders.percent_of_total_supply(
              contract,


### PR DESCRIPTION
## Changes

- Clean the contract addresses handling a little bit.
- Introduce `opts` keyword param that controls which contract address to return.
- Introduce a new contract label `latest_onchain_contract` that points to the latest real on-chain contract address. This is used together with the custom contracts like `reputation_contract` which is needed when a project has more than 1 contract or migrates to a new one.
  - After deploying everything will work 1:1 as before. The only change occurs after the new label is added to any project.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
