### PR TITLE
Add pulse_text field to the insight GraphQL type

### DIFF
--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -548,6 +548,7 @@ defmodule Sanbase.Insight.Post do
     |> Repo.all()
   end
 
+  def is_pulse?(%__MODULE__{is_pulse: is_pulse}), do: is_pulse
   # Helper functions
 
   defp publish_post(post) do

--- a/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
@@ -154,6 +154,18 @@ defmodule SanbaseWeb.Graphql.Resolvers.InsightResolver do
     {:ok, search_result_insights}
   end
 
+  @doc ~s"""
+  When fetching all insights we need to directly show only the text of the pulse insights.
+  In order to transport less data over the network, this field can be used instead of
+  the `text` field as it will be filled only for those insights.
+  """
+  def pulse_text(%Post{} = post, _args, _resolution) do
+    case Post.is_pulse?(post) do
+      true -> {:ok, post.text}
+      false -> {:ok, nil}
+    end
+  end
+
   def create_post(_root, args, %{context: %{auth: %{current_user: user}}}) do
     case Post.can_create?(user.id) do
       {:ok, _} -> Post.create(user, args)

--- a/lib/sanbase_web/graphql/schema/types/insight_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/insight_types.ex
@@ -37,6 +37,11 @@ defmodule SanbaseWeb.Graphql.InsightTypes do
     field(:title, non_null(:string))
     field(:short_desc, :string)
     field(:text, :string)
+
+    field :pulse_text, :string do
+      resolve(&InsightResolver.pulse_text/3)
+    end
+
     field(:state, :string)
     field(:moderation_comment, :string)
     field(:ready_state, :string)

--- a/test/sanbase_web/graphql/insight/insight_api_test.exs
+++ b/test/sanbase_web/graphql/insight/insight_api_test.exs
@@ -107,7 +107,8 @@ defmodule SanbaseWeb.Graphql.InsightApiTest do
         currentUser {
           insights {
             id,
-            text,
+            text
+            pulseText
             readyState
           }
         }
@@ -121,12 +122,14 @@ defmodule SanbaseWeb.Graphql.InsightApiTest do
           %{
             "id" => published.id,
             "readyState" => "#{published.ready_state}",
-            "text" => "#{published.text}"
+            "text" => "#{published.text}",
+            "pulseText" => nil
           },
           %{
             "id" => draft.id,
             "readyState" => "#{draft.ready_state}",
-            "text" => "#{draft.text}"
+            "text" => "#{draft.text}",
+            "pulseText" => nil
           }
         ]
         |> Enum.sort_by(& &1["id"])

--- a/test/sanbase_web/graphql/insight/pulse_insight_api_test.exs
+++ b/test/sanbase_web/graphql/insight/pulse_insight_api_test.exs
@@ -48,6 +48,7 @@ defmodule SanbaseWeb.Graphql.PulseInsightApiTest do
         insights(isPulse: true) {
           id
           text
+          pulseText
           readyState
         }
       }
@@ -64,12 +65,14 @@ defmodule SanbaseWeb.Graphql.PulseInsightApiTest do
         %{
           "id" => published.id,
           "readyState" => "#{published.ready_state}",
-          "text" => "#{published.text}"
+          "text" => "#{published.text}",
+          "pulseText" => "#{published.text}"
         },
         %{
           "id" => draft.id,
           "readyState" => "#{draft.ready_state}",
-          "text" => "#{draft.text}"
+          "text" => "#{draft.text}",
+          "pulseText" => "#{draft.text}"
         }
       ]
       |> Enum.sort_by(& &1["id"])
@@ -87,13 +90,19 @@ defmodule SanbaseWeb.Graphql.PulseInsightApiTest do
     {
       insight(id: #{post.id}) {
         text
+        pulseText
       }
     }
     """
 
-    result = conn |> post("/graphql", query_skeleton(query, "post"))
+    insight =
+      conn
+      |> post("/graphql", query_skeleton(query, "post"))
+      |> json_response(200)
+      |> get_in(["data", "insight"])
 
-    assert json_response(result, 200)["data"]["insight"] |> Map.get("text") == post.text
+    assert insight |> Map.get("text") == post.text
+    assert insight |> Map.get("pulseText") == post.text
   end
 
   test "getting pulse insight by id for anon user", %{user: user} do
@@ -103,7 +112,7 @@ defmodule SanbaseWeb.Graphql.PulseInsightApiTest do
     query = """
     {
       insight(id: #{post.id}) {
-        state,
+        state
         createdAt
         updatedAt
       }
@@ -276,8 +285,9 @@ defmodule SanbaseWeb.Graphql.PulseInsightApiTest do
     query = """
     {
       allInsightsUserVoted(user_id: #{user.id}, isPulse: true) {
-        id,
+        id
         text
+        pulseText
       }
     }
     """
@@ -290,6 +300,7 @@ defmodule SanbaseWeb.Graphql.PulseInsightApiTest do
 
     assert result |> Enum.count() == 1
     assert result |> hd() |> Map.get("text") == post.text
+    assert result |> hd() |> Map.get("pulseText") == post.text
   end
 
   test "get all insights by a list of tags", %{user: user} do
@@ -335,6 +346,7 @@ defmodule SanbaseWeb.Graphql.PulseInsightApiTest do
           id
           title
           text
+          pulseText
           user { id }
           votes{ totalVotes }
           state
@@ -414,6 +426,7 @@ defmodule SanbaseWeb.Graphql.PulseInsightApiTest do
               id
               title
               text
+              pulseText
               tags { name }
           }
         }
@@ -449,6 +462,7 @@ defmodule SanbaseWeb.Graphql.PulseInsightApiTest do
               id
               title
               text
+              pulseText
               tags { name }
           }
         }


### PR DESCRIPTION
## Changes

The GraphQL insight type has a new field - `pulseText`. It is filled with the value of the `text` field only if the  insight is Pulse. This is done because the APIs that fetch list of insights need to show the text only for the Pulse ones. Fetching the `text` for all of them is resulting in too much data being fetched and discarded.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
