### PR TITLE
Add get_nft_trades_count API

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/nft_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/nft_resolver.ex
@@ -14,4 +14,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.NftResolver do
     opts = [page: page, page_size: page_size, order_by: order_by]
     Sanbase.Clickhouse.NftTrade.get_trades(label_key, from, to, opts)
   end
+
+  def get_nft_trades_count(_root, %{from: from, to: to, label_key: label_key}, _resolution) do
+    Sanbase.Clickhouse.NftTrade.get_trades_count(label_key, from, to)
+  end
 end

--- a/lib/sanbase_web/graphql/schema/queries/nft_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/nft_queries.ex
@@ -20,6 +20,15 @@ defmodule SanbaseWeb.Graphql.Schema.NftQueries do
 
       cache_resolve(&NftResolver.get_nft_trades/3, ttl: 30, max_ttl_offset: 30)
     end
+
+    field :get_nft_trades_count, :integer do
+      meta(access: :free)
+      arg(:label_key, non_null(:nft_trade_label_key))
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+
+      cache_resolve(&NftResolver.get_nft_trades_count/3, ttl: 30, max_ttl_offset: 30)
+    end
   end
 
   object :nft_mutations do

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -78,6 +78,7 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           :get_most_recent,
           :get_most_voted,
           :get_nft_trades,
+          :get_nft_trades_count,
           :get_primary_user,
           :get_raw_signals,
           :get_reports_by_tags,

--- a/test/sanbase_web/graphql/nft/nft_trades_api_test.exs
+++ b/test/sanbase_web/graphql/nft/nft_trades_api_test.exs
@@ -1,4 +1,4 @@
-defmodule SanbaseWeb.Graphql.GetNftTradesApiTest do
+defmodule SanbaseWeb.Graphql.NftTradesApiTest do
   use SanbaseWeb.ConnCase, async: true
 
   import SanbaseWeb.Graphql.TestHelpers
@@ -105,6 +105,7 @@ defmodule SanbaseWeb.Graphql.GetNftTradesApiTest do
         trxHash
         marketplace
         currencyProject { slug }
+
         amount
       }
     }


### PR DESCRIPTION
## Changes
```graphql
{
  getNftTradesCount(labelKey: NFT_INFLUENCER, from: "utc_now-30d", to: "utc_now")
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
