### PR TITLE
Add /cryptocompare_asset_mapping to be used in CH dictionary

### DIFF
--- a/lib/sanbase_web/controllers/cryptocompare_asset_mapping_controller.ex
+++ b/lib/sanbase_web/controllers/cryptocompare_asset_mapping_controller.ex
@@ -1,0 +1,22 @@
+defmodule SanbaseWeb.CryptocompareAssetMappingController do
+  use SanbaseWeb, :controller
+
+  alias Sanbase.Model.Project
+  require Logger
+
+  def data(conn, _params) do
+    data = Sanbase.Cache.get_or_store({__MODULE__, __ENV__.function}, &get_data/0)
+
+    conn
+    |> put_resp_header("content-type", "application/json; charset=utf-8")
+    |> Plug.Conn.send_resp(200, data)
+  end
+
+  defp get_data() do
+    Project.SourceSlugMapping.get_source_slug_mappings("cryptocompare")
+    |> Enum.map(fn {cpc_slug, san_slug} ->
+      %{"base_asset" => cpc_slug, "slug" => san_slug} |> Jason.encode!()
+    end)
+    |> Enum.join("\n")
+  end
+end

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -122,6 +122,7 @@ defmodule SanbaseWeb.Router do
   scope "/", SanbaseWeb do
     get("/api_metric_name_mapping", MetricNameController, :api_metric_name_mapping)
     get("/projects_data", ProjectDataController, :data)
+    get("/cryptocompare_asset_mapping", CryptocompareAssetMappingController, :data)
     post("/stripe_webhook", StripeController, :webhook)
   end
 


### PR DESCRIPTION
## Changes

Returns data in the following format:
```json
{"base_asset":"CTPT","slug":"contents-protocol"}
{"base_asset":"OCEAN","slug":"ocean-protocol"}
{"base_asset":"PAX","slug":"paxos-standard"}
{"base_asset":"WAXP","slug":"wax"}
{"base_asset":"OXEN","slug":"loki"}
{"base_asset":"PERL","slug":"perlin"}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
