### PR TITLE
Adding binance OI/OV metrics

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -1501,5 +1501,77 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Binance USDT Exchange Open Interest",
+    "name": "usdt_bnb_open_interest",
+    "metric": "usdt_bnb_open_interest",
+    "aliases": ["usdt_binance_open_interest"],
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "avg",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Binance USDT Exchange Open Value",
+    "name": "usdt_bnb_open_value",
+    "metric": "usdt_bnb_open_value",
+    "aliases": ["usdt_binance_open_value"],
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "avg",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Binance BUSD Exchange Open Interest",
+    "name": "busd_bnb_open_interest",
+    "metric": "busd_bnb_open_interest",
+    "aliases": ["busd_binance_open_interest"],
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "avg",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Binance BUSD Exchange Open Value",
+    "name": "busd_bnb_open_value",
+    "metric": "busd_bnb_open_value",
+    "aliases": ["busd_binance_open_value"],
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "avg",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
   }
 ]

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -782,7 +782,16 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "sentiment_volume_consumed_total_change_30d",
         # contract metrics
         "contract_interacting_addresses_count",
-        "contract_transactions_count"
+        "contract_transactions_count",
+        # binance oi/ov metrics
+        "usdt_bnb_open_interest",
+        "usdt_binance_open_interest",
+        "usdt_bnb_open_value",
+        "usdt_binance_open_value",
+        "busd_bnb_open_interest",
+        "busd_binance_open_interest",
+        "busd_bnb_open_value",
+        "busd_binance_open_value"
       ]
       |> Enum.sort()
 


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

Adding binance open interest and value metrics to the API. Added the aliases as they are in the funding rates' case for consistency.

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
