### PR TITLE
Increase timeout and reduce concurrency in included_slugs_by_filters

### DIFF
--- a/lib/sanbase/model/project/list/selector/list_selector.ex
+++ b/lib/sanbase/model/project/list/selector/list_selector.ex
@@ -205,8 +205,9 @@ defmodule Sanbase.Model.Project.ListSelector do
 
           slugs |> MapSet.new()
         end,
+        timeout: 40_000,
         ordered: false,
-        max_concurrency: 8
+        max_concurrency: 4
       )
 
     case filters_combinator do


### PR DESCRIPTION
## Changes

It happens often in the signals that the `included_slugs_by_filters` times out. Reducing the concurrency (to still a high value) and increasing the timeout should remedy this.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
