### PR TITLE
Replace plainto_tsquery with websearch_to_tsquery in insights search

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ slaveTemplates.dockerTemplate { label ->
         sh "docker run \
             --rm --name test-postgres-${scmVars.GIT_COMMIT}-${env.BUILD_ID}-${env.CHANGE_ID} \
             -e POSTGRES_PASSWORD=password \
-            -d postgres:10.10-alpine"
+            -d postgres:12.7-alpine"
 
         try {
           sh "docker run --rm \

--- a/lib/sanbase/insight/search/search.ex
+++ b/lib/sanbase/insight/search/search.ex
@@ -15,7 +15,7 @@ defmodule Sanbase.Insight.Search do
         to_tsquery_incomplete_search(query, search_term, opts)
 
       false ->
-        plainto_tsquery_complete_search(query, search_term, opts)
+        websearch_to_tsquery_complete_search(query, search_term, opts)
     end
   end
 
@@ -29,7 +29,7 @@ defmodule Sanbase.Insight.Search do
     # for every new character. For example if the search term is `mvrv`,
     # then we can show some results when only `mvr` is typed.
     # The function call appends `:*` to the search term and executes it
-    # via the `to_tsquery` function instead of `plainto_tsquery` which
+    # via the `to_tsquery` function instead of `websearch_to_tsquery` which
     # accepts a wider range of inputs and formats them.
     search_term = modify_search_term(search_term)
     {limit, offset} = opts_to_limit_offset(opts)
@@ -55,21 +55,21 @@ defmodule Sanbase.Insight.Search do
     |> transform_highlights()
   end
 
-  defp plainto_tsquery_complete_search(query, search_term, opts) do
+  defp websearch_to_tsquery_complete_search(query, search_term, opts) do
     {limit, offset} = opts_to_limit_offset(opts)
 
     from(
       post in query,
-      join: map in plainto_tsquery_search_insights_fragment(^search_term, ^limit, ^offset),
+      join: map in websearch_to_tsquery_search_insights_fragment(^search_term, ^limit, ^offset),
       on: post.id == map.id,
       select: %{
         post: post,
         rank: map.rank,
         highlights: %{
-          title: plainto_tsquery_highlight_fragment(post.title, ^search_term),
-          text: plainto_tsquery_highlight_fragment(post.text, ^search_term),
-          tags: plainto_tsquery_highlight_fragment(map.tags_str, ^search_term),
-          metrics: plainto_tsquery_highlight_fragment(map.metrics_str, ^search_term)
+          title: websearch_to_tsquery_highlight_fragment(post.title, ^search_term),
+          text: websearch_to_tsquery_highlight_fragment(post.text, ^search_term),
+          tags: websearch_to_tsquery_highlight_fragment(map.tags_str, ^search_term),
+          metrics: websearch_to_tsquery_highlight_fragment(map.metrics_str, ^search_term)
         }
       },
       order_by: [desc: map.rank]

--- a/lib/sanbase/insight/search/search_macro.ex
+++ b/lib/sanbase/insight/search/search_macro.ex
@@ -1,8 +1,8 @@
 defmodule Sanbase.Insight.Search.Macro do
-  defmacro plainto_tsquery_highlight_fragment(field, search_term) do
+  defmacro websearch_to_tsquery_highlight_fragment(field, search_term) do
     quote do
       fragment(
-        "ts_headline(?, plainto_tsquery(?), 'StartSel=<__internal_highlight__>, StopSel=</__internal_highlight__>')",
+        "ts_headline(?, websearch_to_tsquery(?), 'StartSel=<__internal_highlight__>, StopSel=</__internal_highlight__>')",
         unquote(field),
         unquote(search_term)
       )
@@ -19,13 +19,13 @@ defmodule Sanbase.Insight.Search.Macro do
     end
   end
 
-  defmacro plainto_tsquery_search_insights_fragment(search_term, limit, offset) do
+  defmacro websearch_to_tsquery_search_insights_fragment(search_term, limit, offset) do
     quote do
       fragment(
         """
         SELECT
           posts.id AS id,
-          ts_rank(posts.document_tokens, plainto_tsquery(?)) AS rank,
+          ts_rank(posts.document_tokens, websearch_to_tsquery(?)) AS rank,
           coalesce((string_agg(tags.name, ' ' ORDER BY tags.name)), '') AS tags_str,
           coalesce((string_agg(metrics.name, ' ' ORDER BY metrics.name)), '') AS metrics_str
         FROM posts
@@ -33,7 +33,7 @@ defmodule Sanbase.Insight.Search.Macro do
         LEFT OUTER JOIN tags ON tags.id = posts_tags.tag_id
         LEFT OUTER JOIN posts_metrics ON posts.id = posts_metrics.post_id
         LEFT OUTER JOIN metrics ON metrics.id = posts_metrics.metric_id
-        WHERE posts.document_tokens @@ plainto_tsquery(?)
+        WHERE posts.document_tokens @@ websearch_to_tsquery(?)
         GROUP BY posts.id
         ORDER BY rank DESC
         LIMIT ? OFFSET ?


### PR DESCRIPTION
## Changes

- The `websearch_to_tsquery` allows for widely known operators to be used
like: OR, quotes for phrases, - for removing matches, etc.
- Update Jenkinsfile to use the currently used postgres version on stage/prod.

This can be deployed only after prod postgres major version is upgraded.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
