### PR TITLE
Migrate some graphql id types to integer

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/chart_configuration/chart_configuration_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/chart_configuration/chart_configuration_resolver.ex
@@ -4,7 +4,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.ChartConfigurationResolver do
   alias Sanbase.Chart.Configuration
   alias Sanbase.Accounts.User
   alias SanbaseWeb.Graphql.SanbaseDataloader
-  alias Sanbase.Billing.Subscription
 
   require Logger
 

--- a/lib/sanbase_web/graphql/schema/types/comment_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/comment_types.ex
@@ -16,7 +16,7 @@ defmodule SanbaseWeb.Graphql.CommentTypes do
   end
 
   object :comments_feed_item do
-    field(:id, non_null(:id))
+    field(:id, non_null(:integer))
     field(:insight, :post)
     field(:short_url, :short_url)
     field(:timeline_event, :timeline_event)
@@ -28,41 +28,41 @@ defmodule SanbaseWeb.Graphql.CommentTypes do
       resolve(&UserResolver.user_no_preloads/3)
     end
 
-    field(:parent_id, :id)
-    field(:root_parent_id, :id)
+    field(:parent_id, :integer)
+    field(:root_parent_id, :integer)
     field(:subcomments_count, :integer)
     field(:inserted_at, non_null(:datetime))
     field(:edited_at, :datetime)
   end
 
   object :comment do
-    field(:id, non_null(:id))
+    field(:id, non_null(:integer))
 
-    field :insight_id, non_null(:id) do
+    field :insight_id, non_null(:integer) do
       cache_resolve(&CommentEntityIdResolver.insight_id/3)
     end
 
-    field :timeline_event_id, non_null(:id) do
+    field :timeline_event_id, non_null(:integer) do
       cache_resolve(&CommentEntityIdResolver.timeline_event_id/3)
     end
 
-    field :blockchain_address_id, non_null(:id) do
+    field :blockchain_address_id, non_null(:integer) do
       cache_resolve(&CommentEntityIdResolver.blockchain_address_id/3)
     end
 
-    field :proposal_id, non_null(:id) do
+    field :proposal_id, non_null(:integer) do
       cache_resolve(&CommentEntityIdResolver.proposal_id/3)
     end
 
-    field :watchlist_id, non_null(:id) do
+    field :watchlist_id, non_null(:integer) do
       cache_resolve(&CommentEntityIdResolver.watchlist_id/3)
     end
 
-    field :chart_configuration_id, non_null(:id) do
+    field :chart_configuration_id, non_null(:integer) do
       cache_resolve(&CommentEntityIdResolver.chart_configuration_id/3)
     end
 
-    field :short_url_id, non_null(:id) do
+    field :short_url_id, non_null(:integer) do
       cache_resolve(&CommentEntityIdResolver.short_url_id/3)
     end
 
@@ -72,8 +72,8 @@ defmodule SanbaseWeb.Graphql.CommentTypes do
       resolve(&SanbaseWeb.Graphql.Resolvers.UserResolver.user_no_preloads/3)
     end
 
-    field(:parent_id, :id)
-    field(:root_parent_id, :id)
+    field(:parent_id, :integer)
+    field(:root_parent_id, :integer)
     field(:subcomments_count, :integer)
     field(:inserted_at, non_null(:datetime))
     field(:edited_at, :datetime)

--- a/lib/sanbase_web/graphql/schema/types/insight_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/insight_types.ex
@@ -28,7 +28,7 @@ defmodule SanbaseWeb.Graphql.InsightTypes do
   end
 
   object :post do
-    field(:id, non_null(:id))
+    field(:id, non_null(:integer))
 
     field :user, non_null(:public_user) do
       resolve(&SanbaseWeb.Graphql.Resolvers.UserResolver.user_no_preloads/3)

--- a/lib/sanbase_web/graphql/schema/types/timeline_event_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/timeline_event_types.ex
@@ -36,7 +36,7 @@ defmodule SanbaseWeb.Graphql.TimelineEventTypes do
   end
 
   object :timeline_event do
