### PR TITLE
Return price_eth from intraday metrics after fix

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -2084,8 +2084,8 @@
   },
   {
     "human_readable_name": "Price in ETH",
-    "name": "price_eth_5m",
-    "metric": "price_eth_5m",
+    "name": "price_eth",
+    "metric": "price_eth",
     "version": "2019-01-01",
     "access": "free",
     "selectors": ["slug"],

--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -2098,5 +2098,22 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Price in ETH",
+    "name": "price_eth_5m",
+    "metric": "price_eth",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
   }
 ]

--- a/lib/sanbase/prices/metric_adapter.ex
+++ b/lib/sanbase/prices/metric_adapter.ex
@@ -5,7 +5,7 @@ defmodule Sanbase.Price.MetricAdapter do
   @aggregations [:any, :sum, :avg, :min, :max, :last, :first, :median]
   @default_aggregation :last
 
-  @timeseries_metrics ["price_usd", "price_btc", "price_eth", "volume_usd", "marketcap_usd"]
+  @timeseries_metrics ["price_usd", "price_btc", "volume_usd", "marketcap_usd"]
   @histogram_metrics []
   @table_metrics []
 

--- a/lib/sanbase/prices/price.ex
+++ b/lib/sanbase/prices/price.ex
@@ -12,7 +12,7 @@ defmodule Sanbase.Price do
   alias Sanbase.ClickhouseRepo
 
   @default_source "coinmarketcap"
-  @metrics [:price_usd, :price_btc, :price_eth, :marketcap_usd, :volume_usd]
+  @metrics [:price_usd, :price_btc, :marketcap_usd, :volume_usd]
   @metrics @metrics ++ Enum.map(@metrics, &Atom.to_string/1)
   @aggregations Sanbase.Metric.SqlQuery.Helper.aggregations()
 
@@ -169,17 +169,6 @@ defmodule Sanbase.Price do
         ) ::
           timeseries_metric_data_result
   def timeseries_metric_data(slug_or_slugs, metric, from, to, interval, opts \\ [])
-
-  def timeseries_metric_data(slug_or_slugs, "price_eth", from, to, interval, opts) do
-    async with {:ok, prices_slug_usd} <- timeseries_data(slug_or_slugs, from, to, interval, opts),
-               {:ok, prices_ethereum_usd} <- timeseries_data("ethereum", from, to, interval, opts) do
-      transform_func = fn value1, value2 ->
-        if value1 != nil && value2 != 0 && value2 != nil, do: value1 / value2, else: 0
-      end
-
-      {:ok, merge_by_datetime(prices_slug_usd, prices_ethereum_usd, transform_func, :price_usd)}
-    end
-  end
 
   def timeseries_metric_data("TOTAL_ERC20", metric, from, to, interval, opts) do
     Project.List.erc20_projects_slugs()

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -36,7 +36,6 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "price_usd",
         "price_eth",
         "price_usd_5m",
-        "price_eth_5m",
         "volume_usd",
         "twitter_followers",
         "total_supply",

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -36,6 +36,7 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "price_usd",
         "price_eth",
         "price_usd_5m",
+        "price_eth_5m",
         "volume_usd",
         "twitter_followers",
         "total_supply",


### PR DESCRIPTION
## Changes

Bring back `price_eth` from intraday metrics after it is historically backfilled

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
