### PR TITLE
Run the sync with stripe once per 20 minutes

### DIFF
--- a/config/scheduler_config.exs
+++ b/config/scheduler_config.exs
@@ -66,7 +66,7 @@ config :sanbase, Sanbase.Scrapers.Scheduler,
       task: {Sanbase.Billing, :sync_products_with_stripe, []}
     ],
     sync_stripe_subscriptions: [
-      schedule: "2-59/5 * * * *",
+      schedule: "2-59/20 * * * *",
       task: {Sanbase.Billing, :sync_stripe_subscriptions, []}
     ],
     remove_duplicate_subscriptions: [


### PR DESCRIPTION
Before it was running once every 5 minutes. The task cannot finish in 5
minutes so it was overlapping

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
