### PR TITLE
Add update_blockchain_address_user_pair mutation API

### DIFF
--- a/lib/mix/failure_test_formatter.ex
+++ b/lib/mix/failure_test_formatter.ex
@@ -15,19 +15,18 @@ defmodule Sanbase.FailedTestFormatter do
   def handle_cast({:test_finished, %ExUnit.Test{state: {:failed, _}} = test}, config) do
     config =
       case test do
-        %ExUnit.Test{state: {:failed, [{:error, _error, failures}]}} when is_list(failures) ->
-          case List.last(failures) do
-            {_module, _test_name, _, [file: file, line: line]} ->
-              %{
-                config
-                | failed: ["#{file}:#{line}" | config.failed],
-                  failure_counter: config.failure_counter + 1
-              }
+        %ExUnit.Test{state: {:failed, [{:error, _error, failures}]}} = test
+        when is_list(failures) ->
+          # Add a leading dot so the file:line string can be copy-pasted in the
+          # terminal to directly execute it
+          file = String.replace_leading(test.tags.file, File.cwd!(), ".")
+          line = test.tags.line
 
-            elem ->
-              IO.warn("Unexpected element in failures: #{inspect(elem)}")
-              config
-          end
+          %{
+            config
+            | failed: ["#{file}:#{line}" | config.failed],
+              failure_counter: config.failure_counter + 1
+          }
 
         _ ->
           IO.warn("Unexpected failed test format.")

--- a/lib/sanbase/blockchain_address/blockchain_address.ex
+++ b/lib/sanbase/blockchain_address/blockchain_address.ex
@@ -26,6 +26,19 @@ defmodule Sanbase.BlockchainAddress do
     end
   end
 
