### PR TITLE
Add more filters, add votes

### DIFF
--- a/lib/sanbase/auth/eth_account.ex
+++ b/lib/sanbase/auth/eth_account.ex
@@ -1,6 +1,7 @@
 defmodule Sanbase.Accounts.EthAccount do
   use Ecto.Schema
   import Ecto.Changeset
+  import Ecto.Query
 
   alias Sanbase.Repo
   alias Sanbase.SmartContracts.UniswapPair
@@ -35,6 +36,11 @@ defmodule Sanbase.Accounts.EthAccount do
 
   def by_address(address) do
     Repo.get_by(__MODULE__, address: address)
+  end
+
+  def wallets_by_user(user_id) do
+    from(e in __MODULE__, where: e.user_id == ^user_id, select: e.address)
+    |> Repo.all()
   end
 
   def san_balance(%__MODULE__{address: address}) do

--- a/lib/sanbase/smart_contracts/utils.ex
+++ b/lib/sanbase/smart_contracts/utils.ex
@@ -82,4 +82,16 @@ defmodule Sanbase.SmartContracts.Utils do
   def encode_address(address) do
     "0x" <> Base.encode16(address, case: :lower)
   end
+
+  def address_strip_zeros(address) do
+    address =
+      address
+      |> String.slice(2..-1)
+      |> Integer.parse(16)
+      |> elem(0)
+      |> Integer.to_string(16)
+      |> String.downcase()
+
+    "0x" <> address
+  end
 end

--- a/lib/sanbase_web/graphql/resolvers/wallet_hunters_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/wallet_hunters_resolver.ex
@@ -13,8 +13,17 @@ defmodule SanbaseWeb.Graphql.Resolvers.WalletHuntersResolver do
     Proposal.create(args)
   end
 
+  def wallet_hunters_proposals(_root, args, %{context: %{auth: %{current_user: current_user}}}) do
+    selector = args[:selector] || %{}
+    Sanbase.WalletHunters.Proposal.fetch_all(selector, current_user)
+  end
+
   def wallet_hunters_proposals(_root, args, _resolution) do
     selector = args[:selector] || %{}
-    {:ok, Sanbase.WalletHunters.Proposal.fetch_all(selector)}
+    Sanbase.WalletHunters.Proposal.fetch_all(selector)
+  end
+
+  def wallet_hunters_proposal(_root, args, _resolution) do
+    Sanbase.WalletHunters.Proposal.fetch_by_id(args.id)
   end
 end

--- a/lib/sanbase_web/graphql/schema/queries/wallet_hunter_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/wallet_hunter_queries.ex
@@ -8,9 +8,18 @@ defmodule SanbaseWeb.Graphql.Schema.WalletHunterQueries do
   object :wallet_hunter_queries do
     field :wallet_hunters_proposals, list_of(:wallet_hunter_proposal) do
       meta(access: :free)
+
       arg(:selector, :wallet_hunters_proposals_selector_input_object)
 
       cache_resolve(&WalletHuntersResolver.wallet_hunters_proposals/3)
+    end
+
+    field :wallet_hunters_proposal, :wallet_hunter_proposal do
+      meta(access: :free)
+
+      arg(:id, non_null(:integer))
+
+      cache_resolve(&WalletHuntersResolver.wallet_hunters_proposal/3)
     end
   end
 

--- a/lib/sanbase_web/graphql/schema/types/wallet_hunters_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/wallet_hunters_types.ex
@@ -5,6 +5,12 @@ defmodule SanbaseWeb.Graphql.WalletHuntersTypes do
 
   alias SanbaseWeb.Graphql.Resolvers.BlockchainAddressResolver
 
+  enum :wallet_hunter_proposal_types do
+    value(:all)
+    value(:only_voted)
+    value(:only_mine)
+  end
+
   enum :wallet_hunter_proposal_states do
     value(:active)
     value(:approved)
@@ -32,6 +38,13 @@ defmodule SanbaseWeb.Graphql.WalletHuntersTypes do
     field(:sort_by, :wallet_hunters_sort_object)
     field(:page, :integer, default_value: 1)
     field(:page_size, :integer, default_value: 10)
+    field(:type, :wallet_hunter_proposal_types, default_value: :all)
+  end
+
+  object :proposal_vote do
+    field(:amount, :float)
+    field(:voted_for, :boolean)
+    field(:voter_address, :string)
   end
 
   object :wallet_hunter_proposal do
