### PR TITLE
Convert blockchain addresses to interval format before checking cooldown

### DIFF
--- a/config/notifications_config.exs
+++ b/config/notifications_config.exs
@@ -11,7 +11,7 @@ config :sanbase, Sanbase.Notifications.Insight,
   insights_discord_publish_user: {:system, "INSIGHTS_DISCORD_PUBLISH_USER", "New Insight"}
 
 config :sanbase, Sanbase.Telegram,
-  bot_username: {:system, "TELEGRAM_NOTIFICATAIONS_BOT_USERNAME", "SanbaseAlertsStageBot"},
+  bot_username: {:system, "TELEGRAM_NOTIFICATAIONS_BOT_USERNAME", "SantimentSignalsStageBot"},
   telegram_endpoint: {:system, "TELEGRAM_ENDPOINT_RANDOM_STRING", "some_random_string"},
   token: {:system, "TELEGRAM_SIGNALS_BOT_TOKEN"}
 

--- a/lib/sanbase/alerts/trigger/settings/wallet_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/wallet_trigger_settings.ex
@@ -174,9 +174,21 @@ defmodule Sanbase.Alert.Trigger.WalletTriggerSettings do
     end
 
     def cache_key(%WalletTriggerSettings{} = settings) do
+      to_internal = fn target, field ->
+        case Map.get(target, field) do
+          nil -> nil
+          value -> Sanbase.BlockchainAddress.to_internal_format(value)
+        end
+      end
+
+      target =
+        settings.target
+        |> Map.replace(:address, to_internal.(settings.target, :address))
+        |> Map.replace(:eth_address, to_internal.(settings.target, :eth_address))
+
       construct_cache_key([
         settings.type,
-        settings.target,
+        target,
         settings.selector,
         settings.time_window,
         settings.operation

--- a/lib/sanbase/alerts/trigger/trigger.ex
+++ b/lib/sanbase/alerts/trigger/trigger.ex
@@ -219,6 +219,7 @@ defmodule Sanbase.Alert.Trigger do
        when is_binary(address) or is_list(address) do
     address
     |> List.wrap()
+    |> Enum.map(&Sanbase.BlockchainAddress.to_internal_format/1)
     |> remove_targets_on_cooldown(trigger, :eth_address)
   end
 
@@ -226,6 +227,7 @@ defmodule Sanbase.Alert.Trigger do
        when is_binary(address) or is_list(address) do
     address
     |> List.wrap()
+    |> Enum.map(&Sanbase.BlockchainAddress.to_internal_format/1)
     |> remove_targets_on_cooldown(trigger, :address)
   end
 

--- a/lib/sanbase/model/project_eth_address.ex
+++ b/lib/sanbase/model/project_eth_address.ex
@@ -20,7 +20,7 @@ defmodule Sanbase.Model.ProjectEthAddress do
     project_eth_address
     |> cast(attrs, [:address, :project_id, :source, :comments])
     |> validate_required([:address, :project_id])
-    |> update_change(:address, &String.downcase/1)
+    |> update_change(:address, &Sanbase.BlockchainAddress.to_internal_format/1)
     |> unique_constraint(:address)
   end
 


### PR DESCRIPTION
## Changes

This fixes the issue where the address is stored in internal format
(without casing for case-insenstive chains like Ethereum) but the check
is not performed in such way.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
