### PR TITLE
Add most voted api

### DIFF
--- a/lib/sanbase/comments/notification.ex
+++ b/lib/sanbase/comments/notification.ex
@@ -290,7 +290,7 @@ defmodule Sanbase.Comments.Notification do
   defp last_id(%TimelineEventComment{id: id}, _, _), do: id
 
   def feed_entity_title(timeline_event_id) do
-    Sanbase.Timeline.TimelineEvent.by_id(timeline_event_id)
+    Sanbase.Timeline.TimelineEvent.by_id!(timeline_event_id)
     |> case do
       %{post: %{title: title}} -> title
       %{user_list: %{name: name}} -> name

--- a/lib/sanbase/insight/post_ecto.ex
+++ b/lib/sanbase/insight/post_ecto.ex
@@ -1,0 +1,7 @@
+defmodule Sanbase.Insight.Post.Ecto do
+  defmacro is_public(post) do
+    quote bind_quoted: [post: post] do
+      fragment("?.ready_state = 'published' and ?.state = 'approved'", ^post)
+    end
+  end
+end

--- a/lib/sanbase/internal_services/ethauth.ex
+++ b/lib/sanbase/internal_services/ethauth.ex
@@ -1,11 +1,15 @@
 defmodule Sanbase.InternalServices.Ethauth do
   use Tesla
+
+  require Logger
   require Sanbase.Utils.Config, as: Config
 
   @san_token_decimals 1_000_000_000_000_000_000
   @tesla_opts [adapter: [recv_timeout: 15_000]]
 
   def token_decimals(contract) when is_binary(contract) do
+    Logger.info("[Ethauth] Get token decimals for #{contract}")
+
     case get(client(), "decimals", query: [contract: contract], opts: @tesla_opts) do
       {:ok, %Tesla.Env{status: 200, body: body}} ->
         Jason.decode(body)
@@ -19,6 +23,8 @@ defmodule Sanbase.InternalServices.Ethauth do
   end
 
   def total_supply(contract) when is_binary(contract) do
+    Logger.info("[Ethauth] Get total supply for #{contract}")
+
     with {:ok, %Tesla.Env{status: 200, body: body}} <-
            get(client(), "total_supply", query: [contract: contract], opts: @tesla_opts),
          {:ok, total_supply} <- Jason.decode(body),
@@ -38,6 +44,8 @@ defmodule Sanbase.InternalServices.Ethauth do
   """
   @spec verify_signature(any(), any(), any()) :: boolean() | {:error, String.t()}
   def verify_signature(signature, address, message_hash) do
+    Logger.info(["[Ethauth] Verify signature"])
+
     with {:ok, %Tesla.Env{status: 200, body: body}} <-
            get(client(), "recover",
              query: [sign: signature, hash: message_hash],
@@ -58,6 +66,8 @@ defmodule Sanbase.InternalServices.Ethauth do
   Fetch the latest SAN balance of `address`
   """
   def san_balance(address) do
+    Logger.info("[Ethauth] Get san balance for #{address}")
+
     get(client(), "san_balance", query: [addr: address], opts: @tesla_opts)
     |> case do
       {:ok, %Tesla.Env{status: 200, body: body}} ->

--- a/lib/sanbase/tag/preloader.ex
+++ b/lib/sanbase/tag/preloader.ex
@@ -9,7 +9,6 @@ defmodule Sanbase.Tag.Preloader do
 
   def order_tags([%Post{} | _] = structs) do
     structs = Repo.preload(structs, [:tags])
-
     post_id_to_ordered_tag_ids = post_id_to_ordered_tag_ids(structs)
 
     Enum.map(structs, fn

--- a/lib/sanbase/timeline/query.ex
+++ b/lib/sanbase/timeline/query.ex
@@ -20,8 +20,10 @@ defmodule Sanbase.Timeline.Query do
       on: event.user_trigger_id == ut.id,
       left_join: ul in UserList,
       on: event.user_list_id == ul.id,
+      left_join: post in Sanbase.Insight.Post,
       where:
-        not is_nil(event.post_id) or
+        (not is_nil(event.post_id) and post.ready_state == "published" and
+           post.state == "approved") or
           ul.is_public == true or
           fragment("?.trigger->>'is_public' = 'true'", ut)
     )

