### PR TITLE
Add selector to raw signals API

### DIFF
--- a/lib/sanbase/model/project/selector.ex
+++ b/lib/sanbase/model/project/selector.ex
@@ -1,4 +1,4 @@
-defmodule Sanbase.Metric.Selector do
+defmodule Sanbase.Model.Project.Selector do
   @moduledoc """
   Module that is used for transforming selector from user-facing facing to the
   internal format.

--- a/lib/sanbase/signal/behaviour.ex
+++ b/lib/sanbase/signal/behaviour.ex
@@ -1,6 +1,6 @@
 defmodule Sanbase.Signal.Behaviour do
   @type slug :: String.t()
-  @type selector :: slug | map()
+  @type selector :: map()
   @type signal :: String.t()
   @type interval :: String.t()
   @type available_data_types :: :timeseries | :histogram | :table
@@ -55,6 +55,7 @@ defmodule Sanbase.Signal.Behaviour do
 
   @callback raw_data(
               signals :: :all | list(signal),
+              selector :: :all | selector(),
               from :: DateTime.t(),
               to :: DateTime.t()
             ) :: raw_data_result()

--- a/lib/sanbase/signal/signal.ex
+++ b/lib/sanbase/signal/signal.ex
@@ -16,6 +16,7 @@ defmodule Sanbase.Signal do
   @type aggregation :: Type.aggregation()
   @type interval :: Type.interval()
   @type selector :: Type.selector()
+  @type raw_signals_selector :: :all | selector()
 
   @spec has_signal?(signal) :: true | {:error, String.t()}
   def has_signal?(signal), do: SignalAdapter.has_signal?(signal)
@@ -94,11 +95,11 @@ defmodule Sanbase.Signal do
   @doc ~s"""
   Get metadata for a given signal
   """
-  @spec metadata(signal) :: Type.metadata() | {:error, String.t()}
+  @spec metadata(signal) :: {:ok, Type.metadata()} | {:error, String.t()}
   def metadata(signal) do
     case SignalAdapter.has_signal?(signal) do
       true -> SignalAdapter.metadata(signal)
-      error -> error
+      {:error, error} -> {:error, error}
     end
   end
 
@@ -122,9 +123,9 @@ defmodule Sanbase.Signal do
   If the `signals` arguments has a list of signals as a value, then all of those
   signals that occured in the given from-to interval are returned.
   """
