### PR TITLE
Add healthcheck to the cryptocompare websocket exporter

### DIFF
--- a/lib/sanbase/cryptocompare/websocket_scraper.ex
+++ b/lib/sanbase/cryptocompare/websocket_scraper.ex
@@ -1,4 +1,8 @@
 defmodule Sanbase.Cryptocompare.WebsocketScraper do
+  defmodule HealthcheckError do
+    defexception [:message]
+  end
+
   @moduledoc ~s"""
   Scrape the prices from Cryptocompare websocket API
   https://min-api.cryptocompare.com/documentation/websockets
@@ -26,6 +30,16 @@ defmodule Sanbase.Cryptocompare.WebsocketScraper do
   @asset_price_pairs_only_exporter :asset_price_pairs_only_exporter
   @asset_prices_exporter :prices_exporter
 
+  # Attempt a healthcheck every `@healthcheck_interval milliseconds` and check
+  # whether the last price message was received within the last `@price_message_timeout`
+  # milliseconds. If this check fails `@healthcheck_max_failures` times, terminate
+  # the exporter as there might be something wrong with the connection. The parameters
+  # are picked to be bigger so the number of resets is not too high and we don't
+  # reach the allowed number of websocket connections attempts.
+  @healthcheck_interval 60_000
+  @healthcheck_tolerance 60_000
+  @healthcheck_max_failures 5
+
   def child_spec(_opts \\ []) do
     %{
       id: :__cryptocompare_websocket_price_scraper__,
@@ -35,12 +49,17 @@ defmodule Sanbase.Cryptocompare.WebsocketScraper do
 
   def start_link() do
     state = %{
+      start_time: DateTime.utc_now(),
       last_points: %{},
+      healthcheck_sequential_failures: 0,
       subscriptions: MapSet.new(),
-      msg_number: 0
+      msg_number: 0,
+      last_price_message_time: DateTime.utc_now()
     }
 
     extra_headers = [{"authorization", "Apikey #{api_key()}"}]
+
+    Process.send_after(@name, :healthcheck, @healthcheck_interval)
 
     WebSockex.start_link(websocket_url(), __MODULE__, state,
       name: @name,
@@ -51,14 +70,44 @@ defmodule Sanbase.Cryptocompare.WebsocketScraper do
   def enabled?(), do: Config.get(:enabled?) |> String.to_existing_atom()
 
   def terminate(reason, state) do
-    if reason != :normal do
-      Logger.error("""
-      [CryptocompareWS] Terminate with reason: #{inspect(reason)}.
-      State: #{inspect(state)}
-      """)
-    end
+    base_error_msg = "[CryptocompareWS] Terminate the websocket connection #{state[:socket_id]}."
+
+    error_msg =
+      case reason do
+        {%{} = exception, _stacktrace} ->
+          base_error_msg <> " Reason: #{Exception.message(exception)}"
+
+        _ ->
+          base_error_msg <> " Reason: #{inspect(reason)}"
+      end
+
+    Logger.error(error_msg)
 
     :ok
+  end
+
+  def handle_info(:healthcheck, state) do
+    # If more than 3 consecutive times there are no new messages in the last
+    # 30 seconds, we consider the connection to be dead and it will be terminated
+    # so it can be freshly started.
+    last_message_elapsed =
+      DateTime.diff(DateTime.utc_now(), state.last_price_message_time, :millisecond)
+
+    state =
+      case last_message_elapsed > @healthcheck_tolerance do
+        true -> Map.update(state, :healthcheck_sequential_failures, 1, &(&1 + 1))
+        false -> Map.put(state, :healthcheck_sequential_failures, 0)
+      end
+
+    if state.healthcheck_sequential_failures > @healthcheck_max_failures do
+      raise(HealthcheckError,
+        message: "More than #{@healthcheck_max_failures} consecutive healthchecks have failed"
+      )
+    end
+
+    Process.send_after(self(), :healthcheck, @healthcheck_interval)
+
+    {:ok, state}
   end
 
   def handle_info(:init_wildcard_subscription, state) do
@@ -101,6 +150,7 @@ defmodule Sanbase.Cryptocompare.WebsocketScraper do
 
   # Aggregate Index (CCCAGG)
   def handle_frame(%{"TYPE" => "5"} = msg, _frame, state) do
+    now = DateTime.utc_now()
     point_unique_key = {"CCCAGG", msg["FROMSYMBOL"], msg["TOSYMBOL"]}
 
     last_point = Map.get(state.last_points, point_unique_key, %{})
@@ -121,7 +171,13 @@ defmodule Sanbase.Cryptocompare.WebsocketScraper do
     last_points = Map.put(state.last_points, point_unique_key, point)
     export_data_point(point, last_points)
 
-    {:ok, %{state | last_points: last_points, msg_number: state.msg_number + 1}}
+    {:ok,
+     %{
+       state
+       | last_points: last_points,
+         msg_number: state.msg_number + 1,
+         last_price_message_time: now
+     }}
   end
 
   def handle_frame(%{"MESSAGE" => "FORCE_DISCONNECT"} = msg, _frame, state) do


### PR DESCRIPTION
## Changes

The healthcheck is the following: The exporter has exported a new price in the last 60 seconds.
If this healthcheck has failed 5 times in a row, the exporter will be terminated so it can be started with clean state and a new socket can be initiated.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
