### PR TITLE
Fix datetime in the get_latest_metric_data API

### DIFF
--- a/lib/sanbase/metric/latest_metric.ex
+++ b/lib/sanbase/metric/latest_metric.ex
@@ -51,7 +51,7 @@ defmodule Sanbase.Metric.LatestMetric do
       name AS slug,
       metric_id,
       argMax(value, dt) AS value,
-      toUnixTimestamp(max(dt)) AS max_dt,
+      toUnixTimestamp(max(toDateTime(dt))) AS max_dt,
       toUnixTimestamp(argMax(computed_at, dt)) AS computed_at
     FROM(
       SELECT


### PR DESCRIPTION
## Changes

In case `dt` is `Date` and not `Datetime`, the `toUnixTimestamp` does not work as intended and returns the year 1970.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
