### PR TITLE
Add realtime price validator

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -51,6 +51,7 @@ config :sanbase, Sanbase.Repo,
   pool_size: 5
 
 config :sanbase, Sanbase.ClickhouseRepo,
+  clickhouse_repo_enabled?: false,
   pool: Ecto.Adapters.SQL.Sandbox,
   database: "sanbase_test",
   pool_size: 5

--- a/lib/sanbase/clickhouse_repo.ex
+++ b/lib/sanbase/clickhouse_repo.ex
@@ -10,7 +10,11 @@ defmodule Sanbase.ClickhouseRepo do
   require Logger
 
   def enabled?() do
-    System.get_env("CLICKHOUSE_REPO_ENABLED", "true") |> String.to_existing_atom()
+    case Config.module_get(__MODULE__, :clickhouse_repo_enabled?) do
+      true -> true
+      false -> false
+      nil -> System.get_env("CLICKHOUSE_REPO_ENABLED", "true") |> String.to_existing_atom()
+    end
   end
 
   @doc """

--- a/lib/sanbase/external_services/coinmarketcap/ticker.ex
+++ b/lib/sanbase/external_services/coinmarketcap/ticker.ex
@@ -101,57 +101,61 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.Ticker do
       json
       |> Jason.decode!()
 
-    data
-    |> Enum.map(fn project_data ->
-      %{
-        "id" => id,
-        "name" => name,
-        "symbol" => symbol,
-        "slug" => slug,
-        "cmc_rank" => rank,
-        "circulating_supply" => circulating_supply,
-        "total_supply" => total_supply,
-        "max_supply" => _max_supply,
-        "last_updated" => last_updated,
-        "quote" => %{
-          "USD" => %{
-            "price" => price_usd,
-            "volume_24h" => volume_24h_usd,
-            "market_cap" => mcap_usd,
-            "percent_change_1h" => percent_change_1h_usd,
-            "percent_change_24h" => percent_change_24h_usd,
-            "percent_change_7d" => percent_change_7d_usd
-          },
-          "BTC" => %{
-            "price" => price_btc,
-            "volume_24h" => _volume_btc,
-            "market_cap" => _mcap_btc,
-            "percent_change_1h" => _percent_change_1h_btc,
-            "percent_change_24h" => _percent_change_24h_btc,
-            "percent_change_7d" => _percent_change_7d_btc
+    data =
+      data
+      |> Enum.map(fn project_data ->
+        %{
+          "id" => id,
+          "name" => name,
+          "symbol" => symbol,
+          "slug" => slug,
+          "cmc_rank" => rank,
+          "circulating_supply" => circulating_supply,
+          "total_supply" => total_supply,
+          "max_supply" => _max_supply,
+          "last_updated" => last_updated,
+          "quote" => %{
+            "USD" => %{
+              "price" => price_usd,
+              "volume_24h" => volume_24h_usd,
+              "market_cap" => mcap_usd,
+              "percent_change_1h" => percent_change_1h_usd,
+              "percent_change_24h" => percent_change_24h_usd,
+              "percent_change_7d" => percent_change_7d_usd
+            },
+            "BTC" => %{
+              "price" => price_btc,
+              "volume_24h" => _volume_btc,
+              "market_cap" => _mcap_btc,
+              "percent_change_1h" => _percent_change_1h_btc,
+              "percent_change_24h" => _percent_change_24h_btc,
+              "percent_change_7d" => _percent_change_7d_btc
+            }
           }
-        }
-      } = project_data
+        } = project_data
 
-      %__MODULE__{
-        id: id,
-        slug: slug,
-        name: name,
-        symbol: symbol,
-        price_usd: price_usd,
-        price_btc: price_btc,
-        rank: rank,
-        volume_usd: volume_24h_usd,
-        market_cap_usd: mcap_usd,
-        last_updated: last_updated,
-        available_supply: circulating_supply,
-        total_supply: total_supply,
-        percent_change_1h: percent_change_1h_usd,
-        percent_change_24h: percent_change_24h_usd,
-        percent_change_7d: percent_change_7d_usd
-      }
-    end)
-    |> Enum.filter(fn %__MODULE__{last_updated: last_updated} -> last_updated end)
+        %__MODULE__{
+          id: id,
+          slug: slug,
+          name: name,
+          symbol: symbol,
+          price_usd: price_usd,
+          price_btc: price_btc,
+          rank: rank,
+          volume_usd: volume_24h_usd,
+          market_cap_usd: mcap_usd,
+          last_updated: last_updated,
+          available_supply: circulating_supply,
+          total_supply: total_supply,
+          percent_change_1h: percent_change_1h_usd,
+          percent_change_24h: percent_change_24h_usd,
+          percent_change_7d: percent_change_7d_usd
+        }
+      end)
+      |> Enum.filter(fn %__MODULE__{last_updated: last_updated} -> last_updated end)
+
+    require(IEx).pry
+    data
   end
 
   @spec convert_for_importing(%__MODULE__{}, %{}) :: [%Measurement{}]

--- a/lib/sanbase/external_services/coinmarketcap/ticker_fetcher.ex
+++ b/lib/sanbase/external_services/coinmarketcap/ticker_fetcher.ex
@@ -46,18 +46,16 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcher do
     # Fetch current coinmarketcap data for many tickers
     {:ok, tickers} = Ticker.fetch_data(opts)
 
+    # Create a map where the coinmarketcap_id is key and the values is the list of
+    # santiment slugs that have that coinmarketcap_id
+    cmc_id_to_slugs_mapping = coinmarketcap_to_santiment_slug_map()
+
+    tickers = remove_not_valid_prices(tickers, cmc_id_to_slugs_mapping)
+
     # Create a project if it's a new one in the top projects and we don't have it
     tickers
     |> Enum.take(top_projects_to_follow())
     |> Enum.each(&insert_or_update_project/1)
-
-    # Create a map where the coinmarketcap_id is key and the values is the list of
-    # santiment slugs that have that coinmarketcap_id
-    cmc_id_to_slugs_mapping =
-      Project.List.projects_with_source("coinmarketcap", include_hidden: true)
-      |> Enum.reduce(%{}, fn %Project{slug: slug} = project, acc ->
-        Map.update(acc, Project.coinmarketcap_id(project), [slug], fn slugs -> [slug | slugs] end)
-      end)
 
     # Store the data in LatestCoinmarketcapData in postgres
 
@@ -78,6 +76,55 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcher do
       "[CMC] Fetching realtime data from coinmarketcap done. The data is imported in the database."
     )
   end
+
+  defp coinmarketcap_to_santiment_slug_map() do
+    Project.List.projects_with_source("coinmarketcap", include_hidden: true)
+    |> Enum.reduce(%{}, fn %Project{slug: slug} = project, acc ->
+      Map.update(acc, Project.coinmarketcap_id(project), [slug], fn slugs -> [slug | slugs] end)
+    end)
+  end
+
+  defp remove_not_valid_prices(tickers, cmc_id_to_slugs_mapping) do
+    tickers
+    |> Enum.each(fn %{slug: cmc_slug, price_usd: price_usd, price_btc: price_btc} ->
+      # This implementation does not remove/change anything. It will be deployed first
+      # so we can observe the behaviour first.
+      slug = Map.get(cmc_id_to_slugs_mapping, cmc_slug)
+
+      case Sanbase.Price.Validator.valid_price?(slug, "USD", price_usd) do
+        {:error, error} -> Logger.info("[CMC] Price validation failed: #{error}")
+        _ -> :ok
+      end
+
+      case Sanbase.Price.Validator.valid_price?(slug, "BTC", price_btc) do
+        {:error, error} -> Logger.info("[CMC] Price validation failed: #{error}")
+        _ -> :ok
+      end
+    end)
+
+    tickers
+  end
+
+  # TODO: Revert to this implementation after we the debug implementation is
+  # tested and all potential issues are fixed
+  # defp remove_not_valid_prices(tickers, cmc_id_to_slugs_mapping) do
+  #   tickers
+  #   |> Enum.map(fn %{slug: cmc_slug, price_usd: price_usd, price_btc: price_btc} = ticker ->
+  #     slug = Map.get(cmc_id_to_slugs_mapping, cmc_slug)
+
+  #     ticker
+  #     |> then(fn t ->
+  #       if true == Sanbase.Price.Validator.valid_price?(slug, "USD", price_usd),
+  #         do: t,
+  #         else: Map.put(t, :price_usd, nil)
+  #     end)
+  #     |> then(fn t ->
+  #       if true == Sanbase.Price.Validator.valid_price?(slug, "BTC", price_btc),
+  #         do: t,
+  #         else: Map.put(t, :price_usd, nil)
+  #     end)
+  #   end)
+  # end
 
   defp export_to_kafka(tickers, cmc_id_to_slugs_mapping) do
     tickers

--- a/lib/sanbase/prices/price.ex
+++ b/lib/sanbase/prices/price.ex
@@ -383,6 +383,16 @@ defmodule Sanbase.Price do
     end
   end
 
+  def latest_prices_per_slug(slugs, limit_per_slug) do
+    {query, args} = latest_prices_per_slug_query(slugs, limit_per_slug)
+
+    ClickhouseRepo.query_reduce(query, args, %{}, fn [slug, prices_usd, prices_btc], acc ->
+      acc
+      |> Map.put({slug, "USD"}, prices_usd)
+      |> Map.put({slug, "BTC"}, prices_btc)
+    end)
+  end
+
   # TODO: Implement `opts`, read and use `:source`
   def slugs_by_filter(metric, from, to, operator, threshold, aggregation) do
     {query, args} = slugs_by_filter_query(metric, from, to, operator, threshold, aggregation)

--- a/lib/sanbase/prices/price_sql_query.ex
+++ b/lib/sanbase/prices/price_sql_query.ex
@@ -472,6 +472,25 @@ defmodule Sanbase.Price.SqlQuery do
     {query, args}
   end
 
+  def latest_prices_per_slug_query(slugs, limit_per_slug) do
+    query = """
+    SELECT slug, arrayReverse(groupArray(price_usd)) AS last_prices_usd,  arrayReverse(groupArray(price_btc)) AS last_prices_btc
+    FROM (
+      SELECT slug, price_usd, price_btc
+      FROM asset_prices_v3
+      PREWHERE dt >= now() - interval 1 week AND slug IN (?1)
+      ORDER BY dt desc
+      LIMIT ?2 BY slug
+    )
+    GROUP BY slug
+
+    """
+
+    args = [slugs, limit_per_slug]
+
+    {query, args}
+  end
+
   # Private functions
 
   defp timerange_parameters(from, to, interval \\ nil)

--- a/lib/sanbase/prices/validator/validator.ex
+++ b/lib/sanbase/prices/validator/validator.ex
@@ -1,17 +1,24 @@
 defmodule Sanbase.Price.Validator do
+  @moduledoc ~s"""
+  Validates new realtime prices by comparing them to its previous values.
+
+  This validators starts 8 GenServers, each one handling a portion of the
+  slugs. Every slug is dispatched to its proper GenServer, which handles
+  all the state and valiadtions.
+  More more info see the  Sanbase.Price.Validator.Node module and its
+  documentation
+  """
   use Supervisor
 
   @gen_servers_count 8
 
-  def start_link(opts) do
-    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  def start_link(_opts) do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  def init(opts) do
-    gen_servers_count = Keyword.get(opts, :gen_servers_count, @gen_servers_count)
-
+  def init(_opts) do
     children =
-      for num <- 0..(gen_servers_count - 1) do
+      for num <- 0..(@gen_servers_count - 1) do
         name = String.to_atom("Sanbase.Price.Validator.Node_#{num}")
         {Sanbase.Price.Validator.Node, name: name, number: num}
       end
@@ -19,17 +26,21 @@ defmodule Sanbase.Price.Validator do
     Supervisor.init(children, strategy: :one_for_one)
   end
 
-  def valid_price?(slug, quote_asset, price) do
-    GenServer.call(node_name(slug), {:valid_price?, slug, quote_asset, price}, 1000)
-  rescue
-    _ ->
-      # The price validation is nice but not necessary. In case it times out,
-      # just ingest the price so it's not lost.
-      true
+  def clean_state() do
+    for num <- 0..(@gen_servers_count - 1) do
+      name = String.to_atom("Sanbase.Price.Validator.Node_#{num}")
+      :ok = GenServer.call(name, :clean_state)
+    end
   end
 
-  def update_prices(slug, quote_asset, prices) do
-    GenServer.call(node_name(slug), {:update_prices, slug, quote_asset, prices}, 100_000)
+  @doc ~s"""
+  Validate a new realtime price for a slug/currency pair. If the price is valid
+  `true` is returned, otherwise `{:error, reason}` is returned.
+  See the Sanbase.Price.Validator.Node module for more info.
+  """
+  @spec valid_price?(String.t(), String.t(), float()) :: true | {:error, String.t()}
+  def valid_price?(slug, quote_asset, price) when quote_asset in ["BTC", "USD"] do
+    GenServer.call(node_name(slug), {:valid_price?, slug, quote_asset, price}, 1000)
   rescue
     _ ->
       # The price validation is nice but not necessary. In case it times out,

--- a/lib/sanbase/prices/validator/validator.ex
+++ b/lib/sanbase/prices/validator/validator.ex
@@ -1,0 +1,47 @@
+defmodule Sanbase.Price.Validator do
+  use Supervisor
+
+  @gen_servers_count 8
+
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def init(opts) do
+    gen_servers_count = Keyword.get(opts, :gen_servers_count, @gen_servers_count)
+
+    children =
+      for num <- 0..(gen_servers_count - 1) do
+        name = String.to_atom("Sanbase.Price.Validator.Node_#{num}")
+        {Sanbase.Price.Validator.Node, name: name, number: num}
+      end
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  def valid_price?(slug, quote_asset, price) do
+    GenServer.call(node_name(slug), {:valid_price?, slug, quote_asset, price}, 1000)
+  rescue
+    _ ->
+      # The price validation is nice but not necessary. In case it times out,
+      # just ingest the price so it's not lost.
+      true
+  end
+
+  def update_prices(slug, quote_asset, prices) do
+    GenServer.call(node_name(slug), {:update_prices, slug, quote_asset, prices}, 100_000)
+  rescue
+    _ ->
+      # The price validation is nice but not necessary. In case it times out,
+      # just ingest the price so it's not lost.
+      true
+  end
+
+  def slug_to_number(slug) do
+    :erlang.phash2(slug, @gen_servers_count)
+  end
+
+  defp node_name(slug) do
+    "Sanbase.Price.Validator.Node_#{slug_to_number(slug)}" |> String.to_atom()
+  end
+end

--- a/lib/sanbase/prices/validator/validator_node.ex
+++ b/lib/sanbase/prices/validator/validator_node.ex
@@ -1,0 +1,98 @@
+defmodule Sanbase.Price.Validator.Node do
+  use GenServer
+  @max_prices 6
+
+  alias Sanbase.Model.Project
+  alias Sanbase.Price
+
+  def child_spec(opts) do
+    name = Keyword.fetch!(opts, :name)
+
+    %{
+      id: name,
+      start: {__MODULE__, :start_link, [opts]}
+    }
+  end
+
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :name)
+
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  def init(opts) do
+    number = Keyword.fetch!(opts, :number)
+
+    slugs =
+      Sanbase.Cache.get_or_store(:all_project_slugs_include_hidden_no_preload, fn ->
+        Project.List.projects_slugs(include_hidden: true, preload?: false)
+      end)
+      |> Enum.filter(&(Price.Validator.slug_to_number(&1) == number))
+
+    {:ok, latest_prices} = Price.latest_prices_per_slug(slugs, @max_prices)
+
+    state = latest_prices |> Map.put(:number, number)
+
+    {:ok, state}
+  end
+
+  def handle_call({:valid_price?, slug, quote_asset, price}, _from, state) do
+    key = {slug, quote_asset}
+
+    case Map.get(state, key, []) do
+      [] ->
+        {:reply, true, Map.put(state, key, [price])}
+
+      prices ->
+        with false <- price_outlier?(slug, quote_asset, price, prices, allowed_times_diff: 5) do
+          prices = maybe_drop_oldest_price(prices) ++ [price]
+
+          state = Map.put(state, key, prices)
+
+          {:reply, true, state}
+        else
+          {:error, _} = error ->
+            {:reply, error, state}
+        end
+    end
+  end
+
+  def handle_call({:update_prices, slug, quote_asset, prices}, _from, state) do
+    {:reply, :ok, Map.put(state, {slug, quote_asset}, prices)}
+  end
+
+  # If there are less than @max_prices prices, return as is
+  # If there are @max_prices in the list, drop the oldest price as we'll add the
+  # newest price to the list. This is executed only if the new price that is
+  # validated is accepted
+  defp maybe_drop_oldest_price(prices) when length(prices) < @max_prices, do: prices
+  defp maybe_drop_oldest_price([_ | prices]), do: prices
+
+  defp price_outlier?(_slug, _quote_asset, _price, [], _opts), do: false
+
+  defp price_outlier?(slug, quote_asset, price, prices, opts) do
+    allowed_times_diff = Keyword.fetch!(opts, :allowed_times_diff)
+
+    count = Enum.count(prices)
+    avg_price = Enum.sum(prices) / count
+
+    cond do
+      price > avg_price and price > avg_price * allowed_times_diff ->
+        {:error,
+         """
+         The #{slug} #{quote_asset} price #{price} is more than #{allowed_times_diff} times bigger than the \
+         average of the last #{count} prices - #{avg_price}
+         """}
+
+      price < avg_price and price * allowed_times_diff < avg_price ->
+        {:error,
+         """
+         The #{slug} #{quote_asset} price #{price} is more than #{allowed_times_diff} times bigger than the \
+         average of the last #{count} prices - #{avg_price}
+         """}
+
+      true ->
+        false
+    end
+  end
+end

--- a/lib/sanbase/prices/validator/validator_node.ex
+++ b/lib/sanbase/prices/validator/validator_node.ex
@@ -64,7 +64,7 @@ defmodule Sanbase.Price.Validator.Node do
         {:reply, true, Map.put(state, key, [price])}
 
       prices ->
-        with false <- price_outlier?(slug, quote_asset, price, prices, allowed_times_diff: 5) do
+        with false <- price_outlier?(slug, quote_asset, price, prices, allowed_times_diff: 30) do
           # Keep the in memory prices to a maximum of @max_prices
           prices = maybe_drop_oldest_price(prices) ++ [price]
           state = Map.put(state, key, prices)

--- a/lib/sanbase/scrapers.ex
+++ b/lib/sanbase/scrapers.ex
@@ -58,6 +58,9 @@ defmodule Sanbase.Application.Scrapers do
         time_between_requests: 10
       ),
 
+      #
+      Sanbase.Price.Validator,
+
       # Historical coinmarketcap price fetcher
       Sanbase.ExternalServices.Coinmarketcap,
 

--- a/test/sanbase/external_services/coinmarketcap/ticker_fetcher_test.exs
+++ b/test/sanbase/external_services/coinmarketcap/ticker_fetcher_test.exs
@@ -1,6 +1,8 @@
 defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcherTest do
   use Sanbase.DataCase, async: false
 
+  import Sanbase.Factory
+
   alias Sanbase.ExternalServices.Coinmarketcap.TickerFetcher
   alias Sanbase.Model.LatestCoinmarketcapData
   alias Sanbase.Model.Project
@@ -52,6 +54,9 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcherTest do
   end
 
   test "ticker fetcher stores prices in kafka" do
+    insert(:project, %{slug: "ethereum"})
+    insert(:project, %{slug: "bitcoin"})
+
     TickerFetcher.work()
     Process.sleep(200)
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -32,6 +32,7 @@ defmodule SanbaseWeb.ConnCase do
 
     SanbaseWeb.Graphql.Cache.clear_all()
     Sanbase.Cache.clear_all()
+    Sanbase.Price.Validator.clean_state()
 
     Sanbase.CaseHelpers.checkout_shared(tags)
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -28,6 +28,7 @@ defmodule Sanbase.DataCase do
 
     SanbaseWeb.Graphql.Cache.clear_all()
     Sanbase.Cache.clear_all()
+    Sanbase.Price.Validator.clean_state()
 
     Sanbase.CaseHelpers.checkout_shared(tags)
     Sanbase.Billing.TestSeed.seed_products_and_plans()


### PR DESCRIPTION
## Changes

Run a swarm of GenServers that will keep in memory the last N (currently 6) prices of a given slug/currency pair (SAN/USD, SAN/BTC, etc.). Run more than 1 for two main reasons:
- increased throughput
- easier handling of restarts - only part of the slugs need to be re-initialized.

Initialize every GenServer with the latest prices found in the Clickhouse database. Every GenServer handles those assets, whose hash falls in the interval 0..N-1

Every price validation returns `true` or `{:error, reason}`. In case the price is validated correctly, it replaces the oldest price in the list of prices.

The
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
