### PR TITLE
Introduce PricePair module

### DIFF
--- a/lib/sanbase/cache/cache.ex
+++ b/lib/sanbase/cache/cache.ex
@@ -19,7 +19,7 @@ defmodule Sanbase.Cache do
   end
 
   def hash(data) do
-    :crypto.hash(:sha256, data |> :erlang.term_to_binary())
+    :crypto.hash(:sha256, :erlang.term_to_binary(data))
     |> Base.encode64()
   end
 

--- a/lib/sanbase/clickhouse/metric/histogram_metric.ex
+++ b/lib/sanbase/clickhouse/metric/histogram_metric.ex
@@ -90,18 +90,22 @@ defmodule Sanbase.Clickhouse.MetricAdapter.HistogramMetric do
     end)
   end
 
-  def first_datetime(metric, %{slug: slug})
+  def first_datetime(metric, selector, opts \\ [])
+
+  def first_datetime(metric, %{slug: slug}, opts)
       when metric in @spent_coins_cost_histograms do
-    with {:ok, dt1} <- Metric.first_datetime("price_usd", %{slug: slug}),
-         {:ok, dt2} <- Metric.first_datetime("age_distribution", %{slug: slug}) do
+    with {:ok, dt1} <- Metric.first_datetime("price_usd", %{slug: slug}, opts),
+         {:ok, dt2} <- Metric.first_datetime("age_distribution", %{slug: slug}, opts) do
       {:ok, Enum.max([dt1, dt2], DateTime)}
     end
   end
 
-  def last_datetime_computed_at(metric, %{slug: slug})
+  def last_datetime_computed_at(metric, selector, opts \\ [])
+
+  def last_datetime_computed_at(metric, %{slug: slug}, opts)
       when metric in @spent_coins_cost_histograms do
-    with {:ok, dt1} <- Metric.last_datetime_computed_at("price_usd", %{slug: slug}),
-         {:ok, dt2} <- Metric.last_datetime_computed_at("age_distribution", %{slug: slug}) do
+    with {:ok, dt1} <- Metric.last_datetime_computed_at("price_usd", %{slug: slug}, opts),
+         {:ok, dt2} <- Metric.last_datetime_computed_at("age_distribution", %{slug: slug}, opts) do
       {:ok, Enum.min([dt1, dt2], DateTime)}
     end
   end

--- a/lib/sanbase/clickhouse/metric/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/metric/metric_adapter.ex
@@ -269,7 +269,8 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
     {query, args} =
       aggregated_timeseries_data_query(metric, slugs, from, to, aggregation, filters)
 