@@ -51,6 +64,7 @@ defmodule SanbaseWeb.Graphql.WalletHuntersTypes do
     field(:hunter_address, :string)
     field(:proposed_address, :string)
     field(:user_labels, list_of(:string))
+    field(:votes, list_of(:proposal_vote))
 
     field :hunter_address_labels, list_of(:blockchain_address_label) do
       cache_resolve(&BlockchainAddressResolver.hunter_address_labels/3,

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -16,6 +16,7 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
         [
           :active_widgets,
           :wallet_hunters_proposals,
+          :wallet_hunters_proposal,
           :address_historical_balance_change,
           :alerts_historical_activity,
           :all_currency_projects,

--- a/test/sanbase_web/graphql/wallet_hunters/wallet_hunters_api_test.exs
+++ b/test/sanbase_web/graphql/wallet_hunters/wallet_hunters_api_test.exs
@@ -11,150 +11,236 @@ defmodule SanbaseWeb.Graphql.WalletHuntersApiTest do
     {:ok, conn: conn, user: user, proposal: proposal}
   end
 
-  test "Create proposal" do
-    mock_fun =
-      [
-        fn -> {:ok, %{rows: labels_rows()}} end,
-        fn -> {:ok, %{rows: labels_rows()}} end
-      ]
-      |> Sanbase.Mock.wrap_consecutives(arity: 2)
+  describe "Create proposal" do
+    test "when user is not logged in" do
+      mock_fun =
+        [
+          fn -> {:ok, %{rows: labels_rows()}} end,
+          fn -> {:ok, %{rows: labels_rows()}} end
+        ]
+        |> Sanbase.Mock.wrap_consecutives(arity: 2)
 
-    Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_call/1, proposal_resp())
-    |> Sanbase.Mock.prepare_mock(Sanbase.ClickhouseRepo, :query, mock_fun)
-    |> Sanbase.Mock.run_with_mocks(fn ->
-      result =
-        execute_mutation(build_conn(), create_proposal_mutation(), "createWalletHunterProposal")
+      Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_new_filter/1, filter_id_resp())
+      |> Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_get_filter_logs/1, votes_resp())
+      |> Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_call/1, proposal_resp())
+      |> Sanbase.Mock.prepare_mock(Sanbase.ClickhouseRepo, :query, mock_fun)
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result =
+          execute_mutation(build_conn(), create_proposal_mutation(), "createWalletHunterProposal")
 