-    field(:id, non_null(:id))
+    field(:id, non_null(:integer))
     field(:event_type, non_null(:string))
     field(:inserted_at, non_null(:datetime))
     field(:user, non_null(:user))
@@ -58,7 +58,7 @@ defmodule SanbaseWeb.Graphql.TimelineEventTypes do
   end
 
   object :seen_event do
-    field(:event_id, non_null(:id))
+    field(:event_id, non_null(:integer))
     field(:seen_at, non_null(:datetime))
   end
 end

--- a/test/sanbase_web/graphql/chart/chart_configuration_api_test.exs
+++ b/test/sanbase_web/graphql/chart/chart_configuration_api_test.exs
@@ -161,7 +161,7 @@ defmodule SanbaseWeb.Graphql.ChartConfigurationApiTest do
       assert config["project"]["slug"] == project.slug
       assert config["user"]["id"] |> String.to_integer() == user.id
       assert config["user"]["email"] == user.email
-      assert config["post"]["id"] |> String.to_integer() == post.id
+      assert config["post"]["id"] == post.id
       assert config["post"]["title"] == post.title
     end
 
@@ -212,7 +212,7 @@ defmodule SanbaseWeb.Graphql.ChartConfigurationApiTest do
       assert config["drawings"] == new_settings.drawings
       assert config["queries"] == new_settings.queries
       assert config["options"] == new_settings.options
-      assert config["post"]["id"] |> String.to_integer() == new_settings.post_id
+      assert config["post"]["id"] == new_settings.post_id
       assert config["post"]["title"] == new_post.title
     end
 
@@ -303,7 +303,7 @@ defmodule SanbaseWeb.Graphql.ChartConfigurationApiTest do
       assert config["project"]["slug"] == project.slug
       assert config["user"]["id"] |> String.to_integer() == user.id
       assert config["user"]["email"] == user.email
-      assert config["post"]["id"] |> String.to_integer() == post.id
+      assert config["post"]["id"] == post.id
       assert config["post"]["title"] == post.title
     end
 

--- a/test/sanbase_web/graphql/comments/blockchain_address_comments_api_test.exs
+++ b/test/sanbase_web/graphql/comments/blockchain_address_comments_api_test.exs
@@ -108,7 +108,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressCommentsApiTest do
 
     [comment, subcomment1, subcomment2] =
       get_comments(conn, blockchain_address.id, @opts)
-      |> Enum.sort_by(&(&1["id"] |> String.to_integer()))
+      |> Enum.sort_by(& &1["id"])
 
     assert comment["parentId"] == nil
     assert comment["rootParentId"] == nil

--- a/test/sanbase_web/graphql/comments/chart_configuration_comments_api_test.exs
+++ b/test/sanbase_web/graphql/comments/chart_configuration_comments_api_test.exs
@@ -111,7 +111,7 @@ defmodule SanbaseWeb.Graphql.ChartConfigurationCommentsApiTest do
 
     [comment, subcomment1, subcomment2] =
       get_comments(conn, chart_configuration.id, @opts)
-      |> Enum.sort_by(&(&1["id"] |> String.to_integer()))
+      |> Enum.sort_by(& &1["id"])
 
     assert comment["parentId"] == nil
     assert comment["rootParentId"] == nil

--- a/test/sanbase_web/graphql/comments/comments_feed_api_test.exs
+++ b/test/sanbase_web/graphql/comments/comments_feed_api_test.exs
@@ -107,19 +107,19 @@ defmodule SanbaseWeb.Graphql.Comments.CommentsFeedApiTest do
              %{
                "blockchainAddress" => nil,
                "content" => timeline_event_comment.content,
-               "id" => timeline_event_comment.id |> Integer.to_string(),
+               "id" => timeline_event_comment.id,
                "insertedAt" =>
                  timeline_event_comment.inserted_at
                  |> DateTime.from_naive!("Etc/UTC")
                  |> DateTime.to_iso8601(),
                "insight" => nil,
                "shortUrl" => nil,
-               "timelineEvent" => %{"id" => context.timeline_event.id |> Integer.to_string()}
+               "timelineEvent" => %{"id" => context.timeline_event.id}
              },
              %{
                "blockchainAddress" => nil,
                "content" => short_url_comment.content,
-               "id" => short_url_comment.id |> Integer.to_string(),
+               "id" => short_url_comment.id,
                "insertedAt" =>
                  short_url_comment.inserted_at
                  |> DateTime.from_naive!("Etc/UTC")
@@ -134,7 +134,7 @@ defmodule SanbaseWeb.Graphql.Comments.CommentsFeedApiTest do
                  "id" => context.blockchain_address.id
                },
                "content" => ba_comment.content,
