### PR TITLE
Unify timeline event voting

### DIFF
--- a/lib/sanbase/voting/vote.ex
+++ b/lib/sanbase/voting/vote.ex
@@ -16,15 +16,19 @@ defmodule Sanbase.Vote do
 
   @type vote_params :: %{
           :user_id => non_neg_integer(),
+          optional(:post_id) => non_neg_integer(),
+          optional(:watchlist_id) => non_neg_integer(),
           optional(:timeline_event_id) => non_neg_integer(),
-          optional(:post_id) => non_neg_integer()
+          optional(:chart_configuration_id) => non_neg_integer()
         }
 
-  @type vote_kw_list_params :: [
-          user_id: non_neg_integer(),
-          timeline_event_id: non_neg_integer(),
-          post_id: non_neg_integer()
-        ]
+  @type vote_option ::
+          {:user_id, non_neg_integer()}
+          | {:post_id, non_neg_integer()}
+          | {:watchlist_id, non_neg_integer()}
+          | {:timeline_event_id, non_neg_integer()}
+          | {:chart_configuration_id, non_neg_integer()}
+  @type vote_kw_list_params :: [vote_option]
 
   @max_votes 20
 

--- a/lib/sanbase_web/graphql/dataloader/postgres_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/postgres_dataloader.ex
@@ -15,6 +15,12 @@ defmodule SanbaseWeb.Graphql.PostgresDataloader do
   def query(:watchlist_vote_stats, data), do: get_votes_stats(:watchlist, :watchlist_id, data)
   def query(:watchlist_voted_at, data), do: get_voted_at(:watchlist, :watchlist_id, data)
 
+  def query(:timeline_event_vote_stats, data),
+    do: get_votes_stats(:timeline_event, :timeline_event_id, data)
+
+  def query(:timeline_event_voted_at, data),
+    do: get_voted_at(:timeline_event, :timeline_event_id, data)
+
   def query(:chart_configuration_vote_stats, data),
     do: get_votes_stats(:chart_configuration, :chart_configuration_id, data)
 

--- a/lib/sanbase_web/graphql/dataloader/sanbase_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/sanbase_dataloader.ex
@@ -59,7 +59,9 @@ defmodule SanbaseWeb.Graphql.SanbaseDataloader do
     :chart_configuration_vote_stats,
     :chart_configuration_voted_at,
     :watchlist_vote_stats,
-    :watchlist_voted_at
+    :watchlist_voted_at,
+    :timeline_event_vote_stats,
+    :timeline_event_voted_at
   ]
   @postgres_dataloader [
     :current_user_address_details,

--- a/lib/sanbase_web/graphql/schema/queries/vote_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/vote_queries.ex
@@ -18,6 +18,7 @@ defmodule SanbaseWeb.Graphql.Schema.VoteQueries do
       arg(:post_id, :integer, deprecate: "Use `insightId` instead")
       arg(:insight_id, :integer)
       arg(:watchlist_id, :integer)
+      arg(:timeline_event_id, :integer)
       arg(:chart_configuration_id, :integer)
 
       middleware(JWTAuth)
@@ -31,6 +32,7 @@ defmodule SanbaseWeb.Graphql.Schema.VoteQueries do
       arg(:post_id, :integer, deprecate: "Use `insightId` instead")
       arg(:insight_id, :integer)
       arg(:watchlist_id, :integer)
+      arg(:timeline_event_id, :integer)
       arg(:chart_configuration_id, :integer)
 
       middleware(JWTAuth)

--- a/priv/repo/migrations/20211126144929_add_watchlsit_votes.exs
+++ b/priv/repo/migrations/20211126144929_add_watchlsit_votes.exs
@@ -1,0 +1,40 @@
+defmodule Sanbase.Repo.Migrations.AddWatchlsitVotes do
+  use Ecto.Migration
+
+  @table :votes
+  def up do
+    alter table(@table) do
+      add(:watchlist_id, references(:user_lists), null: true)
+    end
+
+    fk_check = """
+    (CASE WHEN post_id IS NULL THEN 0 ELSE 1 END) +
+    (CASE WHEN timeline_event_id IS NULL THEN 0 ELSE 1 END) +
+    (CASE WHEN chart_configuration_id IS NULL THEN 0 ELSE 1 END) +
+    (CASE WHEN watchlist_id IS NULL THEN 0 ELSE 1 END) = 1
+    """
+
+    drop(constraint(@table, "only_one_fk"))
+    create(constraint(@table, :only_one_fk, check: fk_check))
+
+    create(unique_index(@table, [:watchlist_id, :user_id]))
+  end
+
+  def down do
+    fk_check = """
+    (CASE WHEN post_id IS NULL THEN 0 ELSE 1 END) +
+    (CASE WHEN timeline_event_id IS NULL THEN 0 ELSE 1 END) +
+    (CASE WHEN chart_configuration_id IS NULL THEN 0 ELSE 1 END) = 1
+    """
+
+    drop(constraint(@table, "only_one_fk"))
+
+    create(constraint(@table, :only_one_fk, check: fk_check))
+
+    drop(unique_index(@table, [:watchlist_id, :user_id]))
+
+    alter table(@table) do
+      remove(:watchlist_id)
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Add timeline event voting to the vote/unvote API used by all of the other entities (insight, watchlist, chart configuration) instead of using custom API for that.

```graphql
mutation{
  vote(timelineEventId: 5){
     votedAt
     votes { currentUserVotes totalVoters totalVotes }
   }
}
```

```graphql
{
  timelineEvent(id: 5){
    votedAt
    votes { currentUserVotes totalVoters totalVotes }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