-      assert result == %{
-               "hunterAddress" => "0xcb8c7409fe98a396f32d6cff4736bedc7b60008c",
-               "createdAt" => "2021-03-24T09:03:19Z",
-               "finishAt" => "2021-03-25T09:03:19Z",
-               "fixedSheriffReward" => 10.0,
-               "isRewardClaimed" => false,
-               "proposalId" => "1",
-               "reward" => 110.0,
-               "sheriffsRewardShare" => 2.0e3,
-               "state" => "DECLINED",
-               "text" => "t",
-               "title" => "t2",
-               "user" => nil,
-               "votesAgainst" => 0.0,
-               "votesFor" => 0.0,
-               "hunterAddressLabels" => [],
-               "proposedAddress" => "0x11111109fe98a396f32d6cff4736bedc7b60008c",
-               "proposedAddressLabels" => [%{"name" => "DEX Trader2"}],
-               "userLabels" => ["test label1", "test label 2"]
-             }
-    end)
+        assert result == %{
+                 "hunterAddress" => "0xcb8c7409fe98a396f32d6cff4736bedc7b60008c",
+                 "createdAt" => "2021-03-24T09:03:19Z",
+                 "finishAt" => "2021-03-25T09:03:19Z",
+                 "fixedSheriffReward" => 10.0,
+                 "isRewardClaimed" => false,
+                 "proposalId" => "1",
+                 "reward" => 110.0,
+                 "sheriffsRewardShare" => 2.0e3,
+                 "state" => "DECLINED",
+                 "text" => "t",
+                 "title" => "t2",
+                 "user" => nil,
+                 "votesAgainst" => 0.0,
+                 "votesFor" => 0.0,
+                 "hunterAddressLabels" => [],
+                 "proposedAddress" => "0x11111109fe98a396f32d6cff4736bedc7b60008c",
+                 "proposedAddressLabels" => [%{"name" => "DEX Trader2"}],
+                 "userLabels" => ["test label1", "test label 2"],
+                 "votes" => []
+               }
+      end)
+    end
+
+    test "when user is logged in", context do
+      Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_new_filter/1, filter_id_resp())
+      |> Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_get_filter_logs/1, votes_resp())
+      |> Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_call/1, proposal_resp())
+      |> Sanbase.Mock.prepare_mock2(
+        &Sanbase.ClickhouseRepo.query/2,
+        {:ok, %{rows: labels_rows()}}
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result =
+          execute_mutation(context.conn, create_proposal_mutation(), "createWalletHunterProposal")
+
+        assert result == %{
+                 "createdAt" => "2021-03-24T09:03:19Z",
+                 "finishAt" => "2021-03-25T09:03:19Z",
+                 "fixedSheriffReward" => 10.0,
+                 "isRewardClaimed" => false,
+                 "proposalId" => "1",
+                 "reward" => 110.0,
+                 "sheriffsRewardShare" => 2.0e3,
+                 "state" => "DECLINED",
+                 "text" => "t",
+                 "title" => "t2",
+                 "user" => %{"email" => context.user.email},
+                 "votesAgainst" => 0.0,
+                 "votesFor" => 0.0,
+                 "hunterAddress" => "0xcb8c7409fe98a396f32d6cff4736bedc7b60008c",
+                 "hunterAddressLabels" => [],
+                 "proposedAddress" => "0x11111109fe98a396f32d6cff4736bedc7b60008c",
+                 "proposedAddressLabels" => [%{"name" => "DEX Trader2"}],
+                 "userLabels" => ["test label1", "test label 2"],
+                 "votes" => []
+               }
+      end)
+    end
+
+    test "when hunter address is in EthAccounts" do
+      Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_new_filter/1, filter_id_resp())
+      |> Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_get_filter_logs/1, votes_resp())
+      |> Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_call/1, proposal_resp())
+      |> Sanbase.Mock.prepare_mock2(
+        &Sanbase.ClickhouseRepo.query/2,
+        {:ok, %{rows: labels_rows()}}
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        user =
+          insert(:user,
+            eth_accounts: [
+              %Sanbase.Accounts.EthAccount{address: "0xcb8c7409fe98a396f32d6cff4736bedc7b60008c"}
+            ]
+          )
+
+        conn = setup_jwt_auth(build_conn(), user)
+
+        result = execute_mutation(conn, create_proposal_mutation(), "createWalletHunterProposal")
+
+        assert result == %{
+                 "createdAt" => "2021-03-24T09:03:19Z",
+                 "finishAt" => "2021-03-25T09:03:19Z",
+                 "fixedSheriffReward" => 10.0,
+                 "hunterAddress" => "0xcb8c7409fe98a396f32d6cff4736bedc7b60008c",
+                 "hunterAddressLabels" => [],
+                 "isRewardClaimed" => false,
+                 "proposalId" => "1",
+                 "proposedAddress" => "0x11111109fe98a396f32d6cff4736bedc7b60008c",
+                 "proposedAddressLabels" => [%{"name" => "DEX Trader2"}],
+                 "reward" => 110.0,
+                 "sheriffsRewardShare" => 2.0e3,
+                 "state" => "DECLINED",
+                 "text" => "t",
+                 "title" => "t2",
+                 "user" => %{"email" => user.email},
+                 "userLabels" => ["test label1", "test label 2"],
+                 "votesAgainst" => 0.0,
+                 "votesFor" => 0.0,
+                 "votes" => []
+               }
+      end)
+    end
   end
 
