### PR TITLE
Tolerate kafka errors in CMC realtime exporter

### DIFF
--- a/lib/sanbase/external_services/coinmarketcap/ticker_fetcher.ex
+++ b/lib/sanbase/external_services/coinmarketcap/ticker_fetcher.ex
@@ -94,6 +94,11 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcher do
       end
     end)
     |> Sanbase.KafkaExporter.persist_sync(@prices_exporter)
+  rescue
+    e ->
+      Logger.error(
+        "[CMC] Realtime exporter failed to export to Kafka. Reason: #{Exception.message(e)}"
+      )
   end
 
   # Helper functions


### PR DESCRIPTION
## Changes
If the kafka export function fails now, the whole genserver is killed and the scrape begins again. This makes it go into an infinite scrape cycle, exhausting the credits.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
