### PR TITLE
Add rate limits to insights and comments creation

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -105,6 +105,20 @@ config :sanbase, Sanbase.Telegram,
   telegram_endpoint: "random_string",
   token: "token"
 
-if File.exists?("config/test.secret.exs") do
+# Increase the limits in test env so they are not hit unless
+# the limit is intentionally lowered by using Application.put_env
+config :sanbase, Sanbase.Comment,
+  creation_limit_hour: 1000,
+  creation_limit_day: 1000,
+  creation_limit_minute: 1000
+
+# Increase the limits in test env so they are not hit unless
+# the limit is intentionally lowered by using Application.put_env
+config :sanbase, Sanbase.Insight.Post,
+  creation_limit_hour: 1000,
+  creation_limit_day: 1000,
+  creation_limit_minute: 1000
+
+if(File.exists?("config/test.secret.exs")) do
   import_config "test.secret.exs"
 end

--- a/lib/sanbase/comments/comment.ex
+++ b/lib/sanbase/comments/comment.ex
@@ -31,6 +31,8 @@ defmodule Sanbase.Comment do
   alias Sanbase.Chart.Configuration, as: ChartConfiguration
   alias Sanbase.WalletHunters.Proposal, as: WHProposal
 
+  require Sanbase.Utils.Config, as: Config
+
   @max_comment_length 15_000
 
   @insights_table "post_comments_mapping"
@@ -88,6 +90,50 @@ defmodule Sanbase.Comment do
     |> validate_length(:content, min: 2, max: @max_comment_length)
     |> foreign_key_constraint(:parent_id)
     |> foreign_key_constraint(:root_parent_id)
+  end
+
+  def can_create?(user_id) do
+    now = NaiveDateTime.utc_now()
+
+    map =
+      from(p in __MODULE__,
+        where: p.user_id == ^user_id,
+        select: %{
+          day:
+            fragment(
+              "COUNT(*) FILTER (WHERE inserted_at >= ?)",
+              ^NaiveDateTime.add(now, -86_400, :second)
+            ),
+          hour:
+            fragment(
+              "COUNT(*) FILTER (WHERE inserted_at >= ?)",
+              ^NaiveDateTime.add(now, -3600, :second)
+            ),
+          minute:
+            fragment(
+              "COUNT(*) FILTER (WHERE inserted_at >= ?)",
+              ^NaiveDateTime.add(now, -60, :second)
+            )
+        }
+      )
+      |> Repo.one()
+
+    limit_day = Config.get(:creation_limit_day, 50)
+    limit_hour = Config.get(:creation_limit_hour, 20)
+    limit_minute = Config.get(:creation_limit_minute, 2)
+
+    error_msg = fn
+      1, period -> {:error, "Cannot create more than 1 comment per #{period}"}
+      limit, period -> {:error, "Cannot create more than #{limit} comments per #{period}"}
+    end
+
+    cond do
+      map.day >= limit_day -> error_msg.(limit_day, "day")
+      map.hour >= limit_hour -> error_msg.(limit_hour, "hour")
+      map.minute >= limit_minute -> error_msg.(limit_minute, "minute")
+      # return an :ok tuple so it can be used inside Ecto.Multi
+      true -> {:ok, true}
+    end
   end
 
   def get_subcomments(comment_id, limit) do

--- a/lib/sanbase/comments/entity_comment.ex
+++ b/lib/sanbase/comments/entity_comment.ex
@@ -40,6 +40,10 @@ defmodule Sanbase.Comments.EntityComment do
   def create_and_link(entity, entity_id, user_id, parent_id, content) do
     Ecto.Multi.new()
     |> Ecto.Multi.run(
+      :check_can_create_comment,
+      fn _repo, _changes -> Comment.can_create?(user_id) end
+    )
+    |> Ecto.Multi.run(
       :create_comment,
       fn _repo, _changes -> Comment.create(user_id, content, parent_id) end
     )

