### PR TITLE
Add weighting and rank ordering to posts search

### DIFF
--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -288,6 +288,10 @@ defmodule Sanbase.Insight.Post do
     end
   end
 
+  def search_published_insights(search_term, opts \\ []) do
+    public_insights_query(opts) |> Sanbase.Insight.Search.run(search_term)
+  end
+
   def related_projects(%Post{} = post) do
     tags =
       post

--- a/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
@@ -131,9 +131,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.InsightResolver do
     ]
 
     # Search is done only on the publicly visible (published) insights.
-    search_result_insights =
-      Post.public_insights_query(opts)
-      |> Sanbase.Insight.Search.run(search_term)
+    search_result_insights = Post.search_published_insights(search_term, opts)
 
     {:ok, search_result_insights}
   end

--- a/priv/repo/migrations/20210712125345_regenerate_post_document_tokens.exs
+++ b/priv/repo/migrations/20210712125345_regenerate_post_document_tokens.exs
@@ -1,0 +1,11 @@
+defmodule Sanbase.Repo.Migrations.RegeneratePostDocumentTokens do
+  use Ecto.Migration
+
+  def up do
+    Sanbase.Insight.Search.update_all_document_tokens()
+  end
+
+  def down do
+    :ok
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -6244,3 +6244,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20210609082745);
 INSERT INTO public."schema_migrations" (version) VALUES (20210616123403);
 INSERT INTO public."schema_migrations" (version) VALUES (20210701130227);
 INSERT INTO public."schema_migrations" (version) VALUES (20210707135227);
+INSERT INTO public."schema_migrations" (version) VALUES (20210712125345);


### PR DESCRIPTION
## Changes
- Add different weights to the different parts of the posts. Highest weight is given to the title, less weight to the tags and metrics and the least weight to the insight body
- Add a partial matching in the title via `ILIKE`. This way the word `ethereu` would still match `ethereum` if found in the title.
- Sort the results in descending order based on the rank. With ordering + weighting now if the match happens in the title it will be higher (in the first positions) in the list.

These features do not change the public API. The only change in the API is now that the order of the results has a meaning - the insights that appear in the start of the list are a better match than those who appear at the end of the list.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
