### PR TITLE
Add NFT Screener enabling features

### DIFF
--- a/lib/sanbase/blockchain_address/blockchain_address.ex
+++ b/lib/sanbase/blockchain_address/blockchain_address.ex
@@ -93,4 +93,20 @@ defmodule Sanbase.BlockchainAddress do
       {:error, error} -> {:error, error}
     end
   end
+
+  def blockchain_from_infrastructure("ETH"), do: "ethereum"
+  def blockchain_from_infrastructure("BTC"), do: "bitcoin"
+  def blockchain_from_infrastructure("BCH"), do: "bitcoin-cash"
+  def blockchain_from_infrastructure("LTC"), do: "litecoin"
+  def blockchain_from_infrastructure("BNB"), do: "binance"
+  def blockchain_from_infrastructure("BEP2"), do: "binance"
+  def blockchain_from_infrastructure("XRP"), do: "ripple"
+  def blockchain_from_infrastructure(_), do: :unsupported_blockchain
+
+  def infrastructure_from_blockchain("ethereum"), do: "ETH"
+  def infrastructure_from_blockchain("bitcoin"), do: "BTC"
+  def infrastructure_from_blockchain("bitcoin-cash"), do: "BCH"
+  def infrastructure_from_blockchain("litecoin"), do: "LTC"
+  def infrastructure_from_blockchain("binance"), do: "BEP2"
+  def infrastructure_from_blockchain("ripple"), do: "XRP"
 end

--- a/lib/sanbase/blockchain_address/list/blockchain_address_list_selector.ex
+++ b/lib/sanbase/blockchain_address/list/blockchain_address_list_selector.ex
@@ -57,6 +57,18 @@ defmodule Sanbase.BlockchainAddress.ListSelector do
     )
   end
 
+  defp blockchain_addresses_by_filter(%{name: "addresses_by_labels", args: args}) do
+    label_fqns = args[:label_fqns]
+    blockchain = args[:blockchain]
+
+    combinator =
+      (args[:labels_combinator] || "or") |> String.downcase() |> String.to_existing_atom()
+
+    opts = [labels_combinator: combinator, blockchain: blockchain]
+
+    Sanbase.Clickhouse.Label.addresses_by_labels(label_fqns, opts)
+  end
+
   # Fetch the top addresses ordered by their balance in descendig order. If the
   # `labels` key is present in the args, only the addresses that have one of these labels
   # are returned.

--- a/lib/sanbase/blockchain_address/metric_adapter.ex
+++ b/lib/sanbase/blockchain_address/metric_adapter.ex
@@ -3,8 +3,9 @@ defmodule Sanbase.BlockchainAddress.MetricAdapter do
 
   import Sanbase.Utils.Transform, only: [maybe_apply_function: 2, rename_map_keys: 2]
 
-  alias Sanbase.Model.Project
   alias Sanbase.Balance
+  alias Sanbase.Model.Project
+  alias Sanbase.BlockchainAddress
 
   @aggregations [:sum, :ohlc]
   @default_aggregation :sum
@@ -58,7 +59,7 @@ defmodule Sanbase.BlockchainAddress.MetricAdapter do
   @impl Sanbase.Metric.Behaviour
   def available_metrics(%{slug: slug}) do
     with {:ok, _, _, infrastructure} <- Project.contract_info_infrastructure_by_slug(slug),
-         str when is_binary(str) <- Balance.blockchain_from_infrastructure(infrastructure) do
+         <<_::binary>> <- BlockchainAddress.blockchain_from_infrastructure(infrastructure) do
       {:ok, @metrics}
     else
       _ -> {:ok, []}

--- a/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
@@ -10,7 +10,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
   import Sanbase.Utils.Transform, only: [maybe_apply_function: 2]
 
   alias Sanbase.Model.Project
-
+  alias Sanbase.BlockchainAddress
   alias Sanbase.Clickhouse.HistoricalBalance.XrpBalance
 
   @balances_aggregated_blockchains ["ethereum", "bitcoin", "bitcoin-cash", "litecoin", "binance"]
@@ -139,7 +139,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
       module: :none,
       asset: String.downcase(contract),
       contract: String.downcase(contract),
-      blockchain: Sanbase.Balance.blockchain_from_infrastructure("ETH"),
+      blockchain: BlockchainAddress.blockchain_from_infrastructure("ETH"),
       slug: Map.get(selector, :slug),
       decimals: decimals
     }