+  def by_selector(%{id: id}), do: by_id(id)
+
+  def by_selector(%{infrastructure: infrastructure, address: address}) do
+    with {:ok, %{id: infrastructure_id}} <- Sanbase.Model.Infrastructure.by_code(infrastructure),
+         {:ok, addr} <-
+           maybe_create(%{
+             address: address,
+             infrastructure_id: infrastructure_id
+           }) do
+      {:ok, addr}
+    end
+  end
+
   @doc ~s"""
   Convert an address to the internal format used in our databases.
 

--- a/lib/sanbase/blockchain_address/blockchain_address_user_pair.ex
+++ b/lib/sanbase/blockchain_address/blockchain_address_user_pair.ex
@@ -7,6 +7,7 @@ defmodule Sanbase.BlockchainAddress.BlockchainAddressUserPair do
 
   @labels_join_through_table "blockchain_address_user_pairs_labels"
 
+  @preloads [:user, :blockchain_address, :labels]
   schema "blockchain_address_user_pairs" do
     field(:notes, :string)
 
@@ -23,11 +24,58 @@ defmodule Sanbase.BlockchainAddress.BlockchainAddressUserPair do
     )
   end
 
-  def changeset(%__MODULE__{} = addr, attrs \\ %{}) do
-    addr
+  def changeset(%__MODULE__{} = pair, attrs \\ %{}) do
+    pair
     |> cast(attrs, [:user_id, :blockchain_address_id, :notes])
     |> validate_required([:user_id, :blockchain_address_id])
     |> put_labels(attrs)
+  end
+
+  def by_selector(%{id: id}, user_id) do
+    from(pair in __MODULE__, where: pair.id == ^id, preload: ^@preloads)
+    |> Sanbase.Repo.one()
+    |> case do
+      %__MODULE__{user_id: ^user_id} = pair ->
+        {:ok, pair}
+
+      %__MODULE__{user_id: _} ->
+        {:error, "Blockchain address pair with id #{id} does not belong to the querying user."}
+
+      _ ->
+        {:error, "Blockchain address pair with #{id} does not exist"}
+    end
+  end
+
+  def by_selector(%{blockchain_address_id: blockchain_address_id}, user_id) do
+    from(pair in __MODULE__,
+      where: pair.user_id == ^user_id and pair.blockchain_address_id == ^blockchain_address_id,
+      preload: ^@preloads
+    )
+    |> Sanbase.Repo.one()
+    |> case do
+      %__MODULE__{user_id: ^user_id} = pair ->
+        {:ok, pair}
+
+      _ ->
+        {:error,
+         """
+         Blockchain address user pair for user id #{user_id} and\
+         blockchain address id #{blockchain_address_id} does not exist
+         """}
+    end
+  end
+
+  def update(%__MODULE__{} = pair, attrs) do
+    # These fields are needed by put_labels/2
+    attrs =
+      attrs
+      |> Map.put(:user_id, pair.user_id)
+      |> Map.put(:blockchain_address_id, pair.blockchain_address_id)
+
+    pair
+    |> cast(attrs, [:notes])
+    |> put_labels(attrs)
+    |> Sanbase.Repo.update()
   end
 
   def maybe_create(attrs_list) when is_list(attrs_list) do

--- a/lib/sanbase/utils/error_handling.ex
+++ b/lib/sanbase/utils/error_handling.ex
@@ -42,6 +42,9 @@ defmodule Sanbase.Utils.ErrorHandling do
         <<"["::utf8, uuid::binary-size(36), "]"::utf8, message::binary>> ->
           {uuid, message |> String.trim()}
 
+        %Ecto.Changeset{} = changeset ->
+          {Ecto.UUID.generate(), changeset_errors_string(changeset)}
+
         _ ->
           {Ecto.UUID.generate(), reason}
       end

--- a/lib/sanbase_web/graphql/resolvers/blockchain_address_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/blockchain_address_resolver.ex
@@ -185,10 +185,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.BlockchainAddressResolver do
     end)
   end
 
-  def blockchain_address_id(root, _args, %{context: %{loader: loader}}) do
-    root_address = root_to_blockchain_address(root)
-    id = root_address.id
-
+  def blockchain_address_id(%Sanbase.Comment{id: id}, _args, %{context: %{loader: loader}}) do
     loader
     |> Dataloader.load(SanbaseDataloader, :comment_blockchain_address_id, id)
     |> on_load(fn loader ->

--- a/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
@@ -229,7 +229,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.InsightResolver do
     {:ok, comments}
   end
 
-  def insight_id(%{id: id}, _args, %{context: %{loader: loader}}) do
+  def insight_id(%Sanbase.Comment{id: id}, _args, %{context: %{loader: loader}}) do
     loader
     |> Dataloader.load(SanbaseDataloader, :comment_insight_id, id)
     |> on_load(fn loader ->

--- a/lib/sanbase_web/graphql/resolvers/timeline/timeline_event_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/timeline/timeline_event_resolver.ex
@@ -59,7 +59,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.TimelineEventResolver do
     end
   end
 
-  def timeline_event_id(%{id: id}, _args, %{context: %{loader: loader}}) do
+  def timeline_event_id(%Sanbase.Comment{id: id}, _args, %{context: %{loader: loader}}) do
     loader
     |> Dataloader.load(SanbaseDataloader, :comment_timeline_event_id, id)
     |> on_load(fn loader ->

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -141,11 +141,11 @@ defmodule SanbaseWeb.Graphql.Schema do
   end
 
   query do
-    import_fields(:signal_queries)
+    import_fields(:alert_queries)
     import_fields(:billing_queries)
     import_fields(:blockchain_address_queries)
-    import_fields(:blockchain_queries)
     import_fields(:blockchain_metric_queries)
+    import_fields(:blockchain_queries)
     import_fields(:comment_queries)
     import_fields(:exchange_queries)
     import_fields(:featured_queries)
@@ -162,21 +162,23 @@ defmodule SanbaseWeb.Graphql.Schema do
     import_fields(:promoter_queries)
     import_fields(:report_queries)
     import_fields(:research_queries)
+    import_fields(:sheets_template_queries)
     import_fields(:short_url_queries)
-    import_fields(:alert_queries)
+    import_fields(:signal_queries)
     import_fields(:social_data_queries)
     import_fields(:table_configuration_queries)
     import_fields(:tech_indicators_queries)
     import_fields(:timeline_queries)
     import_fields(:user_list_queries)
     import_fields(:user_queries)
-    import_fields(:widget_queries)
     import_fields(:wallet_hunter_queries)
-    import_fields(:sheets_template_queries)
+    import_fields(:widget_queries)
   end
 
   mutation do
+    import_fields(:alert_mutations)
     import_fields(:billing_mutations)
+    import_fields(:blockchain_address_mutations)
     import_fields(:comment_mutations)
     import_fields(:email_mutations)
     import_fields(:insight_mutations)
@@ -185,7 +187,6 @@ defmodule SanbaseWeb.Graphql.Schema do
     import_fields(:promoter_mutations)
     import_fields(:report_mutations)
     import_fields(:short_url_mutations)
-    import_fields(:alert_mutations)
     import_fields(:table_configuration_mutations)
     import_fields(:timeline_mutations)
     import_fields(:user_list_mutations)

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -24,8 +24,7 @@ defmodule SanbaseWeb.Graphql.Schema do
   # Types
   import_types(Absinthe.Plug.Types)
   import_types(Graphql.AggregationTypes)
-  import_types(Graphql.BlockchainAddressType)
-  import_types(Graphql.CommentTypes)
+  import_types(Graphql.CustomTypes.BlockchainAddress)
   import_types(Graphql.CustomTypes.Date)
   import_types(Graphql.CustomTypes.DateTime)
   import_types(Graphql.CustomTypes.Decimal)
@@ -36,6 +35,7 @@ defmodule SanbaseWeb.Graphql.Schema do
   import_types(Graphql.AggregationTypes)
   import_types(Graphql.AlertsHistoricalActivityTypes)
   import_types(Graphql.BillingTypes)
+  import_types(Graphql.BlockchainAddressType)
   import_types(Graphql.BlockchainTypes)
   import_types(Graphql.BlockchainAddressType)
   import_types(Graphql.ClickhouseTypes)

--- a/lib/sanbase_web/graphql/schema/custom_types/blockchain_address.ex
+++ b/lib/sanbase_web/graphql/schema/custom_types/blockchain_address.ex
@@ -1,0 +1,38 @@
+defmodule SanbaseWeb.Graphql.CustomTypes.BlockchainAddress do
+  @moduledoc """
+  The interval scalar type allows arbitrary interval values to be passed in and out.
+  """
+  use Absinthe.Schema.Notation
+
+  # Types must have a unique name. `:blockchain_address` is already taken
+  scalar :binary_blockchain_address, name: "binary_blockchain_address" do
+    description("""
+    The `blockchain_address` scalar type is the binary representation of blockchain
+    addresses, represented as UTF-8 character sequences (string).
+    When decoding, some addresses will be lowercased to avoid casing issues (ethereum).
+    The addresses are encoded as they are, without changes.
+    """)
+
+    serialize(&encode/1)
+    parse(&decode/1)
+  end
+
+  @spec decode(Absinthe.Blueprint.Input.String.t()) :: {:ok, term()} | :error
+  @spec decode(Absinthe.Blueprint.Input.Null.t()) :: {:ok, nil}
+  defp decode(%Absinthe.Blueprint.Input.String{value: ""}), do: {:ok, ""}
+
+  defp decode(%Absinthe.Blueprint.Input.String{value: value}) do
+    value = Sanbase.BlockchainAddress.to_internal_format(value)
+    {:ok, value}
+  end
+
+  defp decode(%Absinthe.Blueprint.Input.Null{}) do
+    {:ok, nil}
+  end
+
+  defp decode(_) do
+    :error
+  end
+
+  defp encode(value), do: value
+end

--- a/lib/sanbase_web/graphql/schema/queries/blockchain_address_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/blockchain_address_queries.ex
@@ -4,6 +4,7 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainAddressQueries do
   import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1]
 
   alias SanbaseWeb.Graphql.Resolvers.BlockchainAddressResolver
+  alias SanbaseWeb.Graphql.Middlewares.JWTAuth
 
   object :blockchain_address_queries do
     @desc "Recent transactions for this address"
@@ -21,6 +22,17 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainAddressQueries do
       arg(:selector, non_null(:blockchain_address_selector_input_object))
 
       resolve(&BlockchainAddressResolver.blockchain_address/3)
+    end
+  end
+
+  object :blockchain_address_mutations do
+    field :update_blockchain_address_user_pair, :blockchain_address_user_pair do
+      arg(:id, non_null(:integer))
+      arg(:notes, :string)
+      arg(:labels, list_of(:string))
+
+      middleware(JWTAuth)
+      resolve(&BlockchainAddressResolver.update_blockchain_address_user_pair/3)
     end
   end
 end

--- a/lib/sanbase_web/graphql/schema/queries/blockchain_address_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/blockchain_address_queries.ex
@@ -23,11 +23,18 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainAddressQueries do
 
       resolve(&BlockchainAddressResolver.blockchain_address/3)
     end
+
+    field :blockchain_address_user_pair, :blockchain_address_user_pair do
+      arg(:selector, non_null(:blockchain_address_selector_input_object))
+
+      middleware(JWTAuth)
+      resolve(&BlockchainAddressResolver.blockchain_address_user_pair/3)
+    end
   end
 
   object :blockchain_address_mutations do
     field :update_blockchain_address_user_pair, :blockchain_address_user_pair do
-      arg(:id, non_null(:integer))
+      arg(:selector, non_null(:blockchain_address_selector_input_object))
       arg(:notes, :string)
       arg(:labels, list_of(:string))
 

--- a/lib/sanbase_web/graphql/schema/types/blockchain_address_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/blockchain_address_types.ex
@@ -1,13 +1,21 @@
 defmodule SanbaseWeb.Graphql.BlockchainAddressType do
   use Absinthe.Schema.Notation
 
-  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1, cache_resolve: 2]
+  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1]
 
   alias SanbaseWeb.Graphql.Resolvers.BlockchainAddressResolver
 
   enum :recent_transactions_type do
     value(:eth)
     value(:erc20)
+  end
+
+  object :blockchain_address_user_pair do
+    field(:id, :integer)
+    field(:notes, :string)
+    field(:labels, list_of(:blockchain_address_label))
+    field(:blockchain_address, :blockchain_address)
+    field(:user, :user)
   end
 
   input_object :blockchain_address_selector_input_object do
@@ -26,10 +34,13 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressType do
   object :blockchain_address do
     field(:id, :integer)
     field(:address, :string)
-    field(:infrastructure, :string)
+
+    field :infrastructure, :string do
+      cache_resolve(&BlockchainAddressResolver.infrastructure/3)
+    end
 
     field :labels, list_of(:blockchain_address_label) do
-      cache_resolve(&BlockchainAddressResolver.labels/3, ttl: 600, max_ttl_offset: 600)
+      cache_resolve(&BlockchainAddressResolver.labels/3)
     end
 
     field(:notes, :string)

--- a/lib/sanbase_web/graphql/schema/types/blockchain_address_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/blockchain_address_types.ex
@@ -10,6 +10,12 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressType do
     value(:erc20)
   end
 
+  object :current_user_blockchain_address_data do
+    field(:pair_id, :integer)
+    field(:notes, :string)
+    field(:labels, list_of(:blockchain_address_label))
+  end
+
   object :blockchain_address_user_pair do
     field(:id, :integer)
     field(:notes, :string)

--- a/lib/sanbase_web/graphql/schema/types/blockchain_address_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/blockchain_address_types.ex
@@ -26,7 +26,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressType do
 
   input_object :blockchain_address_selector_input_object do
     field(:id, :id)
-    field(:address, :string)
+    field(:address, :binary_blockchain_address)
     field(:infrastructure, :string)
   end
 
@@ -39,7 +39,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressType do
 
   object :blockchain_address do
     field(:id, :integer)
-    field(:address, :string)
+    field(:address, :binary_blockchain_address)
 
     field :infrastructure, :string do
       cache_resolve(&BlockchainAddressResolver.infrastructure/3)

--- a/lib/sanbase_web/graphql/schema/types/wallet_hunters_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/wallet_hunters_types.ex
@@ -69,7 +69,7 @@ defmodule SanbaseWeb.Graphql.WalletHuntersTypes do
 
     field :hunter_address_labels, list_of(:blockchain_address_label) do
       cache_resolve(
-        &BlockchainAddressResolver.labels(%{address: &1.hunter_address}, &2, &3),
+        &BlockchainAddressResolver.labels(%{address: Map.get(&1, :hunter_address)}, &2, &3),
         ttl: 600,
         max_ttl_offset: 600
       )
@@ -77,7 +77,7 @@ defmodule SanbaseWeb.Graphql.WalletHuntersTypes do
 
     field :proposed_address_labels, list_of(:blockchain_address_label) do
       cache_resolve(
-        &BlockchainAddressResolver.labels(%{address: &1.proposed_address}, &2, &3),
+        &BlockchainAddressResolver.labels(%{address: Map.get(&1, :proposed_address)}, &2, &3),
         ttl: 600,
         max_ttl_offset: 600
       )

--- a/lib/sanbase_web/graphql/schema/types/wallet_hunters_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/wallet_hunters_types.ex
@@ -68,14 +68,16 @@ defmodule SanbaseWeb.Graphql.WalletHuntersTypes do
     field(:votes_count, :integer)
 
     field :hunter_address_labels, list_of(:blockchain_address_label) do
-      cache_resolve(&BlockchainAddressResolver.hunter_address_labels/3,
+      cache_resolve(
+        &BlockchainAddressResolver.labels(%{address: &1.hunter_address}, &2, &3),
         ttl: 600,
         max_ttl_offset: 600
       )
     end
 
     field :proposed_address_labels, list_of(:blockchain_address_label) do
-      cache_resolve(&BlockchainAddressResolver.proposed_address_labels/3,
+      cache_resolve(
+        &BlockchainAddressResolver.labels(%{address: &1.proposed_address}, &2, &3),
         ttl: 600,
         max_ttl_offset: 600
       )

--- a/test/sanbase_web/graphql/blockchain_address/blockchain_address_api_test.exs
+++ b/test/sanbase_web/graphql/blockchain_address/blockchain_address_api_test.exs
@@ -1,171 +1,165 @@
 defmodule SanbaseWeb.Graphql.BlockchainAddressApiTest do
   use SanbaseWeb.ConnCase, async: false
 
-  import SanbaseWeb.Graphql.TestHelpers
   import Sanbase.Factory
+  import SanbaseWeb.Graphql.TestHelpers
 
-  require Sanbase.Utils.Config
+  alias Sanbase.BlockchainAddress.BlockchainAddressUserPair
 
   setup do
-    project = insert(:random_project)
-    {:ok, project: project}
+    user = insert(:user)
+    conn = setup_jwt_auth(build_conn(), user)
+    eth_infrastructure = insert(:infrastructure, code: "ETH")
+
+    %{
+      user: user,
+      conn: conn,
+      eth_infrastructure: eth_infrastructure
+    }
   end
 
-  test "Ethereum recent transactions", context do
-    mock_fun =
-      [
-        fn -> {:ok, %{rows: eth_recent_transactions_result()}} end,
-        fn -> {:ok, %{rows: labels_rows()}} end
-      ]
-      |> Sanbase.Mock.wrap_consecutives(arity: 2)
+  test "fetch (create) a non-existing blockchain address", context do
+    result =
+      blockchain_address(context.conn, %{
+        address: "0x123",
+        infrastructure: "ETH"
+      })
+      |> get_in(["data", "blockchainAddress"])
 
-    Sanbase.Mock.prepare_mock(Sanbase.ClickhouseRepo, :query, mock_fun)
-    |> Sanbase.Mock.run_with_mocks(fn ->
-      query = recent_transactions_query("ETH")
-      result = execute_query(context.conn, query, "recentTransactions")
-      assert result == expected_eth_transactions()
-    end)
+    assert result["address"] == "0x123"
+    assert result["infrastructure"] == "ETH"
+    assert result["labels"] == []
+    assert result["notes"] == nil
   end
 
-  test "Token recent transactions", context do
-    mock_fun =
-      [
-        fn -> {:ok, %{rows: token_recent_transactions_result(context.project)}} end,
-        fn -> {:ok, %{rows: labels_rows()}} end
-      ]
-      |> Sanbase.Mock.wrap_consecutives(arity: 2)
+  test "fetch an existing blockchain address by id", context do
+    address_id =
+      blockchain_address(context.conn, %{
+        address: "0x123",
+        infrastructure: "ETH"
+      })
+      |> get_in(["data", "blockchainAddress", "id"])
 
-    Sanbase.Mock.prepare_mock(Sanbase.ClickhouseRepo, :query, mock_fun)
-    |> Sanbase.Mock.run_with_mocks(fn ->
-      query = recent_transactions_query("ERC20")
-      result = execute_query(context.conn, query, "recentTransactions")
-      assert result == expected_token_transactions(context.project)
-    end)
+    result =
+      blockchain_address(context.conn, %{id: address_id})
+      |> get_in(["data", "blockchainAddress"])
+
+    # The same address if fetched and a new one is not created
+    assert result["id"] == address_id
+
+    assert result["address"] == "0x123"
+    assert result["infrastructure"] == "ETH"
+    assert result["labels"] == []
+    assert result["notes"] == nil
   end
 
-  # ClickhouseRepo will log the error
-  @tag capture_log: true
-  test "error when fetching recent transactions", context do
-    Sanbase.Mock.prepare_mock2(
-      &Sanbase.ClickhouseRepo.query/2,
-      {:error, "Internal error message"}
-    )
-    |> Sanbase.Mock.run_with_mocks(fn ->
-      query = recent_transactions_query("ERC20")
-      error = execute_query_with_error(context.conn, query, "recentTransactions")
+  test "fetch an existing blockchain address by address and infrastructure",
+       context do
+    blockchain_address =
+      insert(:blockchain_address,
+        address: "0x123",
+        infrastructure: context.eth_infrastructure
+      )
 
-      assert error =~
-               "Can't fetch Recent transactions for Address 0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8"
-    end)
+    result =
+      blockchain_address(context.conn, %{
+        address: "0x123",
+        infrastructure: context.eth_infrastructure.code
+      })
+      |> get_in(["data", "blockchainAddress"])
+
+    # The same address if fetched and a new one is not created
+    assert result["id"] == blockchain_address.id
+    assert result["address"] == "0x123"
+    assert result["infrastructure"] == "ETH"
+    assert result["labels"] == []
+    assert result["notes"] == nil
   end
 
-  defp recent_transactions_query(type) do
-    """
+  test "update a blockchain address user pair", context do
+    blockchain_address =
+      insert(:blockchain_address,
+        address: "0x123",
+        infrastructure: context.eth_infrastructure
+      )
+
+    {:ok, [pair]} =
+      BlockchainAddressUserPair.maybe_create([
+        %{
+          user_id: context.user.id,
+          blockchain_address_id: blockchain_address.id
+        }
+      ])
+
+    notes = "some new notes"
+    labels = ["cex trader", "whale", "eth"]
+
+    result =
+      update_blockchain_address_user_pair(context.conn, pair.id, notes, labels)
+      |> get_in(["data", "updateBlockchainAddressUserPair"])
+
+    assert result["id"] == pair.id
+    assert result["notes"] == "some new notes"
+
+    assert result["labels"] == [
+             %{"name" => "cex trader"},
+             %{"name" => "whale"},
+             %{"name" => "eth"}
+           ]
+
+    assert result["blockchainAddress"]["address"] == blockchain_address.address
+    assert result["user"]["id"] |> Sanbase.Math.to_integer() == context.user.id
+  end
+
+  test "error updating a non-existining blockchain address user pair", context do
+    result = update_blockchain_address_user_pair(context.conn, 15_123_123, "notes", [])
+
+    %{"errors" => [%{"message" => error_msg}]} = result
+    assert error_msg =~ "Blockchain address pair with 15123123 does not exist"
+  end
+
+  defp blockchain_address(conn, selector) do
+    query = """
     {
-      recentTransactions(
-        address: "0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8",
-        type: #{type}
-      ) {
-        fromAddress {
+      blockchainAddress(selector: #{map_to_input_object_str(selector)}){
+        id
+        address
+        infrastructure
+        notes
+        labels{ name }
+      }
+    }
+    """
+
+    conn
+    |> post("/graphql", query_skeleton(query))
+    |> json_response(200)
+  end
+
+  defp update_blockchain_address_user_pair(conn, id, notes, labels) do
+    mutation = """
+    mutation {
+      updateBlockchainAddressUserPair(
+        id: #{id}
+        notes: "#{notes}"
+        labels: #{string_list_to_string(labels)}
+      ){
+        id
+        notes
+        labels{ name }
+        blockchainAddress{
           address
-          labels {
-            name
-          }
+          infrastructure
         }
-        toAddress {
-          address
-          labels {
-            name
-          }
-        }
-        trxValue
-        trxHash
-        project {
+        user{
           id
-          slug
         }
       }
     }
     """