-               "id" => ba_comment.id |> Integer.to_string(),
+               "id" => ba_comment.id,
                "insertedAt" =>
                  ba_comment.inserted_at
                  |> DateTime.from_naive!("Etc/UTC")
@@ -146,12 +146,12 @@ defmodule SanbaseWeb.Graphql.Comments.CommentsFeedApiTest do
              %{
                "blockchainAddress" => nil,
                "content" => insight_comment.content,
-               "id" => insight_comment.id |> Integer.to_string(),
+               "id" => insight_comment.id,
                "insertedAt" =>
                  insight_comment.inserted_at
                  |> DateTime.from_naive!("Etc/UTC")
                  |> DateTime.to_iso8601(),
-               "insight" => %{"id" => context.insight.id |> Integer.to_string()},
+               "insight" => %{"id" => context.insight.id},
                "shortUrl" => nil,
                "timelineEvent" => nil
              }

--- a/test/sanbase_web/graphql/comments/insight_comments_api_test.exs
+++ b/test/sanbase_web/graphql/comments/insight_comments_api_test.exs
@@ -156,7 +156,7 @@ defmodule SanbaseWeb.Graphql.InsightCommentApiTest do
 
     [comment, subcomment1, subcomment2] =
       get_comments(conn, post.id, @opts)
-      |> Enum.sort_by(&(&1["id"] |> String.to_integer()))
+      |> Enum.sort_by(& &1["id"])
 
     assert comment["parentId"] == nil
     assert comment["rootParentId"] == nil

--- a/test/sanbase_web/graphql/comments/short_url_comments_api_test.exs
+++ b/test/sanbase_web/graphql/comments/short_url_comments_api_test.exs
@@ -104,7 +104,7 @@ defmodule SanbaseWeb.GraphqlShortUrlCommentsApiTest do
 
     [comment, subcomment1, subcomment2] =
       get_comments(conn, short_url.id, @opts)
-      |> Enum.sort_by(&(&1["id"] |> String.to_integer()))
+      |> Enum.sort_by(& &1["id"])
 
     assert comment["parentId"] == nil
     assert comment["rootParentId"] == nil

--- a/test/sanbase_web/graphql/comments/timeline_event_comments_api_test.exs
+++ b/test/sanbase_web/graphql/comments/timeline_event_comments_api_test.exs
@@ -112,7 +112,7 @@ defmodule SanbaseWeb.GraphqlTimelineEventCommentsApiTest do
 
     [comment, subcomment1, subcomment2] =
       get_comments(conn, timeline_event.id, @opts)
-      |> Enum.sort_by(&(&1["id"] |> String.to_integer()))
+      |> Enum.sort_by(& &1["id"])
 
     assert comment["parentId"] == nil
     assert comment["rootParentId"] == nil

--- a/test/sanbase_web/graphql/comments/wallet_hunters_proposal_comments_api_test.exs
+++ b/test/sanbase_web/graphql/comments/wallet_hunters_proposal_comments_api_test.exs
@@ -117,7 +117,7 @@ defmodule SanbaseWeb.Graphql.WalletHuntersProposalCommentsApiTest do
 
     [comment, subcomment1, subcomment2] =
       get_comments(conn, proposal.id, @opts)
-      |> Enum.sort_by(&(&1["id"] |> String.to_integer()))
+      |> Enum.sort_by(& &1["id"])
 
     assert comment["parentId"] == nil
     assert comment["rootParentId"] == nil