-    ClickhouseRepo.query_reduce(query, args, %{}, fn [slug, value], acc ->
+    ClickhouseRepo.query_reduce(query, args, %{}, fn [slug, value, has_changed], acc ->
+      value = if has_changed == 1, do: value, else: nil
       Map.put(acc, slug, value)
     end)
   end

--- a/lib/sanbase/metric/sql_query_helper.ex
+++ b/lib/sanbase/metric/sql_query_helper.ex
@@ -49,33 +49,25 @@ defmodule Sanbase.Metric.SqlQuery.Helper do
   def asset_id_filter(slug, opts) when is_binary(slug) do
     arg_position = Keyword.fetch!(opts, :argument_position)
 
-    """
-    asset_id = ( SELECT asset_id FROM asset_metadata FINAL PREWHERE name = ?#{arg_position} LIMIT 1 )
-    """
+    "asset_id = ( SELECT asset_id FROM asset_metadata FINAL PREWHERE name = ?#{arg_position} LIMIT 1 )"
   end
 
   def asset_id_filter(slugs, opts) when is_list(slugs) do
     arg_position = Keyword.fetch!(opts, :argument_position)
 
-    """
-    asset_id IN ( SELECT DISTINCT(asset_id) FROM asset_metadata FINAL PREWHERE name IN (?#{arg_position}) )
-    """
+    "asset_id IN ( SELECT DISTINCT(asset_id) FROM asset_metadata FINAL PREWHERE name IN (?#{arg_position}) )"
   end
 
   def metric_id_filter(metric, opts) when is_binary(metric) do
     arg_position = Keyword.fetch!(opts, :argument_position)
 
-    """
-    metric_id = ( SELECT metric_id FROM metric_metadata FINAL PREWHERE name = ?#{arg_position} LIMIT 1 )
-    """
+    "metric_id = ( SELECT metric_id FROM metric_metadata FINAL PREWHERE name = ?#{arg_position} LIMIT 1 )"
   end
 
   def metric_id_filter(metrics, opts) when is_list(metrics) do
     arg_position = Keyword.fetch!(opts, :argument_position)
 
-    """
-    metric_id IN ( SELECT DISTINCT(metric_id) FROM metric_metadata FINAL PREWHERE name IN (?#{arg_position}) )
-    """
+    "metric_id IN ( SELECT DISTINCT(metric_id) FROM metric_metadata FINAL PREWHERE name IN (?#{arg_position}) )"
   end
 
   # Add additional `=`/`in` filters to the query. This is mostly used with labeled

--- a/lib/sanbase/prices/price_pair/metric_adapter.ex
+++ b/lib/sanbase/prices/price_pair/metric_adapter.ex
@@ -1,0 +1,173 @@
+defmodule Sanbase.PricePair.MetricAdapter do
+  @behaviour Sanbase.Metric.Behaviour
+  alias Sanbase.PricePair
+
+  @aggregations [:any, :sum, :avg, :min, :max, :last, :first, :median, :ohlc]
+  @default_aggregation :last
+
+  @timeseries_metrics ["price_usd", "price_btc"]
+  @histogram_metrics []
+  @table_metrics []
+
+  @metrics @histogram_metrics ++ @timeseries_metrics ++ @table_metrics
+
+  @access_map Enum.into(@metrics, %{}, fn metric -> {metric, :free} end)
+  @min_plan_map Enum.into(@metrics, %{}, fn metric -> {metric, :free} end)
+
+  @free_metrics Enum.filter(@access_map, fn {_, level} -> level == :free end)
+                |> Enum.map(&elem(&1, 0))
+  @restricted_metrics Enum.filter(@access_map, fn {_, level} -> level == :restricted end)
+                      |> Enum.map(&elem(&1, 0))
+
+  @default_complexity_weight 0.3
+
+  @impl Sanbase.Metric.Behaviour
+  def has_incomplete_data?(_), do: false
+
+  @impl Sanbase.Metric.Behaviour
+  def complexity_weight(_), do: @default_complexity_weight
+
+  @impl Sanbase.Metric.Behaviour
+  def timeseries_data(metric, %{slug: slug}, from, to, interval, opts) do
+    quote_asset = metric_to_quote_asset(metric)
+    opts = update_opts(opts)
+    PricePair.timeseries_data(slug, quote_asset, from, to, interval, opts)
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def timeseries_data_per_slug(metric, %{slug: slug}, from, to, interval, opts) do
+    quote_asset = metric_to_quote_asset(metric)
+    opts = update_opts(opts)
+
+    PricePair.timeseries_data_per_slug(slug, quote_asset, from, to, interval, opts)
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def aggregated_timeseries_data(metric, %{slug: slug}, from, to, opts) do
+    quote_asset = metric_to_quote_asset(metric)
+    opts = update_opts(opts)
+    PricePair.aggregated_timeseries_data(slug, quote_asset, from, to, update_opts(opts))
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def slugs_by_filter(metric, from, to, operator, threshold, opts) do
+    quote_asset = metric_to_quote_asset(metric)
+    opts = update_opts(opts)
+    PricePair.slugs_by_filter(quote_asset, from, to, operator, threshold, opts)
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def slugs_order(metric, from, to, direction, opts) do
+    quote_asset = metric_to_quote_asset(metric)
+    opts = update_opts(opts)
+    PricePair.slugs_order(quote_asset, from, to, direction, opts)
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def first_datetime(metric, %{slug: slug}) do
+    quote_asset = metric_to_quote_asset(metric)
+    opts = update_opts([])
+    PricePair.first_datetime(slug, quote_asset, opts)
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def last_datetime_computed_at(metric, %{slug: slug}) do
+    quote_asset = metric_to_quote_asset(metric)
+    opts = update_opts([])
+    PricePair.last_datetime_computed_at(slug, quote_asset, opts)
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def metadata(metric) do
+    {:ok,
+     %{
+       metric: metric,
+       min_interval: "1s",
+       default_aggregation: @default_aggregation,
+       available_aggregations: @aggregations,
+       available_selectors: [:slug],
+       data_type: :timeseries,
+       complexity_weight: @default_complexity_weight
+     }}
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def human_readable_name(metric) do
+    case metric do
+      "price_usd" -> {:ok, "Price in USD"}
+      "price_btc" -> {:ok, "Price in BTC"}
+    end
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def available_aggregations(), do: @aggregations
+
+  @impl Sanbase.Metric.Behaviour
+  def available_timeseries_metrics(), do: @timeseries_metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def available_histogram_metrics(), do: @histogram_metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def available_table_metrics(), do: @table_metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def available_metrics(), do: @metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def available_metrics(%{slug: slug}) do
+    cache_key = {__MODULE__, :has_price_data?, slug} |> Sanbase.Cache.hash()
+    cache_key_with_ttl = {cache_key, 600}
+
+    case Sanbase.Cache.get_or_store(cache_key_with_ttl, fn ->
+           PricePair.available_quote_assets(slug)
+         end) do
+      {:ok, quote_assets} ->
+        metrics =
+          if("BTC" in quote_assets, do: ["price_btc"], else: []) ++
+            if "USD" in quote_assets, do: ["price_usd"], else: []
+
+        {:ok, metrics}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def available_slugs() do
+    Sanbase.Cache.get_or_store({__MODULE__, :slugs_with_prices, 600}, fn ->
+      PricePair.available_slugs()
+    end)
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def available_slugs(metric) when metric in @metrics do
+    quote_asset = metric_to_quote_asset(metric)
+    opts = update_opts([])
+
+    Sanbase.Cache.get_or_store({__MODULE__, :available_slugs_for_metric, 600}, fn ->
+      PricePair.available_slugs(quote_asset, opts)
+    end)
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def free_metrics(), do: @free_metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def restricted_metrics(), do: @restricted_metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def access_map(), do: @access_map
+
+  @impl Sanbase.Metric.Behaviour
+  def min_plan_map(), do: @min_plan_map
+
+  # Private functions
+  defp update_opts(opts) do
+    Keyword.update(opts, :aggregation, @default_aggregation, &(&1 || @default_aggregation))
+  end
+
+  defp metric_to_quote_asset("price_btc"), do: "BTC"
+  defp metric_to_quote_asset("price_usd"), do: "USD"
+end

--- a/lib/sanbase/prices/price_pair/price_pair.ex
+++ b/lib/sanbase/prices/price_pair/price_pair.ex
@@ -1,0 +1,250 @@
+defmodule Sanbase.PricePair do
+  import Sanbase.Price.PricePairSql
+
+  import Sanbase.Utils.Transform,
+    only: [
+      maybe_unwrap_ok_value: 1,
+      maybe_apply_function: 2
+    ]
+
+  import Sanbase.Metric.Transform, only: [exec_timeseries_data_query: 2]
+
+  alias Sanbase.ClickhouseRepo
+
+  @default_source "cryptocompare"
+
+  @type error :: String.t()
+  @type slug :: String.t()
+  @type quote_asset :: String.t()
+  @type slugs :: list(slug)
+  @type interval :: String.t()
+  @type opts :: Keyword.t()
+
+  @type timeseries_data_map :: %{
+          datetime: DateTime.t(),
+          slug: slug,
+          value: float()
+        }
+
+  @type timeseries_data_result :: {:ok, list(timeseries_data_map())} | {:error, error()}
+
+  @type timeseries_metric_data_map :: %{
+          datetime: DateTime.t(),
+          value: float() | nil
+        }
+
+  @type timeseries_metric_data_result ::
+          {:ok, list(timeseries_metric_data_map())} | {:error, error()}
+
+  @type aggregated_metric_timeseries_data_map :: %{String.t() => float()}
+
+  @type aggregated_metric_timeseries_data_result ::
+          {:ok, aggregated_metric_timeseries_data_map()} | {:error, error()}
+
+  @type last_record_before_map :: %{
+          datetime: DateTime.t(),
+          value: float()
+        }
+
+  @type last_record_before_result :: {:ok, last_record_before_map()} | {:error, error()}
+
+  @doc ~s"""
+  Return timeseries data for the given time period where every point consists
+  of datetime and price in `quote_asset`
+  """
+
+  def timeseries_data(slug, quote_asset, from, to, interval, opts \\ [])
+
+  def timeseries_data(slug_or_slugs, quote_asset, from, to, interval, opts) do
+    source = Keyword.get(opts, :source) || @default_source
+    aggregation = Keyword.get(opts, :aggregation) || :last
+
+    {query, args} =
+      timeseries_data_query(
+        slug_or_slugs,
+        quote_asset,
+        from,
+        to,
+        interval,
+        source,
+        aggregation
+      )
+
+    # Handle both cases where the aggregation is OHLC or it's not
+    exec_timeseries_data_query(query, args)
+  end
+
+  def timeseries_data_per_slug(slug_or_slugs, quote_asset, from, to, interval, opts) do
+    source = Keyword.get(opts, :source) || @default_source
+    aggregation = Keyword.get(opts, :aggregation) || :last
+    slugs = List.wrap(slug_or_slugs)
+
+    {query, args} =
+      timeseries_data_per_slug_query(slugs, quote_asset, from, to, interval, source, aggregation)
+
+    ClickhouseRepo.query_reduce(query, args, %{}, fn [timestamp, slug, value], acc ->
+      datetime = DateTime.from_unix!(timestamp)
+      elem = %{slug: slug, value: value}
+      Map.update(acc, datetime, [elem], &[elem | &1])
+    end)
+    |> maybe_apply_function(fn list ->
+      Enum.map(list, fn {datetime, data} -> %{datetime: datetime, data: data} end)
+    end)
+    |> maybe_apply_function(fn list ->
+      Enum.sort_by(list, & &1.datetime, {:asc, DateTime})
+    end)
+  end
+
+  @doc ~s"""
+  Returns aggregated price in `quote_asset` for the given slugs and time period.
+  """
+
+  def aggregated_timeseries_data(slug_or_slugs, quote_asset, from, to, opts \\ [])
+  def aggregated_timeseries_data([], _, _, _, _), do: {:ok, []}
+
+  def aggregated_timeseries_data(slugs, quote_asset, from, to, opts)
+      when is_list(slugs) and length(slugs) > 50 do
+    result =
+      Enum.chunk_every(slugs, 50)
+      |> Sanbase.Parallel.map(
+        &aggregated_timeseries_data(&1, quote_asset, from, to, opts),
+        timeout: 25_000,
+        max_concurrency: 8,
+        ordered: false
+      )
+      |> Enum.filter(&match?({:ok, _}, &1))
+      |> Enum.map(&elem(&1, 1))
+      |> Enum.reduce(%{}, &Map.merge(&1, &2))
+
+    {:ok, result}
+  end
+
+  def aggregated_timeseries_data(slug_or_slugs, quote_asset, from, to, opts) do
+    source = Keyword.get(opts, :source, @default_source)
+    aggregation = Keyword.get(opts, :aggregation) || :last
+    slugs = List.wrap(slug_or_slugs)
+
+    {query, args} =
+      aggregated_timeseries_data_query(slugs, quote_asset, from, to, source, aggregation)
+
+    ClickhouseRepo.query_reduce(query, args, %{}, fn [slug, value, has_changed], acc ->
+      # This way if the slug does not have any data still include it in the result
+      # with value `nil`. This way the API can cache the result. In case one of the
+      # aggregated_timeseries_data calls fails, the slugs in it won't be included
+      # at all and they will be retried next time.
+      value = if has_changed == 1, do: value, else: nil
+      Map.put(acc, slug, value)
+    end)
+  end
+
+  def slugs_by_filter(quote_asset, from, to, operator, threshold, opts \\ [])
+
+  def slugs_by_filter(quote_asset, from, to, operator, threshold, opts) do
+    aggregation = Keyword.get(opts, :aggregation) || :last
+    source = Keyword.get(opts, :source, @default_source)
+
+    {query, args} =
+      slugs_by_filter_query(quote_asset, from, to, source, operator, threshold, aggregation)
+
+    ClickhouseRepo.query_transform(query, args, fn [slug, _value] -> slug end)
+  end
+
+  def slugs_order(quote_asset, from, to, direction, opts \\ [])
+
+  def slugs_order(quote_asset, from, to, direction, opts) do
+    aggregation = Keyword.get(opts, :aggregation) || :last
+    source = Keyword.get(opts, :source, @default_source)
+    {query, args} = slugs_order_query(quote_asset, from, to, source, direction, aggregation)
+    ClickhouseRepo.query_transform(query, args, fn [slug, _value] -> slug end)
+  end
+
+  @doc ~s"""
+  Return the last record  before the given `datetime`
+  """
+  def last_record_before(slug, quote_asset, datetime, opts \\ [])
+
+  def last_record_before(slug, quote_asset, datetime, opts) do
+    source = Keyword.get(opts, :source, @default_source)
+    {query, args} = last_record_before_query(slug, quote_asset, datetime, source)
+
+    ClickhouseRepo.query_transform(
+      query,
+      args,
+      fn [unix, value] ->
+        %{
+          datetime: DateTime.from_unix!(unix),
+          value: value
+        }
+      end
+    )
+    |> maybe_unwrap_ok_value()
+  end
+
+  def available_slugs(opts \\ [])
+
+  def available_slugs(opts) do
+    case Keyword.get(opts, :source) || @default_source do
+      "cryptocompare" ->
+        slugs =
+          Sanbase.Model.Project.SourceSlugMapping.get_source_slug_mappings("cryptocompare")
+          |> Enum.map(&elem(&1, 1))
+
+        {:ok, slugs}
+
+      _ ->
+        {:error, "Only cryptocompare is supported as source."}
+    end
+  end
+
+  def available_slugs(quote_asset, opts) do
+    source = Keyword.get(opts, :source) || @default_source
+    {query, args} = available_slugs_query(quote_asset, source)
+
+    ClickhouseRepo.query_transform(query, args, fn [slug] -> slug end)
+  end
+
+  def has_data?(slug, quote_asset, opts \\ [])
+
+  def has_data?(slug, quote_asset, opts) do
+    source = Keyword.get(opts, :source, @default_source)
+    {query, args} = select_any_record_query(slug, quote_asset, source)
+
+    ClickhouseRepo.query_transform(query, args, & &1)
+    |> case do
+      {:ok, [_]} -> {:ok, true}
+      {:ok, []} -> {:ok, false}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  def available_quote_assets(slug, opts \\ [])
+
+  def available_quote_assets(slug, opts) do
+    source = Keyword.get(opts, :source, @default_source)
+    {query, args} = available_quote_assets_query(slug, source)
+
+    ClickhouseRepo.query_transform(query, args, fn [quote_asset] -> quote_asset end)
+  end
+
+  @doc ~s"""
+  Return the first datetime for which `slug` has data
+  """
+  @spec first_datetime(slug, quote_asset, opts) ::
+          {:ok, DateTime.t()} | {:ok, nil} | {:error, error}
+  def first_datetime(slug, quote_asset, opts \\ [])
+
+  def first_datetime(slug, quote_asset, opts) do
+    source = Keyword.get(opts, :source, @default_source)
+    {query, args} = first_datetime_query(slug, quote_asset, source)
+
+    ClickhouseRepo.query_transform(query, args, fn
+      [timestamp] -> DateTime.from_unix!(timestamp)
+    end)
+    |> maybe_unwrap_ok_value()
+  end
+
+  def last_datetime_computed_at(_slug, _quote_asset, _opts) do
+    # TODO FIXME
+    {:ok, DateTime.utc_now()}
+  end
+end

--- a/lib/sanbase/prices/price_pair/price_pair_sql.ex
+++ b/lib/sanbase/prices/price_pair/price_pair_sql.ex
@@ -1,0 +1,286 @@
+defmodule Sanbase.Price.PricePairSql do
+  @table "asset_price_pairs_only"
+
+  import Sanbase.Metric.SqlQuery.Helper, only: [aggregation: 3, generate_comparison_string: 3]
+
+  def timeseries_data_query(slug_or_slugs, quote_asset, from, to, interval, source, aggregation) do
+    {from, to, interval, _span} = timerange_parameters(from, to, interval)
+
+    query = """
+    SELECT
+      toUnixTimestamp(intDiv(toUInt32(toDateTime(dt)), ?1) * ?1) AS time,
+      #{aggregation(aggregation, "price", "dt")} AS value
+    FROM #{@table}
+    PREWHERE
+      #{slug_filter_map(slug_or_slugs, argument_position: 2)} AND
+      quote_asset = ?3 AND
+      source = cast(?4, 'LowCardinality(String)') AND
+      dt >= toDateTime(?5) AND
+      dt < toDateTime(?6)
+    GROUP BY time
+    ORDER BY time
+    """
+
+    args = [interval, slug_or_slugs, quote_asset, source, from, to]
+
+    {query, args}
+  end
+
+  def timeseries_data_per_slug_query(slugs, quote_asset, from, to, interval, source, aggregation) do
+    {from, to, interval, _span} = timerange_parameters(from, to, interval)
+
+    query = """
+    SELECT
+      toUnixTimestamp(intDiv(toUInt32(toDateTime(dt)), ?1) * ?1) AS time,
+      dictGetString('cryptocompare_to_san_asset_mapping', 'slug', tuple(base_asset)) AS slug,
+      #{aggregation(aggregation, "price", "dt")}
+    FROM #{@table}
+    PREWHERE
+      #{slug_filter_map(slugs, argument_position: 2)} AND
+      quote_asset = ?2 AND
+      source = cast(?3, 'LowCardinality(String)') AND
+      dt >= toDateTime(?4) AND
+      dt < toDateTime(?5)
+    GROUP BY time, slug
+    ORDER BY time
+    """
+
+    args = [interval, quote_asset, source, from, to]
+
+    {query, args}
+  end
+
+  def aggregated_timeseries_data_query(slugs, quote_asset, from, to, source, aggregation) do
+    query = """
+    SELECT slug, SUM(value), toUInt32(SUM(has_changed))
+    FROM (
+      SELECT
+        arrayJoin([?1]) AS slug,
+        toFloat64(0) AS value,
+        toUInt32(0) AS has_changed
+
+      UNION ALL
+
+      SELECT
+        dictGetString('cryptocompare_to_san_asset_mapping', 'slug', tuple(base_asset)) AS slug,
+        #{aggregation(aggregation, "price", "dt")} AS value,
+        toUInt32(1) AS has_changed
+
+      FROM #{@table}
+        PREWHERE
+          #{slug_filter_map(slugs, argument_position: 1)} AND
+          quote_asset = ?2 AND
+          dt >= toDateTime(?3) AND
+          dt < toDateTime(?4) AND
+          source = ?5
+      GROUP BY slug
+    )
+    GROUP BY slug
+    """
+
+    {from, to} = timerange_parameters(from, to)
+
+    args = [slugs, quote_asset, from, to, source]
+
+    {query, args}
+  end
+
+  def slugs_by_filter_query(quote_asset, from, to, source, operation, threshold, aggregation) do
+    {query, args} = filter_order_base_query(quote_asset, from, to, source, aggregation)
+
+    query =
+      query <>
+        """
+        WHERE #{generate_comparison_string("value", operation, threshold)}
+        """
+
+    {query, args}
+  end
+
+  def slugs_order_query(quote_asset, from, to, source, direction, aggregation) do
+    {query, args} = filter_order_base_query(quote_asset, from, to, source, aggregation)
+
+    query =
+      query <>
+        """
+        ORDER BY value #{direction |> Atom.to_string() |> String.upcase()}
+        """
+
+    {query, args}
+  end
+
+  defp filter_order_base_query(quote_asset, from, to, source, aggregation) do
+    query = """
+    SELECT slug, value
+    FROM (
+      SELECT
+        dictGetString('cryptocompare_to_san_asset_mapping', 'slug', tuple(base_asset)) AS slug,
+        value
+      FROM (
+        SELECT
+          base_asset,
+          #{aggregation(aggregation, "price", "dt")} AS value
+        FROM #{@table}
+        PREWHERE
+          isNotNull(price) AND NOT isNaN(price) AND
+          quote_asset = ?1 AND
+          source = ?2 AND
+          dt >= toDateTime(?3) AND
+          dt < toDateTime(?4)
+        GROUP BY base_asset
+      )
+      WHERE slug != ''
+    )
+    """
+
+    args = [
+      quote_asset,
+      source,
+      from |> DateTime.to_unix(),
+      to |> DateTime.to_unix()
+    ]
+
+    {query, args}
+  end
+
+  def last_record_before_query(slug, quote_asset, datetime, source) do
+    query = """
+    SELECT
+      toUnixTimestamp(dt), price
+    FROM #{@table}
+    PREWHERE
+      base_asset = dictGetString('san_to_cryptocompare_asset_mapping', 'base_asset', tuple(?1)) AND
+      quote_asset = ?2 AND
+      source = cast(?3, 'LowCardinality(String)') AND
+      dt >= toDateTime(?4) AND
+      dt <= toDateTime(?5)
+    ORDER BY dt DESC
+    LIMIT 1
+    """
+
+    # Put an artificial lower boundary otherwise the query is too slow
+    from = Timex.shift(datetime, days: -14) |> DateTime.to_unix()
+    to = datetime |> DateTime.to_unix()
+    args = [slug, quote_asset, source, from, to]
+
+    {query, args}
+  end
+
+  def select_any_record_query(slug, quote_asset, source) do
+    query = """
+    SELECT any(dt)
+    FROM #{@table}
+    PREWHERE
+      base_asset = dictGetString('san_to_cryptocompare_asset_mapping', 'base_asset', tuple(?1)) AND
+      quote_asset = ?2 AND
+      source = ?3
+    """
+
+    args = [slug, quote_asset, source]
+    {query, args}
+  end
+
+  def first_datetime_query(slug, quote_asset, source) do
+    query = """
+    SELECT
+      toUnixTimestamp(dt)
+    FROM #{@table}
+    PREWHERE
+      base_asset = dictGetString('san_to_cryptocompare_asset_mapping', 'base_asset', tuple(?1)) AND
+      quote_asset = ?2 AND
+      source = ?3
+    ORDER BY dt ASC
+    LIMIT 1
+    """
+
+    args = [slug, quote_asset, source]
+
+    {query, args}
+  end
+
+  def available_quote_assets_query(slug, source) do
+    query = """
+    SELECT distinct(quote_asset)
+    FROM #{@table}
+    PREWHERE
+      base_asset = dictGetString('san_to_cryptocompare_asset_mapping', 'base_asset', tuple(?1)) AND
+      source = ?2
+    """
+
+    args = [slug, source]
+
+    {query, args}
+  end
+
+  def available_slugs_query(source) do
+    query = """
+    SELECT dictGetString('cryptocompare_to_san_asset_mapping', 'slug', tuple(base_asset))
+    FROM (
+      SELECT distinct(base_asset) AS base_asset
+      FROM #{@table}
+      PREWHERE
+        dt >= ?1 AND
+        source = ?3
+    )
+    """
+
+    datetime = Timex.shift(Timex.now(), days: -7) |> DateTime.to_unix()
+
+    args = [datetime, source]
+
+    {query, args}
+  end
+
+  def available_slugs_query(quote_asset, source, days \\ 7) do
+    query = """
+    SELECT dictGetString('cryptocompare_to_san_asset_mapping', 'slug', tuple(base_asset))
+    FROM (
+      SELECT distinct(base_asset) AS base_asset
+      FROM #{@table}
+      PREWHERE
+        quote_asset = ?1 AND
+        dt >= ?2 AND
+        source = ?3
+    )
+    """
+
+    datetime = Timex.shift(Timex.now(), days: -days) |> DateTime.to_unix()
+
+    args = [quote_asset, datetime, source]
+
+    {query, args}
+  end
+
+  # Private functions
+
+  defp slug_filter_map(slug, opts) when is_binary(slug) do
+    pos = Keyword.fetch!(opts, :argument_position)
+
+    "base_asset = cast(dictGetString('san_to_cryptocompare_asset_mapping', 'base_asset', tuple(?#{pos})), 'LowCardinality(String)')"
+  end
+
+  defp slug_filter_map(slugs, opts) when is_list(slugs) do
+    pos = Keyword.fetch!(opts, :argument_position)
+
+    "base_asset IN (SELECT base_asset FROM cryptocompare_asset_mapping WHERE slug IN (?#{pos}))"
+  end
+
+  defp timerange_parameters(from, to, interval \\ nil)
+
+  defp timerange_parameters(from, to, nil) do
+    to = Enum.min_by([to, Timex.now()], &DateTime.to_unix/1)
+    from_unix = DateTime.to_unix(from)
+    to_unix = DateTime.to_unix(to)
+
+    {from_unix, to_unix}
+  end
+
+  defp timerange_parameters(from, to, interval) do
+    from_unix = DateTime.to_unix(from)
+    to_unix = DateTime.to_unix(to)
+    interval_sec = Sanbase.DateTimeUtils.str_to_sec(interval)
+    span = div(to_unix - from_unix, interval_sec) |> max(1)
+
+    {from_unix, to_unix, interval_sec, span}
+  end
+end

--- a/lib/sanbase/prices/price_pair/price_pair_sql.ex
+++ b/lib/sanbase/prices/price_pair/price_pair_sql.ex
@@ -14,7 +14,7 @@ defmodule Sanbase.Price.PricePairSql do
     PREWHERE
       #{slug_filter_map(slug_or_slugs, argument_position: 2)} AND
       quote_asset = ?3 AND
-      source = cast(?4, 'LowCardinality(String)') AND
+      source = ?4 AND
       dt >= toDateTime(?5) AND
       dt < toDateTime(?6)
     GROUP BY time
@@ -38,7 +38,7 @@ defmodule Sanbase.Price.PricePairSql do
     PREWHERE
       #{slug_filter_map(slugs, argument_position: 2)} AND
       quote_asset = ?2 AND
-      source = cast(?3, 'LowCardinality(String)') AND
+      source = ?3 AND
       dt >= toDateTime(?4) AND
       dt < toDateTime(?5)
     GROUP BY time, slug
@@ -151,7 +151,7 @@ defmodule Sanbase.Price.PricePairSql do
     PREWHERE
       base_asset = dictGetString('san_to_cryptocompare_asset_mapping', 'base_asset', tuple(?1)) AND
       quote_asset = ?2 AND
-      source = cast(?3, 'LowCardinality(String)') AND
+      source = ?3 AND
       dt >= toDateTime(?4) AND
       dt <= toDateTime(?5)
     ORDER BY dt DESC
@@ -256,7 +256,7 @@ defmodule Sanbase.Price.PricePairSql do
   defp slug_filter_map(slug, opts) when is_binary(slug) do
     pos = Keyword.fetch!(opts, :argument_position)
 
-    "base_asset = cast(dictGetString('san_to_cryptocompare_asset_mapping', 'base_asset', tuple(?#{pos})), 'LowCardinality(String)')"
+    "base_asset = dictGetString('san_to_cryptocompare_asset_mapping', 'base_asset', tuple(?#{pos}))"
   end
 
   defp slug_filter_map(slugs, opts) when is_list(slugs) do

--- a/lib/sanbase/utils/transform.ex
+++ b/lib/sanbase/utils/transform.ex
@@ -151,4 +151,24 @@ defmodule Sanbase.Utils.Transform do
       {:ok, value} -> Map.put(map, key, String.replace(value, separator, ""))
     end
   end
+
+  def maybe_fill_gaps_last_seen({:ok, values}, key) do
+    result =
+      values
+      |> Enum.reduce({[], 0}, fn
+        %{has_changed: 0} = elem, {acc, last_seen} ->
+          elem = Map.put(elem, key, last_seen) |> Map.delete(:has_changed)
+          {[elem | acc], last_seen}
+
+        %{has_changed: 1} = elem, {acc, _last_seen} ->
+          elem = Map.delete(elem, :has_changed)
+          {[elem | acc], elem[key]}
+      end)
+      |> elem(0)
+      |> Enum.reverse()
+
+    {:ok, result}
+  end
+
+  def maybe_fill_gaps_last_seen({:error, error}, _key), do: {:error, error}
 end

--- a/lib/sanbase_web/graphql/cache/cache.ex
+++ b/lib/sanbase_web/graphql/cache/cache.ex
@@ -109,6 +109,13 @@ defmodule SanbaseWeb.Graphql.Cache do
     CacheProvider.size(@cache_name, :megabytes)
   end
 
+  @doc ~s"""
+  The number of entries in the cache
+  """
+  def count() do
+    CacheProvider.count(@cache_name)
+  end
+
   def get(key) do
     CacheProvider.get(@cache_name, key)
   end
@@ -248,7 +255,6 @@ defmodule SanbaseWeb.Graphql.Cache do
 
     args = args |> convert_values(ttl)
     cache_key = [name, args] |> Sanbase.Cache.hash()
-
     {cache_key, ttl}
   end
 

--- a/lib/sanbase_web/graphql/cache/con_cache_provider.ex
+++ b/lib/sanbase_web/graphql/cache/con_cache_provider.ex
@@ -21,6 +21,13 @@ defmodule SanbaseWeb.Graphql.ConCacheProvider do
     (bytes_size / (1024 * 1024)) |> Float.round(2)
   end
 
+  def count(cache) do
+    cache
+    |> ConCache.ets()
+    |> :ets.tab2list()
+    |> length
+  end
+
   @impl true
   def clear_all(cache) do
     cache

--- a/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
@@ -62,7 +62,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
 
   def available_since(_root, args, %{source: %{metric: metric}}) do
     with {:ok, selector} <- args_to_selector(args),
-         {:ok, first_datetime} <- Metric.first_datetime(metric, selector) do
+         {:ok, opts} <- selector_args_to_opts(args),
+         {:ok, first_datetime} <- Metric.first_datetime(metric, selector, opts) do
       {:ok, first_datetime}
     end
     |> maybe_handle_graphql_error(fn error ->
@@ -76,8 +77,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
 
   def last_datetime_computed_at(_root, args, %{source: %{metric: metric}}) do
     with {:ok, selector} <- args_to_selector(args),
+         {:ok, opts} <- selector_args_to_opts(args),
          true <- valid_metric_selector_pair?(metric, selector) do
-      Metric.last_datetime_computed_at(metric, selector)
+      Metric.last_datetime_computed_at(metric, selector, opts)
     end
     |> maybe_handle_graphql_error(fn error ->
       handle_graphql_error(
@@ -108,7 +110,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     with {:ok, selector} <- args_to_selector(args),
          true <- valid_metric_selector_pair?(metric, selector),
          true <- valid_owners_labels_selection?(args),
-         {:ok, opts} = selector_args_to_opts(args),
+         {:ok, opts} <- selector_args_to_opts(args),
          {:ok, from, to} <-
            calibrate_incomplete_data_params(include_incomplete_data, Metric, metric, from, to),
          {:ok, result} <- Metric.aggregated_timeseries_data(metric, selector, from, to, opts) do

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -238,6 +238,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     the metric.
     """
     field :available_slugs, list_of(:string) do
+      arg(:selector, :aggregated_timeseries_data_selector_input_object)
       cache_resolve(&MetricResolver.get_available_slugs/3, ttl: 600)
     end
 

--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -302,8 +302,8 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       middleware(AccessControl)
 
       cache_resolve(&ProjectMetricsResolver.aggregated_timeseries_data/3,
-        ttl: 600,
-        max_ttl_offset: 600
+        ttl: 120,
+        max_ttl_offset: 60
       )
     end
 

--- a/test/sanbase_web/graphql/metric/api_metric_aggregated_timeseries_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_aggregated_timeseries_data_test.exs
@@ -1,6 +1,7 @@
 defmodule SanbaseWeb.Graphql.ApiMetricAggregatedTimeseriesDataTest do
   use SanbaseWeb.ConnCase, async: false
 
+  import Mock
   import Sanbase.Factory
   import ExUnit.CaptureLog
   import SanbaseWeb.Graphql.TestHelpers
@@ -20,6 +21,41 @@ defmodule SanbaseWeb.Graphql.ApiMetricAggregatedTimeseriesDataTest do
     ]
   end
 
+  test "price_usd when the source is cryptocompare", context do
+    # Test that when the source is cryptocompare the prices are served from the
+    # PricePair module instead of the Price module
+    %{conn: conn, slug: slug, from: from, to: to} = context
+
+    Sanbase.Mock.prepare_mock2(
+      &Sanbase.PricePair.aggregated_timeseries_data/5,
+      {:ok, %{slug => 154.44}}
+    )
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      result =
+        get_aggregated_timeseries_metric(
+          conn,
+          "price_usd",
+          %{slug: slug, source: "cryptocompare"},
+          from,
+          to,
+          :last
+        )
+        |> extract_aggregated_timeseries_data()
+
+      assert result == 154.44
+
+      assert_called(
+        Sanbase.PricePair.aggregated_timeseries_data(
+          slug,
+          "USD",
+          from,
+          to,
+          :_
+        )
+      )
+    end)
+  end
+
   test "returns data for an available metric", context do
     %{conn: conn, slug: slug, from: from, to: to} = context
 
@@ -30,7 +66,14 @@ defmodule SanbaseWeb.Graphql.ApiMetricAggregatedTimeseriesDataTest do
     )
     |> Sanbase.Mock.run_with_mocks(fn ->
       result =
-        get_aggregated_timeseries_metric(conn, "daily_active_addresses", slug, from, to, nil)
+        get_aggregated_timeseries_metric(
+          conn,
+          "daily_active_addresses",
+          %{slug: slug},
+          from,
+          to,
+          nil
+        )
         |> extract_aggregated_timeseries_data()
 
       assert result == 100
@@ -51,7 +94,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricAggregatedTimeseriesDataTest do
     |> Sanbase.Mock.run_with_mocks(fn ->
       for metric <- metrics do
         result =
-          get_aggregated_timeseries_metric(conn, metric, slug, from, to, nil)
+          get_aggregated_timeseries_metric(conn, metric, %{slug: slug}, from, to, nil)
           |> extract_aggregated_timeseries_data()
 
         assert result == 100
@@ -71,7 +114,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricAggregatedTimeseriesDataTest do
     |> Sanbase.Mock.run_with_mocks(fn ->
       for aggregation <- aggregations do
         result =
-          get_aggregated_timeseries_metric(conn, metric, slug, from, to, aggregation)
+          get_aggregated_timeseries_metric(conn, metric, %{slug: slug}, from, to, aggregation)
           |> extract_aggregated_timeseries_data()
 
         assert result == 100
@@ -91,7 +134,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricAggregatedTimeseriesDataTest do
     # aggregation is an enum with available values
     result =
       for aggregation <- rand_aggregations do
-        get_aggregated_timeseries_metric(conn, metric, slug, from, to, aggregation)
+        get_aggregated_timeseries_metric(conn, metric, %{slug: slug}, from, to, aggregation)
       end
 
     # Assert that all results are lists where we have a map with values
@@ -107,7 +150,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricAggregatedTimeseriesDataTest do
     # Do not mock the `timeseries_data` function because it's the one that rejects
     for metric <- rand_metrics do
       %{"errors" => [%{"message" => error_message}]} =
-        get_aggregated_timeseries_metric(conn, metric, slug, from, to, aggregation)
+        get_aggregated_timeseries_metric(conn, metric, %{slug: slug}, from, to, aggregation)
 
       assert error_message == "The metric '#{metric}' is not supported or is mistyped."
     end
@@ -131,8 +174,8 @@ defmodule SanbaseWeb.Graphql.ApiMetricAggregatedTimeseriesDataTest do
 
   # Private functions
 
-  defp get_aggregated_timeseries_metric(conn, metric, slug, from, to, aggregation) do
-    query = get_aggregated_timeseries_query(metric, slug, from, to, aggregation)
+  defp get_aggregated_timeseries_metric(conn, metric, selector, from, to, aggregation) do
+    query = get_aggregated_timeseries_query(metric, selector, from, to, aggregation)
 
     conn
     |> post("/graphql", query_skeleton(query, "getMetric"))
@@ -140,7 +183,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricAggregatedTimeseriesDataTest do
   end
 
   defp get_aggregated_timeseries_metric(conn, metric, from, to, aggregation) do
-    query = get_aggregated_timeseries_query_without_slug(metric, from, to, aggregation)
+    query = get_aggregated_timeseries_query_without_selector(metric, from, to, aggregation)
 
     conn
     |> post("/graphql", query_skeleton(query, "getMetric"))
@@ -152,12 +195,16 @@ defmodule SanbaseWeb.Graphql.ApiMetricAggregatedTimeseriesDataTest do
     |> get_in(["data", "getMetric", "aggregatedTimeseriesData"])
   end
 
-  defp get_aggregated_timeseries_query(metric, slug, from, to, aggregation) do
+  defp get_aggregated_timeseries_query(metric, selector, from, to, aggregation) do
+    # Put so some of the source metrics do not fail. If the source exists do not
+    # replace it. In case the source is not needed it won't be used.
+    selector = selector |> Map.put_new(:source, "twitter")
+
     """
       {
         getMetric(metric: "#{metric}"){
           aggregatedTimeseriesData(
-            selector: {slug: "#{slug}", source: "twitter"}
+            selector: #{map_to_input_object_str(selector)}
             from: "#{from}"
             to: "#{to}"
             #{if aggregation, do: "aggregation: #{Atom.to_string(aggregation) |> String.upcase()}"})
@@ -166,7 +213,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricAggregatedTimeseriesDataTest do
     """
   end
 
-  defp get_aggregated_timeseries_query_without_slug(metric, from, to, aggregation) do
+  defp get_aggregated_timeseries_query_without_selector(metric, from, to, aggregation) do
     """
       {
         getMetric(metric: "#{metric}"){

--- a/test/sanbase_web/graphql/metric/api_metric_timeseries_data_per_slug_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_timeseries_data_per_slug_test.exs
@@ -1,6 +1,7 @@
 defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesDataPerSlugTest do
   use SanbaseWeb.ConnCase, async: false
 
+  import Mock
   import Sanbase.Factory
   import SanbaseWeb.Graphql.TestHelpers
 
@@ -17,6 +18,62 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesDataPerSlugTest do
       from: ~U[2019-01-01 00:00:00Z],
       to: ~U[2019-01-02 00:00:00Z]
     ]
+  end
+
+  test "price_usd when the source is cryptocompare", context do
+    # Test that when the source is cryptocompare the prices are served from the
+    # PricePair module instead of the Price module
+    %{conn: conn, from: from, to: to, project1: project1, project2: project2} = context
+
+    dt1 = ~U[2020-10-10 00:00:00Z]
+    dt2 = ~U[2020-10-11 00:00:00Z]
+
+    data = [
+      %{
+        datetime: dt1,
+        data: [%{slug: project1.slug, value: 200}, %{slug: project2.slug, value: 150}]
+      },
+      %{
+        datetime: dt2,
+        data: [%{slug: project1.slug, value: 400}, %{slug: project2.slug, value: 100}]
+      }
+    ]
+
+    Sanbase.Mock.prepare_mock2(&Sanbase.PricePair.timeseries_data_per_slug/6, {:ok, data})
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      result =
+        get_timeseries_per_slug_metric(
+          conn,
+          "price_usd",
+          %{slugs: [project1.slug, project2.slug], source: "cryptocompare"},
+          from,
+          to,
+          "1d",
+          :last
+        )
+        |> extract_timeseries_data_per_slug()
+
+      assert %{"datetime" => dt_str1, "data" => data1} = result |> Enum.at(0)
+      assert dt_str1 |> Sanbase.DateTimeUtils.from_iso8601!() == dt1
+      assert %{"slug" => project1.slug, "value" => 200.0} in data1
+      assert %{"slug" => project2.slug, "value" => 150.0} in data1
+
+      assert %{"datetime" => dt_str2, "data" => data2} = result |> Enum.at(1)
+      assert dt_str2 |> Sanbase.DateTimeUtils.from_iso8601!() == dt2
+      assert %{"slug" => project1.slug, "value" => 400.0} in data2
+      assert %{"slug" => project2.slug, "value" => 100.0} in data2
+
+      assert_called(
+        Sanbase.PricePair.timeseries_data_per_slug(
+          [project1.slug, project2.slug],
+          "USD",
+          from,
+          to,
+          "1d",
+          :_
+        )
+      )
+    end)
   end
 
   test "returns data", context do
@@ -46,20 +103,12 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesDataPerSlugTest do
         )
         |> extract_timeseries_data_per_slug()
 
-      assert %{
-               "datetime" => dt_str1,
-               "data" => data1
-             } = result |> Enum.at(0)
-
+      assert %{"datetime" => dt_str1, "data" => data1} = result |> Enum.at(0)
       assert dt_str1 |> Sanbase.DateTimeUtils.from_iso8601!() == dt1
       assert %{"slug" => project1.slug, "value" => 400.0} in data1
       assert %{"slug" => project2.slug, "value" => 100.0} in data1
 
-      assert %{
-               "datetime" => dt_str2,
-               "data" => data2
-             } = result |> Enum.at(1)
-
+      assert %{"datetime" => dt_str2, "data" => data2} = result |> Enum.at(1)
       assert dt_str2 |> Sanbase.DateTimeUtils.from_iso8601!() == dt2
       assert %{"slug" => project1.slug, "value" => 500.0} in data2
       assert %{"slug" => project2.slug, "value" => 200.0} in data2


### PR DESCRIPTION
## Changes

- Introduce `PricePair` module that reads from the `asset_price_pairs_only` topic where currently only the cryptocompare exporter writes.
- Introduce `PricePair.MetricAdapter`
- Change the price module to `PricePair.MetricAdapter` when there is `source: "cryptocompare"` and the metric is `price_usd` or `price_btc`
- Add some changes to the rest of the Metric module that are required - first/last datetime also need `opts` so the `source` argument can be properly propagated and used to rewrite the module.
- Add a change to the `aggregated_timeseries_data` of the clickhouse `MetricAdapter` - in case the slug does not have data, provide a `nil` value (use the `has_changed` field). This has a positive effect on the caching - if the slug does not have data in the interval, it will still be cached, instead of refetched every time
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