--- a/lib/sanbase/user_lists/user_list.ex
+++ b/lib/sanbase/user_lists/user_list.ex
@@ -104,7 +104,13 @@ defmodule Sanbase.UserList do
   end
 
   def by_id(ids) when is_list(ids) do
-    query = from(ul in __MODULE__, where: ul.id in ^ids and ul.is_public == true)
+    query =
+      from(
+        ul in __MODULE__,
+        where: ul.id in ^ids and ul.is_public == true,
+        order_by: fragment("array_position(?, ?::int)", ^ids, ul.id)
+      )
+
     {:ok, Repo.all(query)}
   end
 

--- a/lib/sanbase/user_lists/user_list.ex
+++ b/lib/sanbase/user_lists/user_list.ex
@@ -87,7 +87,14 @@ defmodule Sanbase.UserList do
     end
   end
 
-  def by_id(id) do
+  def by_id!(id) do
+    case by_id(id) do
+      {:ok, watchlist} -> watchlist
+      {:error, error} -> raise(error)
+    end
+  end
+
+  def by_id(id) when is_integer(id) or is_binary(id) do
     from(ul in __MODULE__, where: ul.id == ^id)
     |> Repo.one()
     |> case do
@@ -96,12 +103,9 @@ defmodule Sanbase.UserList do
     end
   end
 
-  def by_id!(id) do
-    by_id(id)
-    |> case do
-      {:ok, watchlist} -> watchlist
-      {:error, error} -> raise(error)
-    end
+  def by_id(ids) when is_list(ids) do
+    query = from(ul in __MODULE__, where: ul.id in ^ids and ul.is_public == true)
+    {:ok, Repo.all(query)}
   end
 
   def by_slug(slug) when is_binary(slug) do
@@ -111,6 +115,11 @@ defmodule Sanbase.UserList do
 
   def is_public?(%__MODULE__{is_public: is_public}), do: is_public
   def is_screener?(%__MODULE__{is_screener: is_screener}), do: is_screener
