### PR TITLE
Add cursor to get most recent/voted APIs

### DIFF
--- a/lib/sanbase/clickhouse/github/github.ex
+++ b/lib/sanbase/clickhouse/github/github.ex
@@ -245,7 +245,6 @@ defmodule Sanbase.Clickhouse.Github do
     {query, args} = first_datetime_query(organization_or_organizations)
 
     ClickhouseRepo.query_transform(query, args, fn [timestamp] ->
-      IO.inspect(timestamp)
       timestamp |> DateTime.from_unix!()
     end)
     |> maybe_unwrap_ok_value()

--- a/lib/sanbase/entity/entity.ex
+++ b/lib/sanbase/entity/entity.ex
@@ -1,4 +1,19 @@
 defmodule Sanbase.Entity do
+  @moduledoc ~s"""
+  Provide unified access to all sanbase defined entities.
+
+  Entities include:
+  - Insight
+  - Watchlist
+  - Screener
+  - Timeline Event
+  - Chart Configuration
+
+  This module provides functions for fetching lists of entities of a given type,
+  ordered in a specific way. There are two orderings:
+  - most recent first
+  - most voted first
+  """
   import Ecto.Query
 
   alias Sanbase.Chart

--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -97,6 +97,12 @@ defmodule Sanbase.Insight.Post do
     timestamps()
   end
 