-  test "Create proposal with logged in user", context do
-    Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_call/1, proposal_resp())
-    |> Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:ok, %{rows: labels_rows()}})
-    |> Sanbase.Mock.run_with_mocks(fn ->
-      result =
-        execute_mutation(context.conn, create_proposal_mutation(), "createWalletHunterProposal")
+  describe "Fetch proposals" do
+    test "when fetching all" do
+      Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_new_filter/1, filter_id_resp())
+      |> Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_get_filter_logs/1, votes_resp())
+      |> Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_call/1, all_proposals_resp())
+      |> Sanbase.Mock.prepare_mock2(
+        &Sanbase.ClickhouseRepo.query/2,
+        {:ok, %{rows: labels_rows()}}
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result = execute_query(build_conn(), wallet_hunters_query(), "walletHuntersProposals")
 
-      assert result == %{
-               "createdAt" => "2021-03-24T09:03:19Z",
-               "finishAt" => "2021-03-25T09:03:19Z",
-               "fixedSheriffReward" => 10.0,
-               "isRewardClaimed" => false,
-               "proposalId" => "1",
-               "reward" => 110.0,
-               "sheriffsRewardShare" => 2.0e3,
-               "state" => "DECLINED",
-               "text" => "t",
-               "title" => "t2",
-               "user" => %{"email" => context.user.email},
-               "votesAgainst" => 0.0,
-               "votesFor" => 0.0,
-               "hunterAddress" => "0xcb8c7409fe98a396f32d6cff4736bedc7b60008c",
-               "hunterAddressLabels" => [],
-               "proposedAddress" => "0x11111109fe98a396f32d6cff4736bedc7b60008c",
-               "proposedAddressLabels" => [%{"name" => "DEX Trader2"}],
-               "userLabels" => ["test label1", "test label 2"]
-             }
-    end)
-  end
+        assert result == query_response()
+      end)
+    end
 
-  test "Create proposal with hunter address that is in EthAccount" do
-    Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_call/1, proposal_resp())
-    |> Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:ok, %{rows: labels_rows()}})
-    |> Sanbase.Mock.run_with_mocks(fn ->
+    test "when fetching with sorting and pagination" do
+      Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_new_filter/1, filter_id_resp())
+      |> Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_get_filter_logs/1, votes_resp())
+      |> Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_call/1, all_proposals_resp())
+      |> Sanbase.Mock.prepare_mock2(
+        &Sanbase.ClickhouseRepo.query/2,
+        {:ok, %{rows: labels_rows()}}
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        selector = %{sort_by: %{field: "created_at", direction: :desc}, page: 1, page_size: 2}
+
+        result =
+          execute_query(build_conn(), wallet_hunters_query(selector), "walletHuntersProposals")
+
+        assert result ==
+                 query_response() |> Enum.sort_by(& &1["createdAt"], :desc) |> Enum.take(2)
+      end)
+    end
+
+    test "when fetching with filter" do
+      Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_new_filter/1, filter_id_resp())
+      |> Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_get_filter_logs/1, votes_resp())
+      |> Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_call/1, all_proposals_resp())
+      |> Sanbase.Mock.prepare_mock2(
+        &Sanbase.ClickhouseRepo.query/2,
+        {:ok, %{rows: labels_rows()}}
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        selector = %{
+          filter: [
+            %{field: "state", value: "active"},
+            %{field: "hunter_address", value: "0x26caae548b7cecf98da12ccaaa633d6d140447aa"}
+          ]
+        }
+
+        result =
+          execute_query(build_conn(), wallet_hunters_query(selector), "walletHuntersProposals")
+
+        assert result == query_response() |> Enum.take(-1)
+      end)
+    end
+
+    test "when fetching only mine", context do
+      Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_new_filter/1, filter_id_resp())
+      |> Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_get_filter_logs/1, votes_resp())
+      |> Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_call/1, all_proposals_resp())
+      |> Sanbase.Mock.prepare_mock2(
+        &Sanbase.ClickhouseRepo.query/2,
+        {:ok, %{rows: labels_rows()}}
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        selector = %{type: :only_mine}
+
+        result =
+          execute_query(context.conn, wallet_hunters_query(selector), "walletHuntersProposals")
+
+        expected =
+          query_response()
+          |> List.last()
+          |> Map.merge(%{"user" => %{"email" => context.user.email}})
+
+        assert hd(result) == expected
+      end)
+    end
+
+    test "when fetching only voted", context do
       user =
         insert(:user,
           eth_accounts: [
-            %Sanbase.Accounts.EthAccount{address: "0xcb8c7409fe98a396f32d6cff4736bedc7b60008c"}
+            %Sanbase.Accounts.EthAccount{address: "0x9a70009b09d729453333121a7d47bd9a039b9153"}
           ]
         )
 
       conn = setup_jwt_auth(build_conn(), user)
 
