### PR TITLE
Add subscription type and mark liquidity subscriptions

### DIFF
--- a/lib/sanbase/ecto_enum.ex
+++ b/lib/sanbase/ecto_enum.ex
@@ -1,5 +1,12 @@
 import EctoEnum
 
+defenum(SubscriptionType, :subscription_type, [
+  "fiat",
+  "liquidity",
+  "burning_regular",
+  "burning_nft"
+])
+
 defenum(WatchlistType, :watchlist_type, ["project", "blockchain_address"])
 
 defenum(ColorEnum, :color, ["none", "blue", "red", "green", "yellow", "grey", "black"])

--- a/priv/repo/migrations/20210406104622_add_subscription_types.exs
+++ b/priv/repo/migrations/20210406104622_add_subscription_types.exs
@@ -1,0 +1,25 @@
+defmodule Sanbase.Repo.Migrations.AddSubscriptionTypes do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    DO $$ BEGIN
+      CREATE TYPE public.subscription_type AS ENUM ('fiat', 'liquidity', 'burning_regular', 'burning_nft');
+    EXCEPTION
+      WHEN duplicate_object THEN null;
+    END $$;
+    """)
+
+    alter table(:subscriptions) do
+      add(:type, :subscription_type, null: false, default: "fiat")
+    end
+  end
+
+  def down do
+    alter table(:subscriptions) do
+      remove(:type)
+    end
+
+    SubscriptionType.drop_type()
+  end
+end

--- a/priv/repo/migrations/20210406113235_mark_liquidity_subscriptions.exs
+++ b/priv/repo/migrations/20210406113235_mark_liquidity_subscriptions.exs
@@ -1,0 +1,23 @@
+defmodule Sanbase.Repo.Migrations.MarkLiquiditySubscriptions do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    UPDATE subscriptions
+    SET type = 'liquidity'
+    WHERE id IN (
+      SELECT id FROM subscriptions WHERE stripe_id is NULL
+    );
+    """)
+  end
+
+  def down do
+    execute("""
+    UPDATE subscriptions
+    SET type = 'fiat'
+    WHERE id IN (
+      SELECT id FROM subscriptions WHERE stripe_id is NULL
+    );
+    """)
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -72,6 +72,18 @@ CREATE TYPE public.status AS ENUM (
 
 
 --
+-- Name: subscription_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.subscription_type AS ENUM (
+    'fiat',
+    'liquidity',
+    'burning_regular',
+    'burning_nft'
+);
+
+
+--
 -- Name: watchlist_type; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -2150,7 +2162,8 @@ CREATE TABLE public.subscriptions (
     status public.status DEFAULT 'initial'::public.status NOT NULL,
     trial_end timestamp without time zone,
     inserted_at timestamp without time zone,
-    updated_at timestamp without time zone
+    updated_at timestamp without time zone,
+    type public.subscription_type DEFAULT 'fiat'::public.subscription_type NOT NULL
 );
 
 
@@ -5662,3 +5675,5 @@ INSERT INTO public."schema_migrations" (version) VALUES (20210303094304);
 INSERT INTO public."schema_migrations" (version) VALUES (20210311123253);
 INSERT INTO public."schema_migrations" (version) VALUES (20210323125906);
 INSERT INTO public."schema_migrations" (version) VALUES (20210330100652);
+INSERT INTO public."schema_migrations" (version) VALUES (20210406104622);
+INSERT INTO public."schema_migrations" (version) VALUES (20210406113235);


### PR DESCRIPTION
## Changes

1. Add subscription type field - one of:
```
  "fiat",
  "liquidity",
  "burning_regular",
  "burning_nft"
```

2. Mark subscription without stripe id as type `liquidity`.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
