### PR TITLE
Add blockchain_address to metric selector. Order selector names

### DIFF
--- a/lib/sanbase/balances/balance_sql_query.ex
+++ b/lib/sanbase/balances/balance_sql_query.ex
@@ -268,6 +268,23 @@ defmodule Sanbase.Balance.SqlQuery do
     {query, args}
   end
 
+  def first_datetime_query(address, slug, blockchain) when is_binary(address) do
+    query = """
+    SELECT toUnixTimestamp(min(dt))
+    FROM (
+      SELECT arrayJoin(groupArrayMerge(values)) AS values_merged, values_merged.1 AS dt
+      FROM balances_aggregated
+      WHERE
+        #{address_clause(address, argument_position: 1)} AND
+        blockchain = ?2 AND
+        asset_ref_id = ( SELECT asset_ref_id FROM asset_metadata FINAL WHERE name = ?3 LIMIT 1 )
+    )
+    """
+
+    args = [address, blockchain, slug]
+    {query, args}
+  end
+
   def assets_held_by_address_query(address) do
     query = """
     SELECT

--- a/lib/sanbase/blockchain_address/blockchain_address.ex
+++ b/lib/sanbase/blockchain_address/blockchain_address.ex
@@ -52,9 +52,12 @@ defmodule Sanbase.BlockchainAddress do
   All other chains are sensitive, so they are not changed by this function.
   """
   def to_internal_format(address) do
-    case Regex.match?(~r/^0x([A-Fa-f0-9]{40})$/, address) do
-      true -> String.downcase(address)
-      _ -> address
+    cond do
+      # ETH and ETH forks
+      Regex.match?(~r/^0x([A-Fa-f0-9]{40})$/, address) -> String.downcase(address)
+      # BTC and BTC forks
+      Regex.match?(~r/^(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}$/, address) -> address
+      true -> address
     end
   end
 

--- a/lib/sanbase/blockchain_address/metric_adapter.ex
+++ b/lib/sanbase/blockchain_address/metric_adapter.ex
@@ -72,7 +72,7 @@ defmodule Sanbase.BlockchainAddress.MetricAdapter do
   end
 
   @impl Sanbase.Metric.Behaviour
-  def available_slugs(%{metric: metric}) when metric in @metrics do
+  def available_slugs(metric) when metric in @metrics do
     available_slugs()
   end
 

