### PR TITLE
Alert fixes

### DIFF
--- a/lib/sanbase/alerts/evaluator/scheduler.ex
+++ b/lib/sanbase/alerts/evaluator/scheduler.ex
@@ -42,7 +42,7 @@ defmodule Sanbase.Alert.Scheduler do
 
   # Private functions
 
-  @batch_size 100
+  @batch_size 60
   defp run(type) do
     Logger.info("Schedule evaluation for the alerts of type #{type}")
 

--- a/lib/sanbase/alerts/evaluator/scheduler.ex
+++ b/lib/sanbase/alerts/evaluator/scheduler.ex
@@ -58,6 +58,8 @@ defmodule Sanbase.Alert.Scheduler do
     # The batches are run sequentially for now. If they start running in parallel
     # the batches creation becomes more complicated - all the alerts of a user
     # must end up in a single batch so no race conditions updating the DB can occur.
+    # batches = split_into_batches(alerts)
+
     batches =
       alerts
       |> Enum.chunk_every(@batch_size)
@@ -80,6 +82,12 @@ defmodule Sanbase.Alert.Scheduler do
 
     run_batches(batches, info_map)
   end
+
+  # defp split_into_batches(alerts) do
+  #   user_groups = Enum.group_by(alerts, & &1.user_id)
+
+  #   Enum.reduce(user_groups, )
+  # end
 
   defp run_batches([], info_map) do
     Logger.info("""


### PR DESCRIPTION
## Changes
- Make the alerts of a given user be contained in a single batch. Make the batches a map that contains some general information for the alerts - what part of the all alerts does this batch cover.
- The batch size can now slightly vary. An edge case is when a user has hundreds of alerts as this will lead to a big batch.
-  Reduce the batch size from 200 to 100 but now execute up to 4 batches in parallel.
- Update the logging to properly indicate the changes introduced by the variable batch sizes.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
