### PR TITLE
Add name to the user GQL type and DB table

### DIFF
--- a/lib/sanbase/accounts/accounts_event_emitter.ex
+++ b/lib/sanbase/accounts/accounts_event_emitter.ex
@@ -21,6 +21,11 @@ defmodule Sanbase.Accounts.EventEmitter do
     |> notify()
   end
 
+  def handle_event({:ok, user}, :update_name, %{old_name: _, new_name: _} = args) do
+    Map.merge(%{event_type: :update_name, user_id: user.id}, args)
+    |> notify()
+  end
+
   def handle_event({:ok, user}, :update_username, %{old_username: _, new_username: _} = args) do
     Map.merge(%{event_type: :update_username, user_id: user.id}, args)
     |> notify()

--- a/lib/sanbase/accounts/user.ex
+++ b/lib/sanbase/accounts/user.ex
@@ -297,6 +297,9 @@ defmodule Sanbase.Accounts.User do
     |> String.trim()
   end
 
+  defp validate_name_change(_, name), do: validate_utf8_string_field(:name, name)
+  defp validate_username_change(_, username), do: validate_ascii_or_nil_field(:username, username)
+
   defp validate_ascii_or_nil_field(name, value) when is_atom(name) do
     case ascii_string_or_nil?(value) do
       true -> []
@@ -304,8 +307,12 @@ defmodule Sanbase.Accounts.User do
     end
   end
 
-  defp validate_name_change(_, name), do: validate_ascii_or_nil_field(:name, name)
-  defp validate_username_change(_, username), do: validate_ascii_or_nil_field(:username, username)
+  defp validate_utf8_string_field(name, value) when is_atom(name) do
+    case String.valid?(value) do
+      true -> []
+      false -> [{name, "#{name} can contain is not a valid UTF-8 string."}]
+    end
+  end
 
   defp validate_email_candidate_change(_, email_candidate) do
     if Repo.get_by(User, email: email_candidate) do

--- a/lib/sanbase/accounts/user.ex
+++ b/lib/sanbase/accounts/user.ex
@@ -272,9 +272,9 @@ defmodule Sanbase.Accounts.User do
     end
   end
 
-  def ascii_string?(nil), do: true
+  def ascii_string_or_nil?(nil), do: true
 
-  def ascii_string?(username) do
+  def ascii_string_or_nil?(username) do
     username
     |> String.to_charlist()
     |> List.ascii_printable?()
@@ -297,21 +297,15 @@ defmodule Sanbase.Accounts.User do
     |> String.trim()
   end
 
-  defp validate_name_change(_, name) do
-    if ascii_string?(name) do
-      []
-    else
-      [name: "Name can contain only valid ASCII symbols."]
+  defp validate_ascii_or_nil_field(name, value) when is_atom(name) do
+    case ascii_string_or_nil?(value) do
+      true -> []
+      false -> [{name, "#{name} can contain only valid ASCII symbols."}]
     end
   end
 
-  defp validate_username_change(_, username) do
-    if ascii_string?(username) do
-      []
-    else
-      [username: "Username can contain only valid ASCII symbols."]
-    end
-  end
+  defp validate_name_change(_, name), do: validate_ascii_or_nil_field(:name, name)
+  defp validate_username_change(_, username), do: validate_ascii_or_nil_field(:username, username)
 
   defp validate_email_candidate_change(_, email_candidate) do
     if Repo.get_by(User, email: email_candidate) do

--- a/lib/sanbase/event_bus/event_validation.ex
+++ b/lib/sanbase/event_bus/event_validation.ex
@@ -9,13 +9,13 @@ defmodule Sanbase.EventBus.EventValidation do
   ## Accounts Events
   #############################################################################
   def valid?(%{event_type: :update_username, user_id: id, old_username: old, new_username: new}),
-    do: valid_integer_id?(id) and valid_string_field_change?(old, new)
+    do: valid_integer_id?(id) and valid_maybe_nil_string_field_change?(old, new)
 
   def valid?(%{event_type: :update_name, user_id: id, old_name: old, new_name: new}),
-    do: valid_integer_id?(id) and valid_string_field_change?(old, new)
+    do: valid_integer_id?(id) and valid_maybe_nil_string_field_change?(old, new)
 
   def valid?(%{event_type: :update_email, user_id: id, old_email: old, new_email: new}),