--- a/test/sanbase_web/graphql/comments/watchlist_comments_api_test.exs
+++ b/test/sanbase_web/graphql/comments/watchlist_comments_api_test.exs
@@ -104,7 +104,7 @@ defmodule SanbaseWeb.Graphql.WatchlistCommentsApiTest do
 
     [comment, subcomment1, subcomment2] =
       get_comments(conn, watchlist.id, @opts)
-      |> Enum.sort_by(&(&1["id"] |> String.to_integer()))
+      |> Enum.sort_by(& &1["id"])
 
     assert comment["parentId"] == nil
     assert comment["rootParentId"] == nil

--- a/test/sanbase_web/graphql/featured_item/featured_item_api_test.exs
+++ b/test/sanbase_web/graphql/featured_item/featured_item_api_test.exs
@@ -77,11 +77,18 @@ defmodule Sanbase.FeaturedItemApiTest do
 
   describe "insight featured items" do
     test "no insights are featured", context do
-      assert fetch_insights(context.conn) == %{"data" => %{"featuredInsights" => []}}
+      assert fetch_insights(context.conn) == %{
+               "data" => %{"featuredInsights" => []}
+             }
     end
 
     test "marking insights as featured", context do
-      insight = insert(:post, state: Post.approved_state(), ready_state: Post.published())
+      insight =
+        insert(:post,
+          state: Post.approved_state(),
+          ready_state: Post.published()
+        )
+
       tags = insight.tags |> Enum.map(fn %{name: name} -> %{"name" => name} end)
 
       :ok = FeaturedItem.update_item(insight, true)
@@ -89,7 +96,11 @@ defmodule Sanbase.FeaturedItemApiTest do
       assert fetch_insights(context.conn) == %{
                "data" => %{
                  "featuredInsights" => [
-                   %{"id" => "#{insight.id}", "title" => "#{insight.title}", "tags" => tags}
+                   %{
+                     "id" => insight.id,
+                     "title" => "#{insight.title}",
+                     "tags" => tags
+                   }
                  ]
                }
              }
@@ -99,18 +110,33 @@ defmodule Sanbase.FeaturedItemApiTest do
       insight = insert(:post)
       {:error, _} = FeaturedItem.update_item(insight, true)
 
-      assert fetch_insights(context.conn) == %{"data" => %{"featuredInsights" => []}}
+      assert fetch_insights(context.conn) == %{
+               "data" => %{"featuredInsights" => []}
+             }
     end
 
     test "unmarking insights as featured", context do
-      insight = insert(:post, state: Post.approved_state(), ready_state: Post.published())
+      insight =
+        insert(:post,
+          state: Post.approved_state(),
+          ready_state: Post.published()
+        )
+
       :ok = FeaturedItem.update_item(insight, true)
       :ok = FeaturedItem.update_item(insight, false)
-      assert fetch_insights(context.conn) == %{"data" => %{"featuredInsights" => []}}
+
+      assert fetch_insights(context.conn) == %{
+               "data" => %{"featuredInsights" => []}
+             }
     end
 
     test "marking insight as featured is idempotent", context do
-      insight = insert(:post, state: Post.approved_state(), ready_state: Post.published())
+      insight =
+        insert(:post,
+          state: Post.approved_state(),
+          ready_state: Post.published()
+        )
+
       tags = insight.tags |> Enum.map(fn %{name: name} -> %{"name" => name} end)
       FeaturedItem.update_item(insight, true)
       FeaturedItem.update_item(insight, true)
