### PR TITLE
First check for deprecation, then metric availability

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
@@ -19,8 +19,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   @datapoints 300
 
   def get_metric(_root, %{metric: metric}, _resolution) do
-    with true <- Metric.has_metric?(metric),
-         true <- Metric.is_not_deprecated?(metric) do
+    with true <- Metric.is_not_deprecated?(metric),
+         true <- Metric.has_metric?(metric) do
       {:ok, %{metric: metric}}
     end
   end


### PR DESCRIPTION
## Changes

If a metric is deprecated it is no longer in the list of available
metrics. If the availabilty check is first, the error will not be that
the metric is deprecated, but that it is just not supported. To improve
this error message first check for deprecation. If the metric is not
supported or mistyped, the Metric.is_not_deprecated/1 will return true
and the next availability check will fail

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