+  @impl Sanbase.Entity.Behaviour
+  def public_entity_ids_query(opts) do
+    public_insights_query(opts)
+    |> select([p], p.id)
+  end
+
   def insights_count_map() do
     map =
       from(
@@ -247,12 +253,6 @@ defmodule Sanbase.Insight.Post do
       |> Tag.Preloader.order_tags()
 
     {:ok, result}
-  end
-
-  @impl Sanbase.Entity.Behaviour
-  def public_entity_ids_query(opts) do
-    public_insights_query(opts)
-    |> select([p], p.id)
   end
 
   @spec create(%User{}, map()) :: {:ok, %__MODULE__{}} | {:error, Keyword.t()}
@@ -432,14 +432,6 @@ defmodule Sanbase.Insight.Post do
     |> Tag.Preloader.order_tags()
   end
 
-  def public_insights_query(opts \\ []) do
-    published_and_approved_insights()
-    |> by_is_pulse(Keyword.get(opts, :is_pulse, nil))
-    |> by_is_paywall_required(Keyword.get(opts, :is_paywall_required, nil))
-    |> by_from_to_datetime(Keyword.get(opts, :from, nil), Keyword.get(opts, :to, nil))
-    |> maybe_preload(opts)
-  end
-
   @doc """
   All public insights published after datetime
   """
@@ -549,7 +541,16 @@ defmodule Sanbase.Insight.Post do
   end
 
   def is_pulse?(%__MODULE__{is_pulse: is_pulse}), do: is_pulse
+
   # Helper functions
+
+  defp public_insights_query(opts) do
+    published_and_approved_insights()
+    |> by_is_pulse(Keyword.get(opts, :is_pulse, nil))
+    |> by_is_paywall_required(Keyword.get(opts, :is_paywall_required, nil))
+    |> by_from_to_datetime(Keyword.get(opts, :from, nil), Keyword.get(opts, :to, nil))
+    |> maybe_preload(opts)
+  end
 
   defp publish_post(post) do
     publish_changeset = publish_changeset(post, %{ready_state: Post.published()})

--- a/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
@@ -1,15 +1,25 @@
 defmodule SanbaseWeb.Graphql.Resolvers.EntityResolver do
   def get_most_voted(_root, args, _resolution) do
     type = Map.get(args, :type)
-    page = Map.get(args, :page, 1)
-    page_size = Map.get(args, :page_size, 10)
-    Sanbase.Entity.get_most_voted(type, page: page, page_size: page_size)
+
+    opts = [
+      page: Map.get(args, :page, 1),
+      page_size: Map.get(args, :page_size, 10),
+      cursor: Map.get(args, :cursor)
+    ]
+
+    Sanbase.Entity.get_most_voted(type, opts)
   end
 
   def get_most_recent(_root, args, _resolution) do
     type = Map.get(args, :type)
-    page = Map.get(args, :page, 1)
-    page_size = Map.get(args, :page_size, 10)
-    Sanbase.Entity.get_most_recent(type, page: page, page_size: page_size)
+
+    opts = [
+      page: Map.get(args, :page, 1),
+      page_size: Map.get(args, :page_size, 10),
+      cursor: Map.get(args, :cursor)
+    ]
+
+    Sanbase.Entity.get_most_recent(type, opts)
   end
 end

--- a/lib/sanbase_web/graphql/resolvers/vote_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/vote_resolver.ex
@@ -13,25 +13,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.VoteResolver do
 
   require Logger
 
-  def get_most_voted(_root, args, _resolution) do
-    type = Map.get(args, :type)
-    page = Map.get(args, :page, 1)
-    page_size = Map.get(args, :page_size, 10)
-    Sanbase.Entity.get_most_voted(type, page: page, page_size: page_size)
-  end
-
-  def get_most_recent(_root, args, _resolution) do
-    type = Map.get(args, :type)
-    page = Map.get(args, :page, 1)
-    page_size = Map.get(args, :page_size, 10)
-    Sanbase.Entity.get_most_recent(type, page: page, page_size: page_size)
-  end
-
   @doc ~s"""
-    Returns a tuple `{total_votes, total_san_votes}` where:
-    - `total_votes` represents the number of votes where each vote's weight is 1
-    - `total_san_votes` represents the number of votes where each vote's weight is
-    equal to the san balance of the voter
+  Returns a tuple `{total_votes, total_san_votes}` where:
+  - `total_votes` represents the number of votes where each vote's weight is 1
+  - `total_san_votes` represents the number of votes where each vote's weight is
+  equal to the san balance of the voter
   """
   def votes(%Post{} = post, _args, %{context: %{loader: loader} = context}) do
     user = get_in(context, [:auth, :current_user]) || %User{id: nil}

--- a/lib/sanbase_web/graphql/schema/queries/entity_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/entity_queries.ex
@@ -14,6 +14,7 @@ defmodule SanbaseWeb.Graphql.Schema.EntityQueries do
       arg(:type, :entity_type)
       arg(:page, :integer)
       arg(:page_size, :integer)
+      arg(:cursor, :cursor_input_no_order, default_value: nil)
 
       cache_resolve(&EntityResolver.get_most_voted/3, ttl: 30, max_ttl_offset: 30)
     end
@@ -23,6 +24,7 @@ defmodule SanbaseWeb.Graphql.Schema.EntityQueries do
       arg(:type, :entity_type)
       arg(:page, :integer)
       arg(:page_size, :integer)
+      arg(:cursor, :cursor_input_no_order, default_value: nil)
 
       resolve(&EntityResolver.get_most_recent/3)
     end

--- a/lib/sanbase_web/graphql/schema/queries/vote_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/vote_queries.ex
@@ -10,23 +10,6 @@ defmodule SanbaseWeb.Graphql.Schema.VoteQueries do
   alias SanbaseWeb.Graphql.Middlewares.JWTAuth
 
   object :vote_queries do
-    field :get_most_voted, list_of(:entity_result) do
-      meta(access: :free)
-      arg(:type, :entity_type)
-      arg(:page, :integer)
-      arg(:page_size, :integer)
-
-      cache_resolve(&VoteResolver.get_most_voted/3, ttl: 30, max_ttl_offset: 30)
-    end
-
-    field :get_most_recent, list_of(:entity_result) do
-      meta(access: :free)
-      arg(:type, :entity_type)
-      arg(:page, :integer)
-      arg(:page_size, :integer)
-
-      resolve(&VoteResolver.get_most_recent/3)
-    end
   end
 
   object :vote_mutations do

--- a/lib/sanbase_web/graphql/schema/types/pagination_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/pagination_types.ex
@@ -3,6 +3,11 @@ defmodule SanbaseWeb.Graphql.PaginationTypes do
 
   enum(:cursor_type, values: [:before, :after])
 
+  input_object :cursor_input_no_order do
+    field(:type, non_null(:cursor_type))
+    field(:datetime, non_null(:datetime))
+  end
+
   input_object :cursor_input do
     field(:type, non_null(:cursor_type))
     field(:datetime, non_null(:datetime))

--- a/test/sanbase/telegram/telegram_test.exs
+++ b/test/sanbase/telegram/telegram_test.exs
@@ -2,7 +2,6 @@ defmodule Sanbase.TelegramTest do
   use SanbaseWeb.ConnCase, async: false
 
   import SanbaseWeb.Graphql.TestHelpers
-  require Sanbase.Utils.Config, as: Config
 
   alias Sanbase.Repo
   alias Sanbase.Accounts.{User, Settings, UserSettings}

--- a/test/sanbase_web/graphql/entity/get_most_recent_api_test.exs
+++ b/test/sanbase_web/graphql/entity/get_most_recent_api_test.exs
@@ -109,15 +109,16 @@ defmodule SanbaseWeb.Graphql.GetMostRecentApitest do
   defp get_most_recent(conn, entity) do
     query = """
     {
-    getMostRecent(
-      type: #{entity |> Atom.to_string() |> String.upcase()}
-      page: 1
-      pageSize: 10){
-        insight{ id }
-        watchlist{ id }
-        screener{ id }
-        timelineEvent{ id }
-        chartConfiguration{ id }
+      getMostRecent(
+        type: #{entity |> Atom.to_string() |> String.upcase()}
+        page: 1
+        pageSize: 10
+      ){
+          insight{ id }
+          watchlist{ id }
+          screener{ id }
+          timelineEvent{ id }
+          chartConfiguration{ id }
       }
     }
     """

--- a/test/support/factory/factory.ex
+++ b/test/support/factory/factory.ex
@@ -108,7 +108,8 @@ defmodule Sanbase.Factory do
       metrics: [
         Sanbase.Repo.get_by(Sanbase.Metric.MetricPostgresData, name: metric) ||
           build(:metric_postgres, %{name: metric})
-      ]
+      ],
+      published_at: DateTime.utc_now()
     }
   end
 


### PR DESCRIPTION
## Changes
1. Add `cursor` that allows filtering by datetime. This is useful when you want to fetch only the most voted entities, created in the past 1 week/1 month/etc. The most voted for all time might be some very old entity that is not very relevant today.
```graphql
    {
      getMostVoted(
        type: INSIGHT
        page: 1
        pageSize: 10
        cursor: { type: AFTER, datetime: "utc_now-7d" }
      ){
          insight{ id }
          watchlist{ id }
          screener{ id }
          timelineEvent{ id }
          chartConfiguration{ id }
      }
    }
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
