### PR TITLE
Improve the insights searching capabilities

### DIFF
--- a/test/sanbase_web/graphql/insight/insight_search_api_test.exs
+++ b/test/sanbase_web/graphql/insight/insight_search_api_test.exs
@@ -126,7 +126,7 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
     assert insight_ids == [post1.id, post3.id, post2.id]
   end
 
-  test "partial match of titles", context do
+  test "partial match", context do
     %{conn: conn, user: user} = context
 
     {:ok, post1} = Post.create(user, %{title: "Uniswap in title", text: "Something here"})
@@ -139,8 +139,11 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
 
     insights = search_insights(conn, "unisw")
     # Partial matching is done only in the title
-    assert length(insights) == 1
-    assert get_in(insights, [Access.at(0), "id"]) |> String.to_integer() == post1.id
+    assert length(insights) == 3
+    ids = Enum.map(insights, &String.to_integer(&1["id"]))
+
+    # The posts are returned in order of rank
+    assert ids == [post1.id, post3.id, post2.id]
   end
 
   defp search_insights(conn, search_term) do


### PR DESCRIPTION
## Changes

Introduce a prefix searching for the whole document instead of using
ILIKE only for the title. If the input is a single alphanumeric word,
treat it as an incomplete word and append ':*' to the end, so it is
searching for prefixes. For example 'mvr' would yield results very
similar to 'mvrv'.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
