### PR TITLE
Add all templates mailchimp templates in a single file

### DIFF
--- a/lib/sanbase/alerts/alert.ex
+++ b/lib/sanbase/alerts/alert.ex
@@ -222,7 +222,8 @@ defimpl Sanbase.Alert, for: Any do
   end
 
   defp do_send_email(email, payload, trigger_id) do
-    Sanbase.MandrillApi.send("signals", email, %{
+    Sanbase.Email.Template.alerts_template()
+    |> Sanbase.MandrillApi.send(email, %{
       payload:
         extend_payload(payload, trigger_id)
         |> Earmark.as_html!(breaks: true, timeout: nil, mapper: &Enum.map/2)
@@ -339,7 +340,8 @@ defimpl Sanbase.Alert, for: Any do
   end
 
   defp send_limit_reached_notification("email", user) do
-    Sanbase.MandrillApi.send("signals", user.email, %{
+    Sanbase.Email.Template.alerts_template()
+    |> Sanbase.MandrillApi.send(user.email, %{
       payload: limit_reached_payload("email") |> Earmark.as_html!(breaks: true)
     })
     |> case do

--- a/lib/sanbase/billing/subscription/sign_up_trial.ex
+++ b/lib/sanbase/billing/subscription/sign_up_trial.ex
@@ -37,18 +37,7 @@ defmodule Sanbase.Billing.Subscription.SignUpTrial do
     7 => :sent_second_education_email
   }
 
-  @templates %{
-    # immediately after sign up
-    sent_welcome_email: "sanbase-post-registration2",
-    # on the 4th day
-    sent_first_education_email: "first-edu-email2",
-    # on the 7th day
-    sent_second_education_email: "second-edu-email2",
-    # 3 days before end with coupon code
-    sent_trial_will_end_email: "trial-three-days-before-end2",
-    # when we cancel - ~ 2 hours before end
-    sent_trial_finished_without_cc: "trial-finished-without-card2"
-  }
+  @templates Sanbase.Email.Template.sign_up_trial_templates()
 
   schema "sign_up_trials" do
     belongs_to(:user, User)

--- a/lib/sanbase/comments/notification.ex
+++ b/lib/sanbase/comments/notification.ex
@@ -10,7 +10,6 @@ defmodule Sanbase.Comments.Notification do
   alias Sanbase.Timeline.TimelineEventComment
   alias Sanbase.Repo
 
-  @email_template "notification"
   @default_avatar "https://production-sanbase-images.s3.amazonaws.com/uploads/684aec65d98c952d6a29c8f0fbdcaea95787f1d4e752e62316e955a84ae97bf5_1588611275860_default-avatar.png"
 
   schema "comment_notifications" do
@@ -301,7 +300,8 @@ defmodule Sanbase.Comments.Notification do
   end
 
   defp send_email(email, params) do
-    Sanbase.MandrillApi.send(@email_template, email, params, %{
+    Sanbase.Email.Template.comment_notification_template()
+    |> Sanbase.MandrillApi.send(@email_template, email, params, %{
       merge_language: "handlebars"
     })
   end

--- a/lib/sanbase/email/newsletter_token.ex
+++ b/lib/sanbase/email/newsletter_token.ex
@@ -53,7 +53,9 @@ defmodule Sanbase.Email.NewsletterToken do
 
   def send_email(%__MODULE__{email: email, token: token}) do
     link = verify_url(token, email, "weekly_digest")
-    Sanbase.MandrillApi.send("verify_email_weekly_digest", email, %{VERIFY_LINK: link})
+
+    Sanbase.Email.Template.verification_email_template()
+    |> Sanbase.MandrillApi.send(email, %{VERIFY_LINK: link})
   end
 
   def subscribe_to_newsletter(email) do

--- a/lib/sanbase/email/template.ex
+++ b/lib/sanbase/email/template.ex
@@ -6,15 +6,15 @@ defmodule Sanbase.Email.Template do
   @alerts_template "signals"
   @sign_up_trial_templates %{
     # immediately after sign up
-    sent_welcome_email: "sanbase-post-registration",
+    sent_welcome_email: "sanbase_post_registration",
     # on the 4th day
-    sent_first_education_email: "first-edu-email",
+    sent_first_education_email: "first_edu_email",
     # on the 7th day
-    sent_second_education_email: "second-edu-email",
+    sent_second_education_email: "second_edu_email",
     # 3 days before end with coupon code
-    sent_trial_will_end_email: "trial-three-days-before-end",
+    sent_trial_will_end_email: "trial_three_days_before_end",
     # when we cancel - ~ 2 hours before end
-    sent_trial_finished_without_cc: "trial-finished-without-card"
+    sent_trial_finished_without_cc: "trial_finished_without_card"
   }
 
   @comment_notification_template "notification"

--- a/lib/sanbase/email/template.ex
+++ b/lib/sanbase/email/template.ex
@@ -2,12 +2,30 @@ defmodule Sanbase.Email.Template do
   @sanbase_login_templates %{login: "sanbase-sign-in", register: "sanbase-sign-up"}
   @neuro_login_templates %{login: "neuro-sign-in", register: "neuro-sign-up"}
   @sheets_login_templates %{login: "sheets-sign-in", register: "sheets-sign-up"}
-  @devcon_templates %{
-    login: "coupon-for-products-copy-01-1",
-    register: "coupon-for-products-copy-01-1"
-  }
   @verification_email_template "verify email"
+  @alerts_template "signals"
+  @sign_up_trial_templates %{
+    # immediately after sign up
+    sent_welcome_email: "sanbase-post-registration2",
+    # on the 4th day
+    sent_first_education_email: "first-edu-email2",
+    # on the 7th day
+    sent_second_education_email: "second-edu-email2",
+    # 3 days before end with coupon code
+    sent_trial_will_end_email: "trial-three-days-before-end2",
+    # when we cancel - ~ 2 hours before end
+    sent_trial_finished_without_cc: "trial-finished-without-card2"
+  }
 
+  @comment_notification_template "notification"
+  @verify_email_weekly_digest_template "verify_email_weekly_digest"
+  @monitoring_watchlist_template "Monitoring watchlist"
+
+  def alerts_template, do: @alerts_template
+  def sign_up_trial_templates, do: @sign_up_trial_templates
+  def comment_notification_template, do: @comment_notification_template
+  def verify_email_weekly_digest_template, do: @verify_email_weekly_digest_template
+  def monitoring_watchlist_template, do: @monitoring_watchlist_template
   def verification_email_template(), do: @verification_email_template
 
   def choose_login_template(origin_url, first_login?: true) when is_binary(origin_url) do

--- a/lib/sanbase/email/template.ex
+++ b/lib/sanbase/email/template.ex
@@ -2,24 +2,24 @@ defmodule Sanbase.Email.Template do
   @sanbase_login_templates %{login: "sanbase-sign-in", register: "sanbase-sign-up"}
   @neuro_login_templates %{login: "neuro-sign-in", register: "neuro-sign-up"}
   @sheets_login_templates %{login: "sheets-sign-in", register: "sheets-sign-up"}
-  @verification_email_template "verify email"
+  @verification_email_template "sanbase_verify_email"
   @alerts_template "signals"
   @sign_up_trial_templates %{
     # immediately after sign up
-    sent_welcome_email: "sanbase-post-registration2",
+    sent_welcome_email: "sanbase-post-registration",
     # on the 4th day
-    sent_first_education_email: "first-edu-email2",
+    sent_first_education_email: "first-edu-email",
     # on the 7th day
-    sent_second_education_email: "second-edu-email2",
+    sent_second_education_email: "second-edu-email",
     # 3 days before end with coupon code
-    sent_trial_will_end_email: "trial-three-days-before-end2",
+    sent_trial_will_end_email: "trial-three-days-before-end",
     # when we cancel - ~ 2 hours before end
-    sent_trial_finished_without_cc: "trial-finished-without-card2"
+    sent_trial_finished_without_cc: "trial-finished-without-card"
   }
 
   @comment_notification_template "notification"
   @verify_email_weekly_digest_template "verify_email_weekly_digest"
-  @monitoring_watchlist_template "Monitoring watchlist"
+  @monitoring_watchlist_template "monitoring_watchlist"
 
   def alerts_template, do: @alerts_template
   def sign_up_trial_templates, do: @sign_up_trial_templates

--- a/lib/sanbase/user_lists/monitor.ex
+++ b/lib/sanbase/user_lists/monitor.ex
@@ -39,7 +39,8 @@ defmodule Sanbase.UserList.Monitor do
       when is_list(watchlists) and is_list(insights) and length(watchlists) > 0 and
              length(insights) > 0 do
     send_result =
-      Sanbase.MandrillApi.send("Monitoring watchlist", user.email, send_params, %{
+      Sanbase.Email.Template.monitoring_watchlist_template()
+      |> Sanbase.MandrillApi.send(user.email, send_params, %{
         merge_language: "handlebars"
       })
 

--- a/test/sanbase/billing/sign_up_trial_test.exs
+++ b/test/sanbase/billing/sign_up_trial_test.exs
@@ -27,7 +27,7 @@ defmodule Sanbase.Billing.SignUpTrialTest do
 
       sign_up_trial = SignUpTrial |> Repo.all() |> hd()
 
-      assert_called(Sanbase.MandrillApi.send("first-edu-email", :_, :_))
+      assert_called(Sanbase.MandrillApi.send("first_edu_email", :_, :_))
       assert sign_up_trial.sent_first_education_email
     end
 
@@ -36,7 +36,7 @@ defmodule Sanbase.Billing.SignUpTrialTest do
 
       SignUpTrial.send_email_on_trial_day()
 
-      refute called(Sanbase.MandrillApi.send("first-edu-email", :_, :_))
+      refute called(Sanbase.MandrillApi.send("first_edu_email", :_, :_))
     end
 
     test "day 7 email is sent successfully and marked as sent", context do
@@ -45,7 +45,7 @@ defmodule Sanbase.Billing.SignUpTrialTest do
 
       sign_up_trial = SignUpTrial |> Repo.all() |> hd()
 
-      assert_called(Sanbase.MandrillApi.send("second-edu-email", :_, :_))
+      assert_called(Sanbase.MandrillApi.send("second_edu_email", :_, :_))
       assert sign_up_trial.sent_second_education_email
     end
   end
@@ -75,7 +75,7 @@ defmodule Sanbase.Billing.SignUpTrialTest do
         SignUpTrial.cancel_about_to_expire_trials()
 
         assert_called(Sanbase.StripeApi.delete_subscription(subscription.stripe_id))
-        assert_called(Sanbase.MandrillApi.send("trial-finished-without-card", :_, :_))
+        assert_called(Sanbase.MandrillApi.send("trial_finished_without_card", :_, :_))
       end
     end
 
@@ -103,7 +103,7 @@ defmodule Sanbase.Billing.SignUpTrialTest do
         SignUpTrial.cancel_about_to_expire_trials()
 
         assert_called(Sanbase.StripeApi.delete_subscription(subscription.stripe_id))
-        assert_called(Sanbase.MandrillApi.send("trial-finished-without-card", :_, :_))
+        assert_called(Sanbase.MandrillApi.send("trial_finished_without_card", :_, :_))
       end
     end
 
@@ -126,7 +126,7 @@ defmodule Sanbase.Billing.SignUpTrialTest do
         SignUpTrial.cancel_about_to_expire_trials()
 
         assert_called(Sanbase.StripeApi.delete_subscription(subscription.stripe_id))
-        refute called(Sanbase.MandrillApi.send("trial-finished-without-card", :_, :_))
+        refute called(Sanbase.MandrillApi.send("trial_finished_without_card", :_, :_))
       end
     end
 
@@ -146,7 +146,7 @@ defmodule Sanbase.Billing.SignUpTrialTest do
         SignUpTrial.cancel_about_to_expire_trials()
 
         refute called(Sanbase.StripeApi.delete_subscription(subscription.stripe_id))
-        refute called(Sanbase.MandrillApi.send("trial-finished-without-card", :_, :_))
+        refute called(Sanbase.MandrillApi.send("trial_finished_without_card", :_, :_))
       end
     end
   end

--- a/test/sanbase/billing/sign_up_trial_test.exs
+++ b/test/sanbase/billing/sign_up_trial_test.exs
@@ -27,7 +27,7 @@ defmodule Sanbase.Billing.SignUpTrialTest do
 
       sign_up_trial = SignUpTrial |> Repo.all() |> hd()
 
-      assert_called(Sanbase.MandrillApi.send("first-edu-email2", :_, :_))
+      assert_called(Sanbase.MandrillApi.send("first-edu-email", :_, :_))
       assert sign_up_trial.sent_first_education_email
     end
 
@@ -36,7 +36,7 @@ defmodule Sanbase.Billing.SignUpTrialTest do
 
       SignUpTrial.send_email_on_trial_day()
 
-      refute called(Sanbase.MandrillApi.send("first-edu-email2", :_, :_))
+      refute called(Sanbase.MandrillApi.send("first-edu-email", :_, :_))
     end
 
     test "day 7 email is sent successfully and marked as sent", context do
@@ -45,7 +45,7 @@ defmodule Sanbase.Billing.SignUpTrialTest do
 
       sign_up_trial = SignUpTrial |> Repo.all() |> hd()
 
-      assert_called(Sanbase.MandrillApi.send("second-edu-email2", :_, :_))
+      assert_called(Sanbase.MandrillApi.send("second-edu-email", :_, :_))
       assert sign_up_trial.sent_second_education_email
     end
   end
@@ -75,7 +75,7 @@ defmodule Sanbase.Billing.SignUpTrialTest do
         SignUpTrial.cancel_about_to_expire_trials()
 
         assert_called(Sanbase.StripeApi.delete_subscription(subscription.stripe_id))
-        assert_called(Sanbase.MandrillApi.send("trial-finished-without-card2", :_, :_))
+        assert_called(Sanbase.MandrillApi.send("trial-finished-without-card", :_, :_))
       end
     end
 
@@ -103,7 +103,7 @@ defmodule Sanbase.Billing.SignUpTrialTest do
         SignUpTrial.cancel_about_to_expire_trials()
 
         assert_called(Sanbase.StripeApi.delete_subscription(subscription.stripe_id))
-        assert_called(Sanbase.MandrillApi.send("trial-finished-without-card2", :_, :_))
+        assert_called(Sanbase.MandrillApi.send("trial-finished-without-card", :_, :_))
       end
     end
 
@@ -126,7 +126,7 @@ defmodule Sanbase.Billing.SignUpTrialTest do
         SignUpTrial.cancel_about_to_expire_trials()
 
         assert_called(Sanbase.StripeApi.delete_subscription(subscription.stripe_id))
-        refute called(Sanbase.MandrillApi.send("trial-finished-without-card2", :_, :_))
+        refute called(Sanbase.MandrillApi.send("trial-finished-without-card", :_, :_))
       end
     end
 
@@ -146,7 +146,7 @@ defmodule Sanbase.Billing.SignUpTrialTest do
         SignUpTrial.cancel_about_to_expire_trials()
 
         refute called(Sanbase.StripeApi.delete_subscription(subscription.stripe_id))
-        refute called(Sanbase.MandrillApi.send("trial-finished-without-card2", :_, :_))
+        refute called(Sanbase.MandrillApi.send("trial-finished-without-card", :_, :_))
       end
     end
   end


### PR DESCRIPTION
## Changes

Add all Mailchimp templates we use to send different emails in a single file so we have a better observability
what is used from backend and what is obsolete.

TODO: Templates in Mailchimp have quite different naming conventions.
Best will be if we can use only lower snake case, without intervals and remove versioning

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
