### PR TITLE
Change the defualt aggregation of sentiment_volume_consumed metrics

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/social_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/social_metrics.json
@@ -48,7 +48,7 @@
       "SANAPI": "free",
       "SANBASE": "free"
     },
-    "aggregation": "sum",
+    "aggregation": "avg",
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
@@ -153,7 +153,7 @@
       "SANAPI": "free",
       "SANBASE": "free"
     },
-    "aggregation": "sum",
+    "aggregation": "avg",
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
@@ -258,7 +258,7 @@
       "SANAPI": "free",
       "SANBASE": "free"
     },
-    "aggregation": "sum",
+    "aggregation": "avg",
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
@@ -363,7 +363,7 @@
       "SANAPI": "free",
       "SANBASE": "free"
     },
-    "aggregation": "sum",
+    "aggregation": "avg",
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
@@ -468,7 +468,7 @@
       "SANAPI": "free",
       "SANBASE": "free"
     },
-    "aggregation": "sum",
+    "aggregation": "avg",
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
@@ -573,7 +573,7 @@
       "SANAPI": "free",
       "SANBASE": "free"
     },
-    "aggregation": "sum",
+    "aggregation": "avg",
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
@@ -678,7 +678,7 @@
       "SANAPI": "free",
       "SANBASE": "free"
     },
-    "aggregation": "sum",
+    "aggregation": "avg",
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,


### PR DESCRIPTION
## Changes

The volume consumed metrics are Z-score metrics, so the SUM aggregation
is not correct. It is changed to the more suitable AVG

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
