### PR TITLE
Fix issue with locking in api calls counting

### DIFF
--- a/lib/sanbase/api_call_limit/api_call_limit_ets.ex
+++ b/lib/sanbase/api_call_limit/api_call_limit_ets.ex
@@ -73,7 +73,7 @@ defmodule Sanbase.ApiCallLimit.ETS do
   # Private functions
 
   defp do_get_quota(entity_type, entity, entity_key) do
-    lock = Mutex.await(Sanbase.ApiCallLimitMutex, {entity, entity_key}, 5_000)
+    lock = Mutex.await(Sanbase.ApiCallLimitMutex, {entity_type, entity_key}, 5_000)
 
     result =
       case :ets.lookup(@ets_table, entity_key) do
@@ -143,7 +143,7 @@ defmodule Sanbase.ApiCallLimit.ETS do
   end
 
   defp do_update_usage(entity_type, entity, entity_key, count) do
-    lock = Mutex.await(Sanbase.ApiCallLimitMutex, {entity, entity_key}, 5_000)
+    lock = Mutex.await(Sanbase.ApiCallLimitMutex, {entity_type, entity_key}, 5_000)
 
     case :ets.lookup(@ets_table, entity_key) do
       [] ->

--- a/lib/sanbase_web/guardian/guardian.ex
+++ b/lib/sanbase_web/guardian/guardian.ex
@@ -117,7 +117,7 @@ defmodule SanbaseWeb.Guardian do
       }) do
     case Configuration.SharedAccessToken.by_uuid(shared_access_token_uuid) do
       {:ok, token} -> {:ok, token}
-      {:errror, _} -> {:error, :no_existing_token}
+      {:error, _} -> {:error, :no_existing_token}
     end
   end
 


### PR DESCRIPTION
## Changes

The locking was using the whole User object which is both slower and
wrong. It is wrong because if the user changes, the lock will not work.
This can happen automatically as well - when the san balance is updated
we store the datetime value and it will cause the structs to differ.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
