### PR TITLE
Rename get_active_sessions to get_auth_sessions

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/user/auth_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/auth_resolver.ex
@@ -5,7 +5,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.AuthResolver do
 
   require Logger
 
-  def get_active_sessions(_root, _args, %{context: %{auth: %{current_user: user}} = context}) do
+  def get_auth_sessions(_root, _args, %{context: %{auth: %{current_user: user}} = context}) do
     refresh_token = context[:jwt_tokens][:refresh_token]
 
     SanbaseWeb.Guardian.Token.refresh_tokens(user.id, refresh_token)

--- a/lib/sanbase_web/graphql/schema/queries/auth_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/auth_queries.ex
@@ -14,10 +14,10 @@ defmodule SanbaseWeb.Graphql.Schema.AuthQueries do
   }
 
   object :auth_queries do
-    field :get_active_sessions, list_of(:auth_session) do
+    field :get_auth_sessions, list_of(:auth_session) do
       meta(access: :free)
       middleware(JWTAuth)
-      resolve(&AuthResolver.get_active_sessions/3)
+      resolve(&AuthResolver.get_auth_sessions/3)
     end
   end
 

--- a/lib/sanbase_web/graphql/schema/types/auth_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/auth_types.ex
@@ -10,6 +10,7 @@ defmodule SanbaseWeb.Graphql.AuthTypes do
     field(:platform, non_null(:string))
     field(:client, non_null(:string))
     field(:is_current, non_null(:boolean))
+    field(:has_expired, non_null(:boolean))
   end
 
   object :login do

--- a/lib/sanbase_web/guardian/guardian_token.ex
+++ b/lib/sanbase_web/guardian/guardian_token.ex
@@ -45,16 +45,18 @@ defmodule SanbaseWeb.Guardian.Token do
       |> Enum.map(fn token ->
         is_current = not is_nil(current_refresh_token) and current_refresh_token == token.jwt
         created_at = DateTime.from_naive!(token.inserted_at, "Etc/UTC")
+        expires_at = DateTime.from_unix!(token.exp)
 
         %{
           type: token.typ,
           jti: token.jti,
-          expires_at: DateTime.from_unix!(token.exp),
+          expires_at: expires_at,
           client: Map.get(token.claims, "client", "unknown"),
           platform: Map.get(token.claims, "platform", "unknown"),
           last_active_at: last_active_at(token, created_at, is_current),
           created_at: created_at,
-          is_current: is_current
+          is_current: is_current,
+          has_expired: DateTime.compare(DateTime.utc_now(), expires_at) == :gt
         }
       end)
 

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -58,7 +58,7 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           :fetch_user_lists,
           :fetch_watchlists,
           :get_access_restrictions,
-          :get_active_sessions,
+          :get_auth_sessions,
           :get_attributes_for_users,
           :get_available_blockchains,
           :get_available_metrics,

--- a/test/sanbase_web/graphql/auth/auth_api_test.exs
+++ b/test/sanbase_web/graphql/auth/auth_api_test.exs
@@ -126,12 +126,13 @@ defmodule SanbaseWeb.Graphql.AuthApiTest do
 
     query = """
     {
-      getActiveSessions {
+      getAuthSessions {
         jti
         type
         createdAt
         expiresAt
         isCurrent
+        hasExpired
         client
         lastActiveAt
         platform
@@ -144,7 +145,7 @@ defmodule SanbaseWeb.Graphql.AuthApiTest do
       |> post("/graphql", query_skeleton(query))
       |> json_response(200)
 
-    sessions = result["data"]["getActiveSessions"]
+    sessions = result["data"]["getAuthSessions"]
 
     assert length(sessions) == 3
     assert [session1, session2, session3] = sessions
@@ -153,6 +154,7 @@ defmodule SanbaseWeb.Graphql.AuthApiTest do
     assert session1["platform"] == "unknown"
     assert session1["type"] == "refresh"
     assert session1["isCurrent"] == true
+    assert session1["hasExpired"] == false
     assert %DateTime{} = from_iso8601!(session1["createdAt"])
     assert %DateTime{} = from_iso8601!(session1["expiresAt"])
     assert %DateTime{} = from_iso8601!(session1["lastActiveAt"])
@@ -161,6 +163,7 @@ defmodule SanbaseWeb.Graphql.AuthApiTest do
     assert session2["platform"] == "iOS 12"
     assert session2["type"] == "refresh"
     assert session2["isCurrent"] == false
+    assert session2["hasExpired"] == false
     assert %DateTime{} = from_iso8601!(session2["createdAt"])
     assert %DateTime{} = from_iso8601!(session2["expiresAt"])
     assert %DateTime{} = from_iso8601!(session2["lastActiveAt"])
@@ -169,6 +172,7 @@ defmodule SanbaseWeb.Graphql.AuthApiTest do
     assert session3["platform"] == "MacOS 10.11.6 El Capitan"
     assert session3["type"] == "refresh"
     assert session3["isCurrent"] == false
+    assert session3["hasExpired"] == false
     assert %DateTime{} = from_iso8601!(session3["createdAt"])
     assert %DateTime{} = from_iso8601!(session3["expiresAt"])
     assert %DateTime{} = from_iso8601!(session3["lastActiveAt"])


### PR DESCRIPTION
## Changes
Rename `getActiveSessions` to `getAuthSessions`.

The API returns also expired sessions, so the 'active' in the name was
not a good fit. Add a field `hasExpired` to indicate if a session has
expired.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
