### PR TITLE
Apply restrictions to get_raw_signals

### DIFF
--- a/lib/sanbase_web/graphql/schema/types/signal_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/signal_types.ex
@@ -23,18 +23,18 @@ defmodule SanbaseWeb.Graphql.SignalTypes do
   end
 
   object :raw_signal do
-    field(:datetime, non_null(:datetime))
-    field(:slug, non_null(:string))
+    field(:signal, non_null(:string))
+    field(:is_hidden, non_null(:boolean))
+    field(:datetime, :datetime)
+    field(:slug, :string)
+    field(:value, :float)
+    field(:metadata, :json)
 
     # The signals can be computed for assets that are no longer linked to
     # an existing project. In this case this field can be nil.
     field :project, :project do
       cache_resolve(&SignalResolver.project/3)
     end
-
-    field(:signal, non_null(:string))
-    field(:value, non_null(:float))
-    field(:metadata, non_null(:json))
   end
 
   object :signal_data do


### PR DESCRIPTION
## Changes

Apply the access restrictions to the result of `get_raw_signals`. The restrictions are applied by removing all the data except the signal name - the rest of the fields are set to null and the `is_hidden` flag is set to true.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
