### PR TITLE
Add Realtime Top Holders. Top Holders improvements

### DIFF
--- a/lib/sanbase/clickhouse/top_holders/top_holders.ex
+++ b/lib/sanbase/clickhouse/top_holders/top_holders.ex
@@ -7,6 +7,9 @@ defmodule Sanbase.Clickhouse.TopHolders do
 
   alias Sanbase.ClickhouseRepo
   alias Sanbase.Clickhouse.Label
+  alias Sanbase.Model.Project
+
+  import Sanbase.Metric.SqlQuery.Helper
 
   @table "eth_top_holders_daily_union"
 
@@ -25,46 +28,58 @@ defmodule Sanbase.Clickhouse.TopHolders do
           part_of_total: number()
         }
 
-  @spec top_holders(
-          slug :: String.t(),
-          contract :: String.t(),
-          token_decimals :: non_neg_integer(),
-          from :: DateTime.t(),
-          to :: DateTime.t(),
-          opts :: Keyword.t()
-        ) :: {:ok, list(top_holders)} | {:error, String.t()}
-  def top_holders(slug, contract, token_decimals, from, to, opts) do
-    {query, args} =
-      top_holders_query(
-        slug,
-        contract,
-        token_decimals,
-        from,
-        to,
-        opts
-      )
+  def realtime_top_holders(slug, opts) do
+    {query, args} = realtime_top_holders_query(slug, opts)
 
-    transform_func = fn [dt, address, value, value_usd, part_of_total] ->
-      %{
-        datetime: DateTime.from_unix!(dt),
-        address: address,
-        value: value,
-        value_usd: value_usd,
-        part_of_total: part_of_total
-      }
-    end
+    ClickhouseRepo.query_transform(query, args, &holder_transform_func/1)
+  end
 
-    with {:ok, top_holders} <- ClickhouseRepo.query_transform(query, args, transform_func),
-         addresses = Enum.map(top_holders, & &1.address),
+  @spec top_holders(String.t(), DateTime.t(), DateTime.t(), Keyword.t()) ::
+          {:ok, list(top_holders)} | {:error, String.t()}
+  def top_holders(slug, from, to, opts) do
+    contract_opts = [contract_type: :latest_onchain_contract]
+
+    with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug, contract_opts),
+         {query, args} <- top_holders_query(slug, contract, decimals, from, to, opts),
+         {:ok, result} <- ClickhouseRepo.query_transform(query, args, &holder_transform_func/1),
+         addresses = Enum.map(result, & &1.address) |> Enum.uniq(),
          {:ok, address_labels_map} <- Label.get_address_labels(slug, addresses) do
       labelled_top_holders =
-        top_holders
-        |> Enum.map(fn top_holder ->
+        Enum.map(result, fn top_holder ->
           labels = Map.get(address_labels_map, top_holder.address, [])
           Map.put(top_holder, :labels, labels)
         end)
 
       {:ok, labelled_top_holders}
+    end
+  end
+
+  @spec percent_of_total_supply(
+          String.t(),
+          non_neg_integer(),
+          DateTime.t(),
+          DateTime.t(),
+          String.t()
+        ) :: {:ok, list(percent_of_total_supply)} | {:error, String.t()}
+  def percent_of_total_supply(slug, holders_count, from, to, interval) do
+    contract_opts = [contract_type: :latest_onchain_contract]
+
+    with {:ok, contract, decimals} <- Project.contract_info_by_slug(slug, contract_opts) do
+      {query, args} =
+        percent_of_total_supply_query(contract, decimals, holders_count, from, to, interval)
+
+      ClickhouseRepo.query_transform(
+        query,
+        args,
+        fn [dt, in_exchanges, outside_exchanges, in_top_holders_total] ->
+          %{
+            datetime: DateTime.from_unix!(dt),
+            in_exchanges: in_exchanges,
+            outside_exchanges: outside_exchanges,
+            in_top_holders_total: in_top_holders_total
+          }
+        end
+      )
     end
   end
 
@@ -76,11 +91,11 @@ defmodule Sanbase.Clickhouse.TopHolders do
           to :: DateTime.t(),
           interval :: String.t()
         ) :: {:ok, list(percent_of_total_supply)} | {:error, String.t()}
