### PR TITLE
Mask the apikey in the errors

### DIFF
--- a/lib/sanbase/accounts/apikey/apikey.ex
+++ b/lib/sanbase/accounts/apikey/apikey.ex
@@ -35,14 +35,22 @@ defmodule Sanbase.Accounts.Apikey do
       {:ok, user}
     else
       {:valid?, _} ->
-        {:error, "Apikey '#{apikey}' is not valid"}
+        {:error, "Apikey '#{mask_apikey(apikey)}' is not valid"}
 
       {:user?, _} ->
-        {:error, "Apikey '#{apikey}' is not valid"}
+        {:error, "Apikey '#{mask_apikey(apikey)}' is not valid"}
 
       {:error, error} ->
         {:error, error}
     end
+  end
+
+  def mask_apikey(apikey) do
+    apikey_length = String.length(apikey)
+    # All between the first 6 chars and the last 2 chars will be hidden
+    hide_what = String.slice(apikey, 6, apikey_length - (6 + 2))
+    hide_with = String.duplicate("*", String.length(hide_what))
+    String.replace(apikey, hide_what, hide_with)
   end
 
   @doc ~s"""

--- a/test/sanbase_web/graphql/context_plug_test.exs
+++ b/test/sanbase_web/graphql/context_plug_test.exs
@@ -84,7 +84,7 @@ defmodule SanbaseWeb.Graphql.ContextPlugTest do
     assert conn.status == 400
 
     assert result["errors"]["details"] ==
-             "Apikey '#{apikey}' is not valid"
+             "Apikey '#{Apikey.mask_apikey(apikey)}' is not valid"
   end
 
   test "malformed apikey returns error" do


### PR DESCRIPTION
## Changes
This change is **NOT** due to any security reasons. If an apikey is not
valid and is then shown in an error message this does not pose any risk
as this apikey is no longer valid and thus cannot be used.
This change addresses issues that at first glance look like a security
risk (but are not). In case a no longer valid apikey is used in a google
sheet, then people who open that sheet might see the invalid apikey.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
