### PR TITLE
Do not use a common process to send data to Kafka in CPC historical

### DIFF
--- a/lib/sanbase/cryptocompare/historical_worker.ex
+++ b/lib/sanbase/cryptocompare/historical_worker.ex
@@ -187,24 +187,21 @@ defmodule Sanbase.Cryptocompare.HistoricalWorker do
     csv_line_to_point([time, fsym, tsym, o, h, l, c, vol_from, vol_to])
   end
 
-  @asset_ohlcv_price_pairs_topic_exporter :asset_ohlcv_price_pairs_exporter
-  @asset_price_pairs_only_exporter :asset_price_pairs_only_exporter
-
   defp export_data(data) do
     export_asset_ohlcv_price_pairs_topic(data)
     export_asset_price_pairs_only_topic(data)
   end
 
   defp export_asset_ohlcv_price_pairs_topic(data) do
-    data
-    |> Enum.map(&to_ohlcv_price_point/1)
-    |> Sanbase.KafkaExporter.persist_sync(@asset_ohlcv_price_pairs_topic_exporter)
+    data = Enum.map(data, &to_ohlcv_price_point/1)
+    topic = Config.module_get!(Sanbase.KafkaExporter, :asset_ohlcv_price_pairs_topic)
+    Sanbase.KafkaExporter.send_data_to_topic_from_current_process(data, topic)
   end
 
   defp export_asset_price_pairs_only_topic(data) do
-    data
-    |> Enum.map(&to_price_only_point/1)
-    |> Sanbase.KafkaExporter.persist_sync(@asset_price_pairs_only_exporter)
+    data = Enum.map(data, &to_price_only_point/1)
+    topic = Config.module_get!(Sanbase.KafkaExporter, :asset_price_pairs_only_topic)
+    Sanbase.KafkaExporter.send_data_to_topic_from_current_process(data, topic)
   end
 
   defp to_ohlcv_price_point(point) do

--- a/lib/sanbase/cryptocompare/supervisor.ex
+++ b/lib/sanbase/cryptocompare/supervisor.ex
@@ -63,21 +63,6 @@ defmodule Sanbase.Cryptocompare.Supervisor do
         start_if(
           fn -> HistoricalScheduler end,
           fn -> HistoricalScheduler.enabled?() end
-        ),
-
-        # Kafka exporter for the historical OHLCV exporter
-        start_if(
-          fn ->
-            Sanbase.KafkaExporter.child_spec(
-              id: :asset_ohlcv_price_pairs_exporter,
-              name: :asset_ohlcv_price_pairs_exporter,
-              topic: Config.module_get!(Sanbase.KafkaExporter, :asset_ohlcv_price_pairs_topic),
-              buffering_max_messages: 1000,
-              can_send_after_interval: 250,
-              kafka_flush_timeout: 2000
-            )
-          end,
-          fn -> HistoricalScheduler.enabled?() end
         )
       ]
       |> normalize_children()

--- a/lib/sanbase/kafka/kafka_exporter.ex
+++ b/lib/sanbase/kafka/kafka_exporter.ex
@@ -81,6 +81,10 @@ defmodule Sanbase.KafkaExporter do
     GenServer.call(exporter, {:persist, data}, timeout)
   end
 
+  def send_data_to_topic_from_current_process(data, topic) do
+    send_data_immediately(data, %{topic: topic, size: length(data)})
+  end
+
   def flush(exporter \\ __MODULE__) do
     GenServer.call(exporter, :flush)
   end


### PR DESCRIPTION
## Changes

Add a function to KafkaExporter that sends the data to a topic
immediately. Prefer using this new function instead of calling
SanExporterEx directly as the latter does not have a in-memory producer
to be used in dev/test.

This new function is used when exporting data in sync from the caller process,
so the errors can be handled and the job can be properly stored along with
the errors. This is an improvement as the Oban queue is running with a
concurrency of 25, so not sequencing everyhing through the same process
makes the processes not wait for the exporter's gen_server to handle their export
so not sequencing everyhing through the same process makes the
processes. This also makes the oban job performs more isolated as now
they do not rely on a KafkaExporter gen_server exporter running.


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