@@ -154,7 +154,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
         module: :none,
         asset: contract,
         contract: contract,
-        blockchain: Sanbase.Balance.blockchain_from_infrastructure("ETH"),
+        blockchain: BlockchainAddress.blockchain_from_infrastructure("ETH"),
         slug: slug,
         decimals: decimals
       }
@@ -167,7 +167,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
         module: :none,
         asset: contract,
         contract: contract,
-        blockchain: Sanbase.Balance.blockchain_from_infrastructure("ETH"),
+        blockchain: BlockchainAddress.blockchain_from_infrastructure("ETH"),
         slug: slug,
         decimals: decimals
       }
@@ -179,7 +179,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
       module: XrpBalance,
       asset: Map.get(selector, :currency, "XRP"),
       currency: Map.get(selector, :currency, "XRP"),
-      blockchain: Sanbase.Balance.blockchain_from_infrastructure("XRP"),
+      blockchain: BlockchainAddress.blockchain_from_infrastructure("XRP"),
       slug: "ripple",
       decimals: 0
     }
@@ -193,7 +193,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
         module: :none,
         asset: contract,
         contract: contract,
-        blockchain: Sanbase.Balance.blockchain_from_infrastructure("BTC"),
+        blockchain: BlockchainAddress.blockchain_from_infrastructure("BTC"),
         slug: slug,
         decimals: decimals
       }
@@ -208,7 +208,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
         module: :none,
         asset: contract,
         contract: contract,
-        blockchain: Sanbase.Balance.blockchain_from_infrastructure("BCH"),
+        blockchain: BlockchainAddress.blockchain_from_infrastructure("BCH"),
         slug: slug,
         decimals: decimals
       }
@@ -223,7 +223,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
         module: :none,
         asset: contract,
         contract: contract,
-        blockchain: Sanbase.Balance.blockchain_from_infrastructure("LTC"),
+        blockchain: BlockchainAddress.blockchain_from_infrastructure("LTC"),
         slug: slug,
         decimals: decimals
       }
@@ -238,7 +238,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
         module: :none,
         asset: contract,
         contract: contract,
-        blockchain: Sanbase.Balance.blockchain_from_infrastructure("BNB"),
+        blockchain: BlockchainAddress.blockchain_from_infrastructure("BNB"),
         slug: slug,
         decimals: decimals
       }

--- a/lib/sanbase/clickhouse/label.ex
+++ b/lib/sanbase/clickhouse/label.ex
@@ -3,6 +3,9 @@ defmodule Sanbase.Clickhouse.Label do
   Labeling addresses
   """
 
+  import Sanbase.Utils.Transform, only: [maybe_apply_function: 2]
+  import Sanbase.Metric.SqlQuery.Helper, only: [label_id_filter: 2]
+
   @type label :: %{
           name: String.t(),
           metadata: String.t()
@@ -21,7 +24,56 @@ defmodule Sanbase.Clickhouse.Label do
     SELECT DISTINCT(label) FROM blockchain_address_labels PREWHERE blockchain = ?1
     """
 
-    Sanbase.ClickhouseRepo.query_transform(query, [blockchain], fn [label] -> label end)
+    Sanbase.ClickhouseRepo.query_transform(query, [blockchain], fn [label] ->
+      label
+    end)
+  end
+
+  def addresses_by_labels(label_fqn_or_fqns, opts) do
+    blockchain = Keyword.get(opts, :blockchain)
+
+    label_fqns = label_fqn_or_fqns |> List.wrap() |> Enum.map(&String.downcase/1)
+
+    {query, args} = addresses_by_labels_query(label_fqns, blockchain)
+
+    Sanbase.ClickhouseRepo.query_reduce(
+      query,
+      args,
+      %{},
+      fn [address, blockchain, label_fqn], acc ->
+        Map.update(acc, {address, blockchain}, [label_fqn], &[label_fqn | &1])
+      end
+    )
+    |> maybe_apply_function(fn address_blockchain_labels_map ->
+      apply_addresses_labels_combinator(
+        address_blockchain_labels_map,
+        label_fqns,
+        opts
+      )
+    end)
+  end
+
+  defp apply_addresses_labels_combinator(
+         address_blockchain_labels_map,
+         label_fqns,
+         opts
+       ) do
+    case Keyword.get(opts, :labels_combinator, :or) do
+      :or ->
+        address_blockchain_labels_map
+
+      :and ->
+        # Reject all addresses that don't have all the required label_fqns
+        Enum.reject(address_blockchain_labels_map, fn {_address_blockchain, address_label_fqns} ->
+          Enum.any?(label_fqns, &(&1 not in address_label_fqns))
+        end)
+    end
+    |> Enum.map(fn {{address, blockchain}, _labels} ->
+      %{
+        address: address,
+        infrastructure: Sanbase.BlockchainAddress.infrastructure_from_blockchain(blockchain)
+      }
+    end)
   end
 
   def add_labels(_, []), do: {:ok, []}