-    do: valid_integer_id?(id) and valid_string_field_change?(old, new)
+    do: valid_integer_id?(id) and valid_maybe_nil_string_field_change?(old, new)
 
   def valid?(%{event_type: :update_email_candidate, user_id: id, email_candidate: email}),
     do: valid_integer_id?(id) and is_binary(email)
@@ -200,8 +200,10 @@ defmodule Sanbase.EventBus.EventValidation do
 
   defp valid_integer_id?(id), do: is_integer(id) and id > 0
   defp valid_string_id?(id), do: is_binary(id) and id != ""
-  defp valid_string_field_change?(nil, new), do: is_binary(new)
   defp valid_string_field_change?(old, new), do: is_binary(old) and is_binary(new) and old != new
+
+  defp valid_maybe_nil_string_field_change?(old, new),
+    do: (is_nil(old) or is_binary(old)) and (is_nil(new) or is_binary(new)) and old != new
 
   defp valid_subscription_stripe_id?(%{type: :liquidity_subscription, stripe_subscription_id: id}),
     do: is_nil(id) or valid_string_id?(id)

--- a/lib/sanbase/event_bus/event_validation.ex
+++ b/lib/sanbase/event_bus/event_validation.ex
@@ -11,6 +11,9 @@ defmodule Sanbase.EventBus.EventValidation do
   def valid?(%{event_type: :update_username, user_id: id, old_username: old, new_username: new}),
     do: valid_integer_id?(id) and valid_string_field_change?(old, new)
 
+  def valid?(%{event_type: :update_name, user_id: id, old_name: old, new_name: new}),
+    do: valid_integer_id?(id) and valid_string_field_change?(old, new)
+
   def valid?(%{event_type: :update_email, user_id: id, old_email: old, new_email: new}),
     do: valid_integer_id?(id) and valid_string_field_change?(old, new)
 
@@ -197,6 +200,7 @@ defmodule Sanbase.EventBus.EventValidation do
 
   defp valid_integer_id?(id), do: is_integer(id) and id > 0
   defp valid_string_id?(id), do: is_binary(id) and id != ""
+  defp valid_string_field_change?(nil, new), do: is_binary(new)
   defp valid_string_field_change?(old, new), do: is_binary(old) and is_binary(new) and old != new
 
   defp valid_subscription_stripe_id?(%{type: :liquidity_subscription, stripe_subscription_id: id}),

--- a/lib/sanbase/event_bus/user_events_subscriber.ex
+++ b/lib/sanbase/event_bus/user_events_subscriber.ex
@@ -40,19 +40,6 @@ defmodule Sanbase.EventBus.UserEventsSubscriber do
     state
   end
 
-  defp handle_event(%{data: %{event_type: :update_email}}, event_shadow, state) do
-    # msg = "The email of sanbae has been changed"
-    # Madril.send(user, msg)
-    EventBus.mark_as_completed({__MODULE__, event_shadow})
-    state
-  end
-
-  defp handle_event(%{data: %{event_type: :update_username}}, event_shadow, state) do
-    # Do something
-    EventBus.mark_as_completed({__MODULE__, event_shadow})
-    state
-  end
-
   defp handle_event(_event, event_shadow, state) do
     # The unhandled events are marked as completed
     EventBus.mark_as_completed({__MODULE__, event_shadow})

--- a/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
@@ -144,11 +144,22 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserResolver do
     end
   end
 
-  def change_username(_root, %{username: new_username}, %{
-        context: %{auth: %{auth_method: :user_token, current_user: user}}
-      }) do
-    User.change_username(user, new_username)
-    |> case do
+  def change_name(_root, %{name: new_name}, %{context: %{auth: %{current_user: user}}}) do
+    case User.change_name(user, new_name) do
+      {:ok, user} ->
+        {:ok, user}
+
+      {:error, changeset} ->
+        {
+          :error,
+          message: "Cannot update current user's name to #{new_name}",
+          details: changeset_errors(changeset)
+        }
+    end
+  end
+
+  def change_username(_root, %{username: new_username}, %{context: %{auth: %{current_user: user}}}) do
+    case User.change_username(user, new_username) do
       {:ok, user} ->
         {:ok, user}
 

--- a/lib/sanbase_web/graphql/schema/queries/user_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/user_queries.ex
@@ -142,6 +142,13 @@ defmodule SanbaseWeb.Graphql.Schema.UserQueries do
       resolve(&UserResolver.change_username/3)
     end
 
