### PR TITLE
Validate price of the known assets only

### DIFF
--- a/lib/sanbase/external_services/coinmarketcap/ticker_fetcher.ex
+++ b/lib/sanbase/external_services/coinmarketcap/ticker_fetcher.ex
@@ -89,16 +89,20 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcher do
     |> Enum.each(fn %{slug: cmc_slug, price_usd: price_usd, price_btc: price_btc} ->
       # This implementation does not remove/change anything. It will be deployed first
       # so we can observe the behaviour first.
-      slug = Map.get(cmc_id_to_slugs_mapping, cmc_slug)
+      case Map.get(cmc_id_to_slugs_mapping, cmc_slug) do
+        nil ->
+          :ok
 
-      case Sanbase.Price.Validator.valid_price?(slug, "USD", price_usd) do
-        {:error, error} -> Logger.info("[CMC] Price validation failed: #{error}")
-        _ -> :ok
-      end
+        slug ->
+          case Sanbase.Price.Validator.valid_price?(slug, "USD", price_usd) do
+            {:error, error} -> Logger.info("[CMC] Price validation failed: #{error}")
+            _ -> :ok
+          end
 
-      case Sanbase.Price.Validator.valid_price?(slug, "BTC", price_btc) do
-        {:error, error} -> Logger.info("[CMC] Price validation failed: #{error}")
-        _ -> :ok
+          case Sanbase.Price.Validator.valid_price?(slug, "BTC", price_btc) do
+            {:error, error} -> Logger.info("[CMC] Price validation failed: #{error}")
+            _ -> :ok
+          end
       end
     end)
 
@@ -110,19 +114,23 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.TickerFetcher do
   # defp remove_not_valid_prices(tickers, cmc_id_to_slugs_mapping) do
   #   tickers
   #   |> Enum.map(fn %{slug: cmc_slug, price_usd: price_usd, price_btc: price_btc} = ticker ->
-  #     slug = Map.get(cmc_id_to_slugs_mapping, cmc_slug)
+  #     case Map.get(cmc_id_to_slugs_mapping, cmc_slug) do
+  #       nil ->
+  #         ticker
 
-  #     ticker
-  #     |> then(fn t ->
-  #       if true == Sanbase.Price.Validator.valid_price?(slug, "USD", price_usd),
-  #         do: t,
-  #         else: Map.put(t, :price_usd, nil)
-  #     end)
-  #     |> then(fn t ->
-  #       if true == Sanbase.Price.Validator.valid_price?(slug, "BTC", price_btc),
-  #         do: t,
-  #         else: Map.put(t, :price_usd, nil)
-  #     end)
+  #       slug ->
+  #         ticker
+  #         |> then(fn t ->
+  #           if true == Sanbase.Price.Validator.valid_price?(slug, "USD", price_usd),
+  #             do: t,
+  #             else: Map.put(t, :price_usd, nil)
+  #         end)
+  #         |> then(fn t ->
+  #           if true == Sanbase.Price.Validator.valid_price?(slug, "BTC", price_btc),
+  #             do: t,
+  #             else: Map.put(t, :price_usd, nil)
+  #         end)
+  #     end
   #   end)
   # end
 


### PR DESCRIPTION
## Changes

If the check is not done, then the slug `nil` is passed to the price
validation. This leads to storing the price of all not known assets
under the same nil key.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