--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -96,47 +96,17 @@ defmodule Sanbase.Insight.Post do
   end
 
   def can_create?(user_id) do
-    now = NaiveDateTime.utc_now()
+    limits = %{
+      day: Config.get(:creation_limit_day, 20),
+      hour: Config.get(:creation_limit_hour, 10),
+      minute: Config.get(:creation_limit_minute, 1)
+    }
 
-    map =
-      from(p in __MODULE__,
-        where: p.user_id == ^user_id,
-        select: %{
-          day:
-            fragment(
-              "COUNT(*) FILTER (WHERE inserted_at >= ?)",
-              ^NaiveDateTime.add(now, -86_400, :second)
-            ),
-          hour:
-            fragment(
-              "COUNT(*) FILTER (WHERE inserted_at >= ?)",
-              ^NaiveDateTime.add(now, -3600, :second)
-            ),
-          minute:
-            fragment(
-              "COUNT(*) FILTER (WHERE inserted_at >= ?)",
-              ^NaiveDateTime.add(now, -60, :second)
-            )
-        }
-      )
-      |> Repo.one()
-
-    limit_day = Config.get(:creation_limit_day, 20)
-    limit_hour = Config.get(:creation_limit_hour, 10)
-    limit_minute = Config.get(:creation_limit_minute, 1)
-
-    error_msg = fn
-      1, period -> {:error, "Cannot create more than 1 insight per #{period}"}
-      limit, period -> {:error, "Cannot create more than #{limit} insights per #{period}"}
-    end
-
-    cond do
-      map.minute >= limit_minute -> error_msg.(limit_minute, "minute")
-      map.hour >= limit_hour -> error_msg.(limit_hour, "hour")
-      map.day >= limit_day -> error_msg.(limit_day, "day")
-      # return an :ok tuple so it can be used inside Ecto.Multi
-      true -> {:ok, true}
-    end
+    Sanbase.Ecto.Common.can_create?(__MODULE__, user_id,
+      limits: limits,
+      entity_singular: "insight",
+      entity_plural: "insights"
+    )
   end
 
   # Needed by ex_admin

--- a/lib/sanbase/utils/ecto_common.ex
+++ b/lib/sanbase/utils/ecto_common.ex
@@ -1,0 +1,59 @@
+defmodule Sanbase.Ecto.Common do
+  import Ecto.Query
+
+  @doc ~s"""
+  Checks whether the user can create a new entity of a given type or if
+  a rate limit must be applied.
+
+  The `module` must have an `inserted_at` datetime column without a timezone.
+  This is the default column of Ecto's `timestamp()`. A rate limit per
+  minute, hour and day are applied. These limits are provided as the `:limits`
+  key in the opts. The keys of that map are `:minute`, `:hour` and `:day`.
+  Additionally, for the error message formatting the `:entity_singular` and
+  `:entity_plural` keys must be present in the opts, too.
+  """
+  @spec can_create?(module, non_neg_integer, Keyword.t()) :: {:ok, true} | {:error, String.t()}
+  def can_create?(module, user_id, opts) do
+    now = NaiveDateTime.utc_now()
+
+    map =
+      from(p in module,
+        where: p.user_id == ^user_id,
+        select: %{
+          day:
+            fragment(
+              "COUNT(*) FILTER (WHERE inserted_at >= ?)",
+              ^NaiveDateTime.add(now, -86_400, :second)
+            ),
+          hour:
+            fragment(
+              "COUNT(*) FILTER (WHERE inserted_at >= ?)",
+              ^NaiveDateTime.add(now, -3600, :second)
+            ),
+          minute:
+            fragment(
+              "COUNT(*) FILTER (WHERE inserted_at >= ?)",
+              ^NaiveDateTime.add(now, -60, :second)
+            )
+        }
+      )
+      |> Sanbase.Repo.one()
+
+    limits = Keyword.fetch!(opts, :limits)
+    entity_singular = Keyword.fetch!(opts, :entity_singular)
+    entity_plural = Keyword.fetch!(opts, :entity_plural)
+
+    error_msg = fn
+      1, period -> {:error, "Cannot create more than 1 #{entity_singular} per #{period}"}
+      limit, period -> {:error, "Cannot create more than #{limit} #{entity_plural} per #{period}"}
+    end
+
+    cond do
+      map.minute >= limits.minute -> error_msg.(limits.minute, "minute")
+      map.hour >= limits.hour -> error_msg.(limits.hour, "hour")
+      map.day >= limits.day -> error_msg.(limits.day, "day")
+      # return an :ok tuple so it can be used inside Ecto.Multi
+      true -> {:ok, true}
+    end
+  end
+end