+
+  def public_watchlists_query(opts) do
+    from(ul in __MODULE__, where: ul.is_public == true)
+    |> maybe_filter_is_screener(opts)
+  end
 
   @doc ~s"""
   Return a list of all blockchain addresses in a watchlist.
@@ -369,6 +378,16 @@ defmodule Sanbase.UserList do
   defp filter_by_is_public_query(query, is_public) do
     query
     |> where([ul], ul.is_public == ^is_public)
+  end
+
+  defp maybe_filter_is_screener(query, opts) do
+    case Keyword.get(opts, :is_screener) do
+      nil ->
+        query
+
+      is_screener when is_screener in [true, false] ->
+        query |> where([ul], ul.is_screener == ^is_screener)
+    end
   end
 
   defp get_or_create_blockchain_address_user_pairs(input_blockchain_addresses, user) do

--- a/lib/sanbase/voting/vote.ex
+++ b/lib/sanbase/voting/vote.ex
@@ -8,11 +8,17 @@ defmodule Sanbase.Vote do
   import Ecto.Changeset
 
   alias Sanbase.Repo
+  alias Sanbase.Accounts.User
+
   alias Sanbase.Chart
   alias Sanbase.Insight.Post
-  alias Sanbase.Timeline.TimelineEvent
-  alias Sanbase.Accounts.User
   alias Sanbase.UserList
+  alias Sanbase.Timeline.TimelineEvent
+
+  require Sanbase.Insight.Post.Ecto
+  # require Sanbase.Insight.Post.Ecto
+  # require Sanbase.Timeline.TimelineEvent.Ecto
+  # require Sanbase.UserList.Ecto
 
   @type vote_params :: %{
           :user_id => non_neg_integer(),
@@ -127,6 +133,10 @@ defmodule Sanbase.Vote do
     end
   end
 
+  def get_most_voted(entity, opts) do
+    do_get_most_voted(entity, opts)
+  end
+
   def voted_at(entity_type, entity_ids, user_id) when is_integer(user_id) do
     voted_at_query(entity_type, entity_ids, user_id)
     |> Repo.all()
@@ -204,8 +214,73 @@ defmodule Sanbase.Vote do
     )
   end
 
-  defp deduce_entity_field(:post), do: :post_id
+  defp do_get_most_voted(entity, opts) do
+    {limit, offset} = Sanbase.Utils.Transform.opts_to_limit_offset(opts)
+    entity_field = deduce_entity_field(entity)
+
+    # We cannot just find the most voted entity as it could be
+    # made private at some point after getting votes. For this reason
+    # look only at entities that are public. In order to have the same
+    # result for everybody the owner of a private entity does not
+    # get their private entities in the ranking
+    public_enitiy_ids_query = public_entity_ids_query(entity)
+
+    entity_ids =
+      from(
+        vote in __MODULE__,
+        where:
+          not is_nil(field(vote, ^entity_field)) and
+            field(vote, ^entity_field) in subquery(public_enitiy_ids_query),
+        group_by: field(vote, ^entity_field),
+        select: field(vote, ^entity_field),
+        order_by: [desc: coalesce(sum(vote.count), 0)],
+        limit: ^limit,
+        offset: ^offset
+      )
+
+    entity_ids
+    |> Sanbase.Repo.all()
+    |> deduce_entity_module(entity).by_id()
+    |> case do
+      {:ok, result} -> {:ok, Enum.map(result, fn e -> %{entity => e} end)}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp public_entity_ids_query(:insight) do
+    query = Post.public_insights_query(preload?: false)
+    from(post in query, select: post.id)
+  end
+
+  defp public_entity_ids_query(:watchlist) do
+    query = UserList.public_watchlists_query(is_screener: false)
+    from(ul in query, select: ul.id)
+  end
+
+  defp public_entity_ids_query(:screener) do
+    query = UserList.public_watchlists_query(is_screener: true)
+    from(ul in query, select: ul.id)
+  end
+
+  defp public_entity_ids_query(:chart_configuration) do
+    query = Chart.Configuration.public_chart_configurations_query()
+    from(conf in query, select: conf.id)
+  end
+
+  defp public_entity_ids_query(:timeline_event) do
+    query = TimelineEvent.public_timeline_events_query()
+    from(conf in query, select: conf.id)
+  end
+
+  defp deduce_entity_module(:insight), do: Post
+  defp deduce_entity_module(:watchlist), do: UserList
+  defp deduce_entity_module(:screener), do: UserList
+  defp deduce_entity_module(:timeline_event), do: TimelineEvent
+  defp deduce_entity_module(:chart_configuration), do: Chart.Configuration
+
+  defp deduce_entity_field(:insight), do: :post_id
+  defp deduce_entity_field(:watchlist), do: :watchlist_id
+  defp deduce_entity_field(:screener), do: :watchlist_id
   defp deduce_entity_field(:timeline_event), do: :timeline_event_id
   defp deduce_entity_field(:chart_configuration), do: :chart_configuration_id
-  defp deduce_entity_field(:watchlist), do: :watchlist_id
 end

--- a/lib/sanbase_web/graphql/dataloader/postgres_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/postgres_dataloader.ex
@@ -9,8 +9,8 @@ defmodule SanbaseWeb.Graphql.PostgresDataloader do
     Dataloader.KV.new(&query/2)
   end
 
-  def query(:insight_vote_stats, data), do: get_votes_stats(:post, :post_id, data)
-  def query(:insight_voted_at, data), do: get_voted_at(:post, :post_id, data)
+  def query(:insight_vote_stats, data), do: get_votes_stats(:insight, :post_id, data)
+  def query(:insight_voted_at, data), do: get_voted_at(:insight, :post_id, data)
 
   def query(:watchlist_vote_stats, data), do: get_votes_stats(:watchlist, :watchlist_id, data)
   def query(:watchlist_voted_at, data), do: get_voted_at(:watchlist, :watchlist_id, data)

--- a/lib/sanbase_web/graphql/resolvers/timeline/timeline_event_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/timeline/timeline_event_resolver.ex
@@ -29,10 +29,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.TimelineEventResolver do
 
   def timeline_event(_root, %{id: timeline_event_id}, _resolution) do
     TimelineEvent.by_id(timeline_event_id)
-    |> case do
-      nil -> {:error, "There is no event with id #{timeline_event_id}"}
-      timeline_event -> {:ok, timeline_event}
-    end
   end
 
   def upvote_timeline_event(_root, %{timeline_event_id: timeline_event_id}, %{
@@ -40,7 +36,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.TimelineEventResolver do
       }) do
     case Vote.create(%{user_id: current_user.id, timeline_event_id: timeline_event_id}) do
       {:ok, _} ->
-        {:ok, TimelineEvent.by_id(timeline_event_id)}
+        TimelineEvent.by_id(timeline_event_id)
 
       {:error, _error} ->
         {:error, "Can't vote for event with id #{timeline_event_id}"}
@@ -52,7 +48,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.TimelineEventResolver do
       }) do
     case Vote.downvote(%{timeline_event_id: timeline_event_id, user_id: current_user.id}) do
       {:ok, _} ->
-        {:ok, TimelineEvent.by_id(timeline_event_id)}
+        TimelineEvent.by_id(timeline_event_id)
 
       {:error, _} ->
         {:error, "Can't remove vote for event with id #{timeline_event_id}"}

--- a/lib/sanbase_web/graphql/resolvers/vote_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/vote_resolver.ex
@@ -13,13 +13,19 @@ defmodule SanbaseWeb.Graphql.Resolvers.VoteResolver do
 
   require Logger
 
+  def get_most_voted(_root, args, _resolution) do
+    type = Map.get(args, :type)
+    page = Map.get(args, :page, 1)
+    page_size = Map.get(args, :page_size, 10)
+    Vote.get_most_voted(type, page: page, page_size: page_size)
+  end
+
   @doc ~s"""
     Returns a tuple `{total_votes, total_san_votes}` where:
     - `total_votes` represents the number of votes where each vote's weight is 1
     - `total_san_votes` represents the number of votes where each vote's weight is
     equal to the san balance of the voter
   """
-
   def votes(%Post{} = post, _args, %{context: %{loader: loader} = context}) do
     user = get_in(context, [:auth, :current_user]) || %User{id: nil}
     selector = %{post_id: post.id, user_id: user.id}
@@ -108,6 +114,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.VoteResolver do
 
   def voted_at(_root, _args, _context), do: {:ok, nil}
 
+  # Private functions
   defp get_votes(loader, query, selector) do
     loader
     |> Dataloader.load(SanbaseDataloader, query, selector)

--- a/lib/sanbase_web/graphql/schema/queries/vote_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/vote_queries.ex
@@ -4,6 +4,8 @@ defmodule SanbaseWeb.Graphql.Schema.VoteQueries do
   """
   use Absinthe.Schema.Notation
 
