### PR TITLE
Implement opts filter/order slugs in Price module

### DIFF
--- a/lib/sanbase/prices/metric_adapter.ex
+++ b/lib/sanbase/prices/metric_adapter.ex
@@ -51,14 +51,12 @@ defmodule Sanbase.Price.MetricAdapter do
 
   @impl Sanbase.Metric.Behaviour
   def slugs_by_filter(metric, from, to, operator, threshold, opts) do
-    aggregation = Keyword.get(opts, :aggregation, nil) || @default_aggregation
-    Price.slugs_by_filter(metric, from, to, operator, threshold, aggregation)
+    Price.slugs_by_filter(metric, from, to, operator, threshold, opts)
   end
 
   @impl Sanbase.Metric.Behaviour
   def slugs_order(metric, from, to, direction, opts) do
-    aggregation = Keyword.get(opts, :aggregation, nil) || @default_aggregation
-    Price.slugs_order(metric, from, to, direction, aggregation)
+    Price.slugs_order(metric, from, to, direction, opts)
   end
 
   @impl Sanbase.Metric.Behaviour

--- a/lib/sanbase/prices/price.ex
+++ b/lib/sanbase/prices/price.ex
@@ -393,16 +393,25 @@ defmodule Sanbase.Price do
     end)
   end
 
-  # TODO: Implement `opts`, read and use `:source`
-  def slugs_by_filter(metric, from, to, operator, threshold, aggregation) do
-    {query, args} = slugs_by_filter_query(metric, from, to, operator, threshold, aggregation)
-    ClickhouseRepo.query_transform(query, args, fn [slug, _value] -> slug end)
+  def slugs_by_filter(metric, from, to, operator, threshold, opts) do
+    with {:ok, source} <- opts_to_source(opts) do
+      aggregation = Keyword.get(opts, :aggregation) || :last
+
+      {query, args} =
+        slugs_by_filter_query(metric, from, to, operator, threshold, aggregation, source)
+
+      ClickhouseRepo.query_transform(query, args, fn [slug, _value] -> slug end)
+    end
   end
 
-  # TODO: Implement `opts`, read and use `:source`
-  def slugs_order(metric, from, to, direction, aggregation) do
-    {query, args} = slugs_order_query(metric, from, to, direction, aggregation)
-    ClickhouseRepo.query_transform(query, args, fn [slug, _value] -> slug end)
+  def slugs_order(metric, from, to, direction, opts) do
+    with {:ok, source} <- opts_to_source(opts) do
+      aggregation = Keyword.get(opts, :aggregation) || :last
+
+      {query, args} = slugs_order_query(metric, from, to, direction, aggregation, source)
+
+      ClickhouseRepo.query_transform(query, args, fn [slug, _value] -> slug end)
+    end
   end
 
   @doc ~s"""


### PR DESCRIPTION
## Changes

Add `opts` to 2 functions in the Price module. This is needed otherwise fields that are not available across all sources (like marketcap_usd is not available in cryptocomapre data) will cause issues when we mix the sources.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