@@ -32,7 +84,12 @@ defmodule Sanbase.Clickhouse.Label do
     {query, args} = addresses_labels_query(slug, blockchain, addresses)
 
     result =
-      Sanbase.ClickhouseRepo.query_reduce(query, args, %{}, fn [address, label, metadata], acc ->
+      Sanbase.ClickhouseRepo.query_reduce(query, args, %{}, fn [
+                                                                 address,
+                                                                 label,
+                                                                 metadata
+                                                               ],
+                                                               acc ->
         label = %{name: label, metadata: metadata, origin: "santiment"}
         Map.update(acc, address, [label], &[label | &1])
       end)
@@ -52,7 +109,12 @@ defmodule Sanbase.Clickhouse.Label do
     blockchain = slug_to_blockchain(slug)
     {query, args} = addresses_labels_query(slug, blockchain, addresses)
 
-    Sanbase.ClickhouseRepo.query_reduce(query, args, %{}, fn [address, label, metadata], acc ->
+    Sanbase.ClickhouseRepo.query_reduce(query, args, %{}, fn [
+                                                               address,
+                                                               label,
+                                                               metadata
+                                                             ],
+                                                             acc ->
       label = %{name: label, metadata: metadata, origin: "santiment"}
       Map.update(acc, address, [label], &[label | &1])
     end)
@@ -62,7 +124,38 @@ defmodule Sanbase.Clickhouse.Label do
 
   # For backwards compatibility, if the slug is nil treat it as ethereum blockchain
   def slug_to_blockchain(nil), do: "ethereum"
-  def slug_to_blockchain(slug), do: Sanbase.Model.Project.slug_to_blockchain(slug)
+
+  def slug_to_blockchain(slug),
+    do: Sanbase.Model.Project.slug_to_blockchain(slug)
+
+  def addresses_by_labels_query(label_fqns, _blockchain = nil) do
+    query = """
+    SELECT address, blockchain, dictGetString('default.labels_dict', 'fqn', label_id) AS label_fqn
+    FROM label_addresses
+    PREWHERE
+      #{label_id_filter(label_fqns, argument_position: 1)}
+    GROUP BY address, blockchain, label_id
+    LIMIT 20000
+    """
+
+    args = [label_fqns]
+    {query, args}
+  end
+
+  def addresses_by_labels_query(label_fqns, blockchain) do
+    query = """
+    SELECT address, blockchain, dictGetString('default.labels_dict', 'fqn', label_id) AS label_fqn
+    FROM label_addresses
+    PREWHERE
+      #{label_id_filter(label_fqns, argument_position: 1)} AND
+      blockchain = ?2
+    GROUP BY address, blockchain, label_id
+    LIMIT 20000
+    """
+
+    args = [label_fqns, blockchain]
+    {query, args}
+  end
 
   defp addresses_labels_query(slug, "ethereum", addresses) do
     query = create_addresses_labels_query(slug)

--- a/lib/sanbase/metric/sql_query_helper.ex
+++ b/lib/sanbase/metric/sql_query_helper.ex
@@ -92,6 +92,27 @@ defmodule Sanbase.Metric.SqlQuery.Helper do
     "metric_id IN ( SELECT DISTINCT(metric_id) FROM metric_metadata FINAL PREWHERE name IN (?#{arg_position}) )"
   end
 
+  def label_id_filter(label_fqn, opts) when is_binary(label_fqn) do
+    arg_position = Keyword.fetch!(opts, :argument_position)
+    "label_id = dictGetUInt64('default.label_ids_dict', 'label_id', tuple(?#{arg_position}))"
+  end
+
+  def label_id_filter(label_fqns, opts) when is_list(label_fqns) do
+    arg_position = Keyword.fetch!(opts, :argument_position)
+
+    "label_id IN (
+      SELECT dictGetUInt64('default.label_ids_dict', 'label_id', tuple(fqn)) AS label_id
+      FROM system.one
+      ARRAY JOIN [?#{arg_position}] AS fqn
+    )"
+  end
+
+  def label_id_filter(label_fqn, opts) when is_binary(label_fqn) do
+    arg_position = Keyword.fetch!(opts, :argument_position)
+
+    "label_id = ( SELECT label_id FROM label_metadata FINAL PREWHERE name = ?#{arg_position} LIMIT 1 )"
+  end
+
   # Add additional `=`/`in` filters to the query. This is mostly used with labeled
   # metrics where additional column filters must be applied.
   def additional_filters([], args, _opts), do: {"", args}

--- a/lib/sanbase/utils/list_selector_validator.ex
+++ b/lib/sanbase/utils/list_selector_validator.ex
@@ -169,6 +169,22 @@ defmodule Sanbase.Utils.ListSelector.Validator do
     end
   end
 
+  def valid_filter?(
+        :blockchain_address,
+        %{name: "addresses_by_labels", args: %{label_fqns: _} = filter}
+      ) do
+    filter_schema =
+      schema(%{
+        blockchain: spec(is_binary()),
+        labels_combinator: spec(is_binary()),
+        label_fqns: spec(is_list() and (&(length(&1) > 0)))
+      })
+
+    with {:ok, _} <- conform(filter, filter_schema) do
+      true
+    end
+  end
+
   def valid_filter?(type, filter),
     do:
       {:error,

--- a/test/sanbase_web/graphql/watchlist/blockchain_address/blockchain_address_dynamic_watchlist_test.exs
+++ b/test/sanbase_web/graphql/watchlist/blockchain_address/blockchain_address_dynamic_watchlist_test.exs
@@ -86,226 +86,361 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressDynamicWatchlistTest do
            } = error
   end
 
-  test "dynamic watchlist for selector", %{conn: conn, user: user} do
-    # Have at least 1 project that is not included in the result
-    insert(:random_erc20_project)
+  describe "top_addresses blockchain address selector" do
+    test "dynamic watchlist for selector", %{conn: conn, user: user} do
+      # Have at least 1 project that is not included in the result
+      insert(:random_erc20_project)
 
-    function = %{
-      "name" => "address_selector",
-      "args" => %{
-        "filters" => [
-          %{
-            "name" => "top_addresses",
-            "args" => %{
-              "slug" => "ethereum",
-              "page" => 1,
-              "page_size" => 2,
-              "labels" => ["centralized_exchange", "decentralized_exchange", "CEX Trader"]
+      function = %{
+        "name" => "address_selector",
+        "args" => %{
+          "filters" => [
+            %{
+              "name" => "top_addresses",
+              "args" => %{
+                "slug" => "ethereum",
+                "page" => 1,
+                "page_size" => 2,
+                "labels" => ["centralized_exchange", "decentralized_exchange", "CEX Trader"]
+              }
             }
-          }
-        ]
+          ]
+        }
       }
-    }
 
-    top_addresses_result = Enum.slice(top_addresses_result(), 0, 2)
+      top_addresses_result = Enum.slice(top_addresses_result(), 0, 2)
 
-    Sanbase.Mock.prepare_mock2(
-      &Sanbase.Balance.current_balance_top_addresses/2,
-      {:ok, top_addresses_result}
-    )
-    |> Sanbase.Mock.prepare_mock2(
-      &Sanbase.Clickhouse.Label.get_address_labels/2,
-      {:ok, labels_result()}
-    )
-    |> Sanbase.Mock.run_with_mocks(fn ->
-      result = execute_mutation(conn, create_watchlist_query(function: function))
+      Sanbase.Mock.prepare_mock2(
+        &Sanbase.Balance.current_balance_top_addresses/2,
+        {:ok, top_addresses_result}
+      )
+      |> Sanbase.Mock.prepare_mock2(
+        &Sanbase.Clickhouse.Label.get_address_labels/2,
+        {:ok, labels_result()}
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result = execute_mutation(conn, create_watchlist_query(function: function))
 
-      user_list = result["data"]["createWatchlist"]
+        user_list = result["data"]["createWatchlist"]
 
-      assert user_list["name"] == "My list"
-      assert user_list["type"] == "BLOCKCHAIN_ADDRESS"
-      assert user_list["color"] == "BLACK"
-      assert user_list["isPublic"] == false
-      assert user_list["user"]["id"] == user.id |> to_string()
+        assert user_list["name"] == "My list"
+        assert user_list["type"] == "BLOCKCHAIN_ADDRESS"
+        assert user_list["color"] == "BLACK"
+        assert user_list["isPublic"] == false
+        assert user_list["user"]["id"] == user.id |> to_string()
 
-      assert length(user_list["listItems"]) == 2
+        assert length(user_list["listItems"]) == 2
 
-      assert %{
-               "blockchainAddress" => %{
-                 "address" => "0x4269cba223b56458d72bdce36afbe48996d78f24",
-                 "infrastructure" => "ETH",
-                 "labels" => [
-                   %{"name" => "CEX Trader", "origin" => "santiment"}
-                 ]
-               }
-             } in user_list["listItems"]
+        assert %{
+                 "blockchainAddress" => %{
+                   "address" => "0x4269cba223b56458d72bdce36afbe48996d78f24",
+                   "infrastructure" => "ETH",
+                   "labels" => [
+                     %{"name" => "CEX Trader", "origin" => "santiment"}
+                   ]
+                 }
+               } in user_list["listItems"]
 
-      assert %{
-               "blockchainAddress" => %{
-                 "address" => "0xa5409ec958c83c3f309868babaca7c86dcb077c1",
-                 "infrastructure" => "ETH",
-                 "labels" => [
-                   %{"name" => "CEX Trader", "origin" => "santiment"}
-                 ]
-               }
-             } in user_list["listItems"]
-    end)
+        assert %{
+                 "blockchainAddress" => %{
+                   "address" => "0xa5409ec958c83c3f309868babaca7c86dcb077c1",
+                   "infrastructure" => "ETH",
+                   "labels" => [
+                     %{"name" => "CEX Trader", "origin" => "santiment"}
+                   ]
+                 }
+               } in user_list["listItems"]
+      end)
+    end
+
+    test "dynamic watchlist for selector with filtersCombinator OR", context do
+      %{conn: conn, user: user} = context
+      # Have at least 1 project that is not included in the result
+      insert(:random_erc20_project)
+
+      function = %{
+        "name" => "address_selector",
+        "args" => %{
+          "filters_combinator" => "or",
+          "filters" => [
+            %{
+              "name" => "top_addresses",
+              "args" => %{
+                "slug" => "ethereum",
+                "page" => 1,
+                "page_size" => 2
+              }
+            },
+            %{
+              "name" => "top_addresses",
+              "args" => %{
+                "slug" => "santiment",
+                "page" => 1,
+                "page_size" => 2
+              }
+            }
+          ]
+        }
+      }
+
+      mock_fun =
+        [
+          fn -> {:ok, Enum.slice(top_addresses_result(), 0, 2)} end,
+          fn -> {:ok, Enum.slice(top_addresses_result(), 2, 2)} end
+        ]
+        |> Sanbase.Mock.wrap_consecutives(arity: 2)
+
+      Sanbase.Mock.prepare_mock(
+        Sanbase.Balance,
+        :current_balance_top_addresses,
+        mock_fun
+      )
+      |> Sanbase.Mock.prepare_mock2(
+        &Sanbase.Clickhouse.Label.get_address_labels/2,
+        {:ok, labels_result()}
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result = execute_mutation(conn, create_watchlist_query(function: function))
+
+        user_list = result["data"]["createWatchlist"]
+
+        assert user_list["name"] == "My list"
+        assert user_list["type"] == "BLOCKCHAIN_ADDRESS"
+        assert user_list["color"] == "BLACK"
+        assert user_list["isPublic"] == false
+        assert user_list["user"]["id"] == user.id |> to_string()
+
+        assert length(user_list["listItems"]) == 4
+
+        assert %{
+                 "blockchainAddress" => %{
+                   "address" => "0x4269cba223b56458d72bdce36afbe48996d78f24",
+                   "infrastructure" => "ETH",
+                   "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
+                 }
+               } in user_list["listItems"]
+
+        assert %{
+                 "blockchainAddress" => %{
+                   "address" => "0x7125160a07a753b988839b004673c668012dd631",
+                   "infrastructure" => "ETH",
+                   "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
+                 }
+               } in user_list["listItems"]
+
+        assert %{
+                 "blockchainAddress" => %{
+                   "address" => "0xa5409ec958c83c3f309868babaca7c86dcb077c1",
+                   "infrastructure" => "ETH",
+                   "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
+                 }
+               } in user_list["listItems"]
+
+        assert %{
+                 "blockchainAddress" => %{
+                   "address" => "0xeb2629a2734e272bcc07bda959863f316f4bd4cf",
+                   "infrastructure" => "ETH",
+                   "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
+                 }
+               } in user_list["listItems"]
+      end)
+    end
+
+    test "dynamic watchlist for selector with filtersCombinator AND", context do
+      %{conn: conn, user: user} = context
+      # Have at least 1 project that is not included in the result
+      insert(:random_erc20_project)
+
+      function = %{
+        "name" => "address_selector",
+        "args" => %{
+          "filters_combinator" => "and",
+          "filters" => [
+            %{
+              "name" => "top_addresses",
+              "args" => %{
+                "slug" => "ethereum",
+                "page" => 1,
+                "page_size" => 1,
+                "threshold" => 2
+              }
+            },
+            %{
+              "name" => "top_addresses",
+              "args" => %{
+                "slug" => "santiment",
+                "page" => 1,
+                "page_size" => 1,
+                "threshold" => 2
+              }
+            }
+          ]
+        }
+      }
+
+      mock_fun =
+        [
+          fn -> {:ok, Enum.slice(top_addresses_result(), 0, 2)} end,
+          fn -> {:ok, Enum.slice(top_addresses_result(), 2, 2)} end
+        ]
+        |> Sanbase.Mock.wrap_consecutives(arity: 2)
+
+      Sanbase.Mock.prepare_mock(
+        Sanbase.Balance,
+        :current_balance_top_addresses,
+        mock_fun
+      )
+      |> Sanbase.Mock.prepare_mock2(
+        &Sanbase.Clickhouse.Label.get_address_labels/2,
+        {:ok, labels_result()}
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result = execute_mutation(conn, create_watchlist_query(function: function))
+
+        user_list = result["data"]["createWatchlist"]
+
+        assert user_list["name"] == "My list"
+        assert user_list["type"] == "BLOCKCHAIN_ADDRESS"
+        assert user_list["color"] == "BLACK"
+        assert user_list["isPublic"] == false
+        assert user_list["user"]["id"] == user.id |> to_string()
+
+        assert length(user_list["listItems"]) == 0
+      end)
+    end
   end
 
-  test "dynamic watchlist for selector with filtersCombinator OR", context do
-    %{conn: conn, user: user} = context
-    # Have at least 1 project that is not included in the result
-    insert(:random_erc20_project)
+  describe "addresses_by_labels blockchain address selector" do
+    test "dynamic watchlist for selector with labels combinator OR", context do
+      %{conn: conn} = context
+      # Have at least 1 project that is not included in the result
+      insert(:random_erc20_project)
 
-    function = %{
-      "name" => "address_selector",
-      "args" => %{
-        "filters_combinator" => "or",
-        "filters" => [
-          %{
-            "name" => "top_addresses",
-            "args" => %{
-              "slug" => "ethereum",
-              "page" => 1,
-              "page_size" => 2
+      function = %{
+        "name" => "address_selector",
+        "args" => %{
+          "filters" => [
+            %{
+              "name" => "addresses_by_labels",
+              "args" => %{
+                "blockchain" => "ethereum",
+                "label_fqns" => [
+                  "santiment/owner->bitfinex:v1",
+                  "santiment/owner->binance:v1",
+                  "santiment/whale(greenmed):v1"
+                ],
+                "labels_combinator" => "or"
+              }
             }
-          },
-          %{
-            "name" => "top_addresses",
-            "args" => %{
-              "slug" => "santiment",
-              "page" => 1,
-              "page_size" => 2
-            }
-          }
-        ]
+          ]
+        }
       }
-    }
 
-    mock_fun =
-      [
-        fn -> {:ok, Enum.slice(top_addresses_result(), 0, 2)} end,
-        fn -> {:ok, Enum.slice(top_addresses_result(), 2, 2)} end
-      ]
-      |> Sanbase.Mock.wrap_consecutives(arity: 2)
+      Sanbase.Mock.prepare_mock2(
+        &Sanbase.ClickhouseRepo.query/2,
+        {:ok, %{rows: addresses_by_labels_result()}}
+      )
+      |> Sanbase.Mock.prepare_mock2(
+        &Sanbase.Clickhouse.Label.get_address_labels/2,
+        {:ok, labels_result()}
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result = execute_mutation(conn, create_watchlist_query(function: function))
 
-    Sanbase.Mock.prepare_mock(
-      Sanbase.Balance,
-      :current_balance_top_addresses,
-      mock_fun
-    )
-    |> Sanbase.Mock.prepare_mock2(
-      &Sanbase.Clickhouse.Label.get_address_labels/2,
-      {:ok, labels_result()}
-    )
-    |> Sanbase.Mock.run_with_mocks(fn ->
-      result = execute_mutation(conn, create_watchlist_query(function: function))
+        user_list = result["data"]["createWatchlist"]
 
-      user_list = result["data"]["createWatchlist"]
+        assert length(user_list["listItems"]) == 4
 
-      assert user_list["name"] == "My list"
-      assert user_list["type"] == "BLOCKCHAIN_ADDRESS"
-      assert user_list["color"] == "BLACK"
-      assert user_list["isPublic"] == false
-      assert user_list["user"]["id"] == user.id |> to_string()
+        assert %{
+                 "blockchainAddress" => %{
+                   "address" => "0x4269cba223b56458d72bdce36afbe48996d78f24",
+                   "infrastructure" => "ETH",
+                   "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
+                 }
+               } in user_list["listItems"]
 
-      assert length(user_list["listItems"]) == 4
+        assert %{
+                 "blockchainAddress" => %{
+                   "address" => "0x7125160a07a753b988839b004673c668012dd631",
+                   "infrastructure" => "ETH",
+                   "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
+                 }
+               } in user_list["listItems"]
 
-      assert %{
-               "blockchainAddress" => %{
-                 "address" => "0x4269cba223b56458d72bdce36afbe48996d78f24",
-                 "infrastructure" => "ETH",
-                 "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
-               }
-             } in user_list["listItems"]
+        assert %{
+                 "blockchainAddress" => %{
+                   "address" => "0xa5409ec958c83c3f309868babaca7c86dcb077c1",
+                   "infrastructure" => "ETH",
+                   "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
+                 }
+               } in user_list["listItems"]
 
-      assert %{
-               "blockchainAddress" => %{
-                 "address" => "0x7125160a07a753b988839b004673c668012dd631",
-                 "infrastructure" => "ETH",
-                 "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
-               }
-             } in user_list["listItems"]
+        assert %{
+                 "blockchainAddress" => %{
+                   "address" => "0xeb2629a2734e272bcc07bda959863f316f4bd4cf",
+                   "infrastructure" => "ETH",
+                   "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
+                 }
+               } in user_list["listItems"]
+      end)
+    end
 
-      assert %{
-               "blockchainAddress" => %{
-                 "address" => "0xa5409ec958c83c3f309868babaca7c86dcb077c1",
-                 "infrastructure" => "ETH",
-                 "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
-               }
-             } in user_list["listItems"]
+    test "dynamic watchlist for selector with labels combinator AND", context do
+      %{conn: conn} = context
+      # Have at least 1 project that is not included in the result
+      insert(:random_erc20_project)
 
-      assert %{
-               "blockchainAddress" => %{
-                 "address" => "0xeb2629a2734e272bcc07bda959863f316f4bd4cf",
-                 "infrastructure" => "ETH",
-                 "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
-               }
-             } in user_list["listItems"]
-    end)
-  end
-
-  test "dynamic watchlist for selector with filtersCombinator AND", context do
-    %{conn: conn, user: user} = context
-    # Have at least 1 project that is not included in the result
-    insert(:random_erc20_project)
-
-    function = %{
-      "name" => "address_selector",
-      "args" => %{
-        "filters_combinator" => "and",
-        "filters" => [
-          %{
-            "name" => "top_addresses",
-            "args" => %{
-              "slug" => "ethereum",
-              "page" => 1,
-              "page_size" => 1,
-              "threshold" => 2
+      function = %{
+        "name" => "address_selector",
+        "args" => %{
+          "filters" => [
+            %{
+              "name" => "addresses_by_labels",
+              "args" => %{
+                "blockchain" => "ethereum",
+                "label_fqns" => [
+                  "santiment/owner->bitfinex:v1",
+                  "santiment/owner->binance:v1"
+                ],
+                "labels_combinator" => "and"
+              }
             }
-          },
-          %{
-            "name" => "top_addresses",
-            "args" => %{
-              "slug" => "santiment",
-              "page" => 1,
-              "page_size" => 1,
-              "threshold" => 2
-            }
-          }
-        ]
+          ]
+        }
       }
-    }
 
-    mock_fun =
-      [
-        fn -> {:ok, Enum.slice(top_addresses_result(), 0, 2)} end,
-        fn -> {:ok, Enum.slice(top_addresses_result(), 2, 2)} end
-      ]
-      |> Sanbase.Mock.wrap_consecutives(arity: 2)
+      Sanbase.Mock.prepare_mock2(
+        &Sanbase.ClickhouseRepo.query/2,
+        {:ok, %{rows: addresses_by_labels_result()}}
+      )
+      |> Sanbase.Mock.prepare_mock2(
+        &Sanbase.Clickhouse.Label.get_address_labels/2,
+        {:ok, labels_result()}
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result = execute_mutation(conn, create_watchlist_query(function: function))
 
-    Sanbase.Mock.prepare_mock(
-      Sanbase.Balance,
-      :current_balance_top_addresses,
-      mock_fun
-    )
-    |> Sanbase.Mock.prepare_mock2(
-      &Sanbase.Clickhouse.Label.get_address_labels/2,
-      {:ok, labels_result()}
-    )
-    |> Sanbase.Mock.run_with_mocks(fn ->
-      result = execute_mutation(conn, create_watchlist_query(function: function))
+        user_list = result["data"]["createWatchlist"]
 
-      user_list = result["data"]["createWatchlist"]
+        assert length(user_list["listItems"]) == 2
 
-      assert user_list["name"] == "My list"
-      assert user_list["type"] == "BLOCKCHAIN_ADDRESS"
-      assert user_list["color"] == "BLACK"
-      assert user_list["isPublic"] == false
-      assert user_list["user"]["id"] == user.id |> to_string()
+        assert %{
+                 "blockchainAddress" => %{
+                   "address" => "0x4269cba223b56458d72bdce36afbe48996d78f24",
+                   "infrastructure" => "ETH",
+                   "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
+                 }
+               } in user_list["listItems"]
 
-      assert length(user_list["listItems"]) == 0
-    end)
+        assert %{
+                 "blockchainAddress" => %{
+                   "address" => "0xeb2629a2734e272bcc07bda959863f316f4bd4cf",
+                   "infrastructure" => "ETH",
+                   "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
+                 }
+               } in user_list["listItems"]
+      end)
+    end
   end
 
   defp create_watchlist_query(opts) do
@@ -369,6 +504,17 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressDynamicWatchlistTest do
     conn
     |> post("/graphql", mutation_skeleton(query))
     |> json_response(200)
+  end
+
+  defp addresses_by_labels_result() do
+    [
+      ["0x4269cba223b56458d72bdce36afbe48996d78f24", "ethereum", "santiment/owner->binance:v1"],
+      ["0x4269cba223b56458d72bdce36afbe48996d78f24", "ethereum", "santiment/owner->bitfinex:v1"],
+      ["0xa5409ec958c83c3f309868babaca7c86dcb077c1", "ethereum", "santiment/owner->binance:v1"],
+      ["0xeb2629a2734e272bcc07bda959863f316f4bd4cf", "ethereum", "santiment/owner->binance:v1"],
+      ["0xeb2629a2734e272bcc07bda959863f316f4bd4cf", "ethereum", "santiment/owner->bitfinex:v1"],
+      ["0x7125160a07a753b988839b004673c668012dd631", "ethereum", "santiment/owner->binance:v1"]
+    ]
   end
 
   defp top_addresses_result() do


### PR DESCRIPTION
## Changes
- Add the `addresses_by_labels` filter. In some cases we need to filter just by labels as will be the case with the NFT screener.
```graphql
mutation {
  createWatchlist(
    type: BLOCKCHAIN_ADDRESS
    name: "My list"
    color: BLACK
    function: "{\"args\":{\"filters\":[{\"args\":{\"label_fqns\":[\"santiment/owner->binance:v1\", \"santiment/owner->bitfinex:v1\"], \"blockchain\":\"ethereum\", \"labels_combinator\": \"or\"},\"name\":\"addresses_by_labels\"}]},\"name\":\"address_selector\"}"
    isScreener: true
    ) {
     id
     name
     type
     color
     isPublic
     isScreener
     user{ id }
     listItems{
       blockchainAddress { address infrastructure labels { name origin }  }
     }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