-  @spec raw_data(signals, datetime, datetime) :: Type.raw_data_result()
-  def raw_data(signals, from, to) do
-    SignalAdapter.raw_data(signals, from, to)
+  @spec raw_data(signals, raw_signals_selector, datetime, datetime) :: Type.raw_data_result()
+  def raw_data(signals, selector, from, to) do
+    SignalAdapter.raw_data(signals, selector, from, to)
   end
 
   @doc ~s"""

--- a/lib/sanbase_web/graphql/resolvers/exchange_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/exchange_resolver.ex
@@ -25,14 +25,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.ExchangeResolver do
         _ -> []
       end
 
-    with {:ok, selector} <- Sanbase.Metric.Selector.args_to_selector(args),
+    with {:ok, selector} <- Sanbase.Model.Project.Selector.args_to_selector(args),
          {:ok, result} <- Exchanges.ExchangeMetric.top_exchanges_by_balance(selector, limit, opts) do
       {:ok, result}
     end
     |> maybe_handle_graphql_error(fn error ->
       handle_graphql_error(
         "Top Exchanges By Balance",
-        Sanbase.Metric.Selector.args_to_raw_selector(args),
+        Sanbase.Model.Project.Selector.args_to_raw_selector(args),
         error
       )
     end)

--- a/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
@@ -5,7 +5,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   import Sanbase.Utils.ErrorHandling,
     only: [handle_graphql_error: 3, maybe_handle_graphql_error: 2]
 
-  import Sanbase.Metric.Selector, only: [args_to_selector: 1, args_to_raw_selector: 1]
+  import Sanbase.Model.Project.Selector, only: [args_to_selector: 1, args_to_raw_selector: 1]
   import SanbaseWeb.Graphql.Helpers.Utils
 
   alias Sanbase.Metric

--- a/lib/sanbase_web/graphql/schema/queries/signal_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/signal_queries.ex
@@ -25,13 +25,13 @@ defmodule SanbaseWeb.Graphql.Schema.SignalQueries do
 
     field :get_raw_signals, list_of(:raw_signal) do
       meta(access: :free)
-      # TODO: Implement later. Now use all assets by default
-      # arg(:selector, ...)
+
+      arg(:selector, :signal_target_selector_input_object)
       arg(:signals, list_of(:string))
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
 
-      cache_resolve(&SignalResolver.get_raw_signals/3, ttl: 60, max_ttl_offset: 60)
+      cache_resolve(&SignalResolver.get_raw_signals/3, ttl: 30, max_ttl_offset: 30)
     end
   end
 end

--- a/lib/sanbase_web/graphql/schema/types/signal_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/signal_types.ex
@@ -13,6 +13,15 @@ defmodule SanbaseWeb.Graphql.SignalTypes do
     field(:slugs, list_of(:string))
   end
 
+  input_object :signal_target_selector_input_object do
+    field(:slug, :string)
+    field(:slugs, list_of(:string))
+    field(:market_segments, list_of(:string))
+    field(:ignored_slugs, list_of(:string))
+    field(:watchlist_id, :integer)
+    field(:watchlist_slug, :string)
+  end
+
   object :raw_signal do
     field(:datetime, non_null(:datetime))
     field(:slug, non_null(:string))
@@ -75,15 +84,10 @@ defmodule SanbaseWeb.Graphql.SignalTypes do
     aggregations see the documentation for `defaultAggregation`
     """
     field(:available_aggregations, list_of(:aggregation))
-
     field(:data_type, :signal_data_type)
-
     field(:is_accessible, :boolean)
-
     field(:is_restricted, :boolean)
-
     field(:restricted_from, :datetime)
-
     field(:restricted_to, :datetime)
   end
 

--- a/test/sanbase_web/graphql/signal/api_signal_raw_data_test.exs
+++ b/test/sanbase_web/graphql/signal/api_signal_raw_data_test.exs
@@ -15,7 +15,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ApiSignalRawDataTest do
     ]
   end
 
-  test "returns data for an available signal without signals filtering", context do
+  test "signal without signals filtering", context do
     %{conn: conn, from: from, to: to} = context
 
     # TODO: Update with different signals when they are added to the JSON file
