### PR TITLE
Fix alias typo in cryptocompare websocket exporter

### DIFF
--- a/lib/sanbase/cryptocompare/websocket_scraper.ex
+++ b/lib/sanbase/cryptocompare/websocket_scraper.ex
@@ -14,7 +14,7 @@ defmodule Sanbase.Cryptocompare.WebsocketScraper do
 
   alias Sanbase.ExternalServices.Coinmarketcap.PricePoint, as: AssetPricesPoint
   alias Sanbase.Cryptocompare.PricePoint, as: CryptocompareAssetPricesPoint
-  alias Sanbase.Cryptocompare.PriceOnlPyoint, as: CryptocompareAssetPricesOnlyPoint
+  alias Sanbase.Cryptocompare.PriceOnlyPoint, as: CryptocompareAssetPricesOnlyPoint
 
   require Logger
   require Sanbase.Utils.Config, as: Config
@@ -183,6 +183,9 @@ defmodule Sanbase.Cryptocompare.WebsocketScraper do
     export_asset_prices_topic(point, last_points)
     export_asset_price_pairs_topic(point)
     export_asset_price_pairs_only_topic(point)
+  rescue
+    e ->
+      Logger.error("[CryptocompareWS] Failed to export data point: #{Exception.message(e)}")
   end
 
   defp export_asset_prices_topic(%{quote_asset: quote_asset} = point, last_points)


### PR DESCRIPTION
## Changes

Add handling of errors

Add a rescue, otherwise such bugs can cause a crashloop which exhaust
the websocket connection limit


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
