### PR TITLE
Add sentiment_volume_consumed_total change metrics

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/change_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/change_metrics.json
@@ -3677,5 +3677,58 @@
     "has_incomplete_data": false,
     "data_type": "timeseries"
   }
-
+,
+  {
+    "human_readable_name": "Sentiment Volume Consumed Total Change (1d)",
+    "name": "sentiment_volume_consumed_total_change_1d",
+    "metric": "sentiment_volume_consumed_1d_change_1d",
+    "version": "2020-07-31",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": true,
+    "data_type": "timeseries"
+  }
+,
+  {
+    "human_readable_name": "Sentiment Volume Consumed Total Change (7d)",
+    "name": "sentiment_volume_consumed_total_change_7d",
+    "metric": "sentiment_volume_consumed_1d_change_7d",
+    "version": "2020-07-31",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": true,
+    "data_type": "timeseries"
+  }
+,
+  {
+    "human_readable_name": "Sentiment Volume Consumed Total Change (30d)",
+    "name": "sentiment_volume_consumed_total_change_30d",
+    "metric": "sentiment_volume_consumed_1d_change_30d",
+    "version": "2020-07-31",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": true,
+    "data_type": "timeseries"
+  }
 ]

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -766,7 +766,10 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         # ftx funding rates metric
         "ftx_perpetual_funding_rate",
         # bitfinex funding rates metric
-        "bitfinex_perpetual_funding_rate"
+        "bitfinex_perpetual_funding_rate",
+        "sentiment_volume_consumed_total_change_1d",
+        "sentiment_volume_consumed_total_change_7d",
+        "sentiment_volume_consumed_total_change_30d"
       ]
       |> Enum.sort()
 


### PR DESCRIPTION
## Changes

Added new CH metrics:
1. sentiment_volume_consumed_total_change_1d
2. sentiment_volume_consumed_total_change_7d
3. sentiment_volume_consumed_total_change_30d

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
