### PR TITLE
Run a cronjob to update the api call limits table

### DIFF
--- a/config/scheduler_config.exs
+++ b/config/scheduler_config.exs
@@ -45,6 +45,10 @@ config :sanbase, Sanbase.Scrapers.Scheduler,
   scheduler_enabled: {:system, "QUANTUM_SCHEDULER_ENABLED", false},
   timeout: 30_000,
   jobs: [
+    update_api_call_limit_plans: [
+      schedule: "@daily",
+      task: {Sanbase.ApiCallLimit.Sync, :run, []}
+    ],
     notify_users_for_comments: [
       schedule: "@hourly",
       task: {Sanbase.Comments.Notification, :notify_users, []}

--- a/lib/sanbase/api_call_limit/api_call_limit_sync.ex
+++ b/lib/sanbase/api_call_limit/api_call_limit_sync.ex
@@ -1,0 +1,21 @@
+defmodule Sanbase.ApiCallLimit.Sync do
+  @moduledoc """
+  Force an update of the stored subscription plans for users in the api call limit table.
+
+  When a subscription changes, the ApiCallLimit.update_user_plan/1 function must be
+  explicitly invoked, otherwise the old api plan restrictions could still apply.
+  To remedy this, invoke the update function once a day prophylactically.
+  """
+  import Ecto.Query
+
+  alias Sanbase.Repo
+  alias Sanbase.ApiCallLimit
+
+  def run() do
+    users =
+      from(acl in ApiCallLimit, where: not is_nil(acl.user_id), preload: [:user])
+      |> Repo.all()
+      |> Enum.map(& &1.user)
+      |> Enum.each(&ApiCallLimit.update_user_plan/1)
+  end
+end


### PR DESCRIPTION
## Changes
There might be cases where the ApiCallLimit.update_user_plan/1 function
is not invoked when a subscription changes. In order to remedy this,
invoke the function once a day in a cronjob

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