--- a/lib/sanbase/blockchain_address/metric_adapter.ex
+++ b/lib/sanbase/blockchain_address/metric_adapter.ex
@@ -1,0 +1,181 @@
+defmodule Sanbase.BlockchainAddress.MetricAdapter do
+  @behaviour Sanbase.Metric.Behaviour
+
+  import Sanbase.Utils.Transform, only: [maybe_apply_function: 2, rename_map_keys: 2]
+
+  alias Sanbase.Model.Project
+  alias Sanbase.Balance
+
+  @aggregations [:sum, :ohlc]
+  @default_aggregation :sum
+
+  @timeseries_metrics ["historical_balance", "historical_balance_changes"]
+  @histogram_metrics []
+  @table_metrics []
+
+  @metrics @histogram_metrics ++ @timeseries_metrics ++ @table_metrics
+
+  @access_map Enum.into(@metrics, %{}, fn metric -> {metric, :free} end)
+  @min_plan_map Enum.into(@metrics, %{}, fn metric -> {metric, :free} end)
+
+  @free_metrics Enum.filter(@access_map, fn {_, level} -> level == :free end)
+                |> Enum.map(&elem(&1, 0))
+  @restricted_metrics Enum.filter(@access_map, fn {_, level} -> level == :restricted end)
+                      |> Enum.map(&elem(&1, 0))
+
+  @required_selectors Enum.into(@metrics, %{}, &{&1, [[:blockchain_address], [:slug]]})
+  @default_complexity_weight 0.3
+
+  @human_readable_name_map %{
+    "historical_balance" => "Historical Balance",
+    "historical_balance_changes" => "Historical Balance Changes"
+  }
+
+  @impl Sanbase.Metric.Behaviour
+  def has_incomplete_data?(_), do: false
+
+  @impl Sanbase.Metric.Behaviour
+  def complexity_weight(_), do: @default_complexity_weight
+
+  @impl Sanbase.Metric.Behaviour
+  def required_selectors(), do: @required_selectors
+
+  @impl Sanbase.Metric.Behaviour
+  def available_aggregations(), do: @aggregations
+
+  @impl Sanbase.Metric.Behaviour
+  def available_timeseries_metrics(), do: @timeseries_metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def available_histogram_metrics(), do: @histogram_metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def available_table_metrics(), do: @table_metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def available_metrics(), do: @metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def available_metrics(%{slug: slug}) do
+    infrastructure = Project.infrastructure(slug)
+
+    case Balance.blockchain_from_infrastructure(infrastructure) do
+      :unsupported_blockchain -> {:ok, []}
+      _ -> {:ok, @metrics}
+    end
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def available_slugs() do
+    infrastructures = Balance.supported_infrastructures()
+    {:ok, Project.List.slugs_by_infrastructure(infrastructures)}
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def available_slugs(%{metric: metric}) when metric in @metrics do
+    available_slugs()
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def first_datetime(metric, %{slug: slug, blockchain_address: %{address: address}})
+      when metric in @metrics do
+    Balance.first_datetime(address, slug)
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def last_datetime_computed_at(metric, %{slug: _slug, blockchain_address: %{address: _address}})
+      when metric in @metrics do
+    # There is no nice value we can put here
+    {:ok, DateTime.utc_now()}
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def free_metrics(), do: @free_metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def restricted_metrics(), do: @restricted_metrics
+
+  @impl Sanbase.Metric.Behaviour
+  def access_map(), do: @access_map
+
+  @impl Sanbase.Metric.Behaviour
+  def min_plan_map(), do: @min_plan_map
+
+  @impl Sanbase.Metric.Behaviour
+  def human_readable_name(metric), do: {:ok, Map.get(@human_readable_name_map, metric)}
+  @impl Sanbase.Metric.Behaviour
+  def metadata(metric) do
+    {:ok,
+     %{
+       metric: metric,
+       min_interval: "5m",
+       default_aggregation: @default_aggregation,
+       available_aggregations: @aggregations,
+       available_selectors: [:blockchain_address, :slug],
+       required_selectors: Map.get(@required_selectors, metric, []),
+       data_type: :timeseries,
+       complexity_weight: @default_complexity_weight
+     }}
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def timeseries_data(
+        "historical_balance",
+        %{slug: slug, blockchain_address: %{address: address}},
+        from,
+        to,
+        interval,
+        opts
+      ) do
+    case Keyword.get(opts, :aggregation) do
+      :ohlc ->
+        Sanbase.Balance.historical_balance_ohlc(address, slug, from, to, interval)
+        |> maybe_apply_function(fn elem ->
+          %{
+            datetime: elem.datetime,
+            open: elem.open_balance,
+            close: elem.close_balance,
+            high: elem.high_balance,
+            low: elem.low_balance
+          }
+        end)
+
+      _ ->
+        Sanbase.Balance.historical_balance(address, slug, from, to, interval)
+        |> rename_map_keys(old_key: :balance, new_key: :value)
+    end
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def timeseries_data(
+        "historical_balance_changes",
+        %{slug: slug, blockchain_address: %{address: address}},
+        from,
+        to,
+        interval,
+        _opts
+      ) do
+    Sanbase.Balance.historical_balance_changes(address, slug, from, to, interval)
+    |> rename_map_keys(old_key: :balance, new_key: :value)
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def aggregated_timeseries_data(metric, _selector, _from, _to, _opts) do
+    not_implemented_error("aggregated timeseries data", metric)
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def slugs_by_filter(metric, _from, _to, _operator, _threshold, _opts) do
+    not_implemented_error("slugs_by_filter", metric)
+  end
+
+  @impl Sanbase.Metric.Behaviour
+  def slugs_order(metric, _from, _to, _direction, _opts) do
+    not_implemented_error("slugs order", metric)
+  end
+
+  # Private functions
+  defp not_implemented_error(function, metric) do
+    {:error, "The #{function} function is not implemented for #{metric}"}
+  end
+end

