### PR TITLE
Fix the SQL of the timeseries data sql of the price pairs

### DIFF
--- a/lib/sanbase/prices/price_pair/price_pair_sql.ex
+++ b/lib/sanbase/prices/price_pair/price_pair_sql.ex
@@ -9,7 +9,7 @@ defmodule Sanbase.Price.PricePairSql do
     query = """
     SELECT
       toUnixTimestamp(intDiv(toUInt32(toDateTime(dt)), ?1) * ?1) AS time,
-      #{aggregation(aggregation, "price", "dt")} AS value
+      #{aggregation(aggregation, "price", "dt")}
     FROM #{@table}
     PREWHERE
       #{slug_filter_map(slug_or_slugs, argument_position: 2)} AND


### PR DESCRIPTION
## Changes

Remove an unnecesary alias that fails when the underlaying aggregation
function also defines aliases. This is the case when the aggregation is
OHLC

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
