### PR TITLE
Implement ohlc aggregation for get_metric timeseries_data

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/metric/metric_adapter.ex
@@ -8,14 +8,9 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
   @behaviour Sanbase.Metric.Behaviour
 
   import Sanbase.Clickhouse.MetricAdapter.SqlQuery
+  import Sanbase.Metric.Transform, only: [exec_timeseries_data_query: 2]
 
-  import Sanbase.Utils.Transform,
-    only: [
-      maybe_unwrap_ok_value: 1,
-      maybe_apply_function: 2,
-      transform_metric_result_func: 0,
-      transform_metric_ohlc_result_func: 0
-    ]
+  import Sanbase.Utils.Transform, only: [maybe_unwrap_ok_value: 1, maybe_apply_function: 2]
 
   alias __MODULE__.{HistogramMetric, FileHandler, TableMetric}
 
@@ -80,11 +75,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
 
     {query, args} = timeseries_data_query(metric, slug, from, to, interval, aggregation, filters)
 
-    if aggregation == :ohlc do
-      ClickhouseRepo.query_transform(query, args, transform_metric_ohlc_result_func())
-    else
-      ClickhouseRepo.query_transform(query, args, transform_metric_result_func())
-    end
+    exec_timeseries_data_query(query, args)
   end
 
   @impl Sanbase.Metric.Behaviour

--- a/lib/sanbase/clickhouse/metric/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/metric/metric_adapter.ex
@@ -73,12 +73,26 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
 
     {query, args} = timeseries_data_query(metric, slug, from, to, interval, aggregation, filters)
 
-    ClickhouseRepo.query_transform(query, args, fn [unix, value] ->
-      %{
-        datetime: DateTime.from_unix!(unix),
-        value: value
-      }
-    end)
+    if aggregation == :ohlc do
+      ClickhouseRepo.query_transform(query, args, fn [unix, open, high, low, close] ->
+        %{
+          datetime: DateTime.from_unix!(unix),
+          value_ohlc: %{
+            open: open,
+            high: high,
+            low: low,
+            close: close
+          }
+        }
+      end)
+    else
+      ClickhouseRepo.query_transform(query, args, fn [unix, value] ->
+        %{
+          datetime: DateTime.from_unix!(unix),
+          value: value
+        }
+      end)
+    end
   end
 
   @impl Sanbase.Metric.Behaviour

--- a/lib/sanbase/metric/sql_query_helper.ex
+++ b/lib/sanbase/metric/sql_query_helper.ex
@@ -1,7 +1,16 @@
 defmodule Sanbase.Metric.SqlQuery.Helper do
-  @aggregations [:any, :sum, :avg, :min, :max, :last, :first, :median, :count]
+  @aggregations [:any, :sum, :avg, :min, :max, :last, :first, :median, :count, :ohlc]
 
   def aggregations(), do: @aggregations
+
+  def aggregation(:ohlc, value_column, dt_column) do
+    """
+    argMin(#{value_column}, #{dt_column}) AS open,
+    max(#{value_column}) AS high,
+    min(#{value_column}) AS low,
+    argMax(#{value_column}, #{dt_column}) AS close
+    """
+  end
 
   def aggregation(:last, value_column, dt_column), do: "argMax(#{value_column}, #{dt_column})"
   def aggregation(:first, value_column, dt_column), do: "argMin(#{value_column}, #{dt_column})"

--- a/lib/sanbase/metric/transform.ex
+++ b/lib/sanbase/metric/transform.ex
@@ -67,4 +67,22 @@ defmodule Sanbase.Metric.Transform do
   end
 
   def remove_missing_values({:error, error}), do: {:error, error}
+
+  def exec_timeseries_data_query(query, args) do
+    Sanbase.ClickhouseRepo.query_transform(query, args, fn
+      [unix, value] ->
+        %{datetime: DateTime.from_unix!(unix), value: value}
+
+      [unix, open, high, low, close] ->
+        %{
+          datetime: DateTime.from_unix!(unix),
+          value_ohlc: %{
+            open: open,
+            high: high,
+            low: low,
+            close: close
+          }
+        }
+    end)
+  end
 end

--- a/lib/sanbase/prices/metric_adapter.ex
+++ b/lib/sanbase/prices/metric_adapter.ex
@@ -2,7 +2,7 @@ defmodule Sanbase.Price.MetricAdapter do
   @behaviour Sanbase.Metric.Behaviour
   alias Sanbase.Price
 
-  @aggregations [:any, :sum, :avg, :min, :max, :last, :first, :median]
+  @aggregations [:any, :sum, :avg, :min, :max, :last, :first, :median, :ohlc]
   @default_aggregation :last
 
   @timeseries_metrics ["price_usd", "price_btc", "volume_usd", "marketcap_usd"]

--- a/lib/sanbase/prices/price.ex
+++ b/lib/sanbase/prices/price.ex
@@ -5,7 +5,13 @@ defmodule Sanbase.Price do
   import Sanbase.Price.SqlQuery
 
   import Sanbase.Utils.Transform,