--- a/lib/sanbase/metric/helper.ex
+++ b/lib/sanbase/metric/helper.ex
@@ -23,7 +23,8 @@ defmodule Sanbase.Metric.Helper do
     Sanbase.Price.MetricAdapter,
     Sanbase.Twitter.MetricAdapter,
     Sanbase.Clickhouse.TopHolders.MetricAdapter,
-    Sanbase.Clickhouse.Uniswap.MetricAdapter
+    Sanbase.Clickhouse.Uniswap.MetricAdapter,
+    Sanbase.BlockchainAddress.MetricAdapter
   ]
 
   Module.register_attribute(__MODULE__, :aggregations_acc, accumulate: true)

--- a/lib/sanbase/model/project/list/list.ex
+++ b/lib/sanbase/model/project/list/list.ex
@@ -203,6 +203,18 @@ defmodule Sanbase.Model.Project.List do
     |> Repo.all()
   end
 
+  def slugs_by_infrastructure(infrastructures, opts \\ []) when is_list(infrastructures) do
+    # explicitly remove preloads as they are not going to be used
+    opts = Keyword.put(opts, :preload?, false)
+
+    from(
+      p in projects_query(opts),
+      left_join: infr in assoc(p, :infrastructure),
+      where: infr.code in ^infrastructures
+    )
+    |> Repo.all()
+  end
+
   @doc ~s"""
   Returns all slugs of the projects that have one or more github organizations
   Filtering out projects based on some conditions can be controled by the options.

--- a/lib/sanbase/model/project/list/list.ex
+++ b/lib/sanbase/model/project/list/list.ex
@@ -207,10 +207,13 @@ defmodule Sanbase.Model.Project.List do
     # explicitly remove preloads as they are not going to be used
     opts = Keyword.put(opts, :preload?, false)
 
+    # If the infrastructure is `own` then use the ticker as infrastructure
     from(
       p in projects_query(opts),
       left_join: infr in assoc(p, :infrastructure),
-      where: infr.code in ^infrastructures,
+      where:
+        infr.code in ^infrastructures or
+          (fragment("lower(?)", infr.code) == "own" and p.ticker in ^infrastructures),
       select: p.slug
     )
     |> Repo.all()

--- a/lib/sanbase/model/project/list/list.ex
+++ b/lib/sanbase/model/project/list/list.ex
@@ -210,7 +210,8 @@ defmodule Sanbase.Model.Project.List do
     from(
       p in projects_query(opts),
       left_join: infr in assoc(p, :infrastructure),
-      where: infr.code in ^infrastructures
+      where: infr.code in ^infrastructures,
+      select: p.slug
     )
     |> Repo.all()
   end

--- a/lib/sanbase/utils/transform.ex
+++ b/lib/sanbase/utils/transform.ex
@@ -2,33 +2,37 @@ defmodule Sanbase.Utils.Transform do
   def wrap_ok(data), do: {:ok, data}
 
   @doc ~s"""
-  Transform the maps from the :ok tuple data so the `key` is renamed to `new_key`
+  Transform the maps from the :ok tuple data so the `key` is duplicated under the
+  `new_key` name, preserving the original value.
 
   ## Examples:
-      iex> Sanbase.Utils.Transform.rename_map_keys({:ok, [%{a: 1}, %{a: 2}]}, old_key: :a, new_key: :b)
-      {:ok, [%{b: 1}, %{b: 2}]}
+      iex> Sanbase.Utils.Transform.duplicate_map_keys({:ok, [%{a: 1}, %{a: 2}]}, old_key: :a, new_key: :b)
+      {:ok, [%{a: 1, b: 1}, %{a: 2, b: 2}]}
 