-  end
 
-  defp labels_rows() do
-    [
-      [
-        "0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8",
-        "centralized_exchange",
-        ~s|{"comment":"Poloniex GNT","is_dex":false,"owner":"Poloniex","source":""}|
-      ],
-      [
-        "0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8",
-        "whale",
-        ~s|{"rank": 58, "value": 1.1438690681177702e+24}|
-      ]
-    ]
-  end
-
-  defp expected_token_transactions(project) do
-    [
-      %{
-        "fromAddress" => %{
-          "address" => "0xc12d1c73ee7dc3615ba4e37e4abfdbddfa38907e",
-          "labels" => []
-        },
-        "project" => %{
-          "slug" => project.slug,
-          "id" => to_string(project.id)
-        },
-        "toAddress" => %{
-          "address" => "0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8",
-          "labels" => [%{"name" => "whale"}, %{"name" => "centralized_exchange"}]
-        },
-        "trxHash" => "0x4bd5d44da7f69c5227530728249431072087b5f9780eec704869fc768922121e",
-        "trxValue" => 888_888.0
-      }
-    ]
-  end
-
-  defp expected_eth_transactions do
-    [
-      %{
-        "fromAddress" => %{
-          "address" => "0x876eabf441b2ee5b5b0554fd502a8e0600950cfa",
-          "labels" => ''
-        },
-        "toAddress" => %{
-          "address" => "0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8",
-          "labels" => [%{"name" => "whale"}, %{"name" => "centralized_exchange"}]
-        },
-        "trxHash" => "0x21a56440bedb1a5c2f4adca4a6f9fbccf13bd741d63c0e3b2214a6ee418a5974",
-        "trxValue" => 5.5,
-        "project" => nil
-      }
-    ]
-  end
-
-  defp token_recent_transactions_result(project) do
-    [
-      [
-        1_579_862_776,
-        "0xc12d1c73ee7dc3615ba4e37e4abfdbddfa38907e",
-        "0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8",
-        "0x4bd5d44da7f69c5227530728249431072087b5f9780eec704869fc768922121e",
-        8.88888e13,
-        project.slug,
-        8
-      ]
-    ]
-  end
-
-  defp eth_recent_transactions_result do
-    [
-      [
-        1_603_725_064,
-        "0x876eabf441b2ee5b5b0554fd502a8e0600950cfa",
-        "0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8",
-        "0x21a56440bedb1a5c2f4adca4a6f9fbccf13bd741d63c0e3b2214a6ee418a5974",
-        5.5e18
-      ]
-    ]
+    conn
+    |> post("/graphql", mutation_skeleton(mutation))
+    |> json_response(200)
   end
 end

