### PR TITLE
Support market-segments-target

### DIFF
--- a/lib/sanbase/alerts/trigger/trigger.ex
+++ b/lib/sanbase/alerts/trigger/trigger.ex
@@ -181,6 +181,19 @@ defmodule Sanbase.Alert.Trigger do
     end
   end
 
+  defp remove_targets_on_cooldown(%{market_segments: market_segments} = target, trigger) do
+    combinator = Map.get(target, :market_segments_combinator, "and")
+
+    projects =
+      case combinator do
+        "and" -> Sanbase.Model.Project.List.by_market_segment_all_of(market_segments)
+        "or" -> Sanbase.Model.Project.List.by_market_segment_any_of(market_segments)
+      end
+
+    Enum.map(projects, & &1.slug)
+    |> remove_targets_on_cooldown(trigger, :slug)
+  end
+
   defp remove_targets_on_cooldown(%{slug: slug}, trigger)
        when is_binary(slug) or is_list(slug) do
     slug

--- a/lib/sanbase/alerts/trigger/validation/target_validation.ex
+++ b/lib/sanbase/alerts/trigger/validation/target_validation.ex
@@ -12,6 +12,9 @@ defmodule Sanbase.Alert.Validation.Target do
   def valid_target?(%{text: text}) when is_binary(text), do: :ok
   def valid_target?(%{word: word}) when is_binary(word), do: :ok
 
+  def valid_target?(%{market_segments: [market_segment | _]}) when is_binary(market_segment),
+    do: :ok
+
   def valid_target?(%{word: words}) when is_list(words) do
     Enum.find(words, fn word -> not is_binary(word) end)
     |> case do


### PR DESCRIPTION
## Changes

Extend the supported values in the `target` of the alert settings with the following:
```
"target": { "market_segments": ["defi", "stablecoin"] }
```

The way the multiple market segments are combined can be controlled by providing the `"market_segments_combinator": "and"|"or"` argument. By default it uses `"and"`. If a single market segment is used, this option has no effect.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
