### PR TITLE
ExKeccak.hash_256/1 now returns the binary data itself instead of :ok tuple

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/user/auth_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/auth_resolver.ex
@@ -155,7 +155,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.AuthResolver do
   defp address_message_hash(address) do
     message = "Login in Santiment with address #{address}"
     full_message = "\x19Ethereum Signed Message:\n" <> "#{String.length(message)}" <> message
-    {:ok, hash} = ExKeccak.hash_256(full_message)
+    hash = ExKeccak.hash_256(full_message)
     "0x" <> Base.encode16(hash, case: :lower)
   end
 end


### PR DESCRIPTION
## Changes

Here https://github.com/tzumby/ex_keccak/commit/781b446db8ce3f5810c57dcb668f6233333d999c the `hash256!` function was removed and the `hash256/1` function was changed to return the binary itself instead of `{:ok, binary}` tuple.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
