### PR TITLE
Restructure the event bus event only when inserting in kafka

### DIFF
--- a/bin/clickhouse/tables_used
+++ b/bin/clickhouse/tables_used
@@ -3,17 +3,19 @@ api_call_data
 asset_metadata
 asset_prices_v3
 blockchain_address_labels
-bnb_balances
-btc_balances
+bnb_balances - still present, not used
+bnb_top_holders
+btc_balances - still present, not used
 daily_label_based_metrics
 daily_metrics_v2
 distribution_deltas_5min
-erc20_balances
-eth_balances
+erc20_balances - still present, not used
+eth_balances - still present, not used
+eth_top_holders_daily_union
 eth2_staking_transfers_mv
 github_v2
 intraday_label_based_metrics
-intraday_metrics
-ltc_balances
+intraday_metrics - still present, not used
+ltc_balances - still present, not used
 metric_metadata
 xrp_balances

--- a/config/config.exs
+++ b/config/config.exs
@@ -51,8 +51,13 @@ config :sanbase, Sanbase.KafkaExporter,
   kafka_url: {:system, "KAFKA_URL", "blockchain-kafka-kafka"},
   kafka_port: {:system, "KAFKA_PORT", "9092"},
   prices_topic: {:system, "KAFKA_PRICES_TOPIC", "asset_prices"},
-  api_call_data_topic: {:system, "KAFKA_API_CALL_DATA_TOPIC", "sanbase_api_call_data"},
-  event_bus_topic: {:system, "KAFKA_EVENT_BUS_TOPIC", "sanbase_event_bus"}
+  api_call_data_topic: {:system, "KAFKA_API_CALL_DATA_TOPIC", "sanbase_api_call_data"}
+
+config :sanbase, Sanbase.EventBus.KafkaExporterSubscriber,
+  event_bus_topic: {:system, "KAFKA_EVENT_BUS_TOPIC", "sanbase_event_bus"},
+  buffering_max_messages: 250,
+  can_send_after_interval: 1000,
+  kafka_flush_timeout: 5000
 
 config :sanbase, Sanbase.ExternalServices.RateLimiting.Server,
   implementation_module: Sanbase.ExternalServices.RateLimiting.WaitServer

--- a/config/test.exs
+++ b/config/test.exs
@@ -28,6 +28,11 @@ config :sanbase, Sanbase.KafkaExporter,
   supervisor: Sanbase.InMemoryKafka.Supervisor,
   producer: Sanbase.InMemoryKafka.Producer
 
+config :sanbase, Sanbase.EventBus.KafkaExporterSubscriber,
+  buffering_max_messages: 0,
+  can_send_after_interval: 0,
+  kafka_flush_timeout: 0
+
 config :sanbase, Sanbase.ExternalServices.RateLimiting.Server,
   implementation_module: Sanbase.ExternalServices.RateLimiting.TestServer
 

--- a/lib/sanbase/event_bus/event_bus.ex
+++ b/lib/sanbase/event_bus/event_bus.ex
@@ -60,8 +60,11 @@ defmodule Sanbase.EventBus do
     # and in this case prod should not break
     params =
       case Sanbase.EventBus.EventValidation.valid?(params.data) do
-        true -> params
-        false -> handle_invalid_event(params)
+        true ->
+          params
+
+        false ->
+          handle_invalid_event(params)
       end
 
     params =
@@ -70,10 +73,8 @@ defmodule Sanbase.EventBus do
         id: Map.get(params, :id, Ecto.UUID.generate()),
         topic: Map.fetch!(params, :topic),
         transaction_id: Map.get(params, :transaction_id),
-        event_type: Map.fetch!(params.data, :event_type),
-        user_id: Map.get(params.data, :user_id)
+        error_topic: Map.fetch!(params, :topic)
       })
-      |> Map.delete(:source)
 
     EventSource.notify params do
       Map.fetch!(params, :data)

--- a/lib/sanbase/event_bus/kafka_exporter_subscriber.ex
+++ b/lib/sanbase/event_bus/kafka_exporter_subscriber.ex
@@ -22,7 +22,8 @@ defmodule Sanbase.EventBus.KafkaExporterSubscriber do
   def handle_cast({topic, id} = event_shadow, state) do
     case EventBus.fetch_event(event_shadow) do
       %{} = event ->
-        kv_tuple = {event.id, event |> Map.from_struct() |> Jason.encode!()}
+        event = restructure_event(event)
+        kv_tuple = {event.id, Jason.encode!(event)}
 
         :ok =
           Sanbase.KafkaExporter.persist_async(
@@ -37,5 +38,17 @@ defmodule Sanbase.EventBus.KafkaExporterSubscriber do
     :ok = EventBus.mark_as_completed({__MODULE__, topic, id})
 
     {:noreply, state}
+  end
+
+  defp restructure_event(event) do
+    event = event |> Map.from_struct()
+
+    # Copy the event_type and user_id (if exists) to the top level for
+    # easier filtering on these 2 fields when the kafka topic is consumed in CH
+    event
+    |> Map.merge(%{
+      event_type: Map.fetch!(event.data, :event_type),
+      user_id: Map.get(event.data, :user_id)
+    })
   end
 end

--- a/lib/sanbase/utils/config.ex
+++ b/lib/sanbase/utils/config.ex
@@ -64,4 +64,8 @@ defmodule Sanbase.Utils.Config do
       |> Sanbase.Utils.Config.parse_config_value()
     end
   end
+
+  def module_get_integer!(module, key) do
+    module_get!(module, key) |> Sanbase.Math.to_integer()
+  end
 end

--- a/test/sanbase/event_bus/kafka_exporter_subscriber_test.exs
+++ b/test/sanbase/event_bus/kafka_exporter_subscriber_test.exs
@@ -1,0 +1,40 @@
+defmodule Sanbase.EventBus.KafkaExporterSubscriberTest do
+  use Sanbase.DataCase, async: false
+  import Sanbase.Factory
+
+  test "check kafka message format" do
+    Sanbase.InMemoryKafka.Producer.clear_state()
+
+    user = insert(:user)
+    Process.put(:__kafka_exporter_async_as_sync__, true)
+
+    Sanbase.Accounts.EventEmitter.emit_event({:ok, user}, :register_user, %{login_origin: :google})
+
+    # Wait a little bit because there are 2 GenServer.cast/2 invokations
+    Process.sleep(100)
+
+    event_bus_data = Sanbase.InMemoryKafka.Producer.get_state()["sanbase_event_bus"]
+
+    assert length(event_bus_data) == 1
+    assert [{_key, value}] = event_bus_data
+
+    user_id = user.id
+
+    assert %{
+             "data" => %{
+               "event_type" => "register_user",
+               "login_origin" => "google",
+               "user_id" => ^user_id
+             },
+             "event_type" => "register_user",
+             "id" => _,
+             "initialized_at" => _,
+             "occurred_at" => _,
+             "source" => "Sanbase.EventBus",
+             "topic" => "user_events",
+             "transaction_id" => nil,
+             "ttl" => nil,
+             "user_id" => ^user_id
+           } = Jason.decode!(value)
+  end
+end


### PR DESCRIPTION
## Changes

The Event structure cannot be changed itself, we can only change the
format we store in Kafka. Add configurable kafka exporter fields so in
test the max buffering messages and intervals can be reduced. This will
make the tests run faster as we don't have to wait for more
time/messages to arrive in order to push the data to kafka.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
