### PR TITLE
Add in_page_order_by(_direction) to top transfers

### DIFF
--- a/lib/sanbase_web/graphql/schema/queries/blockchain_address_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/blockchain_address_queries.ex
@@ -45,6 +45,8 @@ defmodule SanbaseWeb.Graphql.Schema.BlockchainAddressQueries do
       arg(:to, non_null(:datetime))
       arg(:page, :integer)
       arg(:page_size, :integer)
+      arg(:in_page_order_by, :in_page_order_by_type, default_value: :trx_value)
+      arg(:in_page_order_by_direction, :direction_type, default_value: :desc)
 
       cache_resolve(&BlockchainAddressResolver.top_transfers/3)
     end

--- a/lib/sanbase_web/graphql/schema/types/blockchain_address_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/blockchain_address_types.ex
@@ -15,6 +15,11 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressType do
     value(:transfers_count)
   end
 
+  enum :in_page_order_by_type do
+    value(:trx_value)
+    value(:datetime)
+  end
+
   input_object :address_selector do
     field(:address, non_null(:string))
     field(:transaction_type, :transaction_type)

--- a/test/sanbase_web/graphql/transfers/top_transfers_api_test.exs
+++ b/test/sanbase_web/graphql/transfers/top_transfers_api_test.exs
@@ -137,8 +137,17 @@ defmodule SanbaseWeb.Graphql.TopTransactionsApiTest do
 
       assert transfers == [
                %{
-                 "datetime" => "2017-05-13T15:00:00Z",
+                 "datetime" => "2017-05-17T19:00:00Z",
                  "fromAddress" => %{
+                   "address" => @address3,
+                   "currentUserAddressDetails" => %{
+                     "notes" => "note3",
+                     "labels" => [%{"name" => "MyLabel3"}],
+                     "watchlists" => [%{"id" => context.watchlist.id, "name" => "My Watchlist"}]
+                   },
+                   "labels" => []
+                 },
+                 "toAddress" => %{
                    "address" => @address2,
                    "currentUserAddressDetails" => %{
                      "notes" => "note2",
@@ -147,44 +156,7 @@ defmodule SanbaseWeb.Graphql.TopTransactionsApiTest do
                    },
                    "labels" => []
                  },
-                 "toAddress" => %{
-                   "address" => @address1,
-                   "currentUserAddressDetails" => %{
-                     "notes" => "note5",
-                     "labels" => [%{"name" => "MyLabel1"}],
-                     "watchlists" => [
-                       %{"id" => context.watchlist2.id, "name" => "My Other Watchlist"},
-                       %{"id" => context.watchlist.id, "name" => "My Watchlist"}
-                     ]
-                   },
-                   "labels" => []
-                 },
-                 "trxValue" => 500.0
-               },
-               %{
-                 "datetime" => "2017-05-14T16:00:00Z",
-                 "fromAddress" => %{
-                   "address" => @address4,
-                   "currentUserAddressDetails" => %{
-                     "notes" => "note4",
-                     "labels" => [],
-                     "watchlists" => [%{"id" => context.watchlist.id, "name" => "My Watchlist"}]
-                   },
-                   "labels" => []
-                 },
-                 "toAddress" => %{
-                   "address" => @address1,
-                   "currentUserAddressDetails" => %{
-                     "notes" => "note5",
-                     "labels" => [%{"name" => "MyLabel1"}],
-                     "watchlists" => [
-                       %{"id" => context.watchlist2.id, "name" => "My Other Watchlist"},
-                       %{"id" => context.watchlist.id, "name" => "My Watchlist"}
-                     ]
-                   },
-                   "labels" => []
-                 },
-                 "trxValue" => 1.5e3
+                 "trxValue" => 4.5e4
                },
                %{
                  "datetime" => "2017-05-16T18:00:00Z",
@@ -212,17 +184,8 @@ defmodule SanbaseWeb.Graphql.TopTransactionsApiTest do
                  "trxValue" => 2.0e4
                },
                %{
-                 "datetime" => "2017-05-17T19:00:00Z",
+                 "datetime" => "2017-05-13T15:00:00Z",
                  "fromAddress" => %{
-                   "address" => @address3,
-                   "currentUserAddressDetails" => %{
-                     "notes" => "note3",
-                     "labels" => [%{"name" => "MyLabel3"}],
-                     "watchlists" => [%{"id" => context.watchlist.id, "name" => "My Watchlist"}]
-                   },
-                   "labels" => []
-                 },
-                 "toAddress" => %{
                    "address" => @address2,
                    "currentUserAddressDetails" => %{
                      "notes" => "note2",
@@ -231,7 +194,44 @@ defmodule SanbaseWeb.Graphql.TopTransactionsApiTest do
                    },
                    "labels" => []
                  },
-                 "trxValue" => 4.5e4
+                 "toAddress" => %{
+                   "address" => @address1,
+                   "currentUserAddressDetails" => %{
+                     "notes" => "note5",
+                     "labels" => [%{"name" => "MyLabel1"}],
+                     "watchlists" => [
+                       %{"id" => context.watchlist2.id, "name" => "My Other Watchlist"},
+                       %{"id" => context.watchlist.id, "name" => "My Watchlist"}
+                     ]
+                   },
+                   "labels" => []
+                 },
+                 "trxValue" => 2.0e3
+               },
+               %{
+                 "datetime" => "2017-05-14T16:00:00Z",
+                 "fromAddress" => %{
+                   "address" => @address4,
+                   "currentUserAddressDetails" => %{
+                     "notes" => "note4",
+                     "labels" => [],
+                     "watchlists" => [%{"id" => context.watchlist.id, "name" => "My Watchlist"}]
+                   },
+                   "labels" => []
+                 },
+                 "toAddress" => %{
+                   "address" => @address1,
+                   "currentUserAddressDetails" => %{
+                     "notes" => "note5",
+                     "labels" => [%{"name" => "MyLabel1"}],
+                     "watchlists" => [
+                       %{"id" => context.watchlist2.id, "name" => "My Other Watchlist"},
+                       %{"id" => context.watchlist.id, "name" => "My Watchlist"}
+                     ]
+                   },
+                   "labels" => []
+                 },
+                 "trxValue" => 1.5e3
                }
              ]
     end)
