### PR TITLE
Add price_btc change metrics to API

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/change_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/change_metrics.json
@@ -3475,4 +3475,58 @@
     "has_incomplete_data": false,
     "data_type": "timeseries"
   }
+  ,
+  {
+    "human_readable_name": "Price in BTC Change (1d)",
+    "name": "price_btc_change_1d",
+    "metric": "price_btc_change_1d",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  }
+,
+  {
+    "human_readable_name": "Price in BTC Change (7d)",
+    "name": "price_btc_change_7d",
+    "metric": "price_btc_change_7d",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  }
+,
+  {
+    "human_readable_name": "Price in BTC Change (30d)",
+    "name": "price_btc_change_30d",
+    "metric": "price_btc_change_30d",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  }
 ]

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -77,7 +77,10 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "price_usd_change_1h",
         "price_eth_change_1d",
         "price_eth_change_7d",
-        "price_eth_change_30d"
+        "price_eth_change_30d",
+        "price_btc_change_1d",
+        "price_btc_change_7d",
+        "price_btc_change_30d"
       ]
       |> Enum.sort()
 


### PR DESCRIPTION
## Changes

Added API specs for the following CH metrics:

- price_btc_change_1d
- price_btc_change_7d
- price_btc_change_30d

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
