### PR TITLE
Use MigrationRepo in prod env (stage/prod)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,7 @@ slaveTemplates.dockerTemplate { label ->
         try {
           sh "docker run --rm \
             --link test-postgres-${scmVars.GIT_COMMIT}-${env.BUILD_ID}-${env.CHANGE_ID}:test-db \
+            --env DATABASE_URL_MIGRATIONS_USER=postgres://postgres:password@test-db:5432/postgres \
             --env DATABASE_URL=postgres://postgres:password@test-db:5432/postgres \
             -t sanbase-test:${scmVars.GIT_COMMIT}-${env.BUILD_ID}-${env.CHANGE_ID}"
         } finally {

--- a/config/config.exs
+++ b/config/config.exs
@@ -67,6 +67,15 @@ config :sanbase, Sanbase.Repo,
   queue_interval: 1000,
   # because of pgbouncer
   prepare: :unnamed,
+  # Migration related configuration
+  migration_timestamps: [type: :naive_datetime_usec],
+  start_apps_before_migration: [:crypto, :ssl, :postgrex, :ecto, :ecto_sql]
+
+config :sanbase, Sanbase.MigrationRepo,
+  loggers: [Ecto.LogEntry, Sanbase.Prometheus.EctoInstrumenter],
+  adapter: Ecto.Adapters.Postgres,
+  # because of pgbouncer
+  prepare: :unnamed,
   migration_timestamps: [type: :naive_datetime_usec]
 
 config :sanbase, Sanbase.Accounts.Hmac, secret_key: {:system, "APIKEY_HMAC_SECRET_KEY", nil}

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -49,6 +49,13 @@ config :sanbase, Sanbase.Repo,
   hostname: "localhost",
   show_sensitive_data_on_connection_error: true
 
+config :sanbase, Sanbase.MigrationRepo,
+  username: "postgres",
+  password: "postgres",
+  database: "sanbase_dev",
+  hostname: "localhost",
+  show_sensitive_data_on_connection_error: true
+
 # Clickhousex does not support `:system` tuples. The configuration is done
 # by defining defining `:url` in the ClickhouseRepo `init` function.
 # These values are default values that are used locally when developing.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -20,6 +20,11 @@ config :sanbase, SanbaseWeb.Endpoint,
   live_view: [signing_salt: "${PHOENIX_LIVE_VIEW_SIGNING_SALT}"],
   check_origin: ["//*.santiment.net"]
 
+# On production use a special migration_repo with more privileges.
+# This is set only for production otherwise on stage the mix tasks would cause
+# issues like ecto.load will create priv/repo and priv/migration_repo dirs
+config :sanbase, Sanbase.Repo, migration_repo: Sanbase.MigrationRepo
+
 # Clickhousex does not support `:system` tuples. The configuration is done
 # by defining defining `:url` in the ClickhouseRepo `init` function.
 config :sanbase, Sanbase.ClickhouseRepo,

--- a/config/test.exs
+++ b/config/test.exs
@@ -44,6 +44,13 @@ config :sanbase, Sanbase.Repo,
   database: "sanbase_test",
   pool_size: 5
 
+config :sanbase, Sanbase.MigrationRepo,
+  username: "postgres",
+  password: "postgres",
+  database: "sanbase_dev",
+  hostname: "localhost",
+  show_sensitive_data_on_connection_error: true
+
 config :sanbase, Sanbase.ClickhouseRepo,
   pool: Ecto.Adapters.SQL.Sandbox,
   database: "sanbase_test",

--- a/lib/mix/release_tasks/migrate.ex
+++ b/lib/mix/release_tasks/migrate.ex
@@ -1,40 +1,17 @@
 defmodule Sanbase.ReleaseTasks.Migrate do
-  @start_apps [
-    :crypto,
-    :ssl,
-    :postgrex,
-    :ecto,
-    :ecto_sql
-  ]
+  def repos(), do: Application.get_env(:sanbase, :ecto_repos, [])
 
-  def repos, do: Application.get_env(:sanbase, :ecto_repos, [])
+  def migrate do
+    IO.puts("Start migrations...")
 
-  def run do
-    IO.puts("Starting dependencies..")
-    # Start apps necessary for executing migrations
-    Enum.each(@start_apps, &Application.ensure_all_started/1)
-
-    # Start the Repo(s) for myapp
-    IO.puts("Starting repos..")
-    Enum.each(repos(), & &1.start_link(pool_size: 1))
-
-    # Run migrations
-    Enum.each(repos(), &run_migrations_for/1)
+    for repo <- repos() do
+      IO.puts("Running migrations for #{inspect(repo)}")
+      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
+      IO.puts("Finished running migrations for #{inspect(repo)}")
+    end
   end
 
-  defp run_migrations_for(repo) do
-    app = Keyword.get(repo.config, :otp_app)
-    IO.puts("Running migrations for #{app}")
-    Ecto.Migrator.run(repo, migrations_path(repo), :up, all: true)
+  def rollback(repo, version) do
+    {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
   end
-
-  defp migrations_path(repo), do: priv_path_for(repo, "migrations")
-
-  defp priv_path_for(repo, filename) do
-    app = Keyword.get(repo.config, :otp_app)
-    repo_underscore = repo |> Module.split() |> List.last() |> Macro.underscore()
-    Path.join([priv_dir(app), repo_underscore, filename])
-  end
-
-  defp priv_dir(app), do: "#{:code.priv_dir(app)}"
 end

--- a/lib/mix/release_tasks/release_tasks.ex
+++ b/lib/mix/release_tasks/release_tasks.ex
@@ -5,7 +5,7 @@ defmodule Sanbase.ReleaseTasks do
     # Load the code for myapp, but don't start it
     Application.load(:sanbase)
 
-    Migrate.run()
+    Migrate.migrate()
 
     # Alert shutdown
     IO.puts("Success!")

--- a/lib/mix/tasks/database_safety.ex
+++ b/lib/mix/tasks/database_safety.ex
@@ -22,6 +22,10 @@ defmodule Mix.Tasks.DatabaseSafety do
       raise(Mix.Error, "Cannot load Envy")
     end
 
+    # When migrations are run with `mix ecto.migrate` the DATABSE_URL env var is
+    # used. Only in prod environment the DATABASE_URL_MIGRATIONS_USER env var is
+    # used, so here we do not check for it. The purposes of this task is to guard
+    # against running migrations against stage/prod when developing locally.
     env = Config.module_get(Sanbase, :env)
     database_url = System.get_env("DATABASE_URL")
 

--- a/lib/sanbase/migration_repo.ex
+++ b/lib/sanbase/migration_repo.ex
@@ -1,0 +1,26 @@
+defmodule Sanbase.MigrationRepo do
+  use Ecto.Repo, otp_app: :sanbase, adapter: Ecto.Adapters.Postgres
+
+  require Sanbase.Utils.Config, as: Config
+  @database_url_env_var_name "DATABASE_URL_MIGRATIONS_USER"
+  def database_url_env_var(), do: @database_url_env_var_name
+
+  @doc """
+  Dynamically loads the repository url from the
+  DATABASE_URL environment variable.
+  """
+  def init(_, opts) do
+    pool_size = Config.get(:pool_size) |> Sanbase.Math.to_integer()
+    max_overflow = Config.get(:max_overflow) |> Sanbase.Math.to_integer()
+
+    # The migrations sometimes need privileges that are not granted to the
+    # user that queries the database. These privileges include creation of
+    # new schemas and creation of new types.
+    opts =
+      opts
+      |> Keyword.put(:pool_size, pool_size)
+      |> Keyword.put(:url, System.get_env(@database_url_env_var_name))
+
+    {:ok, opts}
+  end
+end


### PR DESCRIPTION
## Changes

Use a separate `MigrationRepo` to run the migrations in prod environment (stage and prod clusters). This way the migrations will be run with a user with more privileges that can create schemas, types, etc.

Also change the way we run migrations in our `mix release` task - newer functions from the the `Ecto.Migrator` modules are used. The `Ecto.Migrator.with_repo/3` function knows of the `migration_repo` config and if it is present, it manually starts the repo with `pool_size: 2` and then stops it. Because of this we don't have to start the repo in our Supervision tree.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
