### PR TITLE
Improve cache key generation. Avoid cache key collisions

### DIFF
--- a/lib/sanbase/alerts/evaluator/evaluator.ex
+++ b/lib/sanbase/alerts/evaluator/evaluator.ex
@@ -41,10 +41,14 @@ defmodule Sanbase.Alert.Evaluator do
     # Along with the trigger settings (the `cache_key`) take into account also
     # the last triggered datetime and cooldown. This is done because an alert
     # can only be fired if it did not fire in the past `cooldown` intereval of time
+    # NOTE: Do not apply hashing on the cache key because it can have :nocache
+    # in the first place and it is trated differently
+    cache_key = {Trigger.cache_key(trigger), {last_triggered, cooldown}}
+
     evaluated_trigger =
       Cache.get_or_store(
         :alerts_evaluator_cache,
-        {Trigger.cache_key(trigger), {last_triggered, cooldown}},
+        cache_key,
         fn -> Trigger.evaluate(trigger) end
       )
 

--- a/lib/sanbase/alerts/trigger/settings/eth_wallet_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/eth_wallet_trigger_settings.ex
@@ -125,7 +125,7 @@ defmodule Sanbase.Alert.Trigger.EthWalletTriggerSettings do
 
   defp balance_change(addresses, slug, from, to) do
     cache_key =
