### PR TITLE
Improve comments speed and correctness

### DIFF
--- a/lib/sanbase/accounts/user.ex
+++ b/lib/sanbase/accounts/user.ex
@@ -207,7 +207,8 @@ defmodule Sanbase.Accounts.User do
       from(
         u in __MODULE__,
         where: u.id in ^user_ids,
-        order_by: fragment("array_position(?, ?::int)", ^user_ids, u.id)
+        order_by: fragment("array_position(?, ?::int)", ^user_ids, u.id),
+        preload: [:eth_accounts, :user_settings]
       )
       |> Repo.all()
 

--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -65,6 +65,18 @@ defmodule Sanbase.Insight.Post do
     has_many(:timeline_events, TimelineEvent, on_delete: :delete_all)
     has_many(:votes, Vote, on_delete: :delete_all)
 
+    # has_many(:post_comments, Sanbase.Comment.PostComment, on_delete: :delete_all)
+
+    # has_many(:comments,
+    #   through: [:post_comments, :comments],
+    #   on_delete: :delete_all
+    # )
+
+    # many_to_many(:comments, Sanbase.Comment,
+    #   join_through: "post_comments_mapping",
+    #   on_delete: :delete_all
+    # )
+
     many_to_many(:tags, Tag,
       join_through: "posts_tags",
       on_replace: :delete,

--- a/lib/sanbase_web/graphql/dataloader/postgres_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/postgres_dataloader.ex
@@ -9,6 +9,13 @@ defmodule SanbaseWeb.Graphql.PostgresDataloader do
     Dataloader.KV.new(&query/2)
   end
 
+  def query(:users_no_preload, user_ids) do
+    user_ids = Enum.to_list(user_ids)
+
+    {:ok, users} = Sanbase.Accounts.User.by_id(user_ids)
+    Map.new(users, &{&1.id, &1})
+  end
+
   def query(:market_segment, market_segment_ids) do
     market_segment_ids = Enum.to_list(market_segment_ids)
 

--- a/lib/sanbase_web/graphql/dataloader/sanbase_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/sanbase_dataloader.ex
@@ -50,7 +50,9 @@ defmodule SanbaseWeb.Graphql.SanbaseDataloader do
     :short_urls_comments_count,
     :timeline_events_comments_count,
     :wallet_hunters_proposals_comments_count,
-    :watchlist_comments_count
+    :watchlist_comments_count,
+    # Users
+    :users_no_preload
   ]
   @postgres_dataloader [
     :current_user_address_details,

--- a/lib/sanbase_web/graphql/schema/types/comment_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/comment_types.ex
@@ -4,7 +4,7 @@ defmodule SanbaseWeb.Graphql.CommentTypes do
   import Absinthe.Resolution.Helpers
   import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1]
 
-  alias SanbaseWeb.Graphql.Resolvers.CommentEntityIdResolver
+  alias SanbaseWeb.Graphql.Resolvers.{CommentEntityIdResolver, UserResolver}
   alias SanbaseWeb.Graphql.SanbaseRepo
 
   enum :comment_entity_type_enum do
@@ -25,7 +25,11 @@ defmodule SanbaseWeb.Graphql.CommentTypes do
     field(:blockchain_address, :blockchain_address_db_stored)
 
     field(:content, non_null(:string))
-    field(:user, non_null(:public_user), resolve: dataloader(SanbaseRepo))
+
+    field :user, non_null(:public_user) do
+      resolve(&UserResolver.user_no_preloads/3)
+    end
+
     field(:parent_id, :id)
     field(:root_parent_id, :id)
     field(:subcomments_count, :integer)

--- a/test/sanbase/event_bus/event_bus_test.exs
+++ b/test/sanbase/event_bus/event_bus_test.exs
@@ -1,5 +1,6 @@
 defmodule Sanbase.EventBusTest do
   use ExUnit.Case, async: false
+  import Sanbase.TestHelpers, only: [wait_event_bus_subscriber: 1]
 
   defmodule EventBusTestSubscriber do
     @receiver_name :__internal_event_test_process_name_given__
@@ -28,7 +29,7 @@ defmodule Sanbase.EventBusTest do
     # register_topic is done via GenServer.call/2, but EventBus.subscribe is
     # done via GenServer.cast/2. Adding a small wait loop to make sure the test
     # starts only after the subscriber is properly established.
-    wait_subscriber(test_events_topic)
+    wait_event_bus_subscriber(test_events_topic)
 
     :ok
   end
@@ -48,17 +49,6 @@ defmodule Sanbase.EventBusTest do
     for i <- 1..50 do
       msg = "ping#{i}"
       assert_receive(^msg, 1000)
-    end
-  end
-
-  defp wait_subscriber(topic) do
-    case Sanbase.EventBusTest.EventBusTestSubscriber in EventBus.subscribers(topic) do
-      true ->
-        :ok
-
-      false ->
-        Process.sleep(50)
-        wait_subscriber(topic)
     end
   end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,4 +1,15 @@
 defmodule Sanbase.TestHelpers do
+  def wait_event_bus_subscriber(topic) do
+    case Sanbase.EventBusTest.EventBusTestSubscriber in EventBus.subscribers(topic) do
+      true ->
+        :ok
+
+      false ->
+        Process.sleep(50)
+        wait_event_bus_subscriber(topic)
+    end
+  end
+
   @moduledoc false
   defmacro setup_all_with_mocks(mocks, do: setup_block) do
     quote do


### PR DESCRIPTION
## Changes

- Improve fetching the users speed by custom dataloader. Otherwise we
get N+1 queries loading user settings
- Remove comments for posts that are not approved and published. This
fixes issues when posts are hidden/deleted because of spam.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
