### PR TITLE
Add mutation for updating short urls

### DIFF
--- a/lib/sanbase/short_url/short_url.ex
+++ b/lib/sanbase/short_url/short_url.ex
@@ -36,6 +36,19 @@ defmodule Sanbase.ShortUrl do
     |> Repo.insert()
   end
 
+  def update(user_id, short_url, params) do
+    case get(short_url) do
+      %__MODULE__{user_id: ^user_id} = struct ->
+        struct
+        |> changeset(params)
+        |> Repo.update()
+
+      _ ->
+        {:error,
+         "The Short URL #{short_url} does not exist or belongs to another user and cannot be updated"}
+    end
+  end
+
   def get(short_url) when is_binary(short_url) do
     from(
       url in __MODULE__,

--- a/lib/sanbase_web/graphql/resolvers/short_url_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/short_url_resolver.ex
@@ -16,6 +16,21 @@ defmodule SanbaseWeb.Graphql.Resolvers.ShortUrlResolver do
     do_create_short_url(args, nil)
   end
 
+  def update_short_url(_root, %{short_url: short_url} = args, %{
+        context: %{auth: %{current_user: current_user}}
+      }) do
+    params = Map.delete(args, :short_url)
+    Sanbase.ShortUrl.update(current_user.id, short_url, params)
+  end
+
+  def update_short_url(_root, %{} = args, _resolution) do
+    {:error,
+     """
+     Only authenticated users can update Short URLs.
+     Short URLs created by anonymous users cannot be updated.
+     """}
+  end
+
   def get_full_url(_root, %{short_url: short_url}, _resolution) do
     case Sanbase.ShortUrl.get(short_url) do
       nil -> {:error, "Short url #{short_url} does not exist."}

--- a/lib/sanbase_web/graphql/schema/queries/short_url_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/short_url_queries.ex
@@ -24,5 +24,13 @@ defmodule SanbaseWeb.Graphql.Schema.ShortUrlQueries do
 
       resolve(&ShortUrlResolver.create_short_url/3)
     end
+
+    field :update_short_url, :short_url do
+      arg(:short_url, non_null(:string))
+      arg(:data, :string)
+      arg(:full_url, :string)
+
+      resolve(&ShortUrlResolver.update_short_url/3)
+    end
   end
 end

--- a/test/sanbase_web/graphql/short_url/short_url_api_test.exs
+++ b/test/sanbase_web/graphql/short_url/short_url_api_test.exs
@@ -1,7 +1,15 @@
 defmodule SanbaseWeb.Graphql.ShortUrlApiTest do
   use SanbaseWeb.ConnCase, async: false
 
+  import Sanbase.Factory
   import SanbaseWeb.Graphql.TestHelpers
+
+  setup do
+    user = insert(:user)
+    conn = setup_jwt_auth(build_conn(), user)
+
+    %{conn: conn, user: user}
+  end
 
   test "create and fetch short url", context do
     short_url =
@@ -24,13 +32,65 @@ defmodule SanbaseWeb.Graphql.ShortUrlApiTest do
              "slug=santiment&from=2020-01-01&to=2020-02-02&interval=10d&isHidden=true&isCartesian=true"
   end
 
+  test "update short url", context do
+    short_url =
+      insert(:short_url, full_url: "/something", data: "slug=santiment", user: context.user)
+
+    updated_short_url =
+      update_short_url(context.conn, %{
+        short_url: short_url.short_url,
+        full_url: "/new_full_url",
+        data:
+          "slug=santiment&from=2020-01-01&to=2020-02-02&interval=10d&isHidden=true&isCartesian=true"
+      })
+      |> get_in(["data", "updateShortUrl"])
+
+    assert updated_short_url["shortUrl"] == short_url.short_url
+    assert updated_short_url["fullUrl"] == "/new_full_url"
+
+    assert updated_short_url["data"] ==
+             "slug=santiment&from=2020-01-01&to=2020-02-02&interval=10d&isHidden=true&isCartesian=true"
+  end
+
+  test "cannot update anonymously created short url", context do
+    short_url = insert(:short_url, full_url: "/something", data: "slug=santiment", user: nil)
+
+    error =
+      update_short_url(context.conn, %{
+        short_url: short_url.short_url,
+        data: "test"
+      })
+      |> Map.get("errors")
+      |> List.first()
+      |> Map.get("message")
+
+    assert error =~ "does not exist or belongs to another user and cannot be updated"
+  end
+
+  test "cannot update short urls of other users", context do
+    user = insert(:user)
+    short_url = insert(:short_url, full_url: "/something", data: "slug=santiment", user: user)
+
+    error =
+      update_short_url(context.conn, %{
+        short_url: short_url.short_url,
+        data: "test"
+      })
+      |> Map.get("errors")
+      |> List.first()
+      |> Map.get("message")
+
+    assert error =~ "does not exist or belongs to another user and cannot be updated"
+  end
+
   defp create_short_url(conn, args) do
     mutation = """
     mutation {
       createShortUrl(
         fullUrl: "#{args.full_url}"
         data: "#{args.data}"){
-        shortUrl
+          shortUrl
+          data
       }
     }
     """
@@ -55,5 +115,24 @@ defmodule SanbaseWeb.Graphql.ShortUrlApiTest do
     |> post("/graphql", mutation_skeleton(mutation))
     |> json_response(200)
     |> get_in(["data", "getFullUrl"])
+  end
+
+  defp update_short_url(conn, args) do
+    mutation = """
+    mutation {
+      updateShortUrl(
+        shortUrl: "#{args[:short_url]}"
+        fullUrl: "#{args[:full_url]}"
+        data: "#{args[:data]}"){
+          data
+          shortUrl
+          fullUrl
+        }
+    }
+    """
+
+    conn
+    |> post("/graphql", mutation_skeleton(mutation))
+    |> json_response(200)
   end
 end


### PR DESCRIPTION
## Changes

Allow updating the `data` and `fullUrl` fields of a short URL.
There are 2 rules that apply:
- Short URLs created by anonymous users cannot be updated.
- A user can update only the short urls created by them.

```graphql
mutation {
    updateShortUrl(
      shortUrl: "existing_short_url"
      data: "new data"
      fullUrl: "new full url"){
        data
        shortUrl
        fullUrl
      }
  }
```

<!--- Describe your changes -->

## Ticket

[Notion Ticket](https://www.notion.so/santiment/updatable-shortUrl-to-make-same-flow-with-shortUrl-as-on-TradingView-65f2591aeb4d4722a42f6abd79484e8d)

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
