### PR TITLE
Rework top holders last datetime computed at.

### DIFF
--- a/lib/sanbase/clickhouse/top_holders/top_holders_sql_query.ex
+++ b/lib/sanbase/clickhouse/top_holders/top_holders_sql_query.ex
@@ -175,7 +175,7 @@ defmodule Sanbase.Clickhouse.TopHolders.SqlQuery do
   def last_datetime_computed_at_query(table, contract) do
     query = """
     SELECT
-      toUnixTimestamp(argMax(computed_at, dt))
+      toUnixTimestamp(max(dt))
     FROM #{table} FINAL
     #{table_to_where_keyword(table)}
       contract = ?1


### PR DESCRIPTION
## Changes

The top holders table do not have a separate computed_at field so take
the last dt instead.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
