### PR TITLE
Add quantity to NFT trades

### DIFF
--- a/lib/sanbase_web/graphql/schema/types/nft_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/nft_types.ex
@@ -38,6 +38,7 @@ defmodule SanbaseWeb.Graphql.NftTypes do
     field(:to_address, :nft_trader)
     field(:datetime, :datetime)
     field(:amount, :float)
+    field(:quantity, :float)
     field(:nft, :nft)
   end
 end

--- a/test/sanbase_web/graphql/nft/nft_trades_api_test.exs
+++ b/test/sanbase_web/graphql/nft/nft_trades_api_test.exs
@@ -18,6 +18,7 @@ defmodule SanbaseWeb.Graphql.NftTradesApiTest do
       [
         1_638_339_408,
         18.3,
+        1.0,
         project.slug,
         "0xa497bf3e9ea849361fc78fc405861abf97ed08addb5ca4e3da688331ffa38344",
         "0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459",
@@ -30,6 +31,7 @@ defmodule SanbaseWeb.Graphql.NftTradesApiTest do
       [
         1_637_831_576,
         16.4,
+        2.0,
         project.slug,
         "0xc98a6ed5c0a139d7437d96d67e120f0ba568915daeb46182bdb27ad37367c0c8",
         "0x694cd849bc80f3f772ab9aef4be2df3af054dc6b",
@@ -56,6 +58,7 @@ defmodule SanbaseWeb.Graphql.NftTradesApiTest do
       assert result_order_by_amount == [
                %{
                  "amount" => 18.3,
+                 "quantity" => 1.0,
                  "datetime" => "2021-12-01T06:16:48Z",
                  "fromAddress" => %{
                    "address" => "0xa88ae2c098a3ad39184a4d64c6ddb39a237531b2",
@@ -75,6 +78,7 @@ defmodule SanbaseWeb.Graphql.NftTradesApiTest do
                },
                %{
                  "amount" => 16.4,
+                 "quantity" => 2.0,
                  "datetime" => "2021-11-25T09:12:56Z",
                  "fromAddress" => %{
                    "address" => "0x721931508df2764fd4f70c53da646cb8aed16ace",
@@ -115,6 +119,7 @@ defmodule SanbaseWeb.Graphql.NftTradesApiTest do
         marketplace
         currencyProject { slug }
         amount
+        quantity
       }
     }
     """


### PR DESCRIPTION
## Changes

Add the `quantity` field to the `getNftTrades` API.

```graphql
{
  getNftTrades(
    labelKey: NFT_INFLUENCER
    from: "utc_now-30d"
    to: "utc_now"
    orderBy: DATETIME
    direction: DESC
    page: 1
    pageSize: 2){
	datetime
    	fromAddress { address labelKey }
    	toAddress { address labelKey }
    	nft{ name contractAddress }
    	trxHash
    	marketplace
    	currencyProject{ slug }
    	amount
        quantity
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