--- a/test/sanbase_web/graphql/blockchain_address/blockchain_address_api_test.exs
+++ b/test/sanbase_web/graphql/blockchain_address/blockchain_address_api_test.exs
@@ -95,7 +95,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressApiTest do
     labels = ["cex trader", "whale", "eth"]
 
     result =
-      update_blockchain_address_user_pair(context.conn, pair.id, notes, labels)
+      update_blockchain_address_user_pair(context.conn, %{id: pair.id}, notes, labels)
       |> get_in(["data", "updateBlockchainAddressUserPair"])
 
     assert result["id"] == pair.id
@@ -112,7 +112,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressApiTest do
   end
 
   test "error updating a non-existining blockchain address user pair", context do
-    result = update_blockchain_address_user_pair(context.conn, 15_123_123, "notes", [])
+    result = update_blockchain_address_user_pair(context.conn, %{id: 15_123_123}, "notes", [])
 
     %{"errors" => [%{"message" => error_msg}]} = result
     assert error_msg =~ "Blockchain address pair with 15123123 does not exist"
@@ -136,11 +136,11 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressApiTest do
     |> json_response(200)
   end
 
-  defp update_blockchain_address_user_pair(conn, id, notes, labels) do
+  defp update_blockchain_address_user_pair(conn, selector, notes, labels) do
     mutation = """
     mutation {
       updateBlockchainAddressUserPair(
-        id: #{id}
+        selector: #{map_to_input_object_str(selector)}
         notes: "#{notes}"
         labels: #{string_list_to_string(labels)}
       ){

--- a/test/sanbase_web/graphql/blockchain_address/blockchain_address_transactions_api_test.exs
+++ b/test/sanbase_web/graphql/blockchain_address/blockchain_address_transactions_api_test.exs
@@ -1,0 +1,171 @@
+defmodule SanbaseWeb.Graphql.BlockchainAddressTransactionsApiTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import SanbaseWeb.Graphql.TestHelpers
+  import Sanbase.Factory
+
+  require Sanbase.Utils.Config
+
+  setup do
+    project = insert(:random_project)
+    {:ok, project: project}
+  end
+
+  test "Ethereum recent transactions", context do
+    mock_fun =
+      [
+        fn -> {:ok, %{rows: eth_recent_transactions_result()}} end,
+        fn -> {:ok, %{rows: labels_rows()}} end
+      ]
+      |> Sanbase.Mock.wrap_consecutives(arity: 2)
+
+    Sanbase.Mock.prepare_mock(Sanbase.ClickhouseRepo, :query, mock_fun)
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      query = recent_transactions_query("ETH")
+      result = execute_query(context.conn, query, "recentTransactions")
+      assert result == expected_eth_transactions()
+    end)
+  end
+
+  test "Token recent transactions", context do
+    mock_fun =
+      [
+        fn -> {:ok, %{rows: token_recent_transactions_result(context.project)}} end,
+        fn -> {:ok, %{rows: labels_rows()}} end
+      ]
+      |> Sanbase.Mock.wrap_consecutives(arity: 2)
+
+    Sanbase.Mock.prepare_mock(Sanbase.ClickhouseRepo, :query, mock_fun)
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      query = recent_transactions_query("ERC20")
+      result = execute_query(context.conn, query, "recentTransactions")
+      assert result == expected_token_transactions(context.project)
+    end)
+  end
+
+  # ClickhouseRepo will log the error
+  @tag capture_log: true
+  test "error when fetching recent transactions", context do
+    Sanbase.Mock.prepare_mock2(
+      &Sanbase.ClickhouseRepo.query/2,
+      {:error, "Internal error message"}
+    )
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      query = recent_transactions_query("ERC20")
+      error = execute_query_with_error(context.conn, query, "recentTransactions")
+
+      assert error =~
+               "Can't fetch Recent transactions for Address 0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8"
+    end)
+  end
+
+  defp recent_transactions_query(type) do
+    """
+    {
+      recentTransactions(
+        address: "0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8",
+        type: #{type}
+      ) {
+        fromAddress {
+          address
+          labels {
+            name
+          }
+        }
+        toAddress {
+          address
+          labels {
+            name
+          }
+        }
+        trxValue
+        trxHash
+        project {
+          id
+          slug
+        }
+      }
+    }
+    """
+  end
+
+  defp labels_rows() do
+    [
+      [
+        "0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8",
+        "centralized_exchange",
+        ~s|{"comment":"Poloniex GNT","is_dex":false,"owner":"Poloniex","source":""}|
+      ],
+      [
+        "0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8",
+        "whale",
+        ~s|{"rank": 58, "value": 1.1438690681177702e+24}|
+      ]
+    ]
+  end
+
+  defp expected_token_transactions(project) do
+    [
+      %{
+        "fromAddress" => %{
+          "address" => "0xc12d1c73ee7dc3615ba4e37e4abfdbddfa38907e",
+          "labels" => []
+        },
+        "project" => %{
+          "slug" => project.slug,
+          "id" => to_string(project.id)
+        },
+        "toAddress" => %{
+          "address" => "0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8",
+          "labels" => [%{"name" => "whale"}, %{"name" => "centralized_exchange"}]
+        },
+        "trxHash" => "0x4bd5d44da7f69c5227530728249431072087b5f9780eec704869fc768922121e",
+        "trxValue" => 888_888.0
+      }
+    ]
+  end
+
+  defp expected_eth_transactions do
+    [
+      %{
+        "fromAddress" => %{
+          "address" => "0x876eabf441b2ee5b5b0554fd502a8e0600950cfa",
+          "labels" => ''
+        },
+        "toAddress" => %{
+          "address" => "0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8",
+          "labels" => [%{"name" => "whale"}, %{"name" => "centralized_exchange"}]
+        },
+        "trxHash" => "0x21a56440bedb1a5c2f4adca4a6f9fbccf13bd741d63c0e3b2214a6ee418a5974",
+        "trxValue" => 5.5,
+        "project" => nil
+      }
+    ]
+  end
+
+  defp token_recent_transactions_result(project) do
+    [
+      [
+        1_579_862_776,
+        "0xc12d1c73ee7dc3615ba4e37e4abfdbddfa38907e",
+        "0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8",
+        "0x4bd5d44da7f69c5227530728249431072087b5f9780eec704869fc768922121e",
+        8.88888e13,
+        project.slug,
+        8
+      ]
+    ]
+  end
+
+  defp eth_recent_transactions_result do
+    [
+      [
+        1_603_725_064,
+        "0x876eabf441b2ee5b5b0554fd502a8e0600950cfa",
+        "0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8",
+        "0x21a56440bedb1a5c2f4adca4a6f9fbccf13bd741d63c0e3b2214a6ee418a5974",
+        5.5e18
+      ]
+    ]
+  end
+end

--- a/test/support/graphql_test_helpers.ex
+++ b/test/support/graphql_test_helpers.ex
@@ -114,6 +114,11 @@ defmodule SanbaseWeb.Graphql.TestHelpers do
     |> Map.get("message")
   end
 
+  def string_list_to_string(list) do
+    str = list |> Enum.map(fn elem -> ~s|"#{elem}"| end) |> Enum.join(",")
+    "[" <> str <> "]"
+  end
+
   def map_to_input_object_str(%{} = map, opts \\ []) do
     map_as_input_object? = Keyword.get(opts, :map_as_input_object, false)
 


### PR DESCRIPTION
## Changes

When a user adds notes/labels to a blockchain address, these values are added not on the blockchain address itself, but on a (blockchain_address, user) pair. The `blockchain address` entity is similar to the `project` entity - external users cannot update any of its fields.

The blockchain address notes and labels can be changed by the Santiment team only.
 
This separation is needed because of 2 main reasons:
- Any wrong/spam labels are not shown to all users.
- Users might want their notes and labels to be private and this is the default behavior.

The (blockchain_addres, user) pair can be created and updated. Creation can be done by invoking the `blockchainAddress` API with a selector containing address and infrastructure. If no such address exists (for the current user) it is created. If such address exists - it is returned.

The pair notes and labels can be updated by the `updateBlockchainAddressUserPair` mutation. In this case if a selector with address and infrastructure is provided and it does not point to an existing pair, an error is returned and no pair is created. 

> Note: The id of pairs and blockchain addresses are not connected. The blockchain address with id 1 and the pair with id 1 do not have anything in common.

Get a pair by id:
```graphql
{
  blockchainAddressUserPair(selector: {id: 1}) {
    id
    labels {
      name
    }
    blockchainAddress {
      address
    }
  }
}

```

Get a pair by address/infrastructure or create it if it does not exist:
```graphql
{
  blockchainAddressUserPair(selector: {address:"0x8644e45ac771c34b6e4e855B6cfa0BB672f89310" infrastructure: "ETH"}) {
    id
    labels {
      name
    }
    blockchainAddress {
      address
    }
  }
}
```

Update an existing blockchain address user pair:
```graphql
mutation{
  updateBlockchainAddressUserPair(
    selector: { id: 1 }
    notes:"new_notes"
    labels: ["label1", "label2"]
  ){
    id
    notes
    labels { name }
    blockchainAddress{ address }
  }
}
```

Update an existing blockchain address user pair by using address/infrastructure selector. If the pair does not exists this will fail.
```graphql
mutation{
  updateBlockchainAddressUserPair(
    selector: { address: "0x123" infrastructure: "ETH" }
    notes:"new_notes"
    labels: ["label1", "label2"]
  ){
    id
    notes
    labels { name }
    blockchainAddress{ address }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
