### PR TITLE
Add active subscriptions for product query and use for liquidity subs…

### DIFF
--- a/lib/sanbase/billing/subscription/liquidity_subscription.ex
+++ b/lib/sanbase/billing/subscription/liquidity_subscription.ex
@@ -4,7 +4,7 @@ defmodule Sanbase.Billing.Subscription.LiquiditySubscription do
   Uniswap liquidity pools. They are present only in Sanbase but not synced in Stripe.
   """
 
-  alias Sanbase.Billing.Subscription
+  alias Sanbase.Billing.{Subscription, Product}
   alias Sanbase.Accounts.User
   alias Sanbase.Repo
 
@@ -53,7 +53,7 @@ defmodule Sanbase.Billing.Subscription.LiquiditySubscription do
   @spec user_has_active_sanbase_subscriptions?(non_neg_integer()) :: boolean()
   def user_has_active_sanbase_subscriptions?(user_id) do
     Subscription
-    |> Subscription.Query.all_active_subscriptions_for_plan(@san_stake_free_plan)
+    |> Subscription.Query.all_active_subscriptions_for_product(Product.product_sanbase())
     |> Subscription.Query.filter_user(user_id)
     |> Repo.all()
     |> Enum.any?()

--- a/lib/sanbase/billing/subscription/query.ex
+++ b/lib/sanbase/billing/subscription/query.ex
@@ -13,6 +13,15 @@ defmodule Sanbase.Billing.Subscription.Query do
     from(q in query, where: q.plan_id == ^plan_id)
   end
 
+  def all_active_subscriptions_for_product(query, product_id) do
+    query = all_active_subscriptions(query)
+
+    from(q in query,
+      join: p in assoc(q, :plan),
+      where: p.product_id == ^product_id
+    )
+  end
+
   # with status `active`, `past_due`, `trialing`
   def all_active_and_trialing_subscriptions(query) do
     from(q in query, where: q.status in ["active", "past_due", "trialing"])


### PR DESCRIPTION
…cription eligibility check

* Add query for active subscriptions by product
* Use it in eligibility for liquidity subscription. Current check looks only for specific sanbase pro plan and ignores rest.

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