@@ -39,7 +39,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ApiSignalRawDataTest do
     Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:ok, %{rows: rows}})
     |> Sanbase.Mock.run_with_mocks(fn ->
       result =
-        get_raw_signals(conn, :all, from, to)
+        get_raw_signals(conn, :all, :all, from, to)
         |> get_in(["data", "getRawSignals"])
 
       assert result == [
@@ -69,7 +69,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ApiSignalRawDataTest do
     end)
   end
 
-  test "returns data for an available signal with signals filtering", context do
+  test "signal with signals filtering", context do
     %{conn: conn, from: from, to: to} = context
 
     rows = [
@@ -92,7 +92,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ApiSignalRawDataTest do
     Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:ok, %{rows: rows}})
     |> Sanbase.Mock.run_with_mocks(fn ->
       result =
-        get_raw_signals(conn, ["dai_mint", "large_transactions"], from, to)
+        get_raw_signals(conn, ["dai_mint", "large_transactions"], :all, from, to)
         |> get_in(["data", "getRawSignals"])
 
       assert result == [
@@ -122,17 +122,63 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ApiSignalRawDataTest do
     end)
   end
 
+  test "signal with selector filtering", context do
+    %{conn: conn, from: from, to: to} = context
+
+    # When the slugs in the selector are validated they must exist
+    insert(:random_erc20_project, slug: "multi-collateral-dai")
+    insert(:random_erc20_project, slug: "not-dai")
+
+    rows = [
+      [
+        ~U[2019-01-01 00:00:00Z] |> DateTime.to_unix(),
+        "dai_mint",
+        "multi-collateral-dai",
+        21029,
+        ~s|{"txHash": "0xecdeb8435aff6e18e08177bb94d52b2da6dd15b95aee7f442021911a7c9861e6", "address": "0x183c9077fb7b74f02d3badda6c85a19c92b1f648"}|
+      ],
+      [
+        ~U[2019-01-02 00:00:00Z] |> DateTime.to_unix(),
+        "dai_mint",
+        "not-dai",
+        12_308_120,
+        ~s|{"txHash": "0x0bb27622fa4fcdf39344251e9b0776467eaa5d9dbf0f025d254f55093848f2bd", "address": "0x61c808d82a3ac53231750dadc13c777b59310bd9"}|
+      ]
+    ]
+
+    Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:ok, %{rows: rows}})
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      result =
+        get_raw_signals(conn, :all, ["multi-collateral-dai"], from, to)
+        |> get_in(["data", "getRawSignals"])
+
+      assert result == [
+               %{
+                 "datetime" => "2019-01-01T00:00:00Z",
+                 "metadata" => %{
+                   "address" => "0x183c9077fb7b74f02d3badda6c85a19c92b1f648",
+                   "txHash" =>
+                     "0xecdeb8435aff6e18e08177bb94d52b2da6dd15b95aee7f442021911a7c9861e6"
+                 },
+                 "value" => 21029.0,
+                 "signal" => "dai_mint",
+                 "slug" => "multi-collateral-dai"
+               }
+             ]
+    end)
+  end
+
   # Private functions
 
-  defp get_raw_signals(conn, signals, from, to) do
-    query = get_raw_signals_query(signals, from, to)
+  defp get_raw_signals(conn, signals, slugs, from, to) do
+    query = get_raw_signals_query(signals, slugs, from, to)
 
     conn
     |> post("/graphql", query_skeleton(query, "getSignal"))
     |> json_response(200)
   end
 
-  defp get_raw_signals_query(:all, from, to) do
+  defp get_raw_signals_query(:all, :all, from, to) do
     """
       {
         getRawSignals(from: "#{from}", to: "#{to}"){
@@ -146,10 +192,26 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ApiSignalRawDataTest do
     """
   end
 
-  defp get_raw_signals_query([_ | _] = signals, from, to) do
+  defp get_raw_signals_query([_ | _] = signals, :all, from, to) do
     """
       {
         getRawSignals(signals: #{string_list_to_string(signals)}, from: "#{from}", to: "#{to}"){
+          datetime
+          signal
+          slug
+          value
+          metadata
+        }
+      }
+    """
+  end
+
+  defp get_raw_signals_query(:all, slugs, from, to) do
+    slugs_str = Enum.map(slugs, &~s/"#{&1}"/) |> Enum.join(",")
+
+    """
+      {
+        getRawSignals(from: "#{from}", to: "#{to}", selector: {slugs: [#{slugs_str}]}){
           datetime
           signal
           slug


### PR DESCRIPTION
## Changes

Also:
- Move the Selector module from the metric to the project context
- Reduce the raw signals cache TTL

```graphql
{
  getRawSignals(
    selector: {slug: "bancor"}
    from: "utc_now-30d"
    to:"utc_now"){
      slug
      signal	
      value
  }
}
```

```graphql
{
  getRawSignals(
    selector: {slugs: ["bancor", "0x", "augur"]}
    from: "utc_now-30d"
    to:"utc_now"){
      slug
      signal	
      value
  }
}
```

```graphql
{
  getRawSignals(
    selector: {watchlistSlug: "stablecoins"}
    from: "utc_now-30d"
    to:"utc_now"){
      slug
      signal	
      value
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
