### PR TITLE
Rework recent_transactions to use group by instead of final

### DIFF
--- a/lib/sanbase/transfers/erc20_transfers.ex
+++ b/lib/sanbase/transfers/erc20_transfers.ex
@@ -317,13 +317,16 @@ defmodule Sanbase.Transfers.Erc20Transfers do
       value,
       name,
       decimals
-    FROM erc20_transfers FINAL
+    FROM (
+      SELECT assetRefId, from, to, value, dt, transactionHash
+      FROM erc20_transfers
+      PREWHERE #{if only_sender, do: "from = ?1", else: "(from = ?1 OR to = ?1)"}
+      GROUP BY assetRefId, from, to, value, dt, transactionHash
+    )
     INNER JOIN (
       SELECT asset_ref_id AS assetRefId, name, decimals
       FROM asset_metadata FINAL
     ) USING (assetRefId)
-    PREWHERE
-      #{if only_sender, do: "from = ?1", else: "(from = ?1 OR to = ?1)"}
     ORDER BY dt DESC
     LIMIT ?2 OFFSET ?3
     """


### PR DESCRIPTION
## Changes

The changes shed off around 10 seconds from the execution time of the query:
Old:
```sql
8 rows in set. Elapsed: 17.988 sec. Processed 619.19 million rows, 56.83 GB (34.42 million rows/s., 3.16 GB/s.) 
```
New:
```sql
8 rows in set. Elapsed: 4.581 sec. Processed 619.18 million rows, 56.83 GB (135.16 million rows/s., 12.40 GB/s.) 
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