-    only: [maybe_unwrap_ok_value: 1, maybe_apply_function: 2, wrap_ok: 1]
+    only: [
+      maybe_unwrap_ok_value: 1,
+      maybe_apply_function: 2,
+      wrap_ok: 1,
+      transform_metric_result_func: 0,
+      transform_metric_ohlc_result_func: 0
+    ]
 
   import Sanbase.Metric.Transform, only: [maybe_nullify_values: 1, remove_missing_values: 1]
 
@@ -199,34 +205,9 @@ defmodule Sanbase.Price do
       timeseries_metric_data_query(slug_or_slugs, metric, from, to, interval, source, aggregation)
 
     if aggregation == :ohlc do
-      ClickhouseRepo.query_transform(
-        query,
-        args,
-        fn
-          [timestamp, open, high, low, close] ->
-            %{
-              datetime: DateTime.from_unix!(timestamp),
-              value_ohlc: %{
-                open: open,
-                high: high,
-                low: low,
-                close: close
-              }
-            }
-        end
-      )
+      ClickhouseRepo.query_transform(query, args, transform_metric_ohlc_result_func())
     else
-      ClickhouseRepo.query_transform(
-        query,
-        args,
-        fn
-          [timestamp, value] ->
-            %{
-              datetime: DateTime.from_unix!(timestamp),
-              value: value
-            }
-        end
-      )
+      ClickhouseRepo.query_transform(query, args, transform_metric_result_func())
     end
   end
 

--- a/lib/sanbase/prices/price.ex
+++ b/lib/sanbase/prices/price.ex
@@ -8,12 +8,15 @@ defmodule Sanbase.Price do
     only: [
       maybe_unwrap_ok_value: 1,
       maybe_apply_function: 2,
-      wrap_ok: 1,
-      transform_metric_result_func: 0,
-      transform_metric_ohlc_result_func: 0
+      wrap_ok: 1
     ]
 
-  import Sanbase.Metric.Transform, only: [maybe_nullify_values: 1, remove_missing_values: 1]
+  import Sanbase.Metric.Transform,
+    only: [
+      maybe_nullify_values: 1,
+      remove_missing_values: 1,
+      exec_timeseries_data_query: 2
+    ]
 
   alias Sanbase.Model.Project
   alias Sanbase.ClickhouseRepo
@@ -204,11 +207,7 @@ defmodule Sanbase.Price do
     {query, args} =
       timeseries_metric_data_query(slug_or_slugs, metric, from, to, interval, source, aggregation)
 
-    if aggregation == :ohlc do
-      ClickhouseRepo.query_transform(query, args, transform_metric_ohlc_result_func())
-    else
-      ClickhouseRepo.query_transform(query, args, transform_metric_result_func())
-    end
+    exec_timeseries_data_query(query, args)
   end
 
   def timeseries_metric_data_per_slug(slug_or_slugs, metric, from, to, interval, opts) do

--- a/lib/sanbase/utils/transform.ex
+++ b/lib/sanbase/utils/transform.ex
@@ -130,27 +130,4 @@ defmodule Sanbase.Utils.Transform do
   def maybe_transform_from_address(address), do: address
   def maybe_transform_to_address("0x0000000000000000000000000000000000000000"), do: "burn"
   def maybe_transform_to_address(address), do: address
-
-  def transform_metric_result_func() do
-    fn [unix, value] ->
-      %{
-        datetime: DateTime.from_unix!(unix),
-        value: value
-      }
-    end
-  end
-
-  def transform_metric_ohlc_result_func() do
-    fn [unix, open, high, low, close] ->
-      %{
-        datetime: DateTime.from_unix!(unix),
-        value_ohlc: %{
-          open: open,
-          high: high,
-          low: low,
-          close: close
-        }
-      }
-    end
-  end
 end

--- a/lib/sanbase/utils/transform.ex
+++ b/lib/sanbase/utils/transform.ex
@@ -130,4 +130,27 @@ defmodule Sanbase.Utils.Transform do
   def maybe_transform_from_address(address), do: address
   def maybe_transform_to_address("0x0000000000000000000000000000000000000000"), do: "burn"
   def maybe_transform_to_address(address), do: address
+
+  def transform_metric_result_func() do
+    fn [unix, value] ->
+      %{
+        datetime: DateTime.from_unix!(unix),
+        value: value
+      }
+    end
+  end
+
+  def transform_metric_ohlc_result_func() do
+    fn [unix, open, high, low, close] ->
+      %{
+        datetime: DateTime.from_unix!(unix),
+        value_ohlc: %{
+          open: open,
+          high: high,
+          low: low,
+          close: close
+        }
+      }
+    end
+  end
 end

--- a/lib/sanbase_web/graphql/helpers/utils.ex
+++ b/lib/sanbase_web/graphql/helpers/utils.ex
@@ -83,6 +83,8 @@ defmodule SanbaseWeb.Graphql.Helpers.Utils do
     |> MapSet.new()
   end
 
+  def requested_fields(_), do: MapSet.new([])
+
   # Private functions
   defp maybe_add_field(opts, :additional_filters, selector) do
     case Map.split(selector, [:owner, :label]) do

