### PR TITLE
Migrate chart_configurations metrics type

### DIFF
--- a/priv/repo/migrations/20210226144252_change_metrics_array_type.exs
+++ b/priv/repo/migrations/20210226144252_change_metrics_array_type.exs
@@ -1,0 +1,16 @@
+defmodule Sanbase.Repo.Migrations.ChangeMetricsArrayType do
+  use Ecto.Migration
+
+  def up do
+    execute("ALTER TABLE chart_configurations ALTER COLUMN metrics TYPE text[];")
+    execute("ALTER TABLE chart_configurations ALTER COLUMN metrics SET DEFAULT array[]::text[];")
+  end
+
+  def down do
+    execute("ALTER TABLE chart_configurations ALTER COLUMN metrics TYPE varchar(255)[];")
+
+    execute(
+      "ALTER TABLE chart_configurations ALTER COLUMN metrics SET DEFAULT array[]::varchar[];"
+    )
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -350,7 +350,7 @@ CREATE TABLE public.chart_configurations (
     title character varying(255),
     description text,
     is_public boolean DEFAULT false,
-    metrics character varying(255)[] DEFAULT ARRAY[]::character varying[],
+    metrics text[] DEFAULT ARRAY[]::text[],
     anomalies character varying(255)[] DEFAULT ARRAY[]::character varying[],
     inserted_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,


### PR DESCRIPTION
## Changes

The frontend builds some custom metrics that are in the format `<metric_name>__MM__<metric_name>__MM__<metric_name>...` that can easily go over the limit of 255. It will require much more work to refactor the frontend not to use this compared to running a DB migration that changes the type from `varchar(255)` to `text`
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
