### PR TITLE
Add limits for number of alerts per sanbase plan

### DIFF
--- a/lib/sanbase/alerts/user_trigger.ex
+++ b/lib/sanbase/alerts/user_trigger.ex
@@ -89,9 +89,9 @@ defmodule Sanbase.Alert.UserTrigger do
     |> user_triggers_for()
   end
 
-  @spec triggers_count_for(%User{}) :: integer()
-  def triggers_count_for(user) do
-    from(ut in UserTrigger, where: ut.user_id == ^user.id, select: fragment("count(*)"))
+  @spec triggers_count_for(non_neg_integer()) :: integer()
+  def triggers_count_for(user_id) when is_integer(user_id) and user_id > 0 do
+    from(ut in UserTrigger, where: ut.user_id == ^user_id, select: fragment("count(*)"))
     |> Repo.one()
   end
 

--- a/lib/sanbase/billing/plan/sanbase_access_checker.ex
+++ b/lib/sanbase/billing/plan/sanbase_access_checker.ex
@@ -12,7 +12,7 @@ defmodule Sanbase.Billing.Plan.SanbaseAccessChecker do
     historical_data_in_days: 2 * 365,
     realtime_data_cut_off_in_days: 30,
     alerts: %{
-      limit: 10
+      limit: 3
     },
     sangraphs_access: false
   }
@@ -20,11 +20,13 @@ defmodule Sanbase.Billing.Plan.SanbaseAccessChecker do
   @pro_plan_stats %{
     realtime_data_cut_off_in_days: 0,
     alerts: %{
-      limit: :no_limit
+      limit: 20
     },
     access_paywalled_insights: true,
     sangraphs_access: true
   }
+
+  @pro_plus_plan_stats @pro_plan_stats |> Map.put(:alerts, %{limit: 1000})
 
   @basic_plan_stats Map.merge(@free_plan_stats, %{access_paywalled_insights: true})
 
@@ -45,19 +47,6 @@ defmodule Sanbase.Billing.Plan.SanbaseAccessChecker do
     |> get_in([:alerts, :limit])
   end
 
-  def alerts_limits_not_reached?(user, subscription) do
-    created_alerts_count = UserTrigger.triggers_count_for(user)
-
-    subscription.plan
-    |> Plan.plan_atom_name()
-    |> alerts_limit()
-    |> case do
-      :no_limit -> true
-      limit when is_integer(limit) and created_alerts_count >= limit -> false
-      _ -> true
-    end
-  end
-
   def can_access_paywalled_insights?(nil), do: false
 
   def can_access_paywalled_insights?(subscription) do
@@ -72,7 +61,7 @@ defmodule Sanbase.Billing.Plan.SanbaseAccessChecker do
       :free -> @free_plan_stats
       :basic -> @basic_plan_stats
       :pro -> @pro_plan_stats
-      :pro_plus -> @pro_plan_stats
+      :pro_plus -> @pro_plus_plan_stats
       :premium -> @custom_plan_stats
       :custom -> @custom_plan_stats
     end

--- a/test/sanbase/alerts/trigger_restrictions_test.exs
+++ b/test/sanbase/alerts/trigger_restrictions_test.exs
@@ -1,0 +1,95 @@
+defmodule Sanbase.Alert.TriggerRestrictionsTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import Sanbase.Factory
+  import SanbaseWeb.Graphql.TestHelpers
+
+  setup do
+    trigger_settings = %{
+      type: "metric_signal",
+      metric: "active_addresses_24h",
+      target: %{slug: "santiment"},
+      channel: "telegram",
+      time_window: "1d",
+      operation: %{percent_up: 300.0}
+    }
+
+    %{trigger_settings: trigger_settings}
+  end
+
+  defp create_trigger(conn) do
+    trigger_settings = %{
+      type: "metric_signal",
+      metric: "active_addresses_24h",
+      target: %{slug: "santiment"},
+      channel: "telegram",
+      time_window: "1d",
+      operation: %{percent_up: 200.0}
+    }
+
+    mutation =
+      ~s"""
+      mutation {
+        createTrigger(
+          settings: '#{Jason.encode!(trigger_settings)}'
+          title: 'Generic title'
+          cooldown: '23h'
+        ) {
+          trigger{
+            id
+            cooldown
+            settings
+          }
+        }
+      }
+      """
+      |> String.replace(~r|\"|, ~S|\\"|)
+      |> String.replace(~r|'|, ~S|"|)
+
+    conn
+    |> post("/graphql", mutation_skeleton(mutation))
+    |> json_response(200)
+  end
+
+  test "sanbase free user has a limit of 3 alerts" do
+    user = insert(:user)
+    conn = setup_jwt_auth(build_conn(), user)
+
+    assert Sanbase.Billing.Plan.SanbaseAccessChecker.alerts_limit(:free) == 3
+
+    for _ <- 1..3 do
+      assert %{"data" => %{"createTrigger" => _}} = create_trigger(conn)
+    end
+
+    error_msg = create_trigger(conn) |> get_in(["errors", Access.at(0), "message"])
+    assert error_msg =~ "Sanbase FREE plan has a limit of 3 alerts"
+  end
+
+  test "sanbase pro user has a limit of 20 alerts" do
+    user = insert(:user)
+    _ = insert(:subscription_pro_sanbase, user: user)
+    conn = setup_jwt_auth(build_conn(), user)
+
+    assert Sanbase.Billing.Plan.SanbaseAccessChecker.alerts_limit(:pro) == 20
+
+    for _ <- 1..20 do
+      assert %{"data" => %{"createTrigger" => _}} = create_trigger(conn)
+    end
+
+    error_msg = create_trigger(conn) |> get_in(["errors", Access.at(0), "message"])
+    assert error_msg =~ "Sanbase PRO plan has a limit of 20 alerts"
+  end
+
+  test "sanbase pro+ user has no limits" do
+    user = insert(:user)
+    _ = insert(:subscription_pro_sanbase, user: user)
+    conn = setup_jwt_auth(build_conn(), user)
+
+    assert Sanbase.Billing.Plan.SanbaseAccessChecker.alerts_limit(:pro_plus) == 1000
+
+    # Creating 1000 would be too slow
+    for _ <- 1..30 do
+      assert %{"data" => %{"createTrigger" => _}} = create_trigger(conn)
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Reintroduce the alerts limits per sanbase plan:
- Free - 3
- Pro - 20
- Pro+ - 1000 (basically limitless, the number is a safety guard)
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