-      iex> Sanbase.Utils.Transform.rename_map_keys({:ok, [%{a: 1}, %{d: 2}]}, old_key: :a, new_key: :b)
-      {:ok, [%{b: 1}, %{d: 2}]}
+      iex> Sanbase.Utils.Transform.duplicate_map_keys({:ok, [%{a: 1}, %{d: 2}]}, old_key: :a, new_key: :b)
+      {:ok, [%{a: 1, b: 1}, %{d: 2}]}
 
 
-      iex> Sanbase.Utils.Transform.rename_map_keys({:error, "bad"}, old_key: :a, new_key: :b)
+      iex> Sanbase.Utils.Transform.duplicate_map_keys({:error, "bad"}, old_key: :a, new_key: :b)
       {:error, "bad"}
   """
-  @spec duplicate_map_keys({:ok, list(map)}, any(), any()) :: {:ok, list(map)}
-  @spec duplicate_map_keys({:error, any()}, any(), any()) :: {:error, any()}
-  def duplicate_map_keys({:ok, data}, key, new_key) do
+  @spec duplicate_map_keys({:ok, list(map)}, keyword(atom)) :: {:ok, list(map)}
+  @spec duplicate_map_keys({:error, any()}, keyword(atom)) :: {:error, any()}
+  def duplicate_map_keys({:ok, data}, opts) do
+    old_key = Keyword.fetch!(opts, :old_key)
+    new_key = Keyword.fetch!(opts, :new_key)
+
     result =
       data
       |> Enum.map(fn
-        %{^key => value} = elem -> elem |> Map.put(new_key, value)
+        %{^old_key => value} = elem -> elem |> Map.put(new_key, value)
         elem -> elem
       end)
 
     {:ok, result}
   end
 
-  def duplicate_map_keys({:error, error}, _, _) do
+  def duplicate_map_keys({:error, error}, _opts) do
     {:error, error}
   end
 
@@ -50,8 +54,8 @@ defmodule Sanbase.Utils.Transform do
   @spec rename_map_keys({:ok, list(map)}, keyword(atom())) :: {:ok, list(map)}
   @spec rename_map_keys({:error, any()}, keyword(atom())) :: {:error, any()}
   def rename_map_keys({:ok, data}, opts) do
-    old_key = Keyword.get(opts, :old_key)
-    new_key = Keyword.get(opts, :new_key)
+    old_key = Keyword.fetch!(opts, :old_key)
+    new_key = Keyword.fetch!(opts, :new_key)
 
     result =
       data

--- a/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/etherbi_resolver.ex
@@ -17,7 +17,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EtherbiResolver do
       args,
       %{source: %{metric: "age_destroyed"}}
     )
-    |> Sanbase.Utils.Transform.duplicate_map_keys(:value, :burn_rate)
+    |> Sanbase.Utils.Transform.duplicate_map_keys(old_key: :value, new_key: :burn_rate)
     |> Sanbase.Utils.Transform.rename_map_keys(old_key: :value, new_key: :token_age_consumed)
   end
 

--- a/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
@@ -5,7 +5,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   import Sanbase.Utils.ErrorHandling,
     only: [handle_graphql_error: 3, maybe_handle_graphql_error: 2]
 
-  import Sanbase.Model.Project.Selector, only: [args_to_selector: 1, args_to_raw_selector: 1]
+  import Sanbase.Model.Project.Selector,
+    only: [args_to_selector: 1, args_to_raw_selector: 1]
+
   import SanbaseWeb.Graphql.Helpers.Utils
 
   alias Sanbase.Metric
@@ -23,16 +25,13 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     end
   end
 
-  def get_available_metrics(
-        _root,
-        %{product: product, plan: plan},
-        _resolution
-      ) do
+  def get_available_metrics(_root, %{product: product, plan: plan}, _resolution) do
     product = product |> Atom.to_string() |> String.upcase()
     {:ok, AccessChecker.get_available_metrics_for_plan(product, plan)}
   end
 
-  def get_available_metrics(_root, _args, _resolution), do: {:ok, Metric.available_metrics()}
+  def get_available_metrics(_root, _args, _resolution),
+    do: {:ok, Metric.available_metrics()}
 
   def get_available_slugs(_root, _args, %{source: %{metric: metric}}),
     do: Metric.available_slugs(metric)
@@ -46,6 +45,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     case Metric.metadata(metric) do
       {:ok, metadata} ->
         access_restrictions = Restrictions.get({:metric, metric}, plan, product_id)
+
         {:ok, Map.merge(access_restrictions, metadata)}
 
       {:error, error} ->
@@ -54,10 +54,15 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   end
 
   def timeseries_data_complexity(_root, args, resolution) do
-    complexity =
-      SanbaseWeb.Graphql.Complexity.from_to_interval(args, _child_complexity = 2, resolution)
+    # Explicitly set `child_complexity` to 2 as this would be the
+    # value if both `datetime` and `value` fields are queried.
+    child_complexity = 2
 
-    {:ok, complexity |> Sanbase.Math.to_integer()}
+    complexity =
+      SanbaseWeb.Graphql.Complexity.from_to_interval(args, child_complexity, resolution)
+      |> Sanbase.Math.to_integer()
+
+    {:ok, complexity}
   end
 
   def available_since(_root, args, %{source: %{metric: metric}}) do
@@ -95,9 +100,19 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     fetch_timeseries_data(metric, args, requested_fields, :timeseries_data)
   end
 
-  def timeseries_data_per_slug(_root, args, %{source: %{metric: metric}} = resolution) do
+  def timeseries_data_per_slug(
+        _root,
+        args,
+        %{source: %{metric: metric}} = resolution
+      ) do
     requested_fields = requested_fields(resolution)
-    fetch_timeseries_data(metric, args, requested_fields, :timeseries_data_per_slug)
+
+    fetch_timeseries_data(
+      metric,
+      args,
+      requested_fields,
+      :timeseries_data_per_slug
+    )
   end
 
   def aggregated_timeseries_data(
@@ -113,8 +128,15 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
          true <- valid_owners_labels_selection?(args),
          {:ok, opts} <- selector_args_to_opts(args),
          {:ok, from, to} <-
-           calibrate_incomplete_data_params(include_incomplete_data, Metric, metric, from, to),
-         {:ok, result} <- Metric.aggregated_timeseries_data(metric, selector, from, to, opts) do
+           calibrate_incomplete_data_params(
+             include_incomplete_data,
+             Metric,
+             metric,
+             from,
+             to
+           ),
+         {:ok, result} <-
+           Metric.aggregated_timeseries_data(metric, selector, from, to, opts) do
       {:ok, Map.values(result) |> List.first()}
     end
     |> maybe_handle_graphql_error(fn error ->
@@ -128,6 +150,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
         %{source: %{metric: metric}}
       ) do
     %{to: to, interval: interval, limit: limit} = args
+
     # from datetime arg is not required for `all_spent_coins_cost` metric which calculates
     # the histogram for all time.
     from = Map.get(args, :from, nil)
@@ -166,7 +189,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   def latest_metrics_data(_root, %{metrics: metrics} = args, _resolution) do
     with {:ok, selector} <- args_to_selector(args),
          :ok <- check_metrics_slugs_cartesian_limit(metrics, selector, 20_000),
-         {:ok, data} <- Metric.LatestMetric.latest_metrics_data(metrics, selector) do
+         {:ok, data} <-
+           Metric.LatestMetric.latest_metrics_data(metrics, selector) do
       {:ok, data}
     end
   end
@@ -180,7 +204,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     selector_names = Map.keys(selector)
 
     with {:ok, required_selectors} <- Metric.required_selectors(metric),
-         true <- do_check_required_selectors(metric, selector_names, required_selectors) do
+         true <-
+           do_check_required_selectors(
+             metric,
+             selector_names,
+             required_selectors
+           ) do
       true
     end
   end
@@ -208,7 +237,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
 
   # This is used when a list of slugs and a list of metrics is provided
   # Every metric is fetched for every slug and the result length can get too big
-  defp check_metrics_slugs_cartesian_limit(metrics, %{slug: slug_or_slugs}, limit) do
+  defp check_metrics_slugs_cartesian_limit(
+         metrics,
+         %{slug: slug_or_slugs},
+         limit
+       ) do
     slugs = List.wrap(slug_or_slugs)
     cartesian_product_length = length(metrics) * length(slugs)
 
@@ -236,7 +269,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
          {:ok, opts} <- selector_args_to_opts(args),
          {:ok, from, to, interval} <-
            transform_datetime_params(selector, metric, transform, args),
-         {:ok, result} <- apply(Metric, function, [metric, selector, from, to, interval, opts]),
+         {:ok, result} <-
+           apply(Metric, function, [metric, selector, from, to, interval, opts]),
          {:ok, result} <- apply_transform(transform, result),
          {:ok, result} <- fit_from_datetime(result, args) do
       {:ok, result |> Enum.reject(&is_nil/1)}
@@ -252,9 +286,24 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     include_incomplete_data = Map.get(args, :include_incomplete_data, false)
 
     with {:ok, from, to, interval} <-
-           calibrate(Metric, metric, selector, from, to, interval, 86_400, @datapoints),
+           calibrate(
+             Metric,
+             metric,
+             selector,
+             from,
+             to,
+             interval,
+             86_400,
+             @datapoints
+           ),
          {:ok, from, to} <-
-           calibrate_incomplete_data_params(include_incomplete_data, Metric, metric, from, to),
+           calibrate_incomplete_data_params(
+             include_incomplete_data,
+             Metric,
+             metric,
+             from,
+             to
+           ),
          {:ok, from} <-
            calibrate_transform_params(transform, from, to, interval) do
       {:ok, from, to, interval}
@@ -266,6 +315,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   defp maybe_enrich_with_labels(_metric, [%{address: address} | _] = data)
        when is_binary(address) do
     addresses = Enum.map(data, & &1.address) |> Enum.uniq()
+
     {:ok, labels} = Sanbase.Clickhouse.Label.get_address_labels("ethereum", addresses)
 
     labeled_data =
@@ -309,11 +359,15 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
 
   defp apply_transform(%{type: "none"}, data), do: {:ok, data}
 
-  defp apply_transform(%{type: "moving_average", moving_average_base: base}, data) do
+  defp apply_transform(
+         %{type: "moving_average", moving_average_base: base},
+         data
+       ) do
     Sanbase.Math.simple_moving_average(data, base, value_key: :value)
   end
 
-  defp apply_transform(%{type: type}, data) when type in ["changes", "consecutive_differences"] do
+  defp apply_transform(%{type: type}, data)
+       when type in ["changes", "consecutive_differences"] do
     result =
       Stream.chunk_every(data, 2, 1, :discard)
       |> Enum.map(fn [%{value: previous}, %{value: current, datetime: datetime}] ->
@@ -349,7 +403,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     {:ok, result}
   end
 
-  defp apply_transform(%{type: type}, data) when type in ["cumulative_percent_change"] do
+  defp apply_transform(%{type: type}, data)
+       when type in ["cumulative_percent_change"] do
     {:ok, cumsum} = apply_transform(%{type: "cumulative_sum"}, data)
     apply_transform(%{type: "percent_change"}, cumsum)
   end
@@ -362,7 +417,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
 
   defp transform_interval(_, interval), do: interval
 
-  @metrics_allowed_missing_from ["all_spent_coins_cost", "eth2_staked_amount_per_label"]
+  @metrics_allowed_missing_from [
+    "all_spent_coins_cost",
+    "eth2_staked_amount_per_label"
+  ]
   # All histogram metrics except "all_spent_coins_cost" require `from` argument
   defp valid_histogram_args?(metric, args) do
     if metric in @metrics_allowed_missing_from or Map.get(args, :from) do
@@ -414,7 +472,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   end
 
   defguard has_binary_key?(selector, key)
-           when is_map_key(selector, key) and is_binary(:erlang.map_get(key, selector))
+           when is_map_key(selector, key) and
+                  is_binary(:erlang.map_get(key, selector))
 
   defp valid_metric_selector_pair?("social_active_users", selector)
        when not has_binary_key?(selector, :source) do

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -20,20 +20,30 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
   end
 
   enum :selector_name do
+    # common
+    value(:blockchain)
+    # blockchain address related
+    value(:blockchain_address)
+    # project related
     value(:slug)
     value(:slugs)
+    value(:ignored_slugs)
+    value(:market_segments)
+    # watchlist related
+    value(:watchlist_slug)
+    value(:watchlist_id)
+    # social related
     value(:text)
+    value(:source)
+    # label related
     value(:owner)
+    value(:owners)
     value(:label)
+    value(:labels)
     value(:label_fqn)
     value(:label_fqns)
-    value(:blockchain)
-    value(:source)
     value(:holders_count)
-    value(:market_segments)
-    value(:ignored_slugs)
-    value(:watchlist_id)
-    value(:watchlist_slug)
+    # cache-controling
     value(:base_ttl)
     value(:max_ttl_offset)
   end
@@ -44,22 +54,29 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
   end
 
   input_object :metric_target_selector_input_object do
+    # common
     field(:blockchain, :string)
+    # blockchain address related
+    field(:blockchain_address, :blockchain_address_selector_input_object)
+    # project related
     field(:slug, :string)
     field(:slugs, list_of(:string))
+    field(:market_segments, list_of(:string))
+    field(:ignored_slugs, list_of(:string))
+    # watchlist related
+    field(:watchlist_id, :integer)
+    field(:watchlist_slug, :string)
+    # social related
     field(:text, :string)
+    field(:source, :string)
+    # label relaated
     field(:owner, :string)
     field(:owners, list_of(:string))
     field(:label, :string)
+    field(:labels, list_of(:string))
     field(:label_fqn, :string)
     field(:label_fqns, list_of(:string))
-    field(:labels, list_of(:string))
-    field(:source, :string)
     field(:holders_count, :integer)
-    field(:market_segments, list_of(:string))
-    field(:ignored_slugs, list_of(:string))
-    field(:watchlist_id, :integer)
-    field(:watchlist_slug, :string)
   end
 
   input_object :timeseries_metric_transform_input_object do

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -32,6 +32,8 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "github_activity",
         "dev_activity_contributors_count",
         "github_activity_contributors_count",
+        "historical_balance",
+        "historical_balance_changes",
         "marketcap_usd",
         "price_btc",
         "price_usd",

--- a/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_product_access_test.exs
+++ b/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_product_access_test.exs
@@ -34,7 +34,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       {from, to} = from_to(2500, 0)
       metric = get_free_timeseries_element(context.next_integer.(), @product, :metric)
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       result = execute_query(context.conn, query, "getMetric")
       assert_called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
@@ -63,7 +64,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       {from, to} = from_to(91, 10)
       metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :free)
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
       assert_called(Metric.timeseries_data(metric, :_, :_, :_, :_, :_))
@@ -93,7 +95,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       {from, to} = from_to(89, 2)
       metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :free)
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
       assert called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
@@ -120,7 +123,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       {from, to} = from_to(2500, 0)
       metric = get_free_timeseries_element(context.next_integer.(), @product, :metric)
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       result = execute_query(context.conn, query, "getMetric")
       assert called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
@@ -151,7 +155,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :basic)
 
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
       assert called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
@@ -180,7 +185,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       {from, to} = from_to(2 * 365 + 1, 2 * 365 - 1)
       metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :basic)
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
       assert_called(Metric.timeseries_data(metric, :_, :_, :_, :_, :_))
@@ -193,7 +199,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       {from, to} = from_to(2 * 365 - 10, 2 * 365 - 2)
       metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :basic)
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       result = execute_query_with_error(context.conn, query, "getMetric")
 
       refute called(Metric.timeseries_data(metric, :_, :_, :_, :_, :_))
@@ -204,7 +211,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       {from, to} = from_to(10, 0)
       metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :basic)
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
       assert called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
@@ -224,7 +232,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       {from, to} = from_to(2 * 365 - 1, 2 * 365 - 2)
       metric = "withdrawal_balance"
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       error_message = execute_query_with_error(context.conn, query, "getMetric")
 
       refute called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
@@ -264,7 +273,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       {from, to} = from_to(89, 2)
       metric = "active_deposits"
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
       assert_called(Metric.timeseries_data(metric, :_, :_, :_, :_, :_))
@@ -282,7 +292,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       {from, to} = from_to(2500, 0)
       metric = get_free_timeseries_element(context.next_integer.(), @product, :metric)
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       result = execute_query(context.conn, query, "getMetric")
       assert called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
@@ -311,7 +322,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       {from, to} = from_to(7 * 365 - 1, 7 * 365 - 2)
       metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :pro)
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
       assert called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
@@ -342,7 +354,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       {from, to} = from_to(7 * 365 + 1, 7 * 365 - 1)
       metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :pro)
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
       assert_called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
@@ -373,7 +386,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       {from, to} = from_to(10, 0)
       metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :pro)
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
       assert called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
@@ -404,7 +418,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       {from, to} = from_to(7 * 365 + 1, 7 * 365 - 1)
       metric = "mvrv_long_short_diff_usd"
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       result = execute_query(context.conn, query, "getMetric")
 
       assert_called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
@@ -422,7 +437,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       {from, to} = from_to(2500, 0)
       metric = get_free_timeseries_element(context.next_integer.(), @product, :metric)
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       result = execute_query(context.conn, query, "getMetric")
       assert_called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
@@ -451,7 +467,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       {from, to} = from_to(2500, 0)
       metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :custom)
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       result = execute_query(context.conn, query, "getMetric")
       assert_called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
@@ -470,7 +487,8 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
       {from, to} = from_to(2500, 0)
       metric = "holders_distribution_0.01_to_0.1"
       slug = context.project.slug
-      query = metric_query(metric, slug, from, to)
+      selector = %{slug: slug}
+      query = metric_query(metric, selector, from, to)
       result = execute_query(context.conn, query, "getMetric")
       assert_called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
       assert result != nil
@@ -479,12 +497,14 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
 
   # Private functions
 
-  defp metric_query(metric, slug, from, to) do
+  defp metric_query(metric, selector, from, to) do
+    selector = extend_selector_with_required_fields(metric, selector)
+
     """
       {
         getMetric(metric: "#{metric}") {
           timeseriesData(
-            slug: "#{slug}"
+            selector: #{map_to_input_object_str(selector)}
             from: "#{from}"
             to: "#{to}"
             interval: "30d"

--- a/test/sanbase_web/graphql/metric/api_metric_metadata_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_metadata_test.exs
@@ -43,7 +43,8 @@ defmodule SanbaseWeb.Graphql.ApiMetricMetadataTest do
                    "SOURCE",
                    "LABEL_FQN",
                    "LABEL_FQNS",
-                   "BLOCKCHAIN"
+                   "BLOCKCHAIN",
+                   "BLOCKCHAIN_ADDRESS"
                  ],
                  &1
                )


### PR DESCRIPTION
## Changes
Add 2 metrics:
- `historical_balance`
- `historical_balance_changes`

These metrics require the `blockchainAddress` and `slug` selectors.
```graphql
{
  getMetric(metric: "historical_balance") {
    timeseriesData(
      selector: {
        slug: "santiment"
        blockchainAddress: {
          address: "0x3476ac8458548f1b77f3803a5612817e2c962577"
        }
      }
      from: "utc_now-900d"
      to: "utc_now"
      interval: "300d"
    ) {
      datetime
      value
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
