### PR TITLE
Expose the alerts left to send today in user settings

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/user_settings_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user_settings_resolver.ex
@@ -9,6 +9,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserSettingsResolver do
     {:ok, UserSettings.settings_for(user)}
   end
 
+  def alerts_per_dy_limit_left(_settings, _args, %{
+        context: %{auth: %{current_user: current_user}}
+      }) do
+    UserSettings.max_alerts_to_send(current_user)
+  end
+
   def update_user_settings(_root, %{settings: settings}, %{
         context: %{auth: %{current_user: current_user}}
       }) do

--- a/lib/sanbase_web/graphql/schema/types/user_settings_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_settings_types.ex
@@ -1,6 +1,8 @@
 defmodule SanbaseWeb.Graphql.UserSettingsTypes do
   use Absinthe.Schema.Notation
 
+  alias SanbaseWeb.Graphql.Resolvers.UserSettingsResolver
+
   enum :newsletter_subscription_type do
     value(:weekly)
     value(:daily)
@@ -20,6 +22,11 @@ defmodule SanbaseWeb.Graphql.UserSettingsTypes do
     field(:alert_notify_email, :boolean)
     field(:alert_notify_telegram, :boolean)
     field(:alerts_per_day_limit, :json)
+
+    field :alerts_per_day_limit_left, :json do
+      resolve(&UserSettingsResolver.alerts_per_dy_limit_left/3)
+    end
+
     field(:favorite_metrics, list_of(:string))
     # Deprecated fields
     field :signal_notify_telegram, :boolean do


### PR DESCRIPTION
## Changes

These new values will be shown along the limits per day in the accounts settings.
![image](https://user-images.githubusercontent.com/6518376/111981110-e3599000-8b0f-11eb-8a43-3557e9cb4d9f.png)

Request:
```graphql
{
  currentUser {
    settings {
      alertsPerDayLimit
      alertsPerDayLimitLeft
    }
  }
}
```

Response:
```json
{
  "data": {
    "currentUser": {
      "settings": {
        "alertsPerDayLimit": {
          "email": 50,
          "telegram": 100,
          "telegram_channel": 1000,
          "webhook": 1000,
          "webpush": 1000
        },
        "alertsPerDayLimitLeft": {
          "email": 50,
          "telegram": 98,
          "telegram_channel": 1000,
          "webhook": 1000,
          "webpush": 1000
        }
      }
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
