### PR TITLE
Metric name aliases mapping

### DIFF
--- a/lib/sanbase_web/controllers/metric_name_controller.ex
+++ b/lib/sanbase_web/controllers/metric_name_controller.ex
@@ -4,13 +4,15 @@ defmodule SanbaseWeb.MetricNameController do
   alias Sanbase.Model.Project
   require Logger
 
-  def clickhouse_metric_aliases(conn, _params) do
+  def api_metric_name_mapping(conn, _params) do
     map = Sanbase.Clickhouse.MetricAdapter.FileHandler.name_to_metric_map()
 
     data =
       Enum.map(map, fn {k, v} ->
         %{public_name: k, internal_name: v}
+        |> Jason.encode!()
       end)
+      |> Enum.join("\n")
 
     conn
     |> put_resp_header("content-type", "application/json; charset=utf-8")

--- a/lib/sanbase_web/controllers/metric_name_controller.ex
+++ b/lib/sanbase_web/controllers/metric_name_controller.ex
@@ -1,0 +1,19 @@
+defmodule SanbaseWeb.MetricNameController do
+  use SanbaseWeb, :controller
+
+  alias Sanbase.Model.Project
+  require Logger
+
+  def clickhouse_metric_aliases(conn, _params) do
+    map = Sanbase.Clickhouse.MetricAdapter.FileHandler.name_to_metric_map()
+
+    data =
+      Enum.map(map, fn {k, v} ->
+        %{public_name: k, internal_name: v}
+      end)
+
+    conn
+    |> put_resp_header("content-type", "application/json; charset=utf-8")
+    |> Plug.Conn.send_resp(200, data)
+  end
+end

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -119,6 +119,7 @@ defmodule SanbaseWeb.Router do
   end
 
   scope "/", SanbaseWeb do
+    get("/api_metric_name_mapping", MetricNameController, :api_metric_name_mapping)
     get("/projects_data", ProjectDataController, :data)
     post("/stripe_webhook", StripeController, :webhook)
   end


### PR DESCRIPTION
## Changes

Add a REST endpoint that returns a list of json lines mapping between the public metric names and their internal counterpart used. This endpoint is to be used to create a clickhouse dictionary. The format in the dictionary is `JSONEachRow`, so every row is a separate JSON map and they are not combined into a list.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