+  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 2]
+
   alias SanbaseWeb.Graphql.Resolvers.VoteResolver
   alias SanbaseWeb.Graphql.Middlewares.JWTAuth
 
@@ -14,7 +16,7 @@ defmodule SanbaseWeb.Graphql.Schema.VoteQueries do
       arg(:page, :integer)
       arg(:page_size, :integer)
 
-      resolve(&VoteResolver.get_most_voted/3)
+      cache_resolve(&VoteResolver.get_most_voted/3, ttl: 30, max_ttl_offset: 30)
     end
   end
 

--- a/lib/sanbase_web/graphql/schema/queries/vote_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/vote_queries.ex
@@ -8,6 +8,14 @@ defmodule SanbaseWeb.Graphql.Schema.VoteQueries do
   alias SanbaseWeb.Graphql.Middlewares.JWTAuth
 
   object :vote_queries do
+    field :get_most_voted, list_of(:most_voted_result) do
+      meta(access: :free)
+      arg(:type, :vote_entity)
+      arg(:page, :integer)
+      arg(:page_size, :integer)
+
+      resolve(&VoteResolver.get_most_voted/3)
+    end
   end
 
   object :vote_mutations do

--- a/lib/sanbase_web/graphql/schema/types/vote_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/vote_types.ex
@@ -3,6 +3,22 @@ defmodule SanbaseWeb.Graphql.VoteTypes do
 
   alias SanbaseWeb.Graphql.Resolvers.VoteResolver
 