+    field :change_name, :user do
+      arg(:name, non_null(:string))
+
+      middleware(JWTAuth)
+      resolve(&UserResolver.change_name/3)
+    end
+
     @desc ~s"""
     Add the given `address` for the currently logged in user. The `signature` and
     `message_hash` are passed to the `web3.eth.accounts.recover` function to recover

--- a/lib/sanbase_web/graphql/schema/types/user_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_types.ex
@@ -38,6 +38,7 @@ defmodule SanbaseWeb.Graphql.UserTypes do
       resolve(&UserResolver.email/3)
     end
 
+    field(:name, :string)
     field(:username, :string)
     field(:avatar_url, :string)
 
@@ -82,6 +83,7 @@ defmodule SanbaseWeb.Graphql.UserTypes do
   object :user do
     field(:id, non_null(:id))
     field(:email, :string)
+    field(:name, :string)
     field(:username, :string)
     field(:consent_id, :string)
     field(:privacy_policy_accepted, :boolean)

--- a/priv/repo/migrations/20211124075928_add_name_to_users.exs
+++ b/priv/repo/migrations/20211124075928_add_name_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Sanbase.Repo.Migrations.AddNameToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add(:name, :string, null: true)
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -3022,7 +3022,8 @@ CREATE TABLE public.users (
     avatar_url character varying(255),
     is_registered boolean DEFAULT false,
     is_superuser boolean DEFAULT false,
-    twitter_id character varying(255) DEFAULT NULL::character varying
+    twitter_id character varying(255) DEFAULT NULL::character varying,
+    name character varying(255)
 );
 
 
@@ -6934,3 +6935,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20210907104919);
 INSERT INTO public."schema_migrations" (version) VALUES (20210921100450);
 INSERT INTO public."schema_migrations" (version) VALUES (20211109131726);
 INSERT INTO public."schema_migrations" (version) VALUES (20211117104935);
+INSERT INTO public."schema_migrations" (version) VALUES (20211124075928);

--- a/test/sanbase/auth/user_test.exs
+++ b/test/sanbase/auth/user_test.exs
@@ -465,7 +465,7 @@ defmodule Sanbase.Accounts.UserTest do
     refute changeset.valid?
 
     assert errors_on(changeset)[:username] |> Enum.at(0) ==
-             "Username can contain only valid ASCII symbols."
+             "username can contain only valid ASCII symbols."
   end
 
   test "trim whitespace on username" do

--- a/test/sanbase/auth/user_test.exs
+++ b/test/sanbase/auth/user_test.exs
@@ -465,7 +465,7 @@ defmodule Sanbase.Accounts.UserTest do
     refute changeset.valid?
 
     assert errors_on(changeset)[:username] |> Enum.at(0) ==
-             "Username can contain only latin letters and numbers"
+             "Username can contain only valid ASCII symbols."
   end
 
   test "trim whitespace on username" do

--- a/test/sanbase_web/graphql/user/user_api_test.exs
+++ b/test/sanbase_web/graphql/user/user_api_test.exs
@@ -212,6 +212,21 @@ defmodule SanbaseWeb.Graphql.UserApiTest do
     end
   end
 
+  test "Change name of current user", %{conn: conn} do
+    new_name = "new_name_changed"
+
+    mutation = """
+    mutation {
+      changeName(name: "#{new_name}") {
+        name
+      }
+    }
+    """
+
+    result = execute_mutation(conn, mutation, "changeName")
+    assert result["name"] == new_name
+  end
+
   test "Change username of current user", %{conn: conn} do
     new_username = "new_username_changed"
 

--- a/test/sanbase_web/graphql/user/user_api_test.exs
+++ b/test/sanbase_web/graphql/user/user_api_test.exs
@@ -213,7 +213,8 @@ defmodule SanbaseWeb.Graphql.UserApiTest do
   end
 
   test "Change name of current user", %{conn: conn} do
-    new_name = "new_name_changed"
+    # allow non-ascii symbols as well
+    new_name = "new име utf8 José"
 
     mutation = """
     mutation {


### PR DESCRIPTION
## Changes

- Add `name` to the user type
- Add `changeName` mutation that changes the current user `name`. The mutation returns the `user` type.

```graphql
mutation {
  updateName(name: "My New Name"){
      id
      name
      username
      email
  }
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
