### PR TITLE
Extend JWT token info

### DIFF
--- a/lib/sanbase/accounts/user/permissions.ex
+++ b/lib/sanbase/accounts/user/permissions.ex
@@ -3,7 +3,7 @@ defmodule Sanbase.Accounts.User.Permissions do
   alias Sanbase.Billing.{Subscription, Product}
 
   def permissions(%User{} = user) do
-    user_subscriptions_product_ids = Subscription.user_subscriptions_product_ids(user)
+    user_subscriptions_product_ids = Subscription.user_subscriptions_product_ids(user.id)
 
     %{
       api: Product.product_api() in user_subscriptions_product_ids,

--- a/lib/sanbase/api_call_limit/api_call_limit.ex
+++ b/lib/sanbase/api_call_limit/api_call_limit.ex
@@ -162,8 +162,8 @@ defmodule Sanbase.ApiCallLimit do
 
   defp user_to_plan(%User{} = user) do
     subscription =
-      Subscription.current_subscription(user, @product_api_id) ||
-        Subscription.current_subscription(user, @product_sanbase_id)
+      Subscription.current_subscription(user.id, @product_api_id) ||
+        Subscription.current_subscription(user.id, @product_sanbase_id)
 
     case subscription do
       %Subscription{plan: %{product: %{id: @product_api_id}}} ->

--- a/lib/sanbase/billing/subscription.ex
+++ b/lib/sanbase/billing/subscription.ex
@@ -262,7 +262,7 @@ defmodule Sanbase.Billing.Subscription do
   @doc """
   List all active user subscriptions with plans and products.
   """
-  def user_subscriptions(%User{id: user_id}) do
+  def user_subscriptions(user_id) do
     __MODULE__
     |> Query.filter_user(user_id)
     |> Query.all_active_and_trialing_subscriptions()
@@ -274,7 +274,7 @@ defmodule Sanbase.Billing.Subscription do
   @doc """
   List active subcriptions' product ids
   """
-  def user_subscriptions_product_ids(%User{id: user_id}) do
+  def user_subscriptions_product_ids(user_id) do
     __MODULE__
     |> Query.filter_user(user_id)
     |> Query.all_active_and_trialing_subscriptions()
@@ -292,12 +292,16 @@ defmodule Sanbase.Billing.Subscription do
   @doc """
   Current subscription is the last active subscription for a product.
   """
-  def current_subscription(%User{id: user_id}, product_id) do
-    fetch_current_subscription(user_id, product_id)
-  end
 
   def current_subscription(user_id, product_id) when is_integer(user_id) do
     fetch_current_subscription(user_id, product_id)
+  end
+
+  def current_subscriptions(user_id) do
+    user_subscriptions(user_id)
+    |> Enum.group_by(fn s -> s.plan.product.id end)
+    |> Enum.map(fn {product_id, list} -> {product_id, Enum.max_by(list, & &1.id)} end)
+    |> Enum.map(fn {_product_id, subscription} -> subscription end)
   end
 
   def plan_name(nil), do: :free

--- a/lib/sanbase/insight/post_paywall.ex
+++ b/lib/sanbase/insight/post_paywall.ex
@@ -20,7 +20,7 @@ defmodule Sanbase.Insight.PostPaywall do
   def maybe_filter_paywalled(insights, nil), do: maybe_filter(insights, nil)
 
   def maybe_filter_paywalled(insights, %User{} = user) do
-    subscription = Subscription.current_subscription(user, @product_sanbase)
+    subscription = Subscription.current_subscription(user.id, @product_sanbase)
 
     if SanbaseAccessChecker.can_access_paywalled_insights?(subscription) do
       insights

--- a/lib/sanbase_web/graphql/context_plug.ex
+++ b/lib/sanbase_web/graphql/context_plug.ex
@@ -308,7 +308,7 @@ defmodule SanbaseWeb.Graphql.ContextPlug do
     case access_token && bearer_authorize(conn, access_token) do
       {:ok, %{current_user: current_user} = map} ->
         subscription =
-          Subscription.current_subscription(current_user, @product_id_sanbase) ||
+          Subscription.current_subscription(current_user.id, @product_id_sanbase) ||
             @free_subscription
 
         %{
@@ -333,12 +333,10 @@ defmodule SanbaseWeb.Graphql.ContextPlug do
   end
 
   def jwt_auth_header_authorization(%Plug.Conn{} = conn) do
-    with {_, ["Bearer " <> token]} <-
-           {:has_header?, get_req_header(conn, "authorization")},
-         {:ok, %{current_user: current_user} = map} <-
-           bearer_authorize(conn, token) do
+    with {_, ["Bearer " <> token]} <- {:has_header?, get_req_header(conn, "authorization")},
+         {:ok, %{current_user: current_user} = map} <- bearer_authorize(conn, token) do
       subscription =
-        Subscription.current_subscription(current_user, @product_id_sanbase) ||
+        Subscription.current_subscription(current_user.id, @product_id_sanbase) ||
           @free_subscription
 
       %{
@@ -398,7 +396,7 @@ defmodule SanbaseWeb.Graphql.ContextPlug do
         |> get_apikey_product_id()
 
       subscription =
-        Subscription.current_subscription(current_user, product_id) ||
+        Subscription.current_subscription(current_user.id, product_id) ||
           @free_subscription
 
       %{

--- a/lib/sanbase_web/graphql/middlewares/access_control.ex
+++ b/lib/sanbase_web/graphql/middlewares/access_control.ex
@@ -139,7 +139,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
        when query in @extension_metrics do
     case resolution.context[:auth][:current_user] do
       %Sanbase.Accounts.User{} = user ->
-        product_ids = Subscription.user_subscriptions_product_ids(user)
+        product_ids = Subscription.user_subscriptions_product_ids(user.id)
 
         if Map.get(@extension_metric_product_map, query) in product_ids do
           resolution

--- a/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
@@ -146,7 +146,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
   end
 
   def subscriptions(%User{} = user, _args, _resolution) do
-    {:ok, Subscription.user_subscriptions(user)}
+    {:ok, Subscription.user_subscriptions(user.id)}
   end
 
   def eligible_for_sanbase_trial?(%User{} = user, _args, _resolution) do

--- a/lib/sanbase_web/graphql/resolvers/report_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/report_resolver.ex
@@ -17,7 +17,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ReportResolver do
 
   def get_reports(_root, _args, %{context: %{auth: %{current_user: user}}}) do
     plan =
-      Subscription.current_subscription(user, @product_sanbase)
+      Subscription.current_subscription(user.id, @product_sanbase)
       |> Subscription.plan_name()
 
     reports = Report.get_published_reports(%{is_logged_in: true, plan_atom_name: plan})
@@ -31,7 +31,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ReportResolver do
 
   def get_reports_by_tags(_root, %{tags: tags}, %{context: %{auth: %{current_user: user}}}) do
     plan =
-      Subscription.current_subscription(user, @product_sanbase)
+      Subscription.current_subscription(user.id, @product_sanbase)
       |> Subscription.plan_name()
 
     reports = Report.get_by_tags(tags, %{is_logged_in: true, plan_atom_name: plan})

--- a/lib/sanbase_web/graphql/resolvers/sheets_template_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/sheets_template_resolver.ex
@@ -8,7 +8,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.SheetsTemplateResolver do
 
   def get_sheets_templates(_root, _args, %{context: %{auth: %{current_user: user}}}) do
     plan =
-      Subscription.current_subscription(user, @product_sanbase)
+      Subscription.current_subscription(user.id, @product_sanbase)
       |> Subscription.plan_name()
 
     {:ok, SheetsTemplate.get_all(%{is_logged_in: true, plan_atom_name: plan})}

--- a/lib/sanbase_web/graphql/resolvers/webinar_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/webinar_resolver.ex
@@ -9,7 +9,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.WebinarResolver do
 
   def get_webinars(_root, _args, %{context: %{auth: %{current_user: user}}}) do
     plan =
-      Subscription.current_subscription(user, @product_sanbase)
+      Subscription.current_subscription(user.id, @product_sanbase)
       |> Subscription.plan_name()
 
     {:ok, Webinar.get_all(%{is_logged_in: true, plan_atom_name: plan})}

--- a/test/sanbase/billing/subscription_test.exs
+++ b/test/sanbase/billing/subscription_test.exs
@@ -93,12 +93,12 @@ defmodule Sanbase.Billing.SubscriptionTest do
     test "when there are subscriptions - currentUser return list of subscriptions", context do
       insert(:subscription_essential, user: context.user)
 
-      subscription = Subscription.user_subscriptions(context.user) |> hd()
+      subscription = Subscription.user_subscriptions(context.user.id) |> hd()
       assert subscription.plan.name == "ESSENTIAL"
     end
 
     test "when there are no subscriptions - return []", context do
-      assert Subscription.user_subscriptions(context.user) == []
+      assert Subscription.user_subscriptions(context.user.id) == []
     end
 
     test "only active subscriptions", context do
@@ -108,7 +108,7 @@ defmodule Sanbase.Billing.SubscriptionTest do
         status: "canceled"
       )
 
-      assert Subscription.user_subscriptions(context.user) == []
+      assert Subscription.user_subscriptions(context.user.id) == []
     end
   end
 
@@ -116,12 +116,16 @@ defmodule Sanbase.Billing.SubscriptionTest do
     test "when there is subscription - return it", context do
       insert(:subscription_essential, user: context.user)
 
-      current_subscription = Subscription.current_subscription(context.user, context.product.id)
+      current_subscription =
+        Subscription.current_subscription(context.user.id, context.product.id)
+
       assert current_subscription.plan.id == context.plans.plan_essential.id
     end
 
     test "when there isn't - return nil", context do
-      current_subscription = Subscription.current_subscription(context.user, context.product.id)
+      current_subscription =
+        Subscription.current_subscription(context.user.id, context.product.id)
+
       assert current_subscription == nil
     end
 
@@ -132,7 +136,9 @@ defmodule Sanbase.Billing.SubscriptionTest do
         status: "canceled"
       )
 
-      current_subscription = Subscription.current_subscription(context.user, context.product.id)
+      current_subscription =
+        Subscription.current_subscription(context.user.id, context.product.id)
+
       assert current_subscription == nil
     end
   end

--- a/test/sanbase_web/graphql/watchlist/blockchain_address/watchlist_api_test.exs
+++ b/test/sanbase_web/graphql/watchlist/blockchain_address/watchlist_api_test.exs
@@ -81,8 +81,8 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressWatchlistApiTest do
                "blockchainAddress" => %{
                  "address" => "0xf4b51b14b9ee30dc37ec970b50a486f37686e2a8",
                  "labels" => [
-                   %{"name" => "DEX", "origin" => "user"},
                    %{"name" => "Trader", "origin" => "user"},
+                   %{"name" => "DEX", "origin" => "user"},
                    %{"name" => "whale", "origin" => "santiment"},
                    %{"name" => "centralized_exchange", "origin" => "santiment"}
                  ]


### PR DESCRIPTION
## Changes

Extend the data stored in JWT so no DB calls need to be made when an API call with JWT is made. Store the user_id and subscriptions in the JWT. Start rework that will replace usage of the user struct with the user_id wherever possible

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
