### PR TITLE
Add freezing to alerts

### DIFF
--- a/config/scheduler_config.exs
+++ b/config/scheduler_config.exs
@@ -12,10 +12,11 @@ config :sanbase, Sanbase.Alerts.Scheduler,
   timeout: 30_000,
   overlap: false,
   jobs: [
-    freeze_user_alerts: [
-      schedule: "0 5 * * *",
-      task: {Sanbase.Alert.Job, :freeze_alerts, []}
-    ],
+    # Enable the freezing cron job only after the frontend handles the frozen alerts
+    # freeze_user_alerts: [
+    #   schedule: "0 5 * * *",
+    #   task: {Sanbase.Alert.Job, :freeze_alerts, []}
+    # ],
     price_volume_difference_sonar_alert: [
       schedule: "1-59/5 * * * *",
       task: {Sanbase.Alert.Scheduler, :run_alert, [Trigger.PriceVolumeDifferenceTriggerSettings]}

--- a/config/scheduler_config.exs
+++ b/config/scheduler_config.exs
@@ -12,6 +12,10 @@ config :sanbase, Sanbase.Alerts.Scheduler,
   timeout: 30_000,
   overlap: false,
   jobs: [
+    freeze_user_alerts: [
+      schedule: "0 5 * * *",
+      task: {Sanbase.Alert.Job, :freeze_alerts, []}
+    ],
     price_volume_difference_sonar_alert: [
       schedule: "1-59/5 * * * *",
       task: {Sanbase.Alert.Scheduler, :run_alert, [Trigger.PriceVolumeDifferenceTriggerSettings]}

--- a/lib/sanbase/accounts/linked_user/linked_user.ex
+++ b/lib/sanbase/accounts/linked_user/linked_user.ex
@@ -112,6 +112,14 @@ defmodule Sanbase.Accounts.LinkedUser do
     {:ok, result}
   end
 
+  def get_all_user_id_pairs() do
+    from(
+      lu in __MODULE__,
+      select: {lu.primary_user_id, lu.secondary_user_id}
+    )
+    |> Sanbase.Repo.all()
+  end
+
   def remove_linked_user_pair(primary_user_id, secondary_user_id) do
     {_num, nil} =
       from(lu in __MODULE__,

--- a/lib/sanbase/alerts/alert_job.ex
+++ b/lib/sanbase/alerts/alert_job.ex
@@ -1,0 +1,36 @@
+defmodule Sanbase.Alert.Job do
+  @days 0
+
+  import Ecto.Query
+  import Sanbase.Alert.TriggerQuery, only: [trigger_is_not_frozen: 0]
+
+  alias Sanbase.Alert.UserTrigger
+
+  def freeze_alerts() do
+    alerts =
+      from(ut in UserTrigger,
+        where: ut.inserted_at >= ago(@days, "day") and trigger_is_not_frozen()
+      )
+      |> Sanbase.Repo.all()
+
+    alerts
+    |> Enum.map(fn alert ->
+      UserTrigger.update_changeset(alert, %{trigger: %{is_frozen: true}})
+    end)
+    |> Enum.with_index()
+    |> Enum.reduce(
+      Ecto.Multi.new(),
+      fn {changeset, offset}, multi ->
+        Ecto.Multi.update(multi, offset, changeset)
+      end
+    )
+    |> Sanbase.Repo.transaction()
+    |> case do
+      {:ok, _} ->
+        :ok
+
+      {:error, _, reason, _} ->
+        {:error, reason}
+    end
+  end
+end

--- a/lib/sanbase/alerts/alert_job.ex
+++ b/lib/sanbase/alerts/alert_job.ex
@@ -1,5 +1,5 @@
 defmodule Sanbase.Alert.Job do
-  @days 0
+  @days 30
 
   import Ecto.Query
   import Sanbase.Alert.TriggerQuery, only: [trigger_is_not_frozen: 0]
@@ -7,34 +7,38 @@ defmodule Sanbase.Alert.Job do
   alias Sanbase.Alert.UserTrigger
 
   def freeze_alerts() do
-    alerts =
-      from(ut in UserTrigger,
-        where: ut.inserted_at >= ago(@days, "day") and trigger_is_not_frozen()
-      )
-      |> Sanbase.Repo.all()
-
-    alerts
+    get_alerts()
     |> Enum.chunk_every(300)
     |> Enum.each(fn alerts_chunk ->
-      multi_update_result =
-        alerts_chunk
-        |> Enum.map(fn alert ->
-          UserTrigger.update_changeset(alert, %{trigger: %{is_frozen: true}})
-        end)
-        |> Enum.with_index()
-        |> Enum.reduce(
-          Ecto.Multi.new(),
-          fn {changeset, offset}, multi -> Ecto.Multi.update(multi, offset, changeset) end
-        )
-        |> Sanbase.Repo.transaction()
-
-      case multi_update_result do
-        {:ok, _} ->
-          :ok
-
-        {:error, _, reason, _} ->
-          {:error, reason}
-      end
+      freeze_alerts(alerts_chunk)
     end)
+  end
+
+  defp get_alerts() do
+    {:ok, user_ids_mapset} = Sanbase.Billing.get_sanbase_pro_user_ids()
+
+    user_ids = Enum.to_list(user_ids_mapset)
+
+    from(ut in UserTrigger,
+      where:
+        ut.inserted_at <= ago(@days, "day") and trigger_is_not_frozen() and
+          ut.user_id not in ^user_ids
+    )
+    |> Sanbase.Repo.all()
+  end
+
+  defp freeze_alerts(alerts) do
+    multi_update_result =
+      alerts
+      |> Enum.reduce(Ecto.Multi.new(), fn alert, multi ->
+        changeset = UserTrigger.update_changeset(alert, %{trigger: %{is_frozen: true}})
+        Ecto.Multi.update(multi, alert.id, changeset)
+      end)
+      |> Sanbase.Repo.transaction()
+
+    case multi_update_result do
+      {:ok, _} -> :ok
+      {:error, _, reason, _} -> {:error, reason}
+    end
   end
 end

--- a/lib/sanbase/alerts/evaluator/scheduler.ex
+++ b/lib/sanbase/alerts/evaluator/scheduler.ex
@@ -54,6 +54,7 @@ defmodule Sanbase.Alert.Scheduler do
       type
       |> UserTrigger.get_active_triggers_by_type()
       |> filter_receivable_triggers(info_map)
+      |> filter_not_frozen_triggers(info_map)
 
     # The batches are run sequentially for now. If they start running in parallel
     # the batches creation becomes more complicated - all the alerts of a user
@@ -193,6 +194,28 @@ defmodule Sanbase.Alert.Scheduler do
     """)
   end
 
+  # Do not execute alerts that are frozen. Frozen alerts are alerts
+  # that were created more than X days ago and their owner is a free user.
+  # This is the current restriction about alerts of free users.
+  defp filter_not_frozen_triggers(user_triggers, info_map) do
+    %{type: type, run_uuid: run_uuid} = info_map
+
+    filtered =
+      Enum.reject(user_triggers, fn %{trigger: trigger} ->
+        Map.get(trigger, :is_frozen, false)
+      end)
+
+    total_count = length(user_triggers)
+    frozen_count = total_count - length(filtered)
+
+    Logger.info("""
+    [#{run_uuid}] In total #{frozen_count}/#{total_count} active receivable alerts of type \
+    #{type} are frozen and won't be processed.
+    """)
+
+    filtered
+  end
+
   defp filter_receivable_triggers(user_triggers, info_map) do
     %{type: type, run_uuid: run_uuid} = info_map
 
@@ -302,7 +325,7 @@ defmodule Sanbase.Alert.Scheduler do
 
   defp update_trigger_last_triggered(user_trigger, last_triggered) do
     {:ok, updated_user_trigger} =
-      UserTrigger.update_user_trigger(user_trigger.user, %{
+      UserTrigger.update_user_trigger(user_trigger.user.id, %{
         id: user_trigger.id,
         last_triggered: last_triggered,
         settings: user_trigger.trigger.settings

--- a/lib/sanbase/alerts/trigger/trigger.ex
+++ b/lib/sanbase/alerts/trigger/trigger.ex
@@ -36,6 +36,7 @@ defmodule Sanbase.Alert.Trigger do
   """
   use Ecto.Schema
   use Vex.Struct
+
   import Ecto.Changeset
 
   alias __MODULE__
@@ -43,6 +44,7 @@ defmodule Sanbase.Alert.Trigger do
 
   embedded_schema do
     field(:settings, :map)
+    field(:is_frozen, :boolean, default: false)
     field(:title, :string)
     field(:description, :string)
     field(:is_public, :boolean, default: false)
@@ -69,6 +71,7 @@ defmodule Sanbase.Alert.Trigger do
   @fields [
     :settings,
     :is_public,
+    :is_frozen,
     :cooldown,
     :last_triggered,
     :title,

--- a/lib/sanbase/alerts/trigger/trigger_query.ex
+++ b/lib/sanbase/alerts/trigger/trigger_query.ex
@@ -1,4 +1,12 @@
 defmodule Sanbase.Alert.TriggerQuery do
+  defmacro trigger_is_not_frozen() do
+    quote do
+      fragment("""
+      trigger->'is_frozen' = 'false'
+      """)
+    end
+  end
+
   defmacro trigger_type_is(type) do
     quote do
       fragment(

--- a/lib/sanbase/alerts/user_trigger.ex
+++ b/lib/sanbase/alerts/user_trigger.ex
@@ -69,7 +69,6 @@ defmodule Sanbase.Alert.UserTrigger do
     |> Tag.put_tags(Map.get(attrs, :trigger, %{}))
     |> cast_embed(:trigger, required: true, with: &Trigger.update_changeset/2)
     |> validate_required([:user_id, :trigger])
-    |> IO.inspect(label: "72", limit: :infinity)
   end
 
   def update_is_active(user_trigger_id, user, is_active) do
@@ -184,8 +183,6 @@ defmodule Sanbase.Alert.UserTrigger do
   """
   @spec trigger_not_frozen?(%__MODULE__{}) :: true | {:error, String.t()}
   def trigger_not_frozen?(%__MODULE__{} = user_trigger) do
-    IO.inspect(user_trigger.trigger, lablel: "trigger")
-
     case Map.get(user_trigger.trigger, :is_frozen, false) do
       false -> true
       true -> {:error, "The trigger with id #{user_trigger.id} is frozen."}
@@ -249,8 +246,6 @@ defmodule Sanbase.Alert.UserTrigger do
     with {_, :ok} <- {:valid?, valid_or_nil?(settings)},
          {_, {:ok, %__MODULE__{} = struct}} <-
            {:get_trigger, get_trigger_by_if_owner(user_id, trigger_id)} do
-      IO.inspect({params, clean_params(params)}, label: "PARAMS")
-
       update_result =
         struct
         |> update_changeset(%{trigger: clean_params(params)})

--- a/lib/sanbase/alerts/user_trigger.ex
+++ b/lib/sanbase/alerts/user_trigger.ex
@@ -69,6 +69,7 @@ defmodule Sanbase.Alert.UserTrigger do
     |> Tag.put_tags(Map.get(attrs, :trigger, %{}))
     |> cast_embed(:trigger, required: true, with: &Trigger.update_changeset/2)
     |> validate_required([:user_id, :trigger])
+    |> IO.inspect(label: "72", limit: :infinity)
   end
 
   def update_is_active(user_trigger_id, user, is_active) do
@@ -183,6 +184,8 @@ defmodule Sanbase.Alert.UserTrigger do
   """
   @spec trigger_not_frozen?(%__MODULE__{}) :: true | {:error, String.t()}
   def trigger_not_frozen?(%__MODULE__{} = user_trigger) do
+    IO.inspect(user_trigger.trigger, lablel: "trigger")
+
     case Map.get(user_trigger.trigger, :is_frozen, false) do
       false -> true
       true -> {:error, "The trigger with id #{user_trigger.id} is frozen."}
@@ -246,6 +249,8 @@ defmodule Sanbase.Alert.UserTrigger do
     with {_, :ok} <- {:valid?, valid_or_nil?(settings)},
          {_, {:ok, %__MODULE__{} = struct}} <-
            {:get_trigger, get_trigger_by_if_owner(user_id, trigger_id)} do
+      IO.inspect({params, clean_params(params)}, label: "PARAMS")
+
       update_result =
         struct
         |> update_changeset(%{trigger: clean_params(params)})

--- a/lib/sanbase/alerts/user_trigger.ex
+++ b/lib/sanbase/alerts/user_trigger.ex
@@ -72,7 +72,7 @@ defmodule Sanbase.Alert.UserTrigger do
   end
 
   def update_is_active(user_trigger_id, user, is_active) do
-    update_user_trigger(user, %{
+    update_user_trigger(user.id, %{
       id: user_trigger_id,
       is_active: is_active
     })
@@ -83,8 +83,8 @@ defmodule Sanbase.Alert.UserTrigger do
   The result is transformed so all trigger settings are loaded in their
   corresponding struct
   """
-  @spec triggers_for(%User{}) :: list(Trigger.t())
-  def triggers_for(%User{id: user_id}) do
+  @spec triggers_for(non_neg_integer()) :: list(%UserTrigger{})
+  def triggers_for(user_id) when is_integer(user_id) and user_id > 0 do
     user_id
     |> user_triggers_for()
   end
@@ -100,14 +100,13 @@ defmodule Sanbase.Alert.UserTrigger do
   The result is transformed so all trigger settings are loaded in their
   corresponding struct
   """
-  @spec public_triggers_for(non_neg_integer() | %User{}) :: list(Trigger.t())
-  def public_triggers_for(%User{id: user_id}), do: user_id |> public_user_triggers_for()
+  @spec public_triggers_for(non_neg_integer()) :: list(%UserTrigger{})
   def public_triggers_for(user_id), do: user_id |> public_user_triggers_for()
 
   @doc ~s"""
   Get all public triggers from the database
   """
-  @spec all_public_triggers() :: list(%__MODULE__{})
+  @spec all_public_triggers() :: list(%UserTrigger{})
   def all_public_triggers() do
     from(ut in UserTrigger, where: trigger_is_public(), preload: [:tags])
     |> Repo.all()
@@ -118,13 +117,16 @@ defmodule Sanbase.Alert.UserTrigger do
   Get the trigger that has an id `trigger_id` if and only if it is owned by the
   user with id `user_id`
   """
-  @spec get_trigger_by_id(%User{} | nil, trigger_id) :: {:ok, %UserTrigger{} | nil}
-  def get_trigger_by_id(user, trigger_id) do
-    get_trigger_by_id_query(user, trigger_id)
-    |> Repo.one()
-    |> case do
-      %UserTrigger{} = ut ->
-        {:ok, trigger_in_struct(ut)}
+  @spec get_trigger_by_id(non_neg_integer() | nil, trigger_id) :: {:ok, %UserTrigger{} | nil}
+  def get_trigger_by_id(user_id, trigger_id)
+      when is_nil(user_id) or (is_integer(user_id) and user_id > 0) do
+    user_trigger =
+      get_trigger_by_id_query(user_id, trigger_id)
+      |> Repo.one()
+
+    case user_trigger do
+      %UserTrigger{} = user_trigger ->
+        {:ok, trigger_in_struct(user_trigger)}
 
       nil ->
         {:ok, nil}
@@ -132,7 +134,7 @@ defmodule Sanbase.Alert.UserTrigger do
   end
 
   def get_trigger_by_if_owner(user_id, trigger_id) do
-    case get_trigger_by_id(%User{id: user_id}, trigger_id) do
+    case get_trigger_by_id(user_id, trigger_id) do
       {:ok, %UserTrigger{user_id: ^user_id} = user_trigger} ->
         {:ok, user_trigger}
 
@@ -173,6 +175,31 @@ defmodule Sanbase.Alert.UserTrigger do
   end
 
   @doc ~s"""
+  Check if a trigger is frozen.
+
+  Triggers get automatically frozen after a predefined number of days if
+  the user does not have a Sanbase PRO subscription. This alert restriction
+  is deprecatng the restriction of having 10 free alerts with free accounts.
+  """
+  @spec trigger_not_frozen?(%__MODULE__{}) :: true | {:error, String.t()}
+  def trigger_not_frozen?(%__MODULE__{} = user_trigger) do
+    case Map.get(user_trigger.trigger, :is_frozen, false) do
+      false -> true
+      true -> {:error, "The trigger with id #{user_trigger.id} is frozen."}
+    end
+  end
+
+  def unfreeze_user_frozen_alerts(user_id) do
+    triggers_for(user_id)
+    |> Enum.each(fn %__MODULE__{} = user_trigger ->
+      case trigger_not_frozen?(user_trigger) do
+        true -> :ok
+        _ -> update_user_trigger(user_id, %{id: user_trigger.id, is_frozen: false})
+      end
+    end)
+  end
+
+  @doc ~s"""
   Create a new user trigger that is used to fire alerts.
   To create a new trigger `settings` and `title` parameters must be present
   """
@@ -210,18 +237,21 @@ defmodule Sanbase.Alert.UserTrigger do
   Update an existing user trigger with a given UUID `trigger_id`.
   There are not required parameters.
   """
-  @spec update_user_trigger(%User{}, map()) ::
+  @spec update_user_trigger(non_neg_integer, map()) ::
           {:ok, %__MODULE__{}} | {:error, String.t()} | {:error, Ecto.Changeset.t()}
-  def update_user_trigger(%User{} = user, %{id: trigger_id} = params) do
+  def update_user_trigger(user_id, %{id: trigger_id} = params)
+      when is_integer(user_id) and user_id > 0 do
     settings = Map.get(params, :settings)
 
     with {_, :ok} <- {:valid?, valid_or_nil?(settings)},
          {_, {:ok, %__MODULE__{} = struct}} <-
-           {:get_trigger, get_trigger_by_if_owner(user.id, trigger_id)} do
-      struct
-      |> update_changeset(%{trigger: clean_params(params)})
-      |> Repo.update()
-      |> case do
+           {:get_trigger, get_trigger_by_if_owner(user_id, trigger_id)} do
+      update_result =
+        struct
+        |> update_changeset(%{trigger: clean_params(params)})
+        |> Repo.update()
+
+      case update_result do
         {:ok, ut} ->
           # Trigger a post-update process only if the settings changed
           if settings != ut.trigger.settings, do: post_update_process(ut), else: {:ok, ut}
@@ -314,7 +344,7 @@ defmodule Sanbase.Alert.UserTrigger do
     )
   end
 
-  defp get_trigger_by_id_query(%User{id: user_id}, trigger_id) do
+  defp get_trigger_by_id_query(user_id, trigger_id) do
     from(
       ut in UserTrigger,
       where: ut.id == ^trigger_id and (trigger_is_public() or ut.user_id == ^user_id),

--- a/lib/sanbase/billing/billing.ex
+++ b/lib/sanbase/billing/billing.ex
@@ -113,4 +113,25 @@ defmodule Sanbase.Billing do
       {:ok, user}
     end
   end
+
+  def get_sanbase_pro_user_ids() do
+    sanbase_user_ids_mapset =
+      Subscription.get_direct_sanbase_pro_user_ids()
+      |> MapSet.new()
+
+    linked_user_id_pairs = Sanbase.Accounts.LinkedUser.get_all_user_id_pairs()
+
+    user_ids_inherited_sanbase_pro =
+      Enum.reduce(linked_user_id_pairs, MapSet.new(), fn pair, acc ->
+        {primary_user_id, secondary_user_id} = pair
+
+        case primary_user_id in sanbase_user_ids_mapset do
+          true -> MapSet.put(acc, secondary_user_id)
+          false -> acc
+        end
+      end)
+
+    result = MapSet.union(sanbase_user_ids_mapset, user_ids_inherited_sanbase_pro)
+    {:ok, result}
+  end
 end

--- a/lib/sanbase/billing/plan/access_checker.ex
+++ b/lib/sanbase/billing/plan/access_checker.ex
@@ -209,12 +209,4 @@ defmodule Sanbase.Billing.Plan.AccessChecker do
       end
     end
   end
-
-  def user_can_create_alert?(user, subscription) do
-    subscription = subscription || @free_subscription
-
-    SanbaseAccessChecker.alerts_limits_not_reached?(user, subscription)
-  end
-
-  def alerts_limits_upgrade_message(), do: SanbaseAccessChecker.alerts_limits_upgrade_message()
 end

--- a/lib/sanbase/billing/plan/sanbase_access_checker.ex
+++ b/lib/sanbase/billing/plan/sanbase_access_checker.ex
@@ -8,11 +8,6 @@ defmodule Sanbase.Billing.Plan.SanbaseAccessChecker do
   alias Sanbase.Billing.Plan
   alias Sanbase.Alert.UserTrigger
 
-  @alerts_limits_upgrade_message """
-  You have reached the maximum number of allowed alerts for your current subscription plan.
-  Please upgrade to PRO subscription plan for unlimited alerts.
-  """
-
   @free_plan_stats %{
     historical_data_in_days: 2 * 365,
     realtime_data_cut_off_in_days: 30,
@@ -62,8 +57,6 @@ defmodule Sanbase.Billing.Plan.SanbaseAccessChecker do
       _ -> true
     end
   end
-
-  def alerts_limits_upgrade_message(), do: @alerts_limits_upgrade_message
 
   def can_access_paywalled_insights?(nil), do: false
 

--- a/lib/sanbase/billing/subscription/subscription.ex
+++ b/lib/sanbase/billing/subscription/subscription.ex
@@ -6,6 +6,7 @@ defmodule Sanbase.Billing.Subscription do
   """
   use Ecto.Schema
 
+  import Ecto.Query
   import Ecto.Changeset
   import Sanbase.Billing.EventEmitter, only: [emit_event: 3]
 
@@ -294,6 +295,14 @@ defmodule Sanbase.Billing.Subscription do
       {:ok, %__MODULE__{plan: %{name: name}}} when name in ["PRO", "PRO_PLUS"] -> name
       _ -> nil
     end
+  end
+
+  def get_direct_sanbase_pro_user_ids() do
+    __MODULE__
+    |> Query.all_active_and_trialing_subscriptions()
+    |> Query.filter_product_id(@product_sanbase)
+    |> select([sub], sub.user_id)
+    |> Sanbase.Repo.all()
   end
 
   def user_has_sanbase_pro?(user_id) do

--- a/lib/sanbase/intercom/intercom.ex
+++ b/lib/sanbase/intercom/intercom.ex
@@ -199,7 +199,7 @@ defmodule Sanbase.Intercom do
   end
 
   defp triggers_type_count(user) do
-    user
+    user.id
     |> UserTrigger.triggers_for()
     |> Enum.group_by(fn ut -> ut.trigger.settings.type end)
     |> Enum.map(fn {type, list} -> {"trigger_" <> type, length(list)} end)

--- a/lib/sanbase/kafka/in_memory_kafka/in_memory_kafka_producer.ex
+++ b/lib/sanbase/kafka/in_memory_kafka/in_memory_kafka_producer.ex
@@ -23,8 +23,6 @@ defmodule Sanbase.InMemoryKafka.Producer do
 
   @impl SanExporterEx.ProducerBehaviour
   def send_data(producer \\ @kafka_producer, topic, data) do
-    now = Timex.now()
-
     Agent.update(
       producer,
       fn state ->

--- a/lib/sanbase_web/graphql/schema/types/user_trigger_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_trigger_types.ex
@@ -24,5 +24,6 @@ defmodule SanbaseWeb.Graphql.UserTriggerTypes do
     field(:is_public, non_null(:boolean))
     field(:is_active, non_null(:boolean))
     field(:is_repeating, non_null(:boolean))
+    field(:is_frozen, non_null(:boolean))
   end
 end

--- a/priv/repo/migrations/20190408081738_migrate_old_triggers_settings_fields.exs
+++ b/priv/repo/migrations/20190408081738_migrate_old_triggers_settings_fields.exs
@@ -34,7 +34,7 @@ defmodule Sanbase.Repo.Migrations.MigrateOldTriggersSettingsFields do
   defp update_triggers(triggers) do
     triggers
     |> Enum.map(fn {user, id, settings} ->
-      UserTrigger.update_user_trigger(user, %{id: id, settings: settings})
+      UserTrigger.update_user_trigger(user.id, %{id: id, settings: settings})
     end)
   end
 

--- a/priv/repo/migrations/20190717072702_migrate_daa_signal_operations_field.exs
+++ b/priv/repo/migrations/20190717072702_migrate_daa_signal_operations_field.exs
@@ -31,7 +31,7 @@ defmodule Sanbase.Repo.Migrations.MigrateDaaAlertOperationsField do
   defp update_triggers(triggers) do
     triggers
     |> Enum.map(fn {user, id, settings} ->
-      UserTrigger.update_user_trigger(user, %{id: id, settings: settings})
+      UserTrigger.update_user_trigger(user.id, %{id: id, settings: settings})
     end)
   end
 

--- a/priv/repo/migrations/20201016091443_migrate_price_percent_change_to_metric_signals.exs
+++ b/priv/repo/migrations/20201016091443_migrate_price_percent_change_to_metric_signals.exs
@@ -25,7 +25,7 @@ defmodule Sanbase.Repo.Migrations.MigratePricePercentChangeToMetricAlerts do
       %{trigger: %{settings: settings}} = user_trigger
 
       {:ok, _} =
-        UserTrigger.update_user_trigger(user_trigger.user, %{
+        UserTrigger.update_user_trigger(user_trigger.user.id, %{
           id: user_trigger.id,
           settings: %{
             type: MetricTriggerSettings.type(),

--- a/priv/repo/migrations/20201016105225_migrate_absolute_value_price_to_metric_signal.exs
+++ b/priv/repo/migrations/20201016105225_migrate_absolute_value_price_to_metric_signal.exs
@@ -25,7 +25,7 @@ defmodule Sanbase.Repo.Migrations.MigrateAbsoluteValuePriceToMetricAlert do
       %{trigger: %{settings: settings}} = user_trigger
 
       {:ok, _} =
-        UserTrigger.update_user_trigger(user_trigger.user, %{
+        UserTrigger.update_user_trigger(user_trigger.user.id, %{
           id: user_trigger.id,
           settings: %{
             type: MetricTriggerSettings.type(),

--- a/priv/repo/migrations/20201016124426_migrate_daa_to_metric_signal.exs
+++ b/priv/repo/migrations/20201016124426_migrate_daa_to_metric_signal.exs
@@ -24,7 +24,7 @@ defmodule Sanbase.Repo.Migrations.MigrateDaaToMetricAlert do
       %{trigger: %{settings: settings}} = user_trigger
 
       {:ok, _} =
-        UserTrigger.update_user_trigger(user_trigger.user, %{
+        UserTrigger.update_user_trigger(user_trigger.user.id, %{
           id: user_trigger.id,
           settings: %{
             type: MetricTriggerSettings.type(),

--- a/priv/repo/migrations/20201110115647_migrate_wrong_wallet_movements_signals.exs
+++ b/priv/repo/migrations/20201110115647_migrate_wrong_wallet_movements_signals.exs
@@ -33,7 +33,7 @@ defmodule Sanbase.Repo.Migrations.MigrateWrongWalletMovementsAlerts do
     new_settings = %{settings | selector: %{slug: currency, infrastructure: infr}}
 
     {:ok, _} =
-      UserTrigger.update_user_trigger(user_trigger.user, %{
+      UserTrigger.update_user_trigger(user_trigger.user.id, %{
         id: user_trigger.id,
         settings: new_settings
       })
@@ -52,7 +52,7 @@ defmodule Sanbase.Repo.Migrations.MigrateWrongWalletMovementsAlerts do
     new_settings = %{settings | selector: %{infrastructure: ETH}}
 
     {:ok, _} =
-      UserTrigger.update_user_trigger(user_trigger.user, %{
+      UserTrigger.update_user_trigger(user_trigger.user.id, %{
         id: user_trigger.id,
         settings: new_settings
       })

--- a/test/sanbase/alerts/scheduler_test.exs
+++ b/test/sanbase/alerts/scheduler_test.exs
@@ -53,7 +53,7 @@ defmodule Sanbase.Alert.SchedulerTest do
   test "active is_repeating: false triggers again", context do
     %{user: user, trigger: trigger, project: project} = context
 
-    UserTrigger.update_user_trigger(user, %{
+    UserTrigger.update_user_trigger(user.id, %{
       id: trigger.id,
       cooldown: "0s",
       is_repeating: false
@@ -79,7 +79,7 @@ defmodule Sanbase.Alert.SchedulerTest do
 
       # Once triggered because of is_repeating: false, is_active
       # has been changed to false
-      UserTrigger.update_user_trigger(user, %{
+      UserTrigger.update_user_trigger(user.id, %{
         id: trigger.id,
         is_active: true
       })

--- a/test/sanbase/alerts/trending_words/trigger_trending_words_send_at_predefiend_time_test.exs
+++ b/test/sanbase/alerts/trending_words/trigger_trending_words_send_at_predefiend_time_test.exs
@@ -101,7 +101,7 @@ defmodule Sanbase.Alert.TriggerTrendingWordsSendAtPredefiendTimeTest do
   end
 
   test "Non active alerts are filtered", context do
-    UserTrigger.update_user_trigger(context.user, %{
+    UserTrigger.update_user_trigger(context.user.id, %{
       id: context.trigger_trending_words.id,
       is_active: false
     })
@@ -117,7 +117,7 @@ defmodule Sanbase.Alert.TriggerTrendingWordsSendAtPredefiendTimeTest do
         %Tesla.Env{status: 200, body: "ok"}
     end)
 
-    UserTrigger.update_user_trigger(context.user, %{
+    UserTrigger.update_user_trigger(context.user.id, %{
       id: context.trigger_trending_words.id,
       is_repeating: false
     })
@@ -131,7 +131,9 @@ defmodule Sanbase.Alert.TriggerTrendingWordsSendAtPredefiendTimeTest do
              end) =~
                "In total 1/1 trending_words alerts were sent successfully"
 
-      {:ok, ut} = UserTrigger.get_trigger_by_id(context.user, context.trigger_trending_words.id)
+      {:ok, ut} =
+        UserTrigger.get_trigger_by_id(context.user.id, context.trigger_trending_words.id)
+
       refute ut.trigger.is_active
     end
   end

--- a/test/sanbase/alerts/trigger_payload_test.exs
+++ b/test/sanbase/alerts/trigger_payload_test.exs
@@ -154,7 +154,8 @@ defmodule Sanbase.Alert.TriggerPayloadTest do
 
       trigger = trigger |> Sanbase.Repo.preload([:user])
 
-      {:ok, user_trigger} = Sanbase.Alert.UserTrigger.get_trigger_by_id(trigger.user, trigger.id)
+      {:ok, user_trigger} =
+        Sanbase.Alert.UserTrigger.get_trigger_by_id(trigger.user.id, trigger.id)
 
       last_triggered_dt =
         user_trigger.trigger.last_triggered

--- a/test/sanbase/alerts/trigger_test.exs
+++ b/test/sanbase/alerts/trigger_test.exs
@@ -41,7 +41,7 @@ defmodule Sanbase.Alert.TriggersTest do
 
     trigger_id = created_trigger.id
 
-    {:ok, %UserTrigger{trigger: trigger}} = UserTrigger.get_trigger_by_id(user, trigger_id)
+    {:ok, %UserTrigger{trigger: trigger}} = UserTrigger.get_trigger_by_id(user.id, trigger_id)
 
     settings = trigger.settings |> Map.from_struct()
     assert drop_diff_keys(settings, trigger_settings) == trigger_settings
@@ -267,7 +267,7 @@ defmodule Sanbase.Alert.TriggersTest do
       trigger: %{title: "Generic title", is_public: true, settings: trigger_settings1}
     )
 
-    assert length(UserTrigger.triggers_for(user)) == 1
+    assert length(UserTrigger.triggers_for(user.id)) == 1
 
     trigger_settings2 = %{
       type: "metric_signal",
@@ -285,7 +285,7 @@ defmodule Sanbase.Alert.TriggersTest do
         settings: trigger_settings2
       })
 
-    assert length(UserTrigger.triggers_for(user)) == 2
+    assert length(UserTrigger.triggers_for(user.id)) == 2
   end
 
   test "update trigger" do
@@ -319,7 +319,7 @@ defmodule Sanbase.Alert.TriggersTest do
       trigger: %{title: "Generic title2", is_public: true, settings: trigger_settings2}
     )
 
-    trigger_id = UserTrigger.triggers_for(user) |> hd |> Map.get(:id)
+    trigger_id = UserTrigger.triggers_for(user.id) |> hd |> Map.get(:id)
 
     updated_trigger = %{
       type: "metric_signal",
@@ -337,7 +337,7 @@ defmodule Sanbase.Alert.TriggersTest do
       "http://stage-sanbase-images.s3.amazonaws.com/uploads/_empowr-coinHY5QG72SCGKYWMN4AEJQ2BRDLXNWXECT.png"
 
     {:ok, _} =
-      UserTrigger.update_user_trigger(user, %{
+      UserTrigger.update_user_trigger(user.id, %{
         id: trigger_id,
         settings: updated_trigger,
         is_public: false,
@@ -346,7 +346,7 @@ defmodule Sanbase.Alert.TriggersTest do
         icon_url: new_icon_url
       })
 
-    triggers = UserTrigger.triggers_for(user)
+    triggers = UserTrigger.triggers_for(user.id)
 
     assert length(triggers) == 2
 
@@ -375,11 +375,11 @@ defmodule Sanbase.Alert.TriggersTest do
       trigger: %{title: "Generic title", is_public: false, settings: trigger_settings}
     )
 
-    ut = UserTrigger.triggers_for(user)
+    ut = UserTrigger.triggers_for(user.id)
     trigger_id = ut |> hd |> Map.get(:id)
 
-    UserTrigger.update_user_trigger(user, %{id: trigger_id, is_public: true, cooldown: "1h"})
-    user_triggers = UserTrigger.triggers_for(user)
+    UserTrigger.update_user_trigger(user.id, %{id: trigger_id, is_public: true, cooldown: "1h"})
+    user_triggers = UserTrigger.triggers_for(user.id)
     assert length(user_triggers) == 1
     trigger = user_triggers |> hd()
     assert trigger.trigger.is_public == true

--- a/test/sanbase_web/graphql/alerts/triggers_api_test.exs
+++ b/test/sanbase_web/graphql/alerts/triggers_api_test.exs
@@ -186,7 +186,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
       trigger: %{is_public: false, settings: trigger_settings}
     )
 
-    user_trigger = UserTrigger.triggers_for(user) |> List.first()
+    user_trigger = UserTrigger.triggers_for(user.id) |> List.first()
     trigger_id = user_trigger.id
 
     mutation =
@@ -209,7 +209,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
     |> post("/graphql", mutation_skeleton(mutation))
     |> json_response(200)
 
-    assert UserTrigger.triggers_for(user) == []
+    assert UserTrigger.triggers_for(user.id) == []
   end
 
   test "get trigger by id", %{user: user, conn: conn} do
@@ -317,16 +317,16 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
       telegram_error
     )
     |> Sanbase.Mock.run_with_mocks(fn ->
-      {:ok, ut1} = UserTrigger.get_trigger_by_id(user, trigger.id)
-      {:ok, ut2} = UserTrigger.get_trigger_by_id(user, trigger2.id)
+      {:ok, ut1} = UserTrigger.get_trigger_by_id(user.id, trigger.id)
+      {:ok, ut2} = UserTrigger.get_trigger_by_id(user.id, trigger2.id)
       assert ut1.trigger.is_active == true
       assert ut2.trigger.is_active == true
 
       Sanbase.Alert.Scheduler.run_alert(Sanbase.Alert.Trigger.MetricTriggerSettings)
 
       # Deactivate only the alert whose only channel is telegram
-      {:ok, ut1} = UserTrigger.get_trigger_by_id(user, trigger.id)
-      {:ok, ut2} = UserTrigger.get_trigger_by_id(user, trigger2.id)
+      {:ok, ut1} = UserTrigger.get_trigger_by_id(user.id, trigger.id)
+      {:ok, ut2} = UserTrigger.get_trigger_by_id(user.id, trigger2.id)
       assert ut1.trigger.is_active == false
       assert ut2.trigger.is_active == true
     end)

--- a/test/sanbase_web/graphql/alerts/update_trigger_api_test.exs
+++ b/test/sanbase_web/graphql/alerts/update_trigger_api_test.exs
@@ -6,20 +6,38 @@ defmodule SanbaseWeb.Graphql.UpdateTriggerApiTest do
 
   setup do
     user = insert(:user)
+    user2 = insert(:user)
     conn = setup_jwt_auth(build_conn(), user)
 
-    %{conn: conn, user: user}
+    %{conn: conn, user: user, user2: user2}
   end
 
-  test "cannot update others' featured trigger", context do
+  test "cannot update other users' triggers", context do
+    %{conn: conn, user2: user2} = context
     # create a trigger for a random new user
-    user_trigger = insert(:user_trigger)
-    Sanbase.FeaturedItem.update_item(user_trigger, true)
+    user_trigger = insert(:user_trigger, user: user2)
 
-    result = update_trigger(context.conn, trigger_id: user_trigger.id, is_active: true)
+    result = update_trigger(conn, trigger_id: user_trigger.id, is_active: false)
 
     assert result["errors"] |> List.first() |> Map.get("message") ==
              "The trigger with id #{user_trigger.id} does not exists or does not belong to the current user"
+  end
+
+  test "cannot update frozen triggers", context do
+    %{conn: conn, user: user} = context
+    # create a trigger for a random new user
+    user_trigger = insert(:user_trigger, user: user)
+
+    {:ok, _} =
+      Sanbase.Alert.UserTrigger.update_user_trigger(user.id, %{
+        id: user_trigger.id,
+        is_frozen: true
+      })
+
+    result = update_trigger(conn, trigger_id: user_trigger.id, is_active: false)
+
+    assert result["errors"] |> List.first() |> Map.get("message") ==
+             "The trigger with id #{user_trigger.id} is frozen"
   end
 
   defp update_trigger(conn, opts) do

--- a/test/sanbase_web/graphql/alerts/update_trigger_api_test.exs
+++ b/test/sanbase_web/graphql/alerts/update_trigger_api_test.exs
@@ -36,7 +36,7 @@ defmodule SanbaseWeb.Graphql.UpdateTriggerApiTest do
 
     result = update_trigger(conn, trigger_id: user_trigger.id, is_active: false)
 
-    assert result["errors"] |> List.first() |> Map.get("message") ==
+    assert result["errors"] |> List.first() |> Map.get("message") =~
              "The trigger with id #{user_trigger.id} is frozen"
   end
 

--- a/test/sanbase_web/graphql/alerts/update_trigger_api_test.exs
+++ b/test/sanbase_web/graphql/alerts/update_trigger_api_test.exs
@@ -19,7 +19,7 @@ defmodule SanbaseWeb.Graphql.UpdateTriggerApiTest do
     result = update_trigger(context.conn, trigger_id: user_trigger.id, is_active: true)
 
     assert result["errors"] |> List.first() |> Map.get("message") ==
-             "Trigger with id #{user_trigger.id} does not exist or is not owned by the current user"
+             "The trigger with id #{user_trigger.id} does not exists or does not belong to the current user"
   end
 
   defp update_trigger(conn, opts) do

--- a/test/sanbase_web/graphql/billing/timeframe_access_restrictions/sanbase_product_access_test.exs
+++ b/test/sanbase_web/graphql/billing/timeframe_access_restrictions/sanbase_product_access_test.exs
@@ -293,11 +293,6 @@ defmodule Sanbase.Billing.SanbaseProductAccessTest do
   end
 
   describe "for SANbase when alerts limit reached" do
-    test "user with FREE plan cannot create new trigger", context do
-      assert create_trigger_mutation_with_error(context) ==
-               SanbaseAccessChecker.alerts_limits_upgrade_message()
-    end
-
     test "user with BASIC plan can create new trigger", context do
       insert(:subscription_pro_sanbase, user: context.user)
 


### PR DESCRIPTION
## Changes

Replace the existing restrictions of 10 alerts per user for free
accounts with the freezing mechanism. Users can now have an unlimited
number of alerts but they will get frozen after a number of predefined days.
Frozen alerts cannot run and are locked for updates. They can only be
deleted. Frozen alerts get unfrozen when the user updates to the Sanbase PRO
plan.

To see if an alert is frozen, check the the `isFrozen` field
```graphql
{
  getTriggerById(id: 5) {
    trigger {
      isFrozen
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
