### PR TITLE
Allow conditional start of the kafka consumer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@
 # HYDRA_CLIENT_SECRET=consent-secret
 # CLIENTS_THAT_REQUIRE_SAN_TOKENS={"grafana": 50}
 # CLICKHOUSE_REPO_ENABLED=true
+# KAFKA_CONSUMER_ENABLED=false
 
 ## To access stage and production services, WireGuard VPN must be on
 ## Apart from the RDS Postgres, the other services do not contain a secret

--- a/config/config.exs
+++ b/config/config.exs
@@ -244,6 +244,7 @@ config :kaffy,
   router: SanbaseWeb.Router
 
 config :sanbase, Sanbase.Kafka.Consumer,
+  enabled?: {:system, "KAFKA_CONSUMER_ENABLED", true},
   metrics_stream_topic: {:system, "KAFKA_METRIC_STREAM_TOPIC", "sanbase_combined_metrics"},
   consumer_group_basename: {:system, "KAFKA_CONSUMER_GROUP_BASENAME", "sanbase_kafka_consumer"}
 

--- a/lib/sanbase/utils/config.ex
+++ b/lib/sanbase/utils/config.ex
@@ -54,6 +54,19 @@ defmodule Sanbase.Utils.Config do
     end
   end
 
+  def parse_boolean_value(value) do
+    cond do
+      value in [0, false] or (is_binary(value) and String.downcase(value) in ["false", "0"]) ->
+        false
+
+      value in [1, true] or (is_binary(value) and String.downcase(value) in ["true", "1"]) ->
+        true
+
+      true ->
+        nil
+    end
+  end
+
   defmacro module_get(module, key, default) do
     quote bind_quoted: [module: module, key: key, default: default] do
       Application.fetch_env(:sanbase, module)
@@ -69,18 +82,15 @@ defmodule Sanbase.Utils.Config do
     module_get!(module, key) |> Sanbase.Math.to_integer()
   end
 
-  def module_get_boolean(module, key) do
-    value = module_get(module, key)
-
-    cond do
-      value in [0, false] or (is_binary(value) and String.downcase(value) in ["false", "0"]) ->
-        false
-
-      value in [1, true] or (is_binary(value) and String.downcase(value) in ["true", "1"]) ->
-        true
-
-      true ->
-        nil
+  def mogule_get_boolean(module, key, default) do
+    case module_get_boolean(module, key) do
+      nil -> default
+      bool when is_boolean(bool) -> bool
     end
+  end
+
+  def module_get_boolean(module, key) do
+    module_get(module, key)
+    |> parse_boolean_value()
   end
 end


### PR DESCRIPTION
## Changes

Check the `KAFKA_CONSUMER_ENABLED` env var when deciding if the kafka consumer should be started. This is useful in dev environment - it can be disabled when working on other parts of the system. To disable the kafka consumer add `KAFKA_CONSUMER_ENABLED=false` to your `.env.dev` file

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
