### PR TITLE
Return max 6 months of timeline events data

### DIFF
--- a/lib/sanbase/timeline/cursor.ex
+++ b/lib/sanbase/timeline/cursor.ex
@@ -1,14 +1,38 @@
 defmodule Sanbase.Timeline.Cursor do
+  @moduledoc """
+  Cursor based pagination for timeline events.
+  Return maximum of 6 months of timeline events data.
+  """
+
   import Ecto.Query
 
-  def filter_by_cursor(query, :before, datetime) do
+  def filter_by_min_dt(query) do
+    min_dt = six_months_ago()
+
     from(
       event in query,
-      where: event.inserted_at <= ^datetime
+      where: event.inserted_at >= ^min_dt
+    )
+  end
+
+  def filter_by_cursor(query, :before, datetime) do
+    min_dt = six_months_ago()
+
+    from(
+      event in query,
+      where: event.inserted_at >= ^min_dt and event.inserted_at <= ^datetime
     )
   end
 
   def filter_by_cursor(query, :after, datetime) do
+    min_dt = six_months_ago()
+
+    datetime =
+      case DateTime.compare(datetime, min_dt) do
+        :gt -> datetime
+        _ -> min_dt
+      end
+
     from(
       event in query,
       where: event.inserted_at >= ^datetime
@@ -29,5 +53,9 @@ defmodule Sanbase.Timeline.Cursor do
          after: after_datetime
        }
      }}
+  end
+
+  defp six_months_ago() do
+    Timex.shift(Timex.now(), months: -6)
   end
 end

--- a/lib/sanbase/timeline/timeline_event.ex
+++ b/lib/sanbase/timeline/timeline_event.ex
@@ -108,6 +108,7 @@ defmodule Sanbase.Timeline.TimelineEvent do
 
   def events(%{order_by: order_by, filter_by: filter_by, limit: limit}) do
     TimelineEvent
+    |> Cursor.filter_by_min_dt()
     |> Filter.filter_by_query(filter_by)
     |> Query.events_by_sanfamily_query()
     |> Query.events_with_public_entities_query()
@@ -146,6 +147,7 @@ defmodule Sanbase.Timeline.TimelineEvent do
 
   def events(%User{id: user_id}, %{order_by: order_by, filter_by: filter_by, limit: limit}) do
     TimelineEvent
+    |> Cursor.filter_by_min_dt()
     |> Filter.filter_by_query(filter_by, user_id)
     |> Query.events_with_public_entities_query(user_id)
     |> Query.events_with_event_type([@publish_insight_type, @trigger_fired])


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

Return maximum of six months of feed data.
Also we have `timeline_events_user_id_inserted_at_index` so it is good to always have a filter on `inserted_at`.

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