+  enum :vote_entity do
+    value(:insight)
+    value(:watchlist)
+    value(:screener)
+    value(:timeline_event)
+    value(:chart_configuration)
+  end
+
+  object :most_voted_result do
+    field(:insight, :post)
+    field(:watchlist, :user_list)
+    field(:screener, :user_list)
+    field(:timeline_event, :timeline_event)
+    field(:chart_configuration, :chart_configuration)
+  end
+
   object :vote_result do
     field(:voted_at, :datetime)
 

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -75,6 +75,7 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           :get_full_url,
           :get_market_exchanges,
           :get_metric,
+          :get_most_voted,
           :get_raw_signals,
           :get_reports_by_tags,
           :get_reports,

--- a/test/sanbase_web/api_call_limit/api_call_limit_api_test.exs
+++ b/test/sanbase_web/api_call_limit/api_call_limit_api_test.exs
@@ -196,7 +196,7 @@ defmodule SanbaseWeb.ApiCallLimitTest do
       Sanbase.Parallel.map(
         1..iterations,
         fn _ ->
-          {:ok, updated} =
+          {:ok, _updated} =
             Sanbase.ApiCallLimit.update_usage_db(:user, context.user, api_calls_per_iteration)
         end,
         max_concurrency: 30

--- a/test/sanbase_web/graphql/vote/most_voted_api_test.exs
+++ b/test/sanbase_web/graphql/vote/most_voted_api_test.exs
@@ -3,7 +3,6 @@ defmodule SanbaseWeb.Graphql.MostVotedApitest do
 
   import SanbaseWeb.Graphql.TestHelpers
   import Sanbase.Factory
-  import Sanbase.TestHelpers
 
   alias Sanbase.Timeline.TimelineEvent
 
@@ -17,14 +16,18 @@ defmodule SanbaseWeb.Graphql.MostVotedApitest do
   test "get most voted insight", %{conn: conn} do
     insight1 = insert(:published_post)
     insight2 = insert(:published_post)
+    insight_without_votes1 = insert(:published_post)
+    insight_without_votes2 = insert(:published_post)
 
     for _ <- 1..10, do: vote(conn, "insightId", insight1.id)
     for _ <- 1..5, do: vote(conn, "insightId", insight2.id)
 
     result = get_most_voted(conn, :insight)
-    assert length(result) == 2
+    assert length(result) == 4
     assert Enum.at(result, 0)["insight"]["id"] == insight1.id
     assert Enum.at(result, 1)["insight"]["id"] == insight2.id
+    assert Enum.at(result, 2)["insight"]["id"] == insight_without_votes2.id
+    assert Enum.at(result, 3)["insight"]["id"] == insight_without_votes1.id
   end
 
   test "get most voted screener", %{conn: conn} do
@@ -32,15 +35,24 @@ defmodule SanbaseWeb.Graphql.MostVotedApitest do
     watchlist0 = insert(:watchlist, is_public: true, is_screener: false)
     watchlist1 = insert(:watchlist, is_public: true, is_screener: true)
     watchlist2 = insert(:watchlist, is_public: true, is_screener: true)
+    watchlist_without_votes1 = insert(:watchlist, is_public: true, is_screener: true)
+    watchlist_without_votes2 = insert(:watchlist, is_public: true, is_screener: true)
 
     for _ <- 1..20, do: vote(conn, "watchlistId", watchlist0.id)
     for _ <- 1..10, do: vote(conn, "watchlistId", watchlist1.id)
     for _ <- 1..5, do: vote(conn, "watchlistId", watchlist2.id)
 
     result = get_most_voted(conn, :screener)
-    assert length(result) == 2
+    assert length(result) == 4
     assert Enum.at(result, 0)["screener"]["id"] |> String.to_integer() == watchlist1.id
     assert Enum.at(result, 1)["screener"]["id"] |> String.to_integer() == watchlist2.id
+
+    # The entities without votes are ordered from newest to oldest
+    assert Enum.at(result, 2)["screener"]["id"] |> String.to_integer() ==
+             watchlist_without_votes2.id
+
+    assert Enum.at(result, 3)["screener"]["id"] |> String.to_integer() ==
+             watchlist_without_votes1.id
   end
 
   test "get most voted watchlist", %{conn: conn} do
@@ -48,15 +60,24 @@ defmodule SanbaseWeb.Graphql.MostVotedApitest do
     watchlist0 = insert(:watchlist, is_public: true, is_screener: true)
     watchlist1 = insert(:watchlist, is_public: true, is_screener: false)
     watchlist2 = insert(:watchlist, is_public: true, is_screener: false)
+    watchlist_without_votes1 = insert(:watchlist, is_public: true, is_screener: false)
+    watchlist_without_votes2 = insert(:watchlist, is_public: true, is_screener: false)
 
     for _ <- 1..20, do: vote(conn, "watchlistId", watchlist0.id)
     for _ <- 1..10, do: vote(conn, "watchlistId", watchlist1.id)
     for _ <- 1..5, do: vote(conn, "watchlistId", watchlist2.id)
 
     result = get_most_voted(conn, :watchlist)
-    assert length(result) == 2
+    assert length(result) == 4
     assert Enum.at(result, 0)["watchlist"]["id"] |> String.to_integer() == watchlist1.id
     assert Enum.at(result, 1)["watchlist"]["id"] |> String.to_integer() == watchlist2.id
+
+    # The entities without votes are ordered from newest to oldest
+    assert Enum.at(result, 2)["watchlist"]["id"] |> String.to_integer() ==
+             watchlist_without_votes2.id
+
+    assert Enum.at(result, 3)["watchlist"]["id"] |> String.to_integer() ==
+             watchlist_without_votes1.id
   end
 
   test "get most voted timeline event", %{conn: conn, user: user} do
@@ -68,31 +89,45 @@ defmodule SanbaseWeb.Graphql.MostVotedApitest do
 
     timeline_event1 = insert(:timeline_event, te_opts)
     timeline_event2 = insert(:timeline_event, te_opts)
+    timeline_event_without_votes1 = insert(:timeline_event, te_opts)
+    timeline_event_without_votes2 = insert(:timeline_event, te_opts)
 
     for _ <- 1..10, do: vote(conn, "timelineEventId", timeline_event1.id)
     for _ <- 1..5, do: vote(conn, "timelineEventId", timeline_event2.id)
 
     result = get_most_voted(conn, :timeline_event)
-    assert length(result) == 2
+    assert length(result) == 4
     assert Enum.at(result, 0)["timelineEvent"]["id"] == timeline_event1.id
     assert Enum.at(result, 1)["timelineEvent"]["id"] == timeline_event2.id
+    # The entities without votes are ordered from newest to oldest
+    assert Enum.at(result, 2)["timelineEvent"]["id"] == timeline_event_without_votes2.id
+    assert Enum.at(result, 3)["timelineEvent"]["id"] == timeline_event_without_votes1.id
   end
 
   test "get most voted chart configuration", %{conn: conn} do
     chart_configuration1 = insert(:chart_configuration, is_public: true)
     chart_configuration2 = insert(:chart_configuration, is_public: true)
+    chart_configuration_without_votes1 = insert(:chart_configuration, is_public: true)
+    chart_configuration_without_votes2 = insert(:chart_configuration, is_public: true)
 
     for _ <- 1..10, do: vote(conn, "chartConfigurationId", chart_configuration1.id)
     for _ <- 1..5, do: vote(conn, "chartConfigurationId", chart_configuration2.id)
 
     result = get_most_voted(conn, :chart_configuration)
-    assert length(result) == 2
+    assert length(result) == 4
 
     assert Enum.at(result, 0)["chartConfiguration"]["id"] ==
              chart_configuration1.id
 
     assert Enum.at(result, 1)["chartConfiguration"]["id"] ==
              chart_configuration2.id
+
+    # The entities without votes are ordered from newest to oldest
+    assert Enum.at(result, 2)["chartConfiguration"]["id"] ==
+             chart_configuration_without_votes2.id
+
+    assert Enum.at(result, 3)["chartConfiguration"]["id"] ==
+             chart_configuration_without_votes1.id
   end
 
   defp vote(conn, entity_key, entity_id) do

--- a/test/sanbase_web/graphql/vote/most_voted_api_test.exs
+++ b/test/sanbase_web/graphql/vote/most_voted_api_test.exs
@@ -1,0 +1,137 @@
+defmodule SanbaseWeb.Graphql.MostVotedApitest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import SanbaseWeb.Graphql.TestHelpers
+  import Sanbase.Factory
+  import Sanbase.TestHelpers
+
+  alias Sanbase.Timeline.TimelineEvent
+
+  setup do
+    user = insert(:user)
+    conn = setup_jwt_auth(build_conn(), user)
+
+    {:ok, conn: conn, user: user}
+  end
+
+  test "get most voted insight", %{conn: conn} do
+    insight1 = insert(:published_post)
+    insight2 = insert(:published_post)
+
+    for _ <- 1..10, do: vote(conn, "insightId", insight1.id)
+    for _ <- 1..5, do: vote(conn, "insightId", insight2.id)
+
+    result = get_most_voted(conn, :insight)
+    assert length(result) == 2
+    assert Enum.at(result, 0)["insight"]["id"] == insight1.id
+    assert Enum.at(result, 1)["insight"]["id"] == insight2.id
+  end
+
+  test "get most voted screener", %{conn: conn} do
+    # The non-screener should not be in the result
+    watchlist0 = insert(:watchlist, is_public: true, is_screener: false)
+    watchlist1 = insert(:watchlist, is_public: true, is_screener: true)
+    watchlist2 = insert(:watchlist, is_public: true, is_screener: true)
+
+    for _ <- 1..20, do: vote(conn, "watchlistId", watchlist0.id)
+    for _ <- 1..10, do: vote(conn, "watchlistId", watchlist1.id)
+    for _ <- 1..5, do: vote(conn, "watchlistId", watchlist2.id)
+
+    result = get_most_voted(conn, :screener)
+    assert length(result) == 2
+    assert Enum.at(result, 0)["screener"]["id"] |> String.to_integer() == watchlist1.id
+    assert Enum.at(result, 1)["screener"]["id"] |> String.to_integer() == watchlist2.id
+  end
+
+  test "get most voted watchlist", %{conn: conn} do
+    # The screener should not be in the result
+    watchlist0 = insert(:watchlist, is_public: true, is_screener: true)
+    watchlist1 = insert(:watchlist, is_public: true, is_screener: false)
+    watchlist2 = insert(:watchlist, is_public: true, is_screener: false)
+
+    for _ <- 1..20, do: vote(conn, "watchlistId", watchlist0.id)
+    for _ <- 1..10, do: vote(conn, "watchlistId", watchlist1.id)
+    for _ <- 1..5, do: vote(conn, "watchlistId", watchlist2.id)
+
+    result = get_most_voted(conn, :watchlist)
+    assert length(result) == 2
+    assert Enum.at(result, 0)["watchlist"]["id"] |> String.to_integer() == watchlist1.id
+    assert Enum.at(result, 1)["watchlist"]["id"] |> String.to_integer() == watchlist2.id
+  end
+
+  test "get most voted timeline event", %{conn: conn, user: user} do
+    te_opts = [
+      user_list: insert(:watchlist, is_public: true),
+      user: user,
+      event_type: TimelineEvent.update_watchlist_type()
+    ]
+
+    timeline_event1 = insert(:timeline_event, te_opts)
+    timeline_event2 = insert(:timeline_event, te_opts)
+
+    for _ <- 1..10, do: vote(conn, "timelineEventId", timeline_event1.id)
+    for _ <- 1..5, do: vote(conn, "timelineEventId", timeline_event2.id)
+
+    result = get_most_voted(conn, :timeline_event)
+    assert length(result) == 2
+    assert Enum.at(result, 0)["timelineEvent"]["id"] == timeline_event1.id
+    assert Enum.at(result, 1)["timelineEvent"]["id"] == timeline_event2.id
+  end
+
+  test "get most voted chart configuration", %{conn: conn} do
+    chart_configuration1 = insert(:chart_configuration, is_public: true)
+    chart_configuration2 = insert(:chart_configuration, is_public: true)
+
+    for _ <- 1..10, do: vote(conn, "chartConfigurationId", chart_configuration1.id)
+    for _ <- 1..5, do: vote(conn, "chartConfigurationId", chart_configuration2.id)
+
+    result = get_most_voted(conn, :chart_configuration)
+    assert length(result) == 2
+
+    assert Enum.at(result, 0)["chartConfiguration"]["id"] ==
+             chart_configuration1.id
+
+    assert Enum.at(result, 1)["chartConfiguration"]["id"] ==
+             chart_configuration2.id
+  end
+
+  defp vote(conn, entity_key, entity_id) do
+    mutation = """
+    mutation {
+      vote(#{entity_key}: #{entity_id}) {
+        votes{
+          totalVotes totalVoters currentUserVotes
+        }
+      }
+    }
+    """
+
+    %{} =
+      conn
+      |> post("/graphql", mutation_skeleton(mutation))
+      |> json_response(200)
+      |> get_in(["data", "vote"])
+  end
+
+  defp get_most_voted(conn, entity) do
+    query = """
+    {
+    getMostVoted(
+    type: #{entity |> Atom.to_string() |> String.upcase()}
+    page: 1
+    pageSize: 10){
+      insight{ id }
+      watchlist{ id }
+      screener{ id }
+      timelineEvent{ id }
+      chartConfiguration{ id }
+    }
+    }
+    """
+
+    conn
+    |> post("/graphql", query_skeleton(query))
+    |> json_response(200)
+    |> get_in(["data", "getMostVoted"])
+  end
+end


### PR DESCRIPTION
## Changes
```graphql
{
  getMostVoted(
    type: INSIGHT | WATCHLIST | SCREENER | TIMELINE_EVENT | CHART_CONFIGURATION
    page: 1
    pageSize: 10){
      insight{ id }
      watchlist{ id }
      screener{ id }
      timelineEvent{ id }
      chartConfiguration{ id }
    }
}
```

Only one of the fields in the result will be filled - the one that corresponds to `type`.

Note that the screener is just a watchlist with `is_screener` flag set to `true`. Voting for screener is the same as voting for insight (`vote(watchlistId: 5)`) but fetching the most voted screeners is different. The different `type` encodes this flag.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