@@ -285,6 +285,31 @@ defmodule SanbaseWeb.Graphql.TopTransactionsApiTest do
       assert transactions ==
                [
                  %{
+                   "datetime" => "2017-05-18T20:00:00Z",
+                   "fromAddress" => %{
+                     "address" => @address1,
+                     "currentUserAddressDetails" => %{
+                       "notes" => "note5",
+                       "labels" => [%{"name" => "MyLabel1"}],
+                       "watchlists" => [
+                         %{"id" => context.watchlist2.id, "name" => "My Other Watchlist"},
+                         %{"id" => context.watchlist.id, "name" => "My Watchlist"}
+                       ]
+                     },
+                     "labels" => []
+                   },
+                   "toAddress" => %{
+                     "address" => @address2,
+                     "currentUserAddressDetails" => %{
+                       "notes" => "note2",
+                       "labels" => [],
+                       "watchlists" => [%{"id" => context.watchlist.id, "name" => "My Watchlist"}]
+                     },
+                     "labels" => []
+                   },
+                   "trxValue" => 2.5e3
+                 },
+                 %{
                    "datetime" => "2017-05-13T15:00:00Z",
                    "fromAddress" => %{
                      "address" => @address2,
@@ -307,7 +332,7 @@ defmodule SanbaseWeb.Graphql.TopTransactionsApiTest do
                      },
                      "labels" => []
                    },
-                   "trxValue" => 500.0
+                   "trxValue" => 1700.0
                  },
                  %{
                    "datetime" => "2017-05-15T17:00:00Z",
@@ -333,34 +358,71 @@ defmodule SanbaseWeb.Graphql.TopTransactionsApiTest do
                      "labels" => []
                    },
                    "trxValue" => 1.5e3
-                 },
-                 %{
-                   "datetime" => "2017-05-18T20:00:00Z",
-                   "fromAddress" => %{
-                     "address" => @address1,
-                     "currentUserAddressDetails" => %{
-                       "notes" => "note5",
-                       "labels" => [%{"name" => "MyLabel1"}],
-                       "watchlists" => [
-                         %{"id" => context.watchlist2.id, "name" => "My Other Watchlist"},
-                         %{"id" => context.watchlist.id, "name" => "My Watchlist"}
-                       ]
-                     },
-                     "labels" => []
-                   },
-                   "toAddress" => %{
-                     "address" => @address2,
-                     "currentUserAddressDetails" => %{
-                       "notes" => "note2",
-                       "labels" => [],
-                       "watchlists" => [%{"id" => context.watchlist.id, "name" => "My Watchlist"}]
-                     },
-                     "labels" => []
-                   },
-                   "trxValue" => 2.5e3
                  }
                ]
     end)
