### PR TITLE
Add deprecation to getMetric API

### DIFF
--- a/lib/sanbase/clickhouse/metric/file_handler.ex
+++ b/lib/sanbase/clickhouse/metric/file_handler.ex
@@ -148,7 +148,14 @@ defmodule Sanbase.Clickhouse.MetricAdapter.FileHandler do
                                        end
                                      )
 
-  @metrics_json Helper.expand_timebound_metrics(@metrics_json_pre_timebound_expand)
+  @metrics_json_including_deprecated Helper.expand_timebound_metrics(
+                                       @metrics_json_pre_timebound_expand
+                                     )
+  @metrics_json Enum.reject(
+                  @metrics_json_including_deprecated,
+                  &(not is_nil(&1["deprecated_since"]))
+                )
+
   @aggregations Sanbase.Metric.SqlQuery.Helper.aggregations()
   @metrics_data_type_map Helper.name_to_field_map(@metrics_json, "data_type",
                            transform_fn: &String.to_atom/1
@@ -200,6 +207,11 @@ defmodule Sanbase.Clickhouse.MetricAdapter.FileHandler do
                           |> Enum.reject(fn {_k, v} -> v == nil end)
                           |> Map.new()
 
+  @deprecated_metrics_map Helper.name_to_field_map(@metrics_json, "deprecated_since",
+                            required?: false,
+                            transform_fn: &Sanbase.DateTimeUtils.from_iso8601!/1
+                          )
+
   @metrics_list @metrics_json |> Enum.map(fn %{"name" => name} -> name end)
   @metrics_mapset MapSet.new(@metrics_list)
 
@@ -243,8 +255,8 @@ defmodule Sanbase.Clickhouse.MetricAdapter.FileHandler do
   def incomplete_data_map(), do: @incomplete_data_map
   def selectors_map(), do: @selectors_map
   def required_selectors_map(), do: @required_selectors_map
-
   def metrics_label_map(), do: @metrics_label_map
+  def deprecated_metrics_map(), do: @deprecated_metrics_map
 
   def metrics_with_access(level) when level in [:free, :restricted] do
     @access_map

--- a/lib/sanbase/clickhouse/metric/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/metric/metric_adapter.ex
@@ -37,6 +37,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
   @selectors_map FileHandler.selectors_map()
   @required_selectors_map FileHandler.required_selectors_map()
   @metric_to_name_map FileHandler.metric_to_name_map()
+  @deprecated_metrics_map FileHandler.deprecated_metrics_map()
   @default_complexity_weight 0.3
 
   @type slug :: String.t()
@@ -48,6 +49,9 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
 
   @impl Sanbase.Metric.Behaviour
   def restricted_metrics(), do: @restricted_metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def deprecated_metrics_map(), do: @deprecated_metrics_map
 
   @impl Sanbase.Metric.Behaviour
   def access_map(), do: @access_map

--- a/lib/sanbase/clickhouse/metric/metric_files/social_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/social_metrics.json
@@ -8,7 +8,10 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -25,7 +28,10 @@
     "metric": "social_dominance_v2",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -36,14 +42,16 @@
     "has_incomplete_data": false,
     "data_type": "timeseries"
   },
