### PR TITLE
Extend signal metadata

### DIFF
--- a/lib/sanbase/signal/signal.ex
+++ b/lib/sanbase/signal/signal.ex
@@ -93,9 +93,12 @@ defmodule Sanbase.Signal do
   @doc ~s"""
   Get metadata for a given signal
   """
-  @spec metadata(signal) :: Type.metadata()
+  @spec metadata(signal) :: Type.metadata() | {:error, String.t()}
   def metadata(signal) do
-    SignalAdapter.metadata(signal)
+    case SignalAdapter.has_signal?(signal) do
+      true -> SignalAdapter.metadata(signal)
+      error -> error
+    end
   end
 
   @doc ~s"""

--- a/lib/sanbase/utils/error_handling.ex
+++ b/lib/sanbase/utils/error_handling.ex
@@ -92,6 +92,9 @@ defmodule Sanbase.Utils.ErrorHandling do
           %{metric: metric} ->
             {"metric", metric}
 
+          %{signal: signal} ->
+            {"signal", signal}
+
           slug when is_binary(slug) ->
             {"project with slug", slug}
 

--- a/lib/sanbase_web/graphql/middlewares/access_control.ex
+++ b/lib/sanbase_web/graphql/middlewares/access_control.ex
@@ -295,8 +295,8 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
         %{restricted_from: restricted_from, restricted_to: restricted_to} =
           Sanbase.Billing.Plan.Restrictions.get(
             context[:__query_argument_atom_name__],
-            context[:auth][:plan],
-            context[:product_id]
+            context[:auth][:plan] || :free,
+            context[:product_id] || Product.product_api()
           )
 
         resolution

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -272,7 +272,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       - Histogram data is an approximate representation of the distribution of
         numerical or categorical data. The metric is represented as a list of data
         points, where every point is represented represented by a tuple containing
-        a range an a value.
+        a range and a value.
     """
     field(:data_type, :metric_data_type)
 

--- a/lib/sanbase_web/graphql/schema/types/signal_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/signal_types.ex
@@ -77,6 +77,14 @@ defmodule SanbaseWeb.Graphql.SignalTypes do
     field(:available_aggregations, list_of(:aggregation))
 
     field(:data_type, :signal_data_type)
+
+    field(:is_accessible, :boolean)
+
+    field(:is_restricted, :boolean)
+
+    field(:restricted_from, :datetime)
+
+    field(:restricted_to, :datetime)
   end
 
   object :signal do

--- a/test/sanbase/signal/signal_metadata_test.exs
+++ b/test/sanbase/signal/signal_metadata_test.exs
@@ -27,7 +27,7 @@ defmodule Sanbase.SignalMetadataTest do
     for signal <- signals do
       {:ok, metadata} = Signal.metadata(signal)
       assert metadata.default_aggregation in aggregations
-      assert metadata.min_interval in ["1m", "5m", "1h", "6h", "8h", "1d"]
+      assert metadata.min_interval == "1m"
     end
   end
 end

--- a/test/sanbase/signal/signal_metadata_test.exs
+++ b/test/sanbase/signal/signal_metadata_test.exs
@@ -1,0 +1,33 @@
+defmodule Sanbase.SignalMetadataTest do
+  use Sanbase.DataCase, async: true
+
+  import Sanbase.Factory, only: [rand_str: 0]
+
+  alias Sanbase.Signal
+
+  test "can fetch metadata for all available signals" do
+    signal = Signal.available_signals()
+    results = for signal <- signal, do: Signal.metadata(signal)
+    assert Enum.all?(results, &match?({:ok, _}, &1))
+  end
+
+  test "cannot fetch metadata for not available signals" do
+    rand_signals = Enum.map(1..100, fn _ -> rand_str() end)
+    rand_signals = rand_signals -- Signal.available_signals()
+
+    results = for signal <- rand_signals, do: Signal.metadata(signal)
+
+    assert Enum.all?(results, &match?({:error, _}, &1))
+  end
+
+  test "metadata properties" do
+    signals = Signal.available_signals()
+    aggregations = Signal.available_aggregations()
+
+    for signal <- signals do
+      {:ok, metadata} = Signal.metadata(signal)
+      assert metadata.default_aggregation in aggregations
+      assert metadata.min_interval in ["1m", "5m", "1h", "6h", "8h", "1d"]
+    end
+  end
+end


### PR DESCRIPTION
## Changes
- Extend the signals' metadata with the following fields: `isAccessible`, `isRestricted`, `restrictedFrom`, `restrictedTo`
- Extend the getAccessRestrictions API with signals
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