--- a/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
@@ -137,7 +137,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.InsightResolver do
   end
 
   def create_post(_root, args, %{context: %{auth: %{current_user: user}}}) do
-    Post.create(user, args)
+    case Post.can_create?(user.id) do
+      {:ok, _} -> Post.create(user, args)
+      {:error, error} -> {:error, error}
+    end
   end
 
   def update_post(_root, %{id: post_id} = args, %{

--- a/test/support/comments_api_helper.ex
+++ b/test/support/comments_api_helper.ex
@@ -2,33 +2,13 @@ defmodule Sanbase.CommentsApiHelper do
   import SanbaseWeb.Graphql.TestHelpers
 
   def create_comment(conn, entity_id, content, opts \\ []) do
-    entity_type = Keyword.fetch!(opts, :entity_type)
-    entity_type = entity_type |> to_string() |> String.upcase()
-    parent_id = Keyword.get(opts, :parent_id, nil)
-
-    extra_fields_str =
-      Keyword.get(opts, :extra_fields, [])
-      |> Enum.join("\n")
-
-    mutation = """
-    mutation {
-      createComment(
-        entityType: #{entity_type}
-        id: #{entity_id}
-        parentId: #{parent_id || "null"}
-        content: "#{content}") {
-          id
-          content
-          user{ id username email }
-          subcommentsCount
-          insertedAt
-          editedAt
-          #{extra_fields_str}
-      }
-    }
-    """
-
+    mutation = create_comment_mutation(entity_id, content, opts)
     execute_mutation(conn, mutation, "createComment")
+  end
+
+  def create_comment_with_error(conn, entity_id, content, opts \\ []) do
+    mutation = create_comment_mutation(entity_id, content, opts)
+    execute_mutation_with_error(conn, mutation)
   end
 
   def update_comment(conn, comment_id, content, opts \\ []) do
@@ -103,5 +83,33 @@ defmodule Sanbase.CommentsApiHelper do
     """
 
     execute_query(conn, query, "comments")
+  end
+
+  defp create_comment_mutation(entity_id, content, opts) do
+    entity_type = Keyword.fetch!(opts, :entity_type)
+    entity_type = entity_type |> to_string() |> String.upcase()
+    parent_id = Keyword.get(opts, :parent_id, nil)
+
+    extra_fields_str =
+      Keyword.get(opts, :extra_fields, [])
+      |> Enum.join("\n")
+
+    mutation = """
+    mutation {
+      createComment(
+        entityType: #{entity_type}
+        id: #{entity_id}
+        parentId: #{parent_id || "null"}
+        content: "#{content}") {
+          id
+          content
+          user{ id username email }
+          subcommentsCount
+          insertedAt
+          editedAt
+          #{extra_fields_str}
+      }
+    }
+    """
   end
 end

--- a/test/support/comments_api_helper.ex
+++ b/test/support/comments_api_helper.ex
@@ -94,7 +94,7 @@ defmodule Sanbase.CommentsApiHelper do
       Keyword.get(opts, :extra_fields, [])
       |> Enum.join("\n")
 
-    mutation = """
+    """
     mutation {
       createComment(
         entityType: #{entity_type}


### PR DESCRIPTION
## Changes

Add limits to how many insights and comments (of any type) a user can create in a time window. 
This is to avoid spam by malicious parties.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
