### PR TITLE
Add FOR UPDATE row-level postgres in ApiCall update

### DIFF
--- a/lib/sanbase/api_call_limit/api_call_limit.ex
+++ b/lib/sanbase/api_call_limit/api_call_limit.ex
@@ -1,7 +1,7 @@
 defmodule Sanbase.ApiCallLimit do
   use Ecto.Schema
 
-  import Ecto.Changeset
+  import Ecto.{Query, Changeset}
 
   alias Sanbase.Repo
   alias Sanbase.Accounts.User
@@ -11,7 +11,6 @@ defmodule Sanbase.ApiCallLimit do
 
   @quota_size_base Application.compile_env(:sanbase, [__MODULE__, :quota_size])
   @quota_size_max_offset Application.compile_env(:sanbase, [__MODULE__, :quota_size_max_offset])
-  @compile inline: [by_user: 1, by_remote_ip: 1]
 
   @plans_without_limits ["sanapi_enterprise", "sanapi_premium", "sanapi_custom"]
   @limits_per_month %{
@@ -54,32 +53,28 @@ defmodule Sanbase.ApiCallLimit do
   end
 
   def update_user_plan(%User{} = user) do
-    case by_user(user) do
-      nil ->
-        {:ok, nil}
+    %__MODULE__{} = acl = get_by_and_lock(:user, user)
 
-      %__MODULE__{} = acl ->
-        changeset =
-          acl
-          |> changeset(%{api_calls_limit_plan: user_to_plan(user)})
+    changeset =
+      acl
+      |> changeset(%{api_calls_limit_plan: user_to_plan(user)})
 
-        case Repo.update(changeset) do
-          {:ok, _} = result ->
-            # Clear the in-memory data for a user so the new restrictions
-            # can be picked up faster. Do this only if the plan actually changes
-            if new_plan = Ecto.Changeset.get_change(changeset, :api_calls_limit_plan) do
-              Logger.info(
-                "Updating ApiCallLimit record for user with id #{user.id}. Was: #{acl.api_calls_limit_plan}, now: #{new_plan}"
-              )
+    case Repo.update(changeset) do
+      {:ok, _} = result ->
+        # Clear the in-memory data for a user so the new restrictions
+        # can be picked up faster. Do this only if the plan actually changes
+        if new_plan = Ecto.Changeset.get_change(changeset, :api_calls_limit_plan) do
+          Logger.info(
+            "Updating ApiCallLimit record for user with id #{user.id}. Was: #{acl.api_calls_limit_plan}, now: #{new_plan}"
+          )
 
-              __MODULE__.ETS.clear_data(:user, user)
-            end
-
-            result
-
-          {:error, error} ->
-            {:error, error}
+          __MODULE__.ETS.clear_data(:user, user)
         end
+
+        result
+
+      {:error, error} ->
+        {:error, error}
     end
   end
 
@@ -89,20 +84,9 @@ defmodule Sanbase.ApiCallLimit do
   def get_quota_db(type, entity) do
     Ecto.Multi.new()
     |> Ecto.Multi.run(:get_acl, fn _repo, _changes ->
-      # {:ok, nil} | {:ok, %__MODULE__{}}
       {:ok, get_by(type, entity)}
     end)
-    |> Ecto.Multi.run(:create_acl, fn _repo, %{get_acl: acl} ->
-      case acl do
-        nil ->
-          {:ok, %__MODULE__{} = acl} = create(type, entity)
-          {:ok, acl}
-
-        %__MODULE__{} = acl ->
-          {:ok, acl}
-      end
-    end)
-    |> Ecto.Multi.run(:get_quota, fn _repo, %{create_acl: acl} ->
+    |> Ecto.Multi.run(:get_quota, fn _repo, %{get_acl: acl} ->
       do_get_quota(acl)
     end)
     |> Repo.transaction()
@@ -115,20 +99,9 @@ defmodule Sanbase.ApiCallLimit do
   def update_usage_db(type, entity, count) do
     Ecto.Multi.new()
     |> Ecto.Multi.run(:get_acl, fn _repo, _changes ->
-      # {:ok, nil} | {:ok, %__MODULE__{}}
-      {:ok, get_by(type, entity)}
+      {:ok, get_by_and_lock(type, entity)}
     end)
-    |> Ecto.Multi.run(:create_acl, fn _repo, %{get_acl: acl} ->
-      case acl do
-        nil ->
-          {:ok, %__MODULE__{} = acl} = create(type, entity)
-          {:ok, acl}
-
-        %__MODULE__{} = acl ->
-          {:ok, acl}
-      end
-    end)
-    |> Ecto.Multi.run(:update_quota, fn _repo, %{create_acl: acl} ->
+    |> Ecto.Multi.run(:update_quota, fn _repo, %{get_acl: acl} ->
       do_update_usage_db(acl, count)
     end)
     |> Repo.transaction()
@@ -177,11 +150,65 @@ defmodule Sanbase.ApiCallLimit do
     |> Repo.insert()
   end
 
-  defp get_by(:user, user), do: by_user(user)
-  defp get_by(:remote_ip, remote_ip), do: by_remote_ip(remote_ip)
+  defp get_by(:user, user) do
+    case Repo.get_by(__MODULE__, user_id: user.id) do
+      nil ->
+        {:ok, acl} = create(:user, user)
+        acl
 
-  defp by_user(%User{} = user), do: Repo.get_by(__MODULE__, user_id: user.id)
-  defp by_remote_ip(remote_ip), do: Repo.get_by(__MODULE__, remote_ip: remote_ip)
+      %__MODULE__{} = acl ->
+        acl
+    end
+  end
+
+  defp get_by(:remote_ip, remote_ip) do
+    case Repo.get_by(__MODULE__, remote_ip: remote_ip) do
+      nil ->
+        {:ok, acl} = create(:remote_ip, remote_ip)
+        acl
+
+      %__MODULE__{} = acl ->
+        acl
+    end
+  end
+
+  defp get_by_and_lock(:user, user) do
+    from(acl in __MODULE__,
+      where: acl.user_id == ^user.id,
+      lock: "FOR UPDATE"
+    )
+    |> Repo.one()
+    |> case do
+      nil ->
+        # Ensure that the result we get back has a lock. This is making more
+        # DB calls, but it should be executed only once per user/remote_ip and
+        # after that all subsequent calls should go into the second case.
+        {:ok, _acl} = create(:user, user)
+        get_by_and_lock(:user, user)
+
+      %__MODULE__{} = acl ->
+        acl
+    end
+  end
+
+  defp get_by_and_lock(:remote_ip, remote_ip) do
+    from(acl in __MODULE__,
+      where: acl.remote_ip == ^remote_ip,
+      lock: "FOR UPDATE"
+    )
+    |> Repo.one()
+    |> case do
+      nil ->
+        # Ensure that the result we get back has a lock. This is making more
+        # DB calls, but it should be executed only once per user/remote_ip and
+        # after that all subsequent calls should go into the second case.
+        {:ok, _acl} = create(:remote_ip, remote_ip)
+        get_by_and_lock(:remote_ip, remote_ip)
+
+      %__MODULE__{} = acl ->
+        acl
+    end
+  end
 
   defp get_time_str_keys() do
     now = DateTime.utc_now()


### PR DESCRIPTION
## Changes

Add a row-level lock `FOR UPDATE` when updating the API call limits in Postgres. It does not have `NOWAIT` or a skip as we need to wait and update the record if someone else (another sanbase pod) is holding the lock. This is acceptable as we have a low number of web pods (3) and we have a random-sized quota (in some range) so in case of constant traffic we won't have all 3 pods needing to update the DB at the same time.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