-      result = execute_mutation(conn, create_proposal_mutation(), "createWalletHunterProposal")
+      Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_new_filter/1, filter_id_resp())
+      |> Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_get_filter_logs/1, votes_resp())
+      |> Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_call/1, all_proposals_resp())
+      |> Sanbase.Mock.prepare_mock2(
+        &Sanbase.ClickhouseRepo.query/2,
+        {:ok, %{rows: labels_rows()}}
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        selector = %{type: :only_voted}
 
-      assert result == %{
-               "createdAt" => "2021-03-24T09:03:19Z",
-               "finishAt" => "2021-03-25T09:03:19Z",
-               "fixedSheriffReward" => 10.0,
-               "hunterAddress" => "0xcb8c7409fe98a396f32d6cff4736bedc7b60008c",
-               "hunterAddressLabels" => [],
-               "isRewardClaimed" => false,
-               "proposalId" => "1",
-               "proposedAddress" => "0x11111109fe98a396f32d6cff4736bedc7b60008c",
-               "proposedAddressLabels" => [%{"name" => "DEX Trader2"}],
-               "reward" => 110.0,
-               "sheriffsRewardShare" => 2.0e3,
-               "state" => "DECLINED",
-               "text" => "t",
-               "title" => "t2",
-               "user" => %{"email" => user.email},
-               "userLabels" => ["test label1", "test label 2"],
-               "votesAgainst" => 0.0,
-               "votesFor" => 0.0
-             }
-    end)
-  end
+        result = execute_query(conn, wallet_hunters_query(selector), "walletHuntersProposals")
 
-  test "Fetch all proposals" do
-    Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_call/1, all_proposals_resp())
-    |> Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:ok, %{rows: labels_rows()}})
-    |> Sanbase.Mock.run_with_mocks(fn ->
-      result = execute_query(build_conn(), wallet_hunters_query(), "walletHuntersProposals")
+        expected = query_response() |> hd()
 
-      assert result == query_response()
-    end)
-  end
-
-  test "Fetch all proposals sorted and paginated" do
-    Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_call/1, all_proposals_resp())
-    |> Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:ok, %{rows: labels_rows()}})
-    |> Sanbase.Mock.run_with_mocks(fn ->
-      selector = %{sort_by: %{field: "created_at", direction: :desc}, page: 1, page_size: 2}
-
-      result =
-        execute_query(build_conn(), wallet_hunters_query(selector), "walletHuntersProposals")
-
-      assert result == query_response() |> Enum.sort_by(& &1["createdAt"], :desc) |> Enum.take(2)
-    end)
-  end
-
-  test "Fetch all proposals filtered" do
-    Sanbase.Mock.prepare_mock2(&Ethereumex.HttpClient.eth_call/1, all_proposals_resp())
-    |> Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:ok, %{rows: labels_rows()}})
-    |> Sanbase.Mock.run_with_mocks(fn ->
-      selector = %{
-        filter: [
-          %{field: "state", value: "active"},
-          %{field: "hunter_address", value: "0x26caae548b7cecf98da12ccaaa633d6d140447aa"}
-        ]
-      }
-
-      result =
-        execute_query(build_conn(), wallet_hunters_query(selector), "walletHuntersProposals")
-
-      assert result == query_response() |> Enum.take(-1)
-    end)
+        assert hd(result) == expected
+      end)
+    end
   end
 
   defp create_proposal_mutation do
@@ -192,6 +278,11 @@ defmodule SanbaseWeb.Graphql.WalletHuntersApiTest do
         votesAgainst
         sheriffsRewardShare
         fixedSheriffReward
+        votes {
+          amount
+          voterAddress
+          votedFor
+        }
       }
     }
     """
@@ -229,6 +320,11 @@ defmodule SanbaseWeb.Graphql.WalletHuntersApiTest do
         votesAgainst
         sheriffsRewardShare
         fixedSheriffReward
+        votes {
+          amount
+          voterAddress
+          votedFor
+        }
       }
     }
     """
@@ -246,12 +342,39 @@ defmodule SanbaseWeb.Graphql.WalletHuntersApiTest do
      "0x0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000cb8c7409fe98a396f32d6cff4736bedc7b60008c000000000000000000000000000000000000000000000005f68e8131ecf800000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000605b005700000000000000000000000000000000000000000000000000000000605c51d70000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000007d00000000000000000000000000000000000000000000000008ac7230489e80000"}
   end
 
