### PR TITLE
Add db indexes on post_id in 5 tables

### DIFF
--- a/priv/repo/migrations/20210716075649_add_post_id_indexes.exs
+++ b/priv/repo/migrations/20210716075649_add_post_id_indexes.exs
@@ -1,0 +1,19 @@
+defmodule Sanbase.Repo.Migrations.AddPostIdIndexes do
+  use Ecto.Migration
+
+  def up do
+    create(index(:post_images, [:post_id]))
+    create(index(:posts_tags, [:post_id]))
+    create(index(:posts_metrics, [:post_id]))
+    create(index(:votes, [:post_id]))
+    create(index(:timeline_events, [:post_id]))
+  end
+
+  def down do
+    drop(index(:post_images, [:post_id]))
+    drop(index(:posts_tags, [:post_id]))
+    drop(index(:posts_metrics, [:post_id]))
+    drop(index(:votes, [:post_id]))
+    drop(index(:timeline_events, [:post_id]))
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -4639,6 +4639,20 @@ CREATE UNIQUE INDEX post_images_image_url_index ON public.post_images USING btre
 
 
 --
+-- Name: post_images_post_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX post_images_post_id_index ON public.post_images USING btree (post_id);
+
+
+--
+-- Name: posts_metrics_post_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX posts_metrics_post_id_index ON public.posts_metrics USING btree (post_id);
+
+
+--
 -- Name: posts_metrics_post_id_metric_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4650,6 +4664,13 @@ CREATE UNIQUE INDEX posts_metrics_post_id_metric_id_index ON public.posts_metric
 --
 
 CREATE UNIQUE INDEX posts_projects_post_id_project_id_index ON public.posts_projects USING btree (post_id, project_id);
+
+
+--
+-- Name: posts_tags_post_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX posts_tags_post_id_index ON public.posts_tags USING btree (post_id);
 
 
 --
@@ -4870,6 +4891,13 @@ CREATE INDEX timeline_event_comments_mapping_timeline_event_id_index ON public.t
 
 
 --
+-- Name: timeline_events_post_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX timeline_events_post_id_index ON public.timeline_events USING btree (post_id);
+
+
+--
 -- Name: timeline_events_user_id_inserted_at_index; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5000,6 +5028,13 @@ CREATE UNIQUE INDEX users_twitter_id_index ON public.users USING btree (twitter_
 --
 
 CREATE UNIQUE INDEX users_username_index ON public.users USING btree (username);
+
+
+--
+-- Name: votes_post_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX votes_post_id_index ON public.votes USING btree (post_id);
 
 
 --
@@ -6245,3 +6280,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20210616123403);
 INSERT INTO public."schema_migrations" (version) VALUES (20210701130227);
 INSERT INTO public."schema_migrations" (version) VALUES (20210707135227);
 INSERT INTO public."schema_migrations" (version) VALUES (20210712125345);
+INSERT INTO public."schema_migrations" (version) VALUES (20210716075649);


### PR DESCRIPTION
## Changes
![image](https://user-images.githubusercontent.com/6518376/125914312-4df050df-df21-4a80-a2e6-c1cfad7864ff.png)

With more data in the tables some operations which don't work with indexes become too slow. In the example above deleting a post takes 16 seconds for deleting the images and 25 seconds for deleting the metrics

<!--- Describe your changes -->

## Ticket
https://www.notion.so/santiment/Fast-delete-insights-f61c992c938041059fbddf64ae976b09
<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
