### PR TITLE
Fix not updating the autogenerated queries

### DIFF
--- a/lib/sanbase/model/project/social_volume_query/social_volume_query_cron_job.ex
+++ b/lib/sanbase/model/project/social_volume_query/social_volume_query_cron_job.ex
@@ -33,7 +33,10 @@ defmodule Sanbase.Model.Project.SocialVolumeQuery.CronJob do
     |> Enum.with_index()
     |> Enum.reduce(Ecto.Multi.new(), fn {changeset, offset}, multi ->
       multi
-      |> Ecto.Multi.insert(offset, changeset, on_conflict: :nothing)
+      |> Ecto.Multi.insert(offset, changeset,
+        conflict_target: [:project_id],
+        on_conflict: :replace_all
+      )
     end)
     |> Sanbase.Repo.transaction()
     |> case do


### PR DESCRIPTION
## Changes

on_conflict: :nothing has been used, which makes it impossible to update
the autogenerated queries for projects that already have some record. In
some cases no autogenerated social volume query is present in the DB. In
other cases even if the autogenerated query changed and a changeset for
this was created, it still cannot be updated. Fix by changing the
:on_conflict to :replace


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