-  def percent_of_total_supply(contract, token_decimals, number_of_holders, from, to, interval) do
+  def percent_of_total_supply(contract, decimals, number_of_holders, from, to, interval) do
     {query, args} =
       percent_of_total_supply_query(
         contract,
-        token_decimals,
+        decimals,
         number_of_holders,
         from,
         to,
@@ -103,14 +118,55 @@ defmodule Sanbase.Clickhouse.TopHolders do
 
   # helpers
 
-  defp top_holders_query(
-         slug,
-         contract,
-         token_decimals,
-         from,
-         to,
-         opts
-       ) do
+  defp holder_transform_func([dt, address, value, value_usd, part_of_total]) do
+    %{
+      datetime: DateTime.from_unix!(dt),
+      address: address,
+      value: value,
+      value_usd: value_usd,
+      part_of_total: part_of_total
+    }
+  end
+
+  defp realtime_top_holders_query(slug, opts) do
+    page = Keyword.get(opts, :page)
+    page_size = Keyword.get(opts, :page_size)
+    offset = (page - 1) * page_size
+
+    table = if slug == "ethereum", do: "eth_balances_realtime", else: "erc20_balances_realtime"
+
+    asset_data = fn column, opts ->
+      argument_position = Keyword.fetch!(opts, :argument_position)
+      "( SELECT #{column} FROM asset_metadata FINAL WHERE name = ?#{argument_position} LIMIT 1 )"
+    end
+
+    query = """
+    WITH
+      ( SELECT argMax(balance, dt) FROM #{table} PREWHERE assetRefId = #{asset_data.("asset_ref_id", argument_position: 1)} AND addressType = 'total' ) AS total_balance,
+      ( SELECT pow(10, decimals) FROM asset_metadata FINAL where name = ?1 LIMIT 1 ) AS decimals,
+      ( SELECT argMax(value, dt) FROM intraday_metrics PREWHERE #{asset_id_filter(slug, argument_position: 1)} AND #{metric_id_filter("price_usd", argument_position: 2)} ) AS price_usd
+
+    SELECT
+      toUnixTimestamp(max(dt)),
+      address,
+      (argMax(balance, dt) / decimals) AS balance2,
+      balance2 * price_usd AS balance_usd,
+      (balance2 / (total_balance / decimals)) AS partOfTotal
+    FROM #{table}
+    PREWHERE
+      assetRefId = #{asset_data.("asset_ref_id", argument_position: 1)} AND
+      addressType = 'normal'
+    GROUP BY address
+    ORDER BY balance2 DESC
+    LIMIT ?3 OFFSET ?4
+    """
+
+    args = [slug, "price_usd", page_size, offset]
+
+    {query, args}
+  end
+
+  defp top_holders_query(slug, contract, decimals, from, to, opts) do
     page = Keyword.get(opts, :page)
     page_size = Keyword.get(opts, :page_size)
     offset = (page - 1) * page_size
@@ -118,7 +174,7 @@ defmodule Sanbase.Clickhouse.TopHolders do
     args = [
       slug,
       contract,
-      token_decimals,
+      decimals,
       DateTime.to_unix(from),
       DateTime.to_unix(to),
       page_size,
@@ -242,7 +298,7 @@ defmodule Sanbase.Clickhouse.TopHolders do
 
   defp percent_of_total_supply_query(
          contract,
-         token_decimals,
+         decimals,
          number_of_holders,
          from,
          to,
@@ -329,7 +385,7 @@ defmodule Sanbase.Clickhouse.TopHolders do
     """
 
     args = [
-      token_decimals,
+      decimals,
       contract,
       number_of_holders,
       from_datetime_unix,

--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -15,6 +15,15 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
 
   require Logger
 
+  def realtime_top_holders(_root, %{slug: slug, page: page, page_size: page_size}, _resolution) do
+    opts = [page: page, page_size: page_size]
+
+    case TopHolders.realtime_top_holders(slug, opts) do
+      {:ok, top_holders} -> {:ok, top_holders}
+      {:error, error} -> {:error, handle_graphql_error("Realtime Top Holders", slug, error)}
+    end
+  end
+
   def top_holders(
         _root,
         %{slug: slug, from: from, to: to, page: page, page_size: page_size} = args,

--- a/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/clickhouse_resolver.ex
@@ -25,21 +25,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
     owners = Map.get(args, :owners, :all)
     opts = [page: page, page_size: page_size, labels: labels, owners: owners]
 
-    with {:ok, contract, token_decimals} <-
-           Project.contract_info_by_slug(slug, contract_type: :latest_onchain_contract),
-         {:ok, top_holders} <-
-           TopHolders.top_holders(
-             slug,
-             contract,
-             token_decimals,
-             from,
-             to,
-             opts
-           ) do
-      {:ok, top_holders}
-    else
-      {:error, error} ->
-        {:error, handle_graphql_error("Top Holders", slug, error)}
+    case TopHolders.top_holders(slug, from, to, opts) do
+      {:ok, top_holders} -> {:ok, top_holders}
+      {:error, error} -> {:error, handle_graphql_error("Top Holders", slug, error)}
     end
   end
 
@@ -54,19 +42,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.ClickhouseResolver do
         },
         _resolution
       ) do
-    with {:ok, contract, token_decimals} <-
-           Project.contract_info_by_slug(slug, contract_type: :latest_onchain_contract),
-         {:ok, percent_of_total_supply} <-
-           TopHolders.percent_of_total_supply(
-             contract,
-             token_decimals,
-             number_of_holders,
-             from,
-             to,
-             interval
-           ) do
-      {:ok, percent_of_total_supply}
-    else
+    case TopHolders.percent_of_total_supply(slug, number_of_holders, from, to, interval) do
+      {:ok, percent_of_total_supply} ->
+        {:ok, percent_of_total_supply}
+
       {:error, error} ->
         {:error, handle_graphql_error("Top Holders - percent of total supply", slug, error)}
     end

--- a/lib/sanbase_web/graphql/schema/queries/blockchain_metric_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/blockchain_metric_queries.ex
@@ -251,6 +251,25 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainMetricQueries do
     end
 
     @desc """
+    Returns the first `number_of_holders` current top holders for ETH or ERC20 token.
+
+    Arguments description:
+    * slug - a string uniquely identifying a project
+    * page and page_size - choose what top holders to return, sorted in descending order by value
+    """
+    field :realtime_top_holders, list_of(:top_holders) do
+      meta(access: :restricted)
+
+      arg(:slug, non_null(:string))
+
+      arg(:page, non_null(:integer), default_value: 1)
+      arg(:page_size, non_null(:integer), default_value: 20)
+
+      middleware(AccessControl)
+      cache_resolve(&ClickhouseResolver.realtime_top_holders/3)
+    end
+
+    @desc """
     Returns the top holders' percent of total supply - in exchanges, outside exchanges and combined.
 
     Arguments description:

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -155,6 +155,7 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           :nvt_ratio,
           :percent_of_token_supply_on_exchanges,
           :realized_value,
+          :realtime_top_holders,
           :social_dominance,
           :social_gainers_losers_status,
           :social_volume,

--- a/test/sanbase/clickhouse/top_holders_test.exs
+++ b/test/sanbase/clickhouse/top_holders_test.exs
@@ -30,8 +30,7 @@ defmodule Sanbase.Clickhouse.TopHoldersTest do
     |> Sanbase.Mock.run_with_mocks(fn ->
       result =
         TopHolders.percent_of_total_supply(
-          context.contract,
-          context.token_decimals,
+          context.slug,
           context.number_of_holders,
           context.from,
           context.to,
@@ -62,8 +61,7 @@ defmodule Sanbase.Clickhouse.TopHoldersTest do
     |> Sanbase.Mock.run_with_mocks(fn ->
       result =
         TopHolders.percent_of_total_supply(
-          context.contract,
-          context.token_decimals,
+          context.slug,
           context.number_of_holders,
           context.from,
           context.to,

--- a/test/sanbase_web/graphql/clickhouse/top_holders_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/top_holders_test.exs
@@ -31,7 +31,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.TopHoldersTest do
 
   test "returns data from TopHolders calculation", context do
     with_mock TopHolders,
-      percent_of_total_supply: fn _, _, _, _, _, _ ->
+      percent_of_total_supply: fn _, _, _, _, _ ->
         {:ok,
          [
            %{
@@ -53,8 +53,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.TopHoldersTest do
 
       assert_called(
         TopHolders.percent_of_total_supply(
-          context.contract,
-          context.token_decimals,
+          context.slug,
           context.number_of_holders,
           context.from,
           context.to,
@@ -80,14 +79,13 @@ defmodule SanbaseWeb.Graphql.Clickhouse.TopHoldersTest do
   end
 
   test "returns empty array when there is no data", context do
-    with_mock TopHolders, percent_of_total_supply: fn _, _, _, _, _, _ -> {:ok, []} end do
+    with_mock TopHolders, percent_of_total_supply: fn _, _, _, _, _ -> {:ok, []} end do
       response = execute_query(context)
       holders = parse_response(response)
 
       assert_called(
         TopHolders.percent_of_total_supply(
-          context.contract,
-          context.token_decimals,
+          context.slug,
           context.number_of_holders,
           context.from,
           context.to,
@@ -103,7 +101,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.TopHoldersTest do
     error = "Some error description here"
 
     with_mock TopHolders,
-      percent_of_total_supply: fn _, _, _, _, _, _ -> {:error, error} end do
+      percent_of_total_supply: fn _, _, _, _, _ -> {:error, error} end do
       assert capture_log(fn ->
                response = execute_query(context)
                holders = parse_response(response)
@@ -118,7 +116,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.TopHoldersTest do
 
     with_mock TopHolders,
               [:passthrough],
-              percent_of_total_supply: fn _, _, _, _, _, _ ->
+              percent_of_total_supply: fn _, _, _, _, _ ->
                 {:error, error}
               end do
       response = execute_query(context)


### PR DESCRIPTION
## Changes
- Rework the `topHolders` API SQL to use `argMax(balance, dt)` instead of `anyLast(balance)` to fix some inconsistencies.
- Add `realtimeTopHolders` API:
```graphql
{
  realtimeTopHolders(slug: "santiment", page: 1, pageSize: 10) {
    address
    value
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