--- a/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
@@ -312,6 +312,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
       value_ohlc_requested? && aggregation != :ohlc ->
         {:error, "Selected field valueOhlc works only with aggregation ohlc"}
 
+      value_requested? and value_ohlc_requested? ->
+        {:error, "Cannot select value and valueOhlc fields at the same time"}
+
       true ->
         true
     end

--- a/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
@@ -85,12 +85,19 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     end)
   end
 
-  def timeseries_data(_root, args, %{source: %{metric: metric}}) do
-    fetch_timeseries_data(metric, args, :timeseries_data)
+  def timeseries_data(_root, args, %{source: %{metric: metric}} = resolution) do
+    requested_fields = requested_fields(resolution)
+    fetch_timeseries_data(metric, args, requested_fields, :timeseries_data)
   end
 
-  def timeseries_data_per_slug(_root, args, %{source: %{metric: metric}}) do
-    fetch_timeseries_data(metric, args, :timeseries_data_per_slug)
+  def timeseries_data(_root, args, %{source: %{metric: metric}} = resolution) do
+    requested_fields = requested_fields(resolution)
+    fetch_timeseries_data(metric, args, requested_fields, :timeseries_data)
+  end
+
+  def timeseries_data_per_slug(_root, args, %{source: %{metric: metric}} = resolution) do
+    requested_fields = requested_fields(resolution)
+    fetch_timeseries_data(metric, args, requested_fields, :timeseries_data_per_slug)
   end
 
   def aggregated_timeseries_data(
@@ -154,13 +161,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   # timeseries_data and timeseries_data_per_slug are processed and fetched in
   # exactly the same way. The only difference is the function that is called
   # from the Metric module.
-  defp fetch_timeseries_data(metric, args, function) do
+  defp fetch_timeseries_data(metric, args, requested_fields, function) do
     transform =
       Map.get(args, :transform, %{type: "none"})
       |> Map.update!(:type, &Inflex.underscore/1)
 
     with {:ok, selector} <- args_to_selector(args),
          {:ok, opts} <- selector_args_to_opts(args),
+         true <- valid_timeseries_selection?(requested_fields, args),
          {:ok, from, to, interval} <-
            transform_datetime_params(selector, metric, transform, args),
          {:ok, result} <- apply(Metric, function, [metric, selector, from, to, interval, opts]),
@@ -289,6 +297,23 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
       true
     else
       {:error, "Missing required `from` argument"}
+    end
+  end
+
+  defp valid_timeseries_selection?(requested_fields, args) do
+    aggregation = Map.get(args, :aggregation, nil)
+    value_requested? = MapSet.member?(requested_fields, "value")
+    value_ohlc_requested? = MapSet.member?(requested_fields, "valueOhlc")
+
+    cond do
+      aggregation == :ohlc && value_requested? ->
+        {:error, "Field value shouldn't be selected when using aggregation ohlc"}
+
+      value_ohlc_requested? && aggregation != :ohlc ->
+        {:error, "Selected field valueOhlc works only with aggregation ohlc"}
+
+      true ->
+        true
     end
   end
 end

--- a/lib/sanbase_web/graphql/schema/types/aggregation_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/aggregation_types.ex
@@ -11,5 +11,6 @@ defmodule SanbaseWeb.Graphql.AggregationTypes do
     value(:min)
     value(:max)
     value(:median)
+    value(:ohlc)
   end
 end

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -68,6 +68,14 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
   object :metric_data do
     field(:datetime, non_null(:datetime))
     field(:value, :float)
+    field(:value_ohlc, :ohlc_data)
+  end
+
+  object :ohlc_data do
+    field(:open, :float)
+    field(:close, :float)
+    field(:high, :float)
+    field(:low, :float)
   end
 
   object :slug_float_value_pair do

--- a/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
@@ -227,6 +227,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesDataTest do
     # manually choose a metric that supports all different aggregations
     metric = "daily_active_addresses"
     {:ok, %{available_aggregations: aggregations}} = Metric.metadata(metric)
+    aggregations = aggregations -- [:ohlc]
 
     Sanbase.Mock.prepare_mock2(
       &Sanbase.Clickhouse.MetricAdapter.timeseries_data/6,


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

## Usage
<!--- (Mainly graphql snippets that showcase how new API is used) -->
```graphql
      {
        getMetric(metric: "price_usd"){
          timeseriesData(
            slug: "ethereum"
            from: "utc_now-5d"
            to: "utc_now"
            interval: "1d"
            aggregation: OHLC
            ){
              datetime
              valueOhlc {
                open
                high
                low
                close
              }
            }
        }
      }
```

```graphql
      {
        getMetric(metric: "daily_active_addresses"){
          timeseriesData(
            slug: "ethereum"
            from: "utc_now-30d"
            to: "utc_now"
            interval: "1w"
            aggregation: OHLC
            ){
              datetime
              valueOhlc {
                open
                high
                low
                close
              }
            }
        }
      }
```

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
