### PR TITLE
Add pagination to top_holders query

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -21,10 +21,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
           slug: slug,
           from: from,
           to: to,
-          number_of_holders: number_of_holders
-        },
+          page: page,
+          page_size: page_size
+        } = args,
         _resolution
       ) do
+    page_size = Enum.min([args[:number_of_holders] || page_size, 100])
+    opts = [page: page, page_size: page_size]
+
     with {:ok, contract, token_decimals} <-
            Project.contract_info_by_slug(slug, contract_type: :latest_onchain_contract),
          {:ok, top_holders} <-
@@ -34,7 +38,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
              token_decimals,
              from,
              to,
-             number_of_holders
+             opts
            ) do
       {:ok, top_holders}
     else

--- a/lib/sanbase_web/graphql/schema/queries/blockchain_metric_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/blockchain_metric_queries.ex
@@ -233,7 +233,13 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainMetricQueries do
       meta(access: :restricted)
 
       arg(:slug, non_null(:string))
-      arg(:number_of_holders, non_null(:integer), default_value: 20)
+
+      arg(:number_of_holders, non_null(:integer),
+        deprecate: "pageSize argument should be used instead"
+      )
+
+      arg(:page, non_null(:integer), default_value: 1)
+      arg(:page_size, non_null(:integer), default_value: 20)
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
 


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

Deprecate `number_of_holders` field in `topHolders` query.
Add `page` and `pageSize` so we can paginate the query.

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
