### PR TITLE
Fix alerts sent twice issue

### DIFF
--- a/config/scheduler_config.exs
+++ b/config/scheduler_config.exs
@@ -45,6 +45,7 @@ config :sanbase, Sanbase.Alerts.Scheduler,
 config :sanbase, Sanbase.Scrapers.Scheduler,
   scheduler_enabled: {:system, "QUANTUM_SCHEDULER_ENABLED", false},
   timeout: 30_000,
+  overlap: false,
   jobs: [
     update_api_call_limit_plans: [
       schedule: "@daily",
@@ -72,13 +73,11 @@ config :sanbase, Sanbase.Scrapers.Scheduler,
     ],
     sync_stripe_subscriptions: [
       schedule: "2-59/20 * * * *",
-      task: {Sanbase.Billing, :sync_stripe_subscriptions, []},
-      overlap: false
+      task: {Sanbase.Billing, :sync_stripe_subscriptions, []}
     ],
     remove_duplicate_subscriptions: [
       schedule: "*/20 * * * *",
-      task: {Sanbase.Billing, :remove_duplicate_subscriptions, []},
-      overlap: false
+      task: {Sanbase.Billing, :remove_duplicate_subscriptions, []}
     ],
     logo_fetcher: [
       schedule: "@daily",

--- a/config/scheduler_config.exs
+++ b/config/scheduler_config.exs
@@ -10,6 +10,7 @@ alias Sanbase.Alert.Trigger
 config :sanbase, Sanbase.Alerts.Scheduler,
   scheduler_enabled: {:system, "QUANTUM_SCHEDULER_ENABLED", false},
   timeout: 30_000,
+  overlap: false,
   jobs: [
     price_volume_difference_sonar_alert: [
       schedule: "1-59/5 * * * *",

--- a/lib/sanbase/alerts/evaluator/scheduler.ex
+++ b/lib/sanbase/alerts/evaluator/scheduler.ex
@@ -100,7 +100,7 @@ defmodule Sanbase.Alert.Scheduler do
           Logger.error("""
           [#{info_map.run_uuid}] Raised an exception while evaluating alerts of type #{
             info_map.type
-          } - batch #{index}. \
+          } - batch #{index}.
 
           #{Exception.format(:error, e, __STACKTRACE__)}
           """)


### PR DESCRIPTION
## Changes

The Quantum docs state:
```
overlap set to false to prevent next job from being executed if previous job is still running, default: true
```
so the alert jobs can be overlapped. The filtering of the triggered alerts happens in the beginning of the alert processing, so it can happen that the same alert is evaluated and sent twice.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
