### PR TITLE
Add project_slug argument to chart_configurations API

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/chart_configuration/chart_configuration_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/chart_configuration/chart_configuration_resolver.ex
@@ -12,25 +12,30 @@ defmodule SanbaseWeb.Graphql.Resolvers.ChartConfigurationResolver do
   end
 
   def chart_configurations(_root, args, resolution) do
-    user = get_in(resolution.context, [:auth, :current_user]) || %User{}
+    with %User{} = user <- get_in(resolution.context, [:auth, :current_user]) || %User{},
+         {:ok, project_id} <- get_project_id_from_args(args) do
+      # Update the project_id if it is not nil. This will reduce the slug case
+      # down to project_id case and handle them the same way
+      args = if project_id, do: Map.put(args, :project_id, project_id), else: args
 
-    case args do
-      %{user_id: user_id, project_id: project_id}
-      when not is_nil(user_id) and not is_nil(project_id) ->
-        # All configurations of user_id for project_id accessible by the current user
-        {:ok, Configuration.user_configurations(user_id, user.id, project_id)}
+      case args do
+        %{user_id: user_id, project_id: project_id}
+        when not is_nil(user_id) and not is_nil(project_id) ->
+          # All configurations of user_id for project_id accessible by the current user
+          {:ok, Configuration.user_configurations(user_id, user.id, project_id)}
 
-      %{user_id: user_id} when not is_nil(user_id) ->
-        # All configurations of user_id accessible by the current user
-        {:ok, Configuration.user_configurations(user_id, user.id)}
+        %{user_id: user_id} when not is_nil(user_id) ->
+          # All configurations of user_id accessible by the current user
+          {:ok, Configuration.user_configurations(user_id, user.id)}
 
-      %{project_id: project_id} when not is_nil(project_id) ->
-        # All configurations of project_id accessible by the current user
-        {:ok, Configuration.project_configurations(project_id, user.id)}
+        %{project_id: project_id} when not is_nil(project_id) ->
+          # All configurations of project_id accessible by the current user
+          {:ok, Configuration.project_configurations(project_id, user.id)}
 
-      %{} ->
-        # All configurations accessible by the current user
-        {:ok, Configuration.configurations(user.id)}
+        %{} ->
+          # All configurations accessible by the current user
+          {:ok, Configuration.configurations(user.id)}
+      end
     end
   end
 
@@ -59,4 +64,21 @@ defmodule SanbaseWeb.Graphql.Resolvers.ChartConfigurationResolver do
       ) do
     Configuration.delete(id, user.id)
   end
+
+  # Private functions
+
+  defp get_project_id_from_args(%{project_id: _, project_slug: _}) do
+    {:error,
+     "Both projectId and projectSlug arguments are provided. Please use only one of them or none."}
+  end
+
+  defp get_project_id_from_args(%{project_id: project_id}) do
+    {:ok, project_id}
+  end
+
+  defp get_project_id_from_args(%{project_slug: slug}) do
+    {:ok, Sanbase.Model.Project.id_by_slug(slug)}
+  end
+
+  defp get_project_id_from_args(_), do: {:ok, nil}
 end

--- a/lib/sanbase_web/graphql/schema/queries/chart_configuration_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/chart_configuration_queries.ex
@@ -23,6 +23,7 @@ defmodule SanbaseWeb.Graphql.Schema.ChartConfigurationQueries do
 
       arg(:user_id, :integer)
       arg(:project_id, :integer)
+      arg(:project_slug, :string)
 
       resolve(&ChartConfigurationResolver.chart_configurations/3)
     end


### PR DESCRIPTION
## Changes

Add `projectSlug` argument to the `chartConfigurations` API. It can be used instead of `projectId`. If both `projectId` and `projectSlug` are provided the API will return an error.

```graphql
{
  chartConfigurations(projectSlug: "bitcoin") {
    id
    title
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
