### PR TITLE
Remove the caching from allProjectsByFunction in some cases

### DIFF
--- a/lib/sanbase_web/graphql/schema/queries/project_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/project_queries.ex
@@ -63,7 +63,8 @@ defmodule SanbaseWeb.Graphql.Schema.ProjectQueries do
       arg(:function, :json)
 
       middleware(ProjectPermissions)
-      cache_resolve(&ProjectListResolver.all_projects_by_function/3)
+
+      cache_resolve(&ProjectListResolver.all_projects_by_function/3, honor_do_not_cache_flag: true)
     end
 
     field :all_projects_by_ticker, list_of(:project) do


### PR DESCRIPTION
## Changes

If all_projects_by_function is used to paginate watchlists, it uses the
base_projects field to supply the watchlist. As watchlists do not have
caching, we want to disable the caching in this case, too. This is done
to improve the UX, as otherwise users will not see any changes to the
watchlist minutes after they are made

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
