### PR TITLE
Add direction to the get_nft_trades API

### DIFF
--- a/lib/sanbase/clickhouse/nft/nft_trade.ex
+++ b/lib/sanbase/clickhouse/nft/nft_trade.ex
@@ -53,9 +53,15 @@ defmodule Sanbase.Clickhouse.NftTrade do
 
   defp get_trades_query(label_key, from, to, opts) do
     order_key =
-      case Keyword.get(opts, :order_by, :datetime) do
+      case Keyword.fetch!(opts, :order_by) do
         :datetime -> "dt"
         :amount -> "amount"
+      end
+
+    direction =
+      case Keyword.fetch!(opts, :direction) do
+        :asc -> "ASC"
+        :desc -> "DESC"
       end
 
     query = """
@@ -70,7 +76,7 @@ defmodule Sanbase.Clickhouse.NftTrade do
            groupArray(type) AS type
     FROM (#{label_key_dt_filtered_subquery(from_arg_position: 1, to_arg_position: 2, label_key_arg_position: 3)})
     GROUP BY tx_hash, dt, amount
-    ORDER BY #{order_key} DESC
+    ORDER BY #{order_key} #{direction}
     LIMIT ?4 OFFSET ?5
     """
 

--- a/lib/sanbase_web/graphql/resolvers/nft_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/nft_resolver.ex
@@ -7,11 +7,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.NftResolver do
           label_key: label_key,
           page: page,
           page_size: page_size,
-          order_by: order_by
+          order_by: order_by,
+          direction: direction
         },
         _resolution
       ) do
-    opts = [page: page, page_size: page_size, order_by: order_by]
+    opts = [page: page, page_size: page_size, order_by: order_by, direction: direction]
     Sanbase.Clickhouse.NftTrade.get_trades(label_key, from, to, opts)
   end
 

--- a/lib/sanbase_web/graphql/schema/queries/nft_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/nft_queries.ex
@@ -16,7 +16,8 @@ defmodule SanbaseWeb.Graphql.Schema.NftQueries do
       arg(:to, non_null(:datetime))
       arg(:page, non_null(:integer))
       arg(:page_size, non_null(:integer))
-      arg(:order_by, non_null(:nft_trades_order_by))
+      arg(:order_by, :nft_trades_order_by, default_value: :datetime)
+      arg(:direction, :sort_direction, default_value: :desc)
 
       cache_resolve(&NftResolver.get_nft_trades/3, ttl: 30, max_ttl_offset: 30)
     end
@@ -27,7 +28,10 @@ defmodule SanbaseWeb.Graphql.Schema.NftQueries do
       arg(:from, non_null(:datetime))
       arg(:to, non_null(:datetime))
 
-      cache_resolve(&NftResolver.get_nft_trades_count/3, ttl: 30, max_ttl_offset: 30)
+      cache_resolve(&NftResolver.get_nft_trades_count/3,
+        ttl: 30,
+        max_ttl_offset: 30
+      )
     end
   end
 

--- a/test/sanbase_web/graphql/nft/nft_trades_api_test.exs
+++ b/test/sanbase_web/graphql/nft/nft_trades_api_test.exs
@@ -46,8 +46,8 @@ defmodule SanbaseWeb.Graphql.NftTradesApiTest do
 
       # Because of the mock both results will be equal. This tests that both
       # order by keys are accepted
-      result_order_by_amount = get_nft_influencer_trades(conn, from, to, 1, 10, :amount)
-      result_order_by_dt = get_nft_influencer_trades(conn, from, to, 1, 10, :datetime)
+      result_order_by_amount = get_nft_influencer_trades(conn, from, to, 1, 10, :amount, :asc)
+      result_order_by_dt = get_nft_influencer_trades(conn, from, to, 1, 10, :datetime, :desc)
 
       assert result_order_by_amount == result_order_by_dt
 
@@ -88,7 +88,7 @@ defmodule SanbaseWeb.Graphql.NftTradesApiTest do
     end)
   end
 
-  defp get_nft_influencer_trades(conn, from, to, page, page_size, order_by) do
+  defp get_nft_influencer_trades(conn, from, to, page, page_size, order_by, direction) do
     query = """
     {
     getNftTrades(
@@ -97,7 +97,8 @@ defmodule SanbaseWeb.Graphql.NftTradesApiTest do
       to: "#{to}"
       page: #{page}
       pageSize: #{page_size}
-      order_by: #{order_by |> Atom.to_string() |> String.upcase()}){
+      order_by: #{order_by |> Atom.to_string() |> String.upcase()}
+      direction: #{direction |> Atom.to_string() |> String.upcase()}){
         datetime
         fromAddress { address labelKey }
         toAddress { address labelKey }
@@ -105,7 +106,6 @@ defmodule SanbaseWeb.Graphql.NftTradesApiTest do
         trxHash
         marketplace
         currencyProject { slug }
-
         amount
       }
     }


### PR DESCRIPTION
## Changes
Add `direction` argument that will choose the sorting direction. It can be `ASC` or `DESC`

```graphql
{
  getNftTrades(
    labelKey: NFT_INFLUENCER
    from: "utc_now-30d"
    to: "utc_now"
    orderBy: DATETIME
    direction: DESC
    page: 1
    pageSize: 2){
        datetime
    	fromAddress { address labelKey }
    	toAddress { address labelKey }
    	nft{ contractAddress }
    	trxHash
    	marketplace
    	currencyProject{ slug }
    	amount
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
