### PR TITLE
Add link to trending words table at certain datetime

### DIFF
--- a/lib/sanbase/alerts/trigger/settings/trending_words_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/trending_words_trigger_settings.ex
@@ -278,13 +278,21 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
     end
 
     defp extend_with_datetime_link({template, kv}) do
-      datetime_iso = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+      datetime_iso = now |> DateTime.to_iso8601()
+      datetime_human_readable = now |> Sanbase.DateTimeUtils.to_human_readable()
 
       template =
-        template <>
-          "[Trending words at #{datetime_iso}](#{
-            SanbaseWeb.Endpoint.trending_words_datetime_url(datetime_iso)
-          })\n"
+        template <> "[Trending words at {{datetime_human_readable}}]({{trending_words_url}})\n"
+
+      kv =
+        kv
+        |> Map.put(:datetime_human_readable, datetime_human_readable)
+        |> Map.put(:datetime_iso, datetime_iso)
+        |> Map.put(
+          :trending_words_url,
+          SanbaseWeb.Endpoint.trending_words_datetime_url(datetime_iso)
+        )
 
       {template, kv}
     end

--- a/lib/sanbase/alerts/trigger/settings/trending_words_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/trending_words_trigger_settings.ex
@@ -209,7 +209,9 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
       ```
       """
 
-      {template, kv} |> maybe_extend_with_explanation(settings)
+      {template, kv}
+      |> extend_with_datetime_link()
+      |> maybe_extend_with_explanation(settings)
     end
 
     defp template_kv(%{operation: %{trending_word: true}} = settings, [word]) do
@@ -225,7 +227,9 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
       🔔 The word {{trending_words_str}} is in the top 10 trending words on crypto social media.
       """
 
-      {template, kv} |> maybe_extend_with_explanation(settings)
+      {template, kv}
+      |> extend_with_datetime_link()
+      |> maybe_extend_with_explanation(settings)
     end
 
     defp template_kv(%{operation: %{trending_word: true}} = settings, [_, _ | _] = words) do
@@ -244,7 +248,9 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
       🔔 The words {{trending_words_str}} are in the top 10 trending words on crypto social media.
       """
 
-      {template, kv} |> maybe_extend_with_explanation(settings)
+      {template, kv}
+      |> extend_with_datetime_link()
+      |> maybe_extend_with_explanation(settings)
     end
 
     defp template_kv(%{operation: %{trending_project: true}} = settings, project) do
@@ -260,13 +266,27 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
       🔔 \#{{project_ticker}} | **{{project_name}}** is in the top 10 trending words on crypto social media.
       """
 
-      {template, kv} |> maybe_extend_with_explanation(settings)
+      {template, kv}
+      |> extend_with_datetime_link()
+      |> maybe_extend_with_explanation(settings)
     end
 
     defp get_max_len(top_words) do
       top_words
       |> Enum.map(&String.length(&1.word))
       |> Enum.max()
+    end
+
+    defp extend_with_datetime_link({template, kv}) do
+      datetime_iso = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+
+      template =
+        template <>
+          "[Trending words at #{datetime_iso}](#{
+            SanbaseWeb.Endpoint.trending_words_datetime_url(datetime_iso)
+          })\n"
+
+      {template, kv}
     end
 
     defp maybe_extend_with_explanation({template, kv}, settings) do

--- a/lib/sanbase_web/endpoint.ex
+++ b/lib/sanbase_web/endpoint.ex
@@ -175,4 +175,8 @@ defmodule SanbaseWeb.Endpoint do
   def show_alert_url(id) do
     sonar_url() <> "/signal/#{id}"
   end
+
+  def trending_words_datetime_url(datetime_iso) do
+    frontend_url() <> "/labs/trends?datetime=#{datetime_iso}"
+  end
 end

--- a/test/sanbase/alerts/trending_words/trigger_trending_words_trending_word_test.exs
+++ b/test/sanbase/alerts/trending_words/trigger_trending_words_trending_word_test.exs
@@ -120,12 +120,13 @@ defmodule Sanbase.Alert.TriggerTrendingWordsTrendingWordTest do
       assert context.trigger_trending_words.id == triggered.id
       payload = triggered.trigger.settings.payload |> Map.values() |> List.first()
 
-      IO.inspect(payload)
+      assert payload =~
+               "The words **san** and **santiment** are in the top 10 trending words on crypto social media."
 
-      assert payload =~ """
-             The words **san** and **santiment** are in the top 10 trending words on crypto social media.
-             A coin's appearance in trending words may suggest an increased risk of local tops and short-term price correction.
-             """
+      assert payload =~ "Trending words at"
+
+      assert payload =~
+               "A coin's appearance in trending words may suggest an increased risk of local tops and short-term price correction."
     end
   end
 


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

Add a link like this: https://app.santiment.net/labs/trends?datetime=2021-06-10T09:04:20.000Z
in the alert text.

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
