### PR TITLE
Change the daily metric to accept all metrics with more than 5m min interval

### DIFF
--- a/lib/sanbase/alerts/trigger/settings/metric/daily_metric_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/metric/daily_metric_trigger_settings.ex
@@ -29,7 +29,7 @@ defmodule Sanbase.Alert.Trigger.DailyMetricTriggerSettings do
             template_kv: %{}
 
   validates(:metric, &valid_metric?/1)
-  validates(:metric, &valid_1_day_min_interval_metric?/1)
+  validates(:metric, &valid_above_5m_min_interval_metric?/1)
   validates(:target, &valid_target?/1)
   validates(:channel, &valid_notification_channel?/1)
   validates(:time_window, &valid_time_window?/1)

--- a/lib/sanbase/utils/validation.ex
+++ b/lib/sanbase/utils/validation.ex
@@ -106,9 +106,9 @@ defmodule Sanbase.Validation do
     end
   end
 
-  def valid_1_day_min_interval_metric?(metric) do
+  def valid_above_5m_min_interval_metric?(metric) do
     with {:ok, %{min_interval: min_interval}} <- Sanbase.Metric.metadata(metric),
-         interval_sec when is_number(interval_sec) and interval_sec >= 86_400 <-
+         interval_sec when is_number(interval_sec) and interval_sec > 300 <-
            Sanbase.DateTimeUtils.str_to_sec(min_interval) do
       :ok
     else


### PR DESCRIPTION
## Changes
Before that there were some metrics with min interval more than 5m but
less than 1d and they were not supported by either of the signals

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