-      {:balance_change, addresses, slug, round_datetime(from, second: 60),
+      {__MODULE__, :balance_change, addresses, slug, round_datetime(from, second: 60),
        round_datetime(to, second: 60)}
       |> Sanbase.Cache.hash()
 

--- a/lib/sanbase/alerts/trigger/settings/signal_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/signal_trigger_settings.ex
@@ -76,7 +76,7 @@ defmodule Sanbase.Alert.Trigger.SignalTriggerSettings do
     %{signal: signal, time_window: time_window} = settings
 
     cache_key =
-      {:signal_alert, signal, selector, time_window, round_datetime(Timex.now())}
+      {__MODULE__, :fetch_signal_data, signal, selector, time_window, round_datetime(Timex.now())}
       |> Sanbase.Cache.hash()
 
     %{

--- a/lib/sanbase/alerts/trigger/settings/wallet_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/wallet_trigger_settings.ex
@@ -144,7 +144,7 @@ defmodule Sanbase.Alert.Trigger.WalletTriggerSettings do
 
   defp balance_change(selector, address, from, to) do
     cache_key =
-      {:wallet_signal, selector, address, round_datetime(from), round_datetime(to)}
+      {__MODULE__, :wallet_signal, selector, address, round_datetime(from), round_datetime(to)}
       |> Sanbase.Cache.hash()
 
     Sanbase.Cache.get_or_store(:alerts_evaluator_cache, cache_key, fn ->

--- a/lib/sanbase/clickhouse/github/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/github/metric_adapter.ex
@@ -202,7 +202,9 @@ defmodule Sanbase.Clickhouse.Github.MetricAdapter do
   def available_slugs() do
     # Providing a 2 element tuple `{any, integer}` will use that second element
     # as TTL for the cache key
-    Sanbase.Cache.get_or_store({:slugs_with_github_org, 1800}, fn ->
+    cache_key = {__MODULE__, :slugs_with_github_org}
+
+    Sanbase.Cache.get_or_store({cache_key, 600}, fn ->
       {:ok, Project.List.slugs_with_github_organization()}
     end)
   end

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -489,7 +489,8 @@ defmodule Sanbase.Metric do
 
     parallel_fun = fn module ->
       cache_key =
-        {__MODULE__, :available_metrics_for_slug, module, selector} |> Sanbase.Cache.hash()
+        {__MODULE__, :available_metrics_for_slug_in_module, module, selector}
+        |> Sanbase.Cache.hash()
 
       Sanbase.Cache.get_or_store(cache_key, fn -> module.available_metrics(selector) end)
     end
@@ -587,10 +588,9 @@ defmodule Sanbase.Metric do
   def available_slugs() do
     # Providing a 2 element tuple `{any, integer}` will use that second element
     # as TTL for the cache key
-    Sanbase.Cache.get_or_store(
-      {:metric_available_slugs_all_metrics, 1800},
-      &get_available_slugs/0
-    )
+    cache_key = {__MODULE__, :available_slugs_all_metrics} |> Sanbase.Cache.hash()
+
+    Sanbase.Cache.get_or_store({cache_key, 1800}, &get_available_slugs/0)
   end
 
   @doc ~s"""

--- a/lib/sanbase/model/project/list/selector/list_selector.ex
+++ b/lib/sanbase/model/project/list/selector/list_selector.ex
@@ -200,7 +200,7 @@ defmodule Sanbase.Model.Project.ListSelector do
       filters
       |> Sanbase.Parallel.map(
         fn filter ->
-          cache_key = {:included_slugs_by_filter, filter}
+          cache_key = {__MODULE__, :included_slugs_by_filter, filter} |> Sanbase.Cache.hash()
           {:ok, slugs} = Sanbase.Cache.get_or_store(cache_key, fn -> slugs_by_filter(filter) end)
 
           slugs |> MapSet.new()

--- a/lib/sanbase/prices/utils.ex
+++ b/lib/sanbase/prices/utils.ex
@@ -7,8 +7,11 @@ defmodule Sanbase.Price.Utils do
   @spec fetch_last_prices_before(String.t(), DateTime.t()) ::
           {number() | nil, number() | nil}
   def fetch_last_prices_before(slug, datetime) do
+    cache_key =
+      {__MODULE__, :last_record_before, slug, round_datetime(datetime)} |> Sanbase.Cache.hash()
+
     last_record =
-      Sanbase.Cache.get_or_store({:last_record_before, slug, round_datetime(datetime)}, fn ->
+      Sanbase.Cache.get_or_store(cache_key, fn ->
         Sanbase.Price.last_record_before(slug, datetime)
       end)
 

--- a/lib/sanbase_web/controllers/cryptocompare_asset_mapping_controller.ex
+++ b/lib/sanbase_web/controllers/cryptocompare_asset_mapping_controller.ex
@@ -5,7 +5,8 @@ defmodule SanbaseWeb.CryptocompareAssetMappingController do
   require Logger
 
   def data(conn, _params) do
-    data = Sanbase.Cache.get_or_store({__MODULE__, __ENV__.function}, &get_data/0)
+    cache_key = {__MODULE__, __ENV__.function} |> Sanbase.Cache.hash()
+    data = Sanbase.Cache.get_or_store(cache_key, &get_data/0)
 
     conn
     |> put_resp_header("content-type", "application/json; charset=utf-8")

--- a/lib/sanbase_web/controllers/project_data_controller.ex
+++ b/lib/sanbase_web/controllers/project_data_controller.ex
@@ -5,7 +5,8 @@ defmodule SanbaseWeb.ProjectDataController do
   require Logger
 
   def data(conn, _params) do
-    {:ok, data} = Sanbase.Cache.get_or_store({__MODULE__, __ENV__.function}, &get_data/0)
+    cache_key = {__MODULE__, __ENV__.function} |> Sanbase.Cache.hash()
+    {:ok, data} = Sanbase.Cache.get_or_store(cache_key, &get_data/0)
 
     conn
     |> put_resp_header("content-type", "application/json; charset=utf-8")

--- a/lib/sanbase_web/graphql/cache/cache.ex
+++ b/lib/sanbase_web/graphql/cache/cache.ex
@@ -242,7 +242,7 @@ defmodule SanbaseWeb.Graphql.Cache do
     max_ttl_offset = Enum.max([max_ttl_offset, 1])
 
     # Used to randomize the TTL for lists of objects like list of projects
-    additional_args = Map.take(args, [:slug, :id])
+    additional_args = Map.take(args, [:slug, :id, :word])
 
     # Using phash2 as a random number between 0 and max_ttl_offset is needed.
     # collisions are allowed and do not lead to errors
@@ -254,7 +254,10 @@ defmodule SanbaseWeb.Graphql.Cache do
     end
 
     args = args |> convert_values(ttl)
-    cache_key = [name, args] |> Sanbase.Cache.hash()
+
+    cache_key =
+      {__MODULE__, :__internal_graphql_api_caching__, name, args} |> Sanbase.Cache.hash()
+
     {cache_key, ttl}
   end
 

--- a/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
@@ -100,14 +100,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver do
         {:ok, value}
 
       :error ->
-        cache_key =
-          {__MODULE__, :available_slugs_for_metric, metric, opts}
-          |> Sanbase.Cache.hash()
-
-        {:ok, slugs_for_metric} =
-          Sanbase.Cache.get_or_store({cache_key, 600}, fn ->
-            Metric.available_slugs(metric, opts)
-          end)
+        {:ok, slugs_for_metric} = available_slugs_for_metric(metric, opts)
 
         # Determine whether the value is missing because it failed to compute or
         # because the metric is not available for the given slug. In the first case
@@ -117,6 +110,16 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver do
           false -> {:ok, nil}
         end
     end
+  end
+
+  defp available_slugs_for_metric(metric, opts) do
+    cache_key =
+      {__MODULE__, :available_slugs_for_metric, metric, opts}
+      |> Sanbase.Cache.hash()
+
+    Sanbase.Cache.get_or_store({cache_key, 600}, fn ->
+      Metric.available_slugs(metric, opts)
+    end)
   end
 
   # Get the available metrics from the rehydrating cache. If the function for computing it

--- a/lib/sanbase_web/graphql/resolvers/project/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_resolver.ex
@@ -138,7 +138,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
       ) do
     project_ethereum =
       Sanbase.Cache.get_or_store(
-        {__MODULE__, :project, "ethereum"} |> Sanbase.Cache.hash(),
+        {__MODULE__, :project_by_slug, "ethereum"} |> Sanbase.Cache.hash(),
         fn -> Project.by_slug("ethereum") end
       )
 


### PR DESCRIPTION
## Changes

A few cache key collisions were found in metric.ex. A few different functions were all using the `{__MODULE__, :available_metrics_for_slug, selector}` key
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