@@ -120,7 +146,7 @@ defmodule Sanbase.FeaturedItemApiTest do
                "data" => %{
                  "featuredInsights" => [
                    %{
-                     "id" => "#{insight.id}",
+                     "id" => insight.id,
                      "title" => "#{insight.title}",
                      "tags" => tags
                    }
@@ -148,7 +174,9 @@ defmodule Sanbase.FeaturedItemApiTest do
 
   describe "watchlist featured items" do
     test "no watchlists are featured", context do
-      assert fetch_watchlists(context.conn) == %{"data" => %{"featuredWatchlists" => []}}
+      assert fetch_watchlists(context.conn) == %{
+               "data" => %{"featuredWatchlists" => []}
+             }
     end
 
     test "marking watchlists as featured", context do
@@ -196,7 +224,10 @@ defmodule Sanbase.FeaturedItemApiTest do
       watchlist = insert(:watchlist, is_public: true)
       :ok = FeaturedItem.update_item(watchlist, true)
       :ok = FeaturedItem.update_item(watchlist, false)
-      assert fetch_watchlists(context.conn) == %{"data" => %{"featuredWatchlists" => []}}
+
+      assert fetch_watchlists(context.conn) == %{
+               "data" => %{"featuredWatchlists" => []}
+             }
     end
 
     test "marking watchlist as featured is idempotent", context do
@@ -247,7 +278,9 @@ defmodule Sanbase.FeaturedItemApiTest do
 
   describe "user_trigger featured items" do
     test "no user_triggers are featured", context do
-      assert fetch_user_triggers(context.conn) == %{"data" => %{"featuredUserTriggers" => []}}
+      assert fetch_user_triggers(context.conn) == %{
+               "data" => %{"featuredUserTriggers" => []}
+             }
     end
 
     test "marking user_triggers as featured", context do
@@ -272,7 +305,10 @@ defmodule Sanbase.FeaturedItemApiTest do
       user_trigger = insert(:user_trigger, is_public: true)
       :ok = FeaturedItem.update_item(user_trigger, true)
       :ok = FeaturedItem.update_item(user_trigger, false)
-      assert fetch_user_triggers(context.conn) == %{"data" => %{"featuredUserTriggers" => []}}
+
+      assert fetch_user_triggers(context.conn) == %{
+               "data" => %{"featuredUserTriggers" => []}
+             }
     end
 
     test "marking user_trigger as featured is idempotent", context do

--- a/test/sanbase_web/graphql/insight/insight_api_test.exs
+++ b/test/sanbase_web/graphql/insight/insight_api_test.exs
@@ -119,12 +119,12 @@ defmodule SanbaseWeb.Graphql.InsightApiTest do
       expected_insights =
         [
           %{
-            "id" => "#{published.id}",
+            "id" => published.id,
             "readyState" => "#{published.ready_state}",
             "text" => "#{published.text}"
           },
           %{
-            "id" => "#{draft.id}",
+            "id" => draft.id,
             "readyState" => "#{draft.ready_state}",
             "text" => "#{draft.text}"
           }
@@ -186,7 +186,7 @@ defmodule SanbaseWeb.Graphql.InsightApiTest do
       expected_insights =
         [
           %{
-            "id" => "#{published.id}",
+            "id" => published.id,
             "readyState" => "#{published.ready_state}",
             "text" => "#{published.text}"
           }
@@ -495,7 +495,7 @@ defmodule SanbaseWeb.Graphql.InsightApiTest do
     Repo.all(Post)
 
     assert json_response(result, 200)["data"]["allInsights"] ==
-             [%{"id" => "#{post2.id}"}, %{"id" => "#{post.id}"}]
+             [%{"id" => post2.id}, %{"id" => post.id}]
   end
 
   test "Search insights by tag", %{user: user, conn: conn} do
@@ -512,7 +512,7 @@ defmodule SanbaseWeb.Graphql.InsightApiTest do
 
     result = execute_query(conn, insights_by_tag_query(tag1), "allInsightsByTag")
 
-    assert result == [%{"id" => "#{post.id}"}]
+    assert result == [%{"id" => post.id}]
   end
 
   test "Search insights by tag for anonymous user", %{user: user} do
@@ -529,7 +529,7 @@ defmodule SanbaseWeb.Graphql.InsightApiTest do
 
     result = execute_query(build_conn(), insights_by_tag_query(tag1), "allInsightsByTag")
 
-    assert result == [%{"id" => "#{post.id}"}]
+    assert result == [%{"id" => post.id}]
   end
 
   test "Get all insights by a list of tags", %{user: user} do
@@ -564,7 +564,7 @@ defmodule SanbaseWeb.Graphql.InsightApiTest do
     result = execute_query(build_conn(), query, "allInsights") |> Enum.sort_by(& &1["id"])
 
     assert result ==
-             [%{"id" => "#{post.id}"}, %{"id" => "#{post3.id}"}] |> Enum.sort_by(& &1["id"])
+             [%{"id" => post.id}, %{"id" => post3.id}] |> Enum.sort_by(& &1["id"])
   end
 
   describe "Create insight" do
@@ -900,7 +900,7 @@ defmodule SanbaseWeb.Graphql.InsightApiTest do
 
       result_post = result["data"]["deleteInsight"]
 
-      assert result_post["id"] == Integer.to_string(sanbase_post.id)
+      assert result_post["id"] == sanbase_post.id
     end
 
     test "deleting an insight which does not belong to the user - returns error", %{
@@ -1198,7 +1198,7 @@ defmodule SanbaseWeb.Graphql.InsightApiTest do
     result = conn |> post("/graphql", query_skeleton(query, "allInsights"))
 
     assert json_response(result, 200)["data"]["allInsights"] ==
-             [%{"id" => "#{post1.id}"}, %{"id" => "#{post2.id}"}]
+             [%{"id" => post1.id}, %{"id" => post2.id}]
   end
 
   # Helper functions

--- a/test/sanbase_web/graphql/insight/insight_search_api_test.exs
+++ b/test/sanbase_web/graphql/insight/insight_search_api_test.exs
@@ -53,7 +53,7 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
       insights = search_insights(conn, "undergoes")
       assert length(insights) == 1
       insight = insights |> hd()
-      assert insight["id"] |> String.to_integer() == post2.id
+      assert insight["id"] == post2.id
     end
 
     test "search works with data in metrics", context do
@@ -62,7 +62,7 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
       insights = search_insights(conn, "price_usd")
       assert length(insights) == 1
       insight = insights |> hd()
-      assert insight["id"] |> String.to_integer() == post1.id
+      assert insight["id"] == post1.id
     end
 
     test "search works with data in text", context do
@@ -72,12 +72,12 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
       insights = search_insights(conn, "explanations")
       assert length(insights) == 1
       insight = insights |> hd()
-      assert insight["id"] |> String.to_integer() == post2.id
+      assert insight["id"] == post2.id
 
       # more than 1 insight
       insights = search_insights(conn, "mvrv")
       assert length(insights) == 2
-      insight_ids = insights |> Enum.map(&(&1["id"] |> String.to_integer())) |> Enum.sort()
+      insight_ids = insights |> Enum.map(& &1["id"]) |> Enum.sort()
       assert post1.id in insight_ids
       assert post2.id in insight_ids
     end
@@ -89,7 +89,7 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
       insights = search_insights(conn, "mvrv metric")
 
       assert length(insights) == 2
-      insight_ids = insights |> Enum.map(&(&1["id"] |> String.to_integer())) |> Enum.sort()
+      insight_ids = insights |> Enum.map(& &1["id"]) |> Enum.sort()
 
       assert post1.id in insight_ids
       assert post2.id in insight_ids
@@ -99,7 +99,7 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
       insights = search_insights(conn, "metric explanations")
       assert length(insights) == 1
       insight = insights |> hd()
-      assert insight["id"] |> String.to_integer() == post2.id
+      assert insight["id"] == post2.id
     end
 
     test "search works with data in tags", context do
@@ -107,7 +107,7 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
 
       insights = search_insights(conn, "SAN")
       assert length(insights) == 2
-      insight_ids = insights |> Enum.map(&(&1["id"] |> String.to_integer())) |> Enum.sort()
+      insight_ids = insights |> Enum.map(& &1["id"]) |> Enum.sort()
       assert post2.id in insight_ids
       assert post3.id in insight_ids
     end
@@ -124,7 +124,7 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
       Post.publish(post3.id, user.id)
 
       insights = search_insights(conn, "uniswap")
-      insight_ids = Enum.map(insights, &(&1["id"] |> String.to_integer()))
+      insight_ids = Enum.map(insights, & &1["id"])
       assert insight_ids == [post1.id, post3.id, post2.id]
     end
 
@@ -142,7 +142,7 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
       insights = search_insights(conn, "unisw")
       # Partial matching is done only in the title
       assert length(insights) == 3
-      ids = Enum.map(insights, &String.to_integer(&1["id"]))
+      ids = Enum.map(insights, & &1["id"])
 
       # The posts are returned in order of rank
       assert ids == [post1.id, post3.id, post2.id]
@@ -207,7 +207,7 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
              }
 
       assert post == %{
-               "id" => "#{post2.id}",
+               "id" => post2.id,
                "metrics" => [],
                "tags" => [
                  %{"name" => "MVRV"},
@@ -249,7 +249,7 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
              }
 
       assert result_post1 == %{
-               "id" => "#{post2.id}",
+               "id" => post2.id,
                "metrics" => [],
                "tags" => [
                  %{"name" => "MVRV"},
@@ -272,7 +272,7 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
              }
 
       assert result_post2 == %{
-               "id" => "#{post1.id}",
+               "id" => post1.id,
                "metrics" => [%{"name" => "price_usd"}],
                "tags" => [%{"name" => "MVRV"}],
                "title" => "Combined metrics"
@@ -304,7 +304,7 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
              }
 
       assert result_post1 == %{
-               "id" => "#{post1.id}",
+               "id" => post1.id,
                "metrics" => [%{"name" => "price_usd"}],
                "tags" => [%{"name" => "MVRV"}],
                "title" => "Combined metrics"
@@ -330,7 +330,7 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
              }
 
       assert result_post1 == %{
-               "id" => "#{post2.id}",
+               "id" => post2.id,
                "metrics" => [],
                "tags" => [
                  %{"name" => "MVRV"},
@@ -347,7 +347,7 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
 
       list = search_insights_highlighted(conn, "SAN")
       assert length(list) == 2
-      insight_ids = list |> Enum.map(&(&1["post"]["id"] |> String.to_integer())) |> Enum.sort()
+      insight_ids = list |> Enum.map(& &1["post"]["id"]) |> Enum.sort()
       assert post2.id in insight_ids
       assert post3.id in insight_ids
     end
@@ -364,7 +364,7 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
       Post.publish(post3.id, user.id)
 
       list = search_insights_highlighted(conn, "uniswap")
-      insight_ids = Enum.map(list, &(&1["post"]["id"] |> String.to_integer()))
+      insight_ids = Enum.map(list, & &1["post"]["id"])
       assert insight_ids == [post1.id, post3.id, post2.id]
     end
 
@@ -382,7 +382,7 @@ defmodule SanbaseWeb.Graphql.InsightSearchApiTest do
       list = search_insights_highlighted(conn, "unisw")
       # Partial matching is done only in the title
       assert length(list) == 3
-      ids = Enum.map(list, &String.to_integer(&1["post"]["id"]))
+      ids = Enum.map(list, & &1["post"]["id"])
 
       # The posts are returned in order of rank
       assert ids == [post1.id, post3.id, post2.id]

--- a/test/sanbase_web/graphql/insight/pulse_insight_api_test.exs
+++ b/test/sanbase_web/graphql/insight/pulse_insight_api_test.exs
@@ -62,12 +62,12 @@ defmodule SanbaseWeb.Graphql.PulseInsightApiTest do
     expected_insights =
       [
         %{
-          "id" => "#{published.id}",
+          "id" => published.id,
           "readyState" => "#{published.ready_state}",
           "text" => "#{published.text}"
         },
         %{
-          "id" => "#{draft.id}",
+          "id" => draft.id,
           "readyState" => "#{draft.ready_state}",
           "text" => "#{draft.text}"
         }
@@ -324,7 +324,7 @@ defmodule SanbaseWeb.Graphql.PulseInsightApiTest do
     result = execute_query(build_conn(), query, "allInsights") |> Enum.sort_by(& &1["id"])
 
     assert result ==
-             [%{"id" => "#{post.id}"}, %{"id" => "#{post3.id}"}] |> Enum.sort_by(& &1["id"])
+             [%{"id" => post.id}, %{"id" => post3.id}] |> Enum.sort_by(& &1["id"])
   end
 
   describe "create pulse insight" do

--- a/test/sanbase_web/graphql/insight/timeline_event_comment_api_test.exs
+++ b/test/sanbase_web/graphql/insight/timeline_event_comment_api_test.exs
@@ -120,7 +120,7 @@ defmodule SanbaseWeb.Graphql.TimelineEventCommentApiTest do
 
     [comment, subcomment1, subcomment2] =
       timeline_event_comments(conn, timeline_event.id)
-      |> Enum.sort_by(&(&1["id"] |> String.to_integer()))
+      |> Enum.sort_by(& &1["id"])
 
     assert comment["parentId"] == nil
     assert comment["rootParentId"] == nil

--- a/test/sanbase_web/graphql/short_url/short_url_comment_api_test.exs
+++ b/test/sanbase_web/graphql/short_url/short_url_comment_api_test.exs
@@ -88,7 +88,7 @@ defmodule SanbaseWeb.Graphql.ShortUrlCommentApiTest do
 
     [comment, subcomment1, subcomment2] =
       short_url_comments(conn, short_url.id)
-      |> Enum.sort_by(&(&1["id"] |> String.to_integer()))
+      |> Enum.sort_by(& &1["id"])
 
     assert comment["parentId"] == nil
     assert comment["rootParentId"] == nil

--- a/test/sanbase_web/graphql/timeline/seen_event_api_test.exs
+++ b/test/sanbase_web/graphql/timeline/seen_event_api_test.exs
@@ -43,7 +43,7 @@ defmodule SanbaseWeb.Graphql.SeenEventApiTest do
 
   test "Fetch only new timeline events", context do
     result = execute_query(context.conn, new_timeline_events_query(), "timelineEvents")
-    assert result == [%{"events" => [%{"id" => "#{context.event1.id}"}]}]
+    assert result == [%{"events" => [%{"id" => context.event1.id}]}]
 
     SeenEvent.fetch_or_create(%{user_id: context.user.id, event_id: context.event1.id})
     result = execute_query(context.conn, new_timeline_events_query(), "timelineEvents")

--- a/test/sanbase_web/graphql/timeline/timeline_event_api_test.exs
+++ b/test/sanbase_web/graphql/timeline/timeline_event_api_test.exs
@@ -1003,6 +1003,6 @@ defmodule SanbaseWeb.Graphql.TimelineEventApiTest do
     result
     |> hd()
     |> Map.get("events", [])
-    |> Enum.map(&String.to_integer(&1["id"]))
+    |> Enum.map(& &1["id"])
   end
 end

--- a/test/sanbase_web/graphql/user/current_user_api_test.exs
+++ b/test/sanbase_web/graphql/user/current_user_api_test.exs
@@ -36,8 +36,8 @@ defmodule SanbaseWeb.Graphql.CurrentUserApiTest do
     assert result["id"] == "#{user.id}"
 
     # Insights
-    assert %{"id" => "#{post.id}"} in result["insights"]
-    assert %{"id" => "#{post2.id}"} in result["insights"]
+    assert %{"id" => post.id} in result["insights"]
+    assert %{"id" => post2.id} in result["insights"]
 
     # Triggers
     assert %{"id" => user_trigger.id} in result["triggers"]

--- a/test/sanbase_web/graphql/user/public_user_api_test.exs
+++ b/test/sanbase_web/graphql/user/public_user_api_test.exs
@@ -57,7 +57,7 @@ defmodule SanbaseWeb.Graphql.PublicUserApiTest do
                  "id" => "#{user.id}",
                  "insightsCount" => %{"totalCount" => 1, "pulseCount" => 1, "paywallCount" => 0},
                  "insights" => [
-                   %{"id" => "#{post.id}"}
+                   %{"id" => post.id}
                  ],
                  "triggers" => [],
                  "username" => "#{user.username}",


### PR DESCRIPTION
## Changes

This is the first PR in a series of PRs where we'll move the `:id` field to have type `:integer` instead of `:id`. The latter one is transported as a string. This causes the frontend to need to cast the IDs to integers. The backend also has harder time testing as the id in the DB is integer, but in the API it is string.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
