### PR TITLE
Add type to table configurations

### DIFF
--- a/lib/sanbase/ecto_enum.ex
+++ b/lib/sanbase/ecto_enum.ex
@@ -8,6 +8,7 @@ defenum(SubscriptionType, :subscription_type, [
 ])
 
 defenum(WatchlistType, :watchlist_type, ["project", "blockchain_address"])
+defenum(TableConfigurationType, :table_configuration_type, ["project", "blockchain_address"])
 
 defenum(ColorEnum, :color, ["none", "blue", "red", "green", "yellow", "grey", "black"])
 

--- a/lib/sanbase/table_configuration/table_configuration.ex
+++ b/lib/sanbase/table_configuration/table_configuration.ex
@@ -6,6 +6,7 @@ defmodule Sanbase.TableConfiguration do
   alias Sanbase.Repo
 
   schema "table_configurations" do
+    field(:type, TableConfigurationType)
     field(:title, :string)
     field(:description, :string)
     field(:is_public, :boolean, default: false)
@@ -24,7 +25,7 @@ defmodule Sanbase.TableConfiguration do
     timestamps()
   end
 
-  @fields [:user_id, :title, :description, :is_public, :page_size, :columns]
+  @fields [:user_id, :type, :title, :description, :is_public, :page_size, :columns]
   def changeset(%__MODULE__{} = table_configuration, attrs \\ %{}) do
     table_configuration
     |> cast(attrs, @fields)

--- a/lib/sanbase_web/graphql/schema/types/table_configuration_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/table_configuration_types.ex
@@ -4,7 +4,13 @@ defmodule SanbaseWeb.Graphql.TableConfigurationTypes do
 
   alias SanbaseWeb.Graphql.SanbaseRepo
 
+  enum :table_configuration_type_enum do
+    value(:project)
+    value(:blockchain_address)
+  end
+
   input_object :table_configuration_input_object do
+    field(:type, :table_configuration_type_enum)
     field(:title, :string)
     field(:description, :string)
     field(:is_public, :boolean)
@@ -14,6 +20,7 @@ defmodule SanbaseWeb.Graphql.TableConfigurationTypes do
 
   object :table_configuration do
     field(:id, non_null(:integer))
+    field(:type, :table_configuration_type_enum)
     field(:title, :string)
     field(:description, :string)
     field(:is_public, :boolean)

--- a/priv/repo/migrations/20210413091357_add_table_config_type.exs
+++ b/priv/repo/migrations/20210413091357_add_table_config_type.exs
@@ -1,0 +1,15 @@
+defmodule Sanbase.Repo.Migrations.AddTableConfigType do
+  use Ecto.Migration
+
+  def up do
+    TableConfigurationType.create_type()
+
+    alter table(:table_configurations) do
+      add(:type, :table_configuration_type)
+    end
+  end
+
+  def down do
+    TableConfigurationType.drop_type()
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -84,6 +84,16 @@ CREATE TYPE public.subscription_type AS ENUM (
 
 
 --
+-- Name: table_configuration_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.table_configuration_type AS ENUM (
+    'project',
+    'blockchain_address'
+);
+
+
+--
 -- Name: watchlist_type; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -2204,7 +2214,8 @@ CREATE TABLE public.table_configurations (
     page_size integer DEFAULT 50,
     columns jsonb,
     inserted_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    type public.table_configuration_type
 );
 
 
@@ -5699,3 +5710,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20210406113235);
 INSERT INTO public."schema_migrations" (version) VALUES (20210408103523);
 INSERT INTO public."schema_migrations" (version) VALUES (20210408131830);
 INSERT INTO public."schema_migrations" (version) VALUES (20210409081625);
+INSERT INTO public."schema_migrations" (version) VALUES (20210413091357);

--- a/test/sanbase_web/graphql/table_configuration/table_configuration_api_test.exs
+++ b/test/sanbase_web/graphql/table_configuration/table_configuration_api_test.exs
@@ -14,6 +14,7 @@ defmodule SanbaseWeb.Graphql.TableConfigurationApiTest do
 
     settings = %{
       title: "My table configuration",
+      type: :project,
       description: "some description",
       is_public: false,
       page_size: 50,
@@ -44,6 +45,7 @@ defmodule SanbaseWeb.Graphql.TableConfigurationApiTest do
         |> get_in(["data", "createTableConfiguration"])
 
       assert table_configuration["title"] == settings.title
+      assert table_configuration["type"] == settings.type |> Atom.to_string() |> String.upcase()
       assert table_configuration["description"] == settings.description
       assert table_configuration["isPublic"] == settings.is_public
       assert table_configuration["pageSize"] == settings.page_size
@@ -61,6 +63,7 @@ defmodule SanbaseWeb.Graphql.TableConfigurationApiTest do
 
       new_settings = %{
         title: "New Title",
+        type: :blockchain_address,
         description: "New description",
         is_public: true,
         page_size: 150,
@@ -72,6 +75,10 @@ defmodule SanbaseWeb.Graphql.TableConfigurationApiTest do
         |> get_in(["data", "updateTableConfiguration"])
 
       assert table_configuration["title"] == new_settings.title
+
+      assert table_configuration["type"] ==
+               new_settings.type |> Atom.to_string() |> String.upcase()
+
       assert table_configuration["description"] == new_settings.description
       assert table_configuration["isPublic"] == new_settings.is_public
       assert table_configuration["pageSize"] == new_settings.page_size
@@ -155,6 +162,7 @@ defmodule SanbaseWeb.Graphql.TableConfigurationApiTest do
         |> get_in(["data", "tableConfiguration"])
 
       assert table_configuration["title"] == settings.title
+      assert table_configuration["type"] == settings.type |> Atom.to_string() |> String.upcase()
       assert table_configuration["description"] == settings.description
       assert table_configuration["isPublic"] == settings.is_public
       assert table_configuration["pageSize"] == settings.page_size
@@ -302,6 +310,7 @@ defmodule SanbaseWeb.Graphql.TableConfigurationApiTest do
       createTableConfiguration(settings: #{map_to_input_object_str(settings)}) {
         id
         title
+        type
         isPublic
         description
         pageSize
@@ -324,6 +333,7 @@ defmodule SanbaseWeb.Graphql.TableConfigurationApiTest do
     }) {
         id
         title
+        type
         isPublic
         description
         pageSize
@@ -344,6 +354,7 @@ defmodule SanbaseWeb.Graphql.TableConfigurationApiTest do
       deleteTableConfiguration(id: #{table_configuration_id}) {
         id
         title
+        type
         isPublic
         description
         pageSize
@@ -364,6 +375,7 @@ defmodule SanbaseWeb.Graphql.TableConfigurationApiTest do
       tableConfiguration(id: #{table_configuration_id}) {
         id
         title
+        type
         isPublic
         description
         pageSize
@@ -384,6 +396,7 @@ defmodule SanbaseWeb.Graphql.TableConfigurationApiTest do
       tableConfigurations {
         id
         title
+        type
         isPublic
         description
         pageSize
@@ -404,6 +417,7 @@ defmodule SanbaseWeb.Graphql.TableConfigurationApiTest do
       tableConfigurations(#{if user_id, do: "user_id: #{user_id}"}) {
         id
         title
+        type
         isPublic
         description
         pageSize


### PR DESCRIPTION
## Changes

Add type to the table configurations. There are two values supported: `PROJECT` and `BLOCKCHAIN_ADDRESS`
```graphql
mutation {
  createTableConfiguration(settings: {title: "Some Title", type: PROJECT}) {
    id
    type
  }
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
