### PR TITLE
Enable/disable the price validator via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@
 
 # DATABASE_URL="ecto://postgres:postgres@localhost:5432/sanbase_dev"
 # CLICKHOUSE_DATABASE_URL="ecto://sanbase@clickhouse-proxy.stage.san:30901/default"
-
+# PRICE_VALIDATOR_ENABLED=false
 # HYDRA_BASE_URL=http://localhost:4444
 # HYDRA_TOKEN_URI=/oauth2/token
 # HYDRA_CONSENT_URI=/oauth2/consent/requests

--- a/config/config.exs
+++ b/config/config.exs
@@ -32,6 +32,8 @@ config :sanbase, Sanbase.Transfers.Erc20Transfers,
   dt_ordered_table: {:system, "DT_ORDERED_ERC20_TRANFERS_TABLE", "erc20_transfers_dt_order"},
   address_ordered_table: {:system, "ADDRESS_ORDERED_ERC20_TRANSFERS_TABLE", "erc20_transfers"}
 
+config :sanbase, Sanbase.Price.Validator, enabled: {:system, "PRICE_VALIDATOR_ENABLED", true}
+
 config :sanbase, Sanbase.Cryptocompare, api_key: {:system, "CRYPTOCOMPARE_API_KEY"}
 
 config :sanbase, Sanbase.KafkaExporter,

--- a/lib/sanbase/prices/validator/validator_node.ex
+++ b/lib/sanbase/prices/validator/validator_node.ex
@@ -9,6 +9,8 @@ defmodule Sanbase.Price.Validator.Node do
   alias Sanbase.Model.Project
   alias Sanbase.Price
 
+  require Sanbase.Utils.Config, as: Config
+
   def child_spec(opts) do
     name = Keyword.fetch!(opts, :name)
 
@@ -23,10 +25,19 @@ defmodule Sanbase.Price.Validator.Node do
     GenServer.start_link(__MODULE__, opts, name: name)
   end
 
+  def enabled?() do
+    with true <- Sanbase.ClickhouseRepo.enabled?(),
+         true <- Config.module_get_boolean(Sanbase.Price.Validator, :enabled) do
+      true
+    else
+      _ -> false
+    end
+  end
+
   def init(opts) do
     number = Keyword.fetch!(opts, :number)
 
-    case Sanbase.ClickhouseRepo.enabled?() do
+    case enabled?() do
       false ->
         # If the ClickhouseRepo is disabled do not initialize anything. This is the
         # flow only in dev/test environment. In case of empty state, the price is

--- a/lib/sanbase/utils/config.ex
+++ b/lib/sanbase/utils/config.ex
@@ -68,4 +68,19 @@ defmodule Sanbase.Utils.Config do
   def module_get_integer!(module, key) do
     module_get!(module, key) |> Sanbase.Math.to_integer()
   end
+
+  def module_get_boolean(module, key) do
+    value = module_get(module, key)
+
+    cond do
+      value in [0, false] or (is_binary(value) and String.downcase(value) in ["false", "0"]) ->
+        false
+
+      value in [1, true] or (is_binary(value) and String.downcase(value) in ["true", "1"]) ->
+        true
+
+      true ->
+        nil
+    end
+  end
 end


### PR DESCRIPTION
## Changes

Add an env var that can be used to enable/disable the price validator.
This is useful for tests and dev environments so it does not run in the
background while other features are developed.

For local development, you can add `PRICE_VALIDATOR_ENABLED=false`
 in your `.env.dev` file and enable it only when you want to work on that
part of the codebase.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