-
   {
     "human_readable_name": "Sentiment Volume Consumed Total",
     "name": "sentiment_volume_consumed_total",
     "metric": "sentiment_volume_consumed",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -60,7 +68,10 @@
     "metric": "sentiment_positive",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -77,7 +88,10 @@
     "metric": "sentiment_negative",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -94,7 +108,10 @@
     "metric": "sentiment_balance",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -114,7 +131,10 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -131,7 +151,10 @@
     "metric": "social_dominance_telegram_v2",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -148,7 +171,10 @@
     "metric": "sentiment_volume_consumed_telegram",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -165,7 +191,10 @@
     "metric": "sentiment_positive_telegram",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -182,7 +211,10 @@
     "metric": "sentiment_negative_telegram",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -199,7 +231,10 @@
     "metric": "sentiment_balance_telegram",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -219,7 +254,10 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -236,7 +274,10 @@
     "metric": "social_dominance_reddit_v2",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -253,7 +294,10 @@
     "metric": "sentiment_volume_consumed_reddit",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -270,7 +314,10 @@
     "metric": "sentiment_positive_reddit",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -287,7 +334,10 @@
     "metric": "sentiment_negative_reddit",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -304,7 +354,10 @@
     "metric": "sentiment_balance_reddit",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -324,7 +377,10 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -333,7 +389,8 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "deprecated_since": "2021-09-21T00:00:00Z"
   },
   {
     "human_readable_name": "Social Dominance Discord",
@@ -341,7 +398,10 @@
     "metric": "social_dominance_discord",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -350,7 +410,8 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "deprecated_since": "2021-09-21T00:00:00Z"
   },
   {
     "human_readable_name": "Sentiment Volume Consumed Discord",
@@ -358,7 +419,10 @@
     "metric": "sentiment_volume_consumed_discord",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -367,7 +431,8 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "deprecated_since": "2021-09-21T00:00:00Z"
   },
   {
     "human_readable_name": "Sentiment Positive Discord",
@@ -375,7 +440,10 @@
     "metric": "sentiment_positive_discord",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -384,7 +452,8 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "deprecated_since": "2021-09-21T00:00:00Z"
   },
   {
     "human_readable_name": "Sentiment Negative Discord",
@@ -392,7 +461,10 @@
     "metric": "sentiment_negative_discord",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -401,7 +473,8 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "deprecated_since": "2021-09-21T00:00:00Z"
   },
   {
     "human_readable_name": "Sentiment Balance Discord",
@@ -409,7 +482,10 @@
     "metric": "sentiment_balance_discord",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -418,7 +494,8 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "deprecated_since": "2021-09-21T00:00:00Z"
   },
   {
     "human_readable_name": "Social Volume Professional Traders Chat",
@@ -429,7 +506,10 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -438,7 +518,8 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "deprecated_since": "2021-09-21T00:00:00Z"
   },
   {
     "human_readable_name": "Social Dominance Professional Traders Chat",
@@ -446,7 +527,10 @@
     "metric": "social_dominance_professional_traders_chat",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -455,7 +539,8 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "deprecated_since": "2021-09-21T00:00:00Z"
   },
   {
     "human_readable_name": "Sentiment Volume Consumed Professional Traders Chat",
@@ -463,7 +548,10 @@
     "metric": "sentiment_volume_consumed_professional_traders_chat",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -472,7 +560,8 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "deprecated_since": "2021-09-21T00:00:00Z"
   },
   {
     "human_readable_name": "Sentiment Positive Professional Traders Chat",
@@ -480,7 +569,10 @@
     "metric": "sentiment_positive_professional_traders_chat",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -489,7 +581,8 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "deprecated_since": "2021-09-21T00:00:00Z"
   },
   {
     "human_readable_name": "Sentiment Negative Professional Traders Chat",
@@ -497,7 +590,10 @@
     "metric": "sentiment_negative_professional_traders_chat",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -506,7 +602,8 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "deprecated_since": "2021-09-21T00:00:00Z"
   },
   {
     "human_readable_name": "Sentiment Balance Professional Traders Chat",
@@ -514,7 +611,10 @@
     "metric": "sentiment_balance_professional_traders_chat",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -523,7 +623,8 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "deprecated_since": "2021-09-21T00:00:00Z"
   },
   {
     "human_readable_name": "Social Volume Twitter",
@@ -534,7 +635,10 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -551,7 +655,10 @@
     "metric": "social_dominance_twitter_v2",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -568,7 +675,10 @@
     "metric": "sentiment_volume_consumed_twitter",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -585,7 +695,10 @@
     "metric": "sentiment_positive_twitter",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -602,7 +715,10 @@
     "metric": "sentiment_negative_twitter",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -619,7 +735,10 @@
     "metric": "sentiment_balance_twitter",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -639,7 +758,10 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -656,7 +778,10 @@
     "metric": "social_dominance_bitcointalk_v2",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -673,7 +798,10 @@
     "metric": "sentiment_volume_consumed_bitcointalk",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -690,7 +818,10 @@
     "metric": "sentiment_positive_bitcointalk",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -707,7 +838,10 @@
     "metric": "sentiment_negative_bitcointalk",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -724,7 +858,10 @@
     "metric": "sentiment_balance_bitcointalk",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -741,7 +878,10 @@
     "metric": "unique_social_volume_5m",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -758,7 +898,10 @@
     "metric": "unique_social_volume_1h",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -775,7 +918,10 @@
     "metric": "social_dominance_1h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -792,7 +938,10 @@
     "metric": "social_dominance_24h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -809,7 +958,10 @@
     "metric": "social_dominance_telegram_1h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -826,7 +978,10 @@
     "metric": "social_dominance_telegram_24h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -843,7 +998,10 @@
     "metric": "social_dominance_reddit_1h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -860,7 +1018,10 @@
     "metric": "social_dominance_reddit_24h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -877,7 +1038,10 @@
     "metric": "social_dominance_twitter_1h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -894,7 +1058,10 @@
     "metric": "social_dominance_twitter_24h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -911,7 +1078,10 @@
     "metric": "social_dominance_bitcointalk_1h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -928,7 +1098,10 @@
     "metric": "social_dominance_bitcointalk_24h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": ["slug", "text"],
+    "selectors": [
+      "slug",
+      "text"
+    ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"

--- a/lib/sanbase/metric/behaviour.ex
+++ b/lib/sanbase/metric/behaviour.ex
@@ -189,6 +189,8 @@ defmodule Sanbase.Metric.Behaviour do
 
   @callback restricted_metrics() :: list(metric)
 
+  @callback deprecated_metrics_map() :: %{required(String.t()) => String.t()}
+
   @callback access_map() :: map()
 
   @callback min_plan_map() :: map()
@@ -196,6 +198,7 @@ defmodule Sanbase.Metric.Behaviour do
   @optional_callbacks [
     histogram_data: 6,
     table_data: 5,
-    timeseries_data_per_slug: 6
+    timeseries_data_per_slug: 6,
+    deprecated_metrics_map: 0
   ]
 end

--- a/lib/sanbase/metric/helper.ex
+++ b/lib/sanbase/metric/helper.ex
@@ -36,6 +36,7 @@ defmodule Sanbase.Metric.Helper do
   Module.register_attribute(__MODULE__, :histogram_metric_module_mapping_acc, accumulate: true)
   Module.register_attribute(__MODULE__, :table_metric_module_mapping_acc, accumulate: true)
   Module.register_attribute(__MODULE__, :required_selectors_map_acc, accumulate: true)
+  Module.register_attribute(__MODULE__, :deprecated_metrics_acc, accumulate: true)
 
   for module <- @metric_modules do
     @required_selectors_map_acc module.required_selectors
@@ -67,6 +68,9 @@ defmodule Sanbase.Metric.Helper do
                                        module.available_table_metrics(),
                                        fn metric -> %{metric: metric, module: module} end
                                      )
+
+    if function_exported?(module, :deprecated_metrics_map, 0),
+      do: @deprecated_metrics_acc(module.deprecated_metrics_map)
   end
 
   flat_unique = fn list -> list |> List.flatten() |> Enum.uniq() end
@@ -120,10 +124,15 @@ defmodule Sanbase.Metric.Helper do
   @table_metrics Enum.map(@table_metric_module_mapping, & &1.metric)
   @table_metrics_mapset MapSet.new(@table_metrics)
 
+  @deprecated_metrics_map Enum.reduce(@deprecated_metrics_acc, %{}, &Map.merge(&1, &2))
+                          |> Enum.reject(&match?({_, nil}, &1))
+                          |> Map.new()
+
   def access_map(), do: @access_map
   def aggregations_per_metric(), do: @aggregations_per_metric
   def aggregations(), do: @aggregations
   def free_metrics(), do: @free_metrics
+  def deprecated_metrics_map(), do: @deprecated_metrics_map
   def histogram_metric_module_mapping(), do: @histogram_metric_module_mapping
   def histogram_metric_to_module_map(), do: @histogram_metric_to_module_map
   def histogram_metrics_mapset(), do: @histogram_metrics_mapset

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -65,6 +65,7 @@ defmodule Sanbase.Metric do
   @table_metrics_mapset Helper.table_metrics_mapset()
   @table_metric_to_module_map Helper.table_metric_to_module_map()
   @required_selectors_map Helper.required_selectors_map()
+  @deprecated_metrics_map Helper.deprecated_metrics_map()
 
   @doc ~s"""
   Check if `metric` is a valid metric name.
@@ -81,6 +82,16 @@ defmodule Sanbase.Metric do
     case metric in @metrics_mapset do
       true -> {:ok, Map.get(@required_selectors_map, metric, [])}
       false -> metric_not_available_error(metric)
+    end
+  end
+
+  def is_not_deprecated?(metric) do
+    case Map.get(@deprecated_metrics_map, metric) do
+      nil ->
+        true
+
+      %DateTime{} = deprecated_since ->
+        {:error, "The metric #{metric} is deprecated since #{deprecated_since}"}
     end
   end
 
@@ -623,7 +634,7 @@ defmodule Sanbase.Metric do
   """
   @spec is_historical_data_allowed?(metric) :: boolean
   def is_historical_data_allowed?(metric) do
-    get_in(@access_map, [metric, "historical"]) === :free
+    get_in(@access_map, [metric, "historical"]) == :free
   end
 
   @doc ~s"""
@@ -631,7 +642,7 @@ defmodule Sanbase.Metric do
   """
   @spec is_realtime_data_allowed?(metric) :: boolean
   def is_realtime_data_allowed?(metric) do
-    get_in(@access_map, [metric, "realtime"]) === :free
+    get_in(@access_map, [metric, "realtime"]) == :free
   end
 
   @doc ~s"""

--- a/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
@@ -17,9 +17,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   @datapoints 300
 
   def get_metric(_root, %{metric: metric}, _resolution) do
-    case Metric.has_metric?(metric) do
-      true -> {:ok, %{metric: metric}}
-      {:error, error} -> {:error, error}
+    with true <- Metric.has_metric?(metric),
+         true <- Metric.is_not_deprecated?(metric) do
+      {:ok, %{metric: metric}}
     end
   end
 


### PR DESCRIPTION
## Changes
```graphql
{
  getMetric(metric: "social_volume_discord") {
    timeseriesData(slug: "bitcoin", from: "utc_now-1d", to: "utc_now") {
      datetime
      value
    }
  }
}
```

```json
{
  "data": {
    "getMetric": null
  },
  "errors": [
    {
      "locations": [
        {
          "column": 3,
          "line": 2
        }
      ],
      "message": "The metric social_volume_discord is deprecated since 2021-08-12 00:00:00Z",
      "path": [
        "getMetric"
      ]
    }
  ]
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
