### PR TITLE
Update visibility by API Plans

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -241,7 +241,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "avg",
@@ -258,7 +258,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "last",
@@ -305,7 +305,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "last",
@@ -332,7 +332,7 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "MVRV for coins that moved in the past {{timebound_human_readable}}",
+    "human_readable_name": "MVRV Intraday for coins that moved in the past {{timebound_human_readable}}",
     "name": "mvrv_usd_intraday_{{timebound}}",
     "metric": "mvrv_usd_intraday_{{timebound}}",
     "timebound": [
@@ -352,7 +352,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "last",
@@ -399,7 +399,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "last",
@@ -417,7 +417,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "sum",
@@ -434,7 +434,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "sum",
@@ -451,7 +451,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "sum",
@@ -468,7 +468,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "sum",
@@ -485,7 +485,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "sum",
@@ -502,7 +502,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "sum",
@@ -519,7 +519,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "sum",
@@ -603,7 +603,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "avg",
@@ -775,7 +775,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "avg",
@@ -792,7 +792,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "sum",
@@ -1252,7 +1252,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "sum",
@@ -1269,7 +1269,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "sum",
@@ -1338,7 +1338,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "last",
@@ -1372,7 +1372,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "last",
@@ -1389,7 +1389,7 @@
     "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
-      "SANAPI": "pro",
+      "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "last",

--- a/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_product_access_test.exs
+++ b/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_product_access_test.exs
@@ -222,7 +222,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
 
     test "can't access metric with min plan PRO", context do
       {from, to} = from_to(2 * 365 - 1, 2 * 365 - 2)
-      metric = "mvrv_long_short_diff_usd"
+      metric = "withdrawal_balance"
       slug = context.project.slug
       query = metric_query(metric, slug, from, to)
       error_message = execute_query_with_error(context.conn, query, "getMetric")


### PR DESCRIPTION
## Changes

Make more metrics visible by Basic, Free plans

List of changed metrics:

- Mean_realized_price_usd_{{timebound}}
- MVRV Long/Short Difference
- MVRV for coins that moved in the past {{timebound_human_readable}}
- MVRV Intraday for coins that moved in the past {{timebound_human_readable}}
- Circulation for coins that moved in the past {{timebound_human_readable}}
- Circulation for coins that have not moved in the past 10 years
- Circulation for coins that have not moved in the past 5 years
- Circulation for coins that have not moved in the past 3 years
- Circulation for coins that have not moved in the past 2 years
- Circulation for coins that have not moved in the past 1 year
- Circulation for coins that have not moved in the past 180 days
- Circulation for coins that have not moved in the past 90 days
- Realized Value for coins that moved in the past {{timebound_human_readable}}
- Active Withdrawals
- Withdrawal Transactions
- Number of Transactions Transferring More Than 100k USD
- Number of Transactions Transferring More Than 1 million USD
- Total Supply Held by Miner Addresses
- Circulation NVT
- Percent of Stablecoin Total Supply held by Whales with more than 5 million USD

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
