### PR TITLE
Introduce propsal_id as argument to the wallet hunters API

### DIFF
--- a/lib/sanbase/comments/entity_comment.ex
+++ b/lib/sanbase/comments/entity_comment.ex
@@ -11,7 +11,7 @@ defmodule Sanbase.Comments.EntityComment do
   alias Sanbase.Insight.PostComment
   alias Sanbase.ShortUrl.ShortUrlComment
   alias Sanbase.BlockchainAddress.BlockchainAddressComment
-  alias Sanbase.WalletHunters.ProposalComment
+  alias Sanbase.WalletHunters.WalletHuntersProposalComment
 
   @type entity ::
           :insight | :timeline_event | :short_url | :blockchain_address | :wallet_hunters_proposal
@@ -73,10 +73,10 @@ defmodule Sanbase.Comments.EntityComment do
   end
 
   @spec link(:wallet_hunters_proposal, non_neg_integer(), non_neg_integer()) ::
-          {:ok, %ProposalComment{}} | {:error, Ecto.Changeset.t()}
+          {:ok, %WalletHuntersProposalComment{}} | {:error, Ecto.Changeset.t()}
   def link(:wallet_hunters_proposal, entity_id, comment_id) do
-    %ProposalComment{}
-    |> ProposalComment.changeset(%{
+    %WalletHuntersProposalComment{}
+    |> WalletHuntersProposalComment.changeset(%{
       comment_id: comment_id,
       proposal_id: entity_id
     })
@@ -126,7 +126,7 @@ defmodule Sanbase.Comments.EntityComment do
 
   def all_comments_query() do
     from(c in Comment,
-      left_join: pc in ProposalComment,
+      left_join: pc in WalletHuntersProposalComment,
       on: c.id == pc.comment_id,
       where: is_nil(pc.proposal_id),
       preload: [:user, :insights, :timeline_events, :short_urls, :blockchain_addresses]
@@ -176,7 +176,7 @@ defmodule Sanbase.Comments.EntityComment do
   end
 
   defp entity_comments_query(:wallet_hunters_proposal, entity_id) do
-    from(comment in ProposalComment,
+    from(comment in WalletHuntersProposalComment,
       preload: [:comment, comment: :user]
     )
     |> maybe_add_entity_id_clause(:proposal_id, entity_id)

--- a/lib/sanbase/wallet_hunters/proposal.ex
+++ b/lib/sanbase/wallet_hunters/proposal.ex
@@ -166,7 +166,7 @@ defmodule Sanbase.WalletHunters.Proposal do
     end
   end
 
-  def fetch_by_id(proposal_id) do
+  def fetch_by_proposal_id(proposal_id) do
     with proposal <- Contract.wallet_proposal(proposal_id) do
       proposal
       |> List.wrap()

--- a/lib/sanbase/wallet_hunters/wallet_hunters_proposal_comment.ex
+++ b/lib/sanbase/wallet_hunters/wallet_hunters_proposal_comment.ex
@@ -1,4 +1,4 @@
-defmodule Sanbase.WalletHunters.ProposalComment do
+defmodule Sanbase.WalletHunters.WalletHuntersProposalComment do
   @moduledoc ~s"""
   A mapping table connecting comments and wallet hunters proposals.
   """

--- a/lib/sanbase_web/graphql/dataloader/postgres_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/postgres_dataloader.ex
@@ -65,7 +65,7 @@ defmodule SanbaseWeb.Graphql.MetricPostgresDataloader do
   def query(:comment_proposal_id, comment_ids) do
     ids = Enum.to_list(comment_ids)
 
-    from(mapping in Sanbase.WalletHunters.ProposalComment,
+    from(mapping in Sanbase.WalletHunters.WalletHuntersProposalComment,
       where: mapping.comment_id in ^ids,
       select: {mapping.comment_id, mapping.proposal_id}
     )
@@ -140,7 +140,7 @@ defmodule SanbaseWeb.Graphql.MetricPostgresDataloader do
   def query(:wallet_hunters_proposals_comments_count, proposal_ids) do
     ids = Enum.to_list(proposal_ids)
 
-    from(mapping in Sanbase.WalletHunters.ProposalComment,
+    from(mapping in Sanbase.WalletHunters.WalletHuntersProposalComment,
       where: mapping.proposal_id in ^ids,
       group_by: mapping.proposal_id,
       select: {mapping.proposal_id, fragment("COUNT(*)")}

--- a/lib/sanbase_web/graphql/resolvers/comment_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/comment_resolver.ex
@@ -36,7 +36,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.CommentResolver do
         %{context: %{auth: %{current_user: user}}}
       ) do
     content =
-      case Sanbase.WalletHunters.ProposalComment.has_type?(comment_id) do
+      case Sanbase.WalletHunters.WalletHuntersProposalComment.has_type?(comment_id) do
         true -> sanitize_markdown(content)
         false -> content
       end

--- a/lib/sanbase_web/graphql/resolvers/wallet_hunters_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/wallet_hunters_resolver.ex
@@ -43,8 +43,15 @@ defmodule SanbaseWeb.Graphql.Resolvers.WalletHuntersResolver do
     Sanbase.WalletHunters.Proposal.fetch_all(selector)
   end
 
-  def wallet_hunters_proposal(_root, args, _resolution) do
-    Sanbase.WalletHunters.Proposal.fetch_by_id(args.id)
+  def wallet_hunters_proposal(_root, %{proposal_id: proposal_id}, _resolution) do
+    Sanbase.WalletHunters.Proposal.fetch_by_proposal_id(proposal_id)
+  end
+
+  # TODO: Once the frontend migrates to fully use `proposal_id` as argument
+  # instead of `id`, we'll switch this id to mean the internal database id
+  # of the onchain proposal id
+  def wallet_hunters_proposal(_root, %{id: id}, _resolution) do
+    Sanbase.WalletHunters.Proposal.fetch_by_proposal_id(id)
   end
 
   def proposal_id(%{id: id}, _args, %{context: %{loader: loader}}) do

--- a/lib/sanbase_web/graphql/schema/queries/wallet_hunter_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/wallet_hunter_queries.ex
@@ -16,7 +16,8 @@ defmodule SanbaseWeb.Graphql.Schema.WalletHunterQueries do
     field :wallet_hunters_proposal, :wallet_hunter_proposal do
       meta(access: :free)
 
-      arg(:id, non_null(:integer))
+      arg(:id, :integer)
+      arg(:proposal_id, :integer)
 
       resolve(&WalletHuntersResolver.wallet_hunters_proposal/3)
     end


### PR DESCRIPTION
## Changes

We have an inconsistency in the arguments used in the wallet hunters APIs.
When it is in the argument, the `id` means `proposal_id` (the on-chain id of the proposal).
Internally and in comments, the `id` means the postgres table id column. To remedy the situation, we're introducing a `proposal_id` argument to the `walletHuntersProposal` API that will act as the current `id` argument.
After all clients are migrated to use it, the `id` argument semantics will be changed to mean the postgres table id.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
