### PR TITLE
Fix how LatestCoinmarketcapData is stored and used

### DIFF
--- a/lib/sanbase/model/latest_coinmarketcap_data.ex
+++ b/lib/sanbase/model/latest_coinmarketcap_data.ex
@@ -66,7 +66,7 @@ defmodule Sanbase.Model.LatestCoinmarketcapData do
     Repo.get_by(LatestCoinmarketcapData, coinmarketcap_id: coinmarketcap_id)
   end
 
-  defp latest_coinmarketcap_data(project) do
+  def latest_coinmarketcap_data(project) do
     with cmc_id when not is_nil(cmc_id) <- Sanbase.Model.Project.coinmarketcap_id(project),
          %__MODULE__{} = latest_cmc <- by_coinmarketcap_id(cmc_id) do
       latest_cmc

--- a/lib/sanbase/model/project/project.ex
+++ b/lib/sanbase/model/project/project.ex
@@ -61,6 +61,7 @@ defmodule Sanbase.Model.Project do
     belongs_to(:infrastructure, Infrastructure, on_replace: :nilify)
     belongs_to(:market_segment, MarketSegment, on_replace: :nilify)
 
+    # TODO: Rework. This is no longer true
     belongs_to(
       :latest_coinmarketcap_data,
       LatestCoinmarketcapData,

--- a/lib/sanbase/model/project/project.ex
+++ b/lib/sanbase/model/project/project.ex
@@ -182,19 +182,6 @@ defmodule Sanbase.Model.Project do
     SanbaseWeb.Endpoint.frontend_url() <> "/projects/#{slug}"
   end
 
-  def supply(%Project{} = project) do
-    case get_supply(project) do
-      nil -> nil
-      s -> Decimal.to_float(s)
-    end
-  end
-
-  defp get_supply(%Project{total_supply: ts, latest_coinmarketcap_data: nil}), do: ts
-
-  defp get_supply(%Project{total_supply: ts, latest_coinmarketcap_data: lcd}) do
-    lcd.available_supply || lcd.total_supply || ts
-  end
-
   @doc ~s"""
   Return a project with a matching ticker. `Repo.one` fails if there are more
   than one project with the same ticker.


### PR DESCRIPTION
## Changes

We had some parts of code that still worked as if slug == cmc_id, which is no longer true.
These issues were leading to some price rescrapes not being able to finish
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
