### PR TITLE
Remove URI.encode/1 call as the library already encodes it

### DIFF
--- a/lib/sanbase/social_data/social_volume.ex
+++ b/lib/sanbase/social_data/social_volume.ex
@@ -106,7 +106,7 @@ defmodule Sanbase.SocialData.SocialVolume do
       options = [
         recv_timeout: @recv_timeout,
         params: [
-          {"search_text", search_text |> URI.encode()},
+          {"search_text", search_text},
           {"from_timestamp", from |> DateTime.truncate(:second) |> DateTime.to_iso8601()},
           {"to_timestamp", to |> DateTime.truncate(:second) |> DateTime.to_iso8601()},
           {"interval", interval},


### PR DESCRIPTION
## Changes

With this URI.encode/1 in place, the URI seems to be encoded twice. The
:params provided to HTTPoison are bassed to `URI.encode_query/1`. This
results in wrongly parsing the request on the metrics-hub-server side
and when some special symbols are in place (parens) it returns wrong
results


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