-  def all_proposals_resp do
+  defp all_proposals_resp do
     {:ok,
      "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000000000000000000000000000000cb8c7409fe98a396f32d6cff4736bedc7b60008c0000000000000000000000000000000000000000000000056bc75e2d631000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000605a50c800000000000000000000000000000000000000000000000000000000605ba2480000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000007d00000000000000000000000000000000000000000000000008ac7230489e800000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000cb8c7409fe98a396f32d6cff4736bedc7b60008c000000000000000000000000000000000000000000000005f68e8131ecf800000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000605b005700000000000000000000000000000000000000000000000000000000605c51d70000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000007d00000000000000000000000000000000000000000000000008ac7230489e80000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000026caae548b7cecf98da12ccaaa633d6d140447aa00000000000000000000000000000000000000000000029d01c7829467b400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000605c4dac00000000000000000000000000000000000000000000000000000000605d9f2c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000007d00000000000000000000000000000000000000000000000008ac7230489e80000"}
   end
 
-  def query_response do
+  defp filter_id_resp do
+    {:ok, "0x10ff0cf22b4d7039171448ac27aa7951ffc2616fdb66"}
+  end
+
+  def votes_resp do
+    {:ok,
+     [
+       %{
+         "address" => "0x772e255402eee3fa243cb17af58001f40da78d90",
+         "blockHash" => "0x72efb342bec68dabb61e5b749a2374760b44b086d44a7efa25fba52a75b1f8eb",
+         "blockNumber" => "0x7f1bd3",
+         "data" =>
+           "0x000000000000000000000000000000000000000000000002b5e3af16b18800000000000000000000000000000000000000000000000000000000000000000001",
+         "logIndex" => "0x5",
+         "removed" => false,
+         "topics" => [
+           "0xb7086a9dd618ffa688aa9500720dfe31d3b288daba445664cecceaed4a1562c3",
+           "0x0000000000000000000000000000000000000000000000000000000000000000",
+           "0x0000000000000000000000009a70009b09d729453333121a7d47bd9a039b9153"
+         ],
+         "transactionHash" =>
+           "0x94ea7542946b1e4e64f7f7f398221fb2fa3eff67dc68cdb8f20fb9250611460f",
+         "transactionIndex" => "0x4"
+       }
+     ]}
+  end
+
+  defp query_response do
     [
       %{
         "createdAt" => "2021-03-23T20:34:16Z",
@@ -271,7 +394,14 @@ defmodule SanbaseWeb.Graphql.WalletHuntersApiTest do
         "hunterAddressLabels" => [],
         "proposedAddress" => nil,
         "proposedAddressLabels" => [],
-        "userLabels" => nil
+        "userLabels" => nil,
+        "votes" => [
+          %{
+            "amount" => 50.0,
+            "votedFor" => true,
+            "voterAddress" => "0x9a70009b09d729453333121a7d47bd9a039b9153"
+          }
+        ]
       },
       %{
         "createdAt" => "2021-03-24T09:03:19Z",
@@ -291,7 +421,8 @@ defmodule SanbaseWeb.Graphql.WalletHuntersApiTest do
         "hunterAddressLabels" => [],
         "proposedAddress" => nil,
         "proposedAddressLabels" => [],
-        "userLabels" => nil
+        "userLabels" => nil,
+        "votes" => []
       },
       %{
         "createdAt" => "2021-03-25T08:45:32Z",
@@ -311,7 +442,8 @@ defmodule SanbaseWeb.Graphql.WalletHuntersApiTest do
         "hunterAddressLabels" => [%{"name" => "DEX Trader"}],
         "proposedAddress" => nil,
         "proposedAddressLabels" => [],
-        "userLabels" => []
+        "userLabels" => [],
+        "votes" => []
       }
     ]
   end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

* Add filtering by `only_mine` (hunter's board), `only voted` (sheriff's board)
* Add votes structure in proposal
* Add fetching only one proposal with `walletHunterProposal`

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->
```graphql
    {
      walletHuntersProposal(
        id:11
      ) {
        proposalId
        user {
          email
        }
        title
        text
        hunterAddress
        hunterAddressLabels {
          name
        }
        proposedAddress
        proposedAddressLabels {
          name
        }
        userLabels
        reward
        state
        isRewardClaimed
        createdAt
        finishAt
        votesFor
        votesAgainst
        sheriffsRewardShare
        fixedSheriffReward
        votes {
          amount
          voterAddress
          votedFor
        }
      }
    }
```
## Screenshots
<!--- (if appropriate) -->
![image](https://user-images.githubusercontent.com/122794/113159615-6af87a80-9245-11eb-8ecb-9c5bf8cc8292.png)

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