+  end
+
+  describe "in page order by" do
+    defp get_top_transfers(conn, slug, order_by, direction) do
+      query = """
+      {
+        topTransfers(
+          slug: "#{slug}"
+          from: "utc_now-10d"
+          to: "utc_now"
+          inPageOrderBy: #{order_by |> Atom.to_string() |> String.upcase()}
+          inPageOrderByDirection: #{direction |> Atom.to_string() |> String.upcase()}){
+            datetime
+            trxValue
+        }
+      }
+      """
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.Transfers.top_transfers/5, {:ok, all_transfers()})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        conn
+        |> post("/graphql", query_skeleton(query, "topTransfers"))
+        |> json_response(200)
+        |> get_in(["data", "topTransfers"])
+      end)
+    end
+
+    test "order by datetime desc", context do
+      assert get_top_transfers(context.conn, context.slug, :datetime, :desc) == [
+               %{"datetime" => "2017-05-17T19:00:00Z", "trxValue" => 4.5e4},
+               %{"datetime" => "2017-05-16T18:00:00Z", "trxValue" => 2.0e4},
+               %{"datetime" => "2017-05-14T16:00:00Z", "trxValue" => 1.5e3},
+               %{"datetime" => "2017-05-13T15:00:00Z", "trxValue" => 2000.0}
+             ]
+    end
+
+    test "order by datetime asc", context do
+      assert get_top_transfers(context.conn, context.slug, :datetime, :asc) == [
+               %{"datetime" => "2017-05-13T15:00:00Z", "trxValue" => 2.0e3},
+               %{"datetime" => "2017-05-14T16:00:00Z", "trxValue" => 1.5e3},
+               %{"datetime" => "2017-05-16T18:00:00Z", "trxValue" => 2.0e4},
+               %{"datetime" => "2017-05-17T19:00:00Z", "trxValue" => 4.5e4}
+             ]
+    end
+
+    test "order by trx volume desc", context do
+      assert get_top_transfers(context.conn, context.slug, :trx_value, :desc) == [
+               %{"datetime" => "2017-05-17T19:00:00Z", "trxValue" => 4.5e4},
+               %{"datetime" => "2017-05-16T18:00:00Z", "trxValue" => 2.0e4},
+               %{"datetime" => "2017-05-13T15:00:00Z", "trxValue" => 2.0e3},
+               %{"datetime" => "2017-05-14T16:00:00Z", "trxValue" => 1.5e3}
+             ]
+    end
+
+    test "order by trx volume asc", context do
+      assert get_top_transfers(context.conn, context.slug, :trx_value, :asc) == [
+               %{"datetime" => "2017-05-14T16:00:00Z", "trxValue" => 1.5e3},
+               %{"datetime" => "2017-05-13T15:00:00Z", "trxValue" => 2.0e3},
+               %{"datetime" => "2017-05-16T18:00:00Z", "trxValue" => 2.0e4},
+               %{"datetime" => "2017-05-17T19:00:00Z", "trxValue" => 4.5e4}
+             ]
+    end
   end
 
   # Private functions
@@ -373,7 +435,7 @@ defmodule SanbaseWeb.Graphql.TopTransactionsApiTest do
         trx_position: 0,
         to_address: @address1,
         trx_hash: "0x9a561c88bb59a1f6dfe63ed4fe036466b3a328d1d86d039377481ab7c4defe4e",
-        trx_value: 500.0
+        trx_value: 2000.0
       },
       %{
         datetime: @datetime2,
@@ -410,7 +472,7 @@ defmodule SanbaseWeb.Graphql.TopTransactionsApiTest do
         trx_position: 0,
         to_address: @address1,
         trx_hash: "0x9a561c88bb59a1f6dfe63ed4fe036466b3a328d1d86d039377481ab7c4defe4e",
-        trx_value: 500.0
+        trx_value: 1700.0
       },
       %{
         datetime: @datetime3,


### PR DESCRIPTION
## Changes
Add 2 arguments to the `topTransfers` API: `inPageOrderBy` and `inPageOrderByDirection` with the following accepted values:
- `inPageOrderBy`: `TRX_VALUE` | `DATETIME` (default: `TRX_VALUE`)
- `inPageOrderByDirection`: `DESC` | `ASC` (default: `DESC`)

These arguments control how the values in the already computed page are ordered. The transactions returned are not changed at all, only their order in that specific page is.


```graphql
{
  topTransfers(
    slug: "santiment"
    from: "utc_now-7d"
    to: "utc_now"
    page: 1
    pageSize: 10
    inPageOrderBy: TRX_VALUE
    inPageOrderByDirection: DESC
  ){
    trxHash
    trxValue
    datetime
  }
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
