### PR TITLE
Rework entities APIs and internals

### DIFF
--- a/lib/sanbase/alerts/evaluator/scheduler.ex
+++ b/lib/sanbase/alerts/evaluator/scheduler.ex
@@ -356,10 +356,6 @@ defmodule Sanbase.Alert.Scheduler do
     # - missing email/telegram linked when such channel is chosen;
     # - webhook failed to be sent;
     # - daily alerts limit is reached;
-    failed_count = fn failed, result ->
-      failed + if result == :ok, do: 0, else: 1
-    end
-
     {last_triggered, total_triggered, total_failed} =
       send_results_list
       |> Enum.reduce({last_triggered, _total = 0, _failed = 0}, fn

--- a/lib/sanbase/chart/chart_configuration.ex
+++ b/lib/sanbase/chart/chart_configuration.ex
@@ -80,7 +80,15 @@ defmodule Sanbase.Chart.Configuration do
 
   @impl Sanbase.Entity.Behaviour
   def public_entity_ids_query(_opts) do
-    from(config in __MODULE__, where: config.is_public == true)
+    from(config in __MODULE__)
+    |> where([config], config.is_public == true)
+    |> select([config], config.id)
+  end
+
+  @impl Sanbase.Entity.Behaviour
+  def user_entity_ids_query(user_id, _opts) do
+    from(config in __MODULE__)
+    |> where([config], config.user_id == ^user_id)
     |> select([config], config.id)
   end
 

--- a/lib/sanbase/entity/entity.ex
+++ b/lib/sanbase/entity/entity.ex
@@ -34,12 +34,17 @@ defmodule Sanbase.Entity do
   # Private functions
 
   defp do_get_most_recent(entity, opts) do
-    entity_ids = entity_ids_query(entity)
+    # The most recent entity could be a private one. For this reasonlook only at
+    # entities that are public. In the case where the user is fetching their own
+    # entities that are with most votes the filter is changed to return only the
+    # creations of that users
+
+    entity_ids = entity_ids_query(entity, opts)
     entity_module = deduce_entity_module(entity)
 
-    # Add named binding as it is used in the subquery to avoid issues
-    # where one query needs to access the right joined table and the
-    # other does not have joins.
+    # Add named binding as it is used in the subquery to avoid issues where one
+    # query needs to access the right joined table and the other does not have
+    # joins.
     entity_ids =
       from(
         entity in entity_module,
@@ -59,19 +64,18 @@ defmodule Sanbase.Entity do
   end
 
   defp do_get_most_voted(entity, opts) do
+    # The most voted entity could have been  made private at some point after
+    # getting votes. For this reasonlook only at entities that are public. In
+    # the case where the user is fetching their own entities that are with most
+    # votes the filter is changed to return only the creations of that users
+
     entity_field = deduce_entity_field(entity)
-
-    # We cannot just find the most voted entity as it could be
-    # made private at some point after getting votes. For this reason
-    # look only at entities that are public. In order to have the same
-    # result for everybody the owner of a private entity does not
-    # get their private entities in the ranking
     entity_module = deduce_entity_module(entity)
-    entity_ids = entity_ids_query(entity)
+    entity_ids = entity_ids_query(entity, opts)
 
-    # Add named binding as it is used in the subquery to avoid issues
-    # where one query needs to access the right joined table and the
-    # other does not have joins.
+    # Add named binding as it is used in the subquery to avoid issues where one
+    # query needs to access the right joined table and the other does not have
+    # joins.
     entity_ids =
       from(
         vote in Sanbase.Vote,
@@ -93,29 +97,42 @@ defmodule Sanbase.Entity do
     end
   end
 
-  defp entity_ids_query(:insight) do
-    opts = [preload?: false, distinct?: false]
+  defp entity_ids_query(:insight, opts) do
+    post_opts = [preload?: false, distinct?: false]
 
-    case Keyword.get(opts, :get_user_entities) do
-      nil ->
-        Post.public_entity_ids_query(opts)
-
-      user_id ->
-        Post.user_insights_query(user_id, opts)
+    case Keyword.get(opts, :current_user_data_only) do
+      nil -> Post.public_entity_ids_query(post_opts)
+      user_id -> Post.user_entity_ids_query(user_id, post_opts)
     end
   end
 
-  defp entity_ids_query(:screener),
-    do: UserList.public_entity_ids_query(is_screener: true)
+  defp entity_ids_query(:screener, opts) do
+    case Keyword.get(opts, :current_user_data_only) do
+      nil -> UserList.public_entity_ids_query(is_screener: true)
+      user_id -> UserList.user_entity_ids_query(user_id, is_screener: true)
+    end
+  end
 
-  defp entity_ids_query(:watchlist),
-    do: UserList.public_entity_ids_query(is_screener: false)
+  defp entity_ids_query(:watchlist, opts) do
+    case Keyword.get(opts, :current_user_data_only) do
+      nil -> UserList.public_entity_ids_query(is_screener: false)
+      user_id -> UserList.user_entity_ids_query(user_id, is_screener: false)
+    end
+  end
 
-  defp entity_ids_query(:chart_configuration),
-    do: Chart.Configuration.public_entity_ids_query([])
+  defp entity_ids_query(:chart_configuration, opts) do
+    case Keyword.get(opts, :current_user_data_only) do
+      nil -> Chart.Configuration.public_entity_ids_query([])
+      user_id -> Chart.Configuration.user_entity_ids_query(user_id, [])
+    end
+  end
 
-  defp entity_ids_query(:timeline_event),
-    do: TimelineEvent.public_entity_ids_query([])
+  defp entity_ids_query(:timeline_event, opts) do
+    case Keyword.get(opts, :current_user_data_only) do
+      nil -> TimelineEvent.public_entity_ids_query([])
+      user_id -> TimelineEvent.user_entity_ids_query(user_id, [])
+    end
+  end
 
   defp deduce_entity_module(:insight), do: Post
   defp deduce_entity_module(:watchlist), do: UserList
@@ -133,15 +150,18 @@ defmodule Sanbase.Entity do
 
   defp maybe_filter_by_cursor(query, entity_type, opts) do
     case Keyword.get(opts, :cursor) do
-      nil -> query
-      %{type: type, datetime: datetime} -> filter_by_cursor(type, query, entity_type, datetime)
+      nil ->
+        query
+
+      %{type: type, datetime: datetime} ->
+        filter_by_cursor(type, query, entity_type, datetime)
     end
   end
 
-  # In the case of most voted API the Vote table is joined with the
-  # entity table, so we need to access the entity from that joined table.
-  # In the other case there are no joins. Solve this difference by
-  # using named bindings in both cases.
+  # In the case of most voted API the Vote table is joined with the entity
+  # table, so we need to access the entity from that joined table. In the other
+  # case there are no joins. Solve this difference by using named bindings in
+  # both cases.
   defp filter_by_cursor(:before, query, entity_type, datetime) do
     field = entity_datetime_field(entity_type)
 

--- a/lib/sanbase/entity/entity_behaviour.ex
+++ b/lib/sanbase/entity/entity_behaviour.ex
@@ -11,4 +11,5 @@ defmodule Sanbase.Entity.Behaviour do
   @callback by_ids!(ids, opts) :: list(entity) | no_return
 
   @callback public_entity_ids_query(opts) :: Ecto.Query.t()
+  @callback user_entity_ids_query(user_id :: non_neg_integer(), opts) :: Ecto.Query.t()
 end

--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -252,11 +252,13 @@ defmodule Sanbase.Insight.Post do
 
   @impl Sanbase.Entity.Behaviour
   def by_ids(post_ids, opts) when is_list(post_ids) do
+    ordering = Enum.with_index(post_ids) |> Map.new()
+
     result =
       public_insights_query(opts)
       |> where([p], p.id in ^post_ids)
-      |> order_by([p], fragment("array_position(?, ?::int)", ^post_ids, p.id))
       |> Repo.all()
+      |> Enum.sort_by(&Map.get(ordering, &1.id))
 
     {:ok, result}
   end
@@ -651,7 +653,7 @@ defmodule Sanbase.Insight.Post do
   end
 
   defp maybe_distinct(query, opts) do
-    case Keyword.get(opts, :distinct?, false) do
+    case Keyword.get(opts, :distinct?, true) do
       true -> from(p in query, distinct: true)
       false -> query
     end

--- a/lib/sanbase/timeline/timeline_event.ex
+++ b/lib/sanbase/timeline/timeline_event.ex
@@ -119,6 +119,13 @@ defmodule Sanbase.Timeline.TimelineEvent do
     |> select([te], te.id)
   end
 
+  @impl Sanbase.Entity.Behaviour
+  def user_entity_ids_query(user_id, _opts) do
+    from(te in __MODULE__)
+    |> where([te], te.user_id == ^user_id)
+    |> select([te], te.id)
+  end
+
   @doc """
   Public events by sanfamily members.
   The events can be paginated with time-based cursor pagination.

--- a/lib/sanbase/user_lists/user_list.ex
+++ b/lib/sanbase/user_lists/user_list.ex
@@ -125,7 +125,16 @@ defmodule Sanbase.UserList do
 
   @impl Sanbase.Entity.Behaviour
   def public_entity_ids_query(opts) do
-    from(ul in __MODULE__, where: ul.is_public == true)
+    from(ul in __MODULE__)
+    |> where([ul], ul.is_public == true)
+    |> select([ul], ul.id)
+    |> maybe_filter_is_screener(opts)
+  end
+
+  @impl Sanbase.Entity.Behaviour
+  def user_entity_ids_query(user_id, opts) do
+    from(ul in __MODULE__)
+    |> where([ul], ul.user_id == ^user_id)
     |> select([ul], ul.id)
     |> maybe_filter_is_screener(opts)
   end

--- a/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
@@ -1,25 +1,38 @@
 defmodule SanbaseWeb.Graphql.Resolvers.EntityResolver do
-  def get_most_voted(_root, args, _resolution) do
+  def get_most_voted(_root, args, resolution) do
     type = Map.get(args, :type)
 
-    opts = [
-      page: Map.get(args, :page, 1),
-      page_size: Map.get(args, :page_size, 10),
-      cursor: Map.get(args, :cursor)
-    ]
+    opts =
+      [
+        page: Map.get(args, :page, 1),
+        page_size: Map.get(args, :page_size, 10),
+        cursor: Map.get(args, :cursor)
+      ]
+      |> maybe_add_current_user_data_only(args, resolution)
 
     Sanbase.Entity.get_most_voted(type, opts)
   end
 
-  def get_most_recent(_root, args, _resolution) do
+  def get_most_recent(_root, args, resolution) do
     type = Map.get(args, :type)
 
-    opts = [
-      page: Map.get(args, :page, 1),
-      page_size: Map.get(args, :page_size, 10),
-      cursor: Map.get(args, :cursor)
-    ]
+    opts =
+      [
+        page: Map.get(args, :page, 1),
+        page_size: Map.get(args, :page_size, 10),
+        cursor: Map.get(args, :cursor)
+      ]
+      |> maybe_add_current_user_data_only(args, resolution)
 
     Sanbase.Entity.get_most_recent(type, opts)
+  end
+
+  defp maybe_add_current_user_data_only(opts, args, resolution) do
+    with true <- Map.get(args, :current_user_data_only, false),
+         user_id when is_integer(user_id) <- resolution.context.auth[:current_user][:id] do
+      Keyword.put(opts, :current_user_data_only, user_id)
+    else
+      _ -> opts
+    end
   end
 end

--- a/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
@@ -54,10 +54,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.InsightResolver do
       is_pulse: Map.get(args, :is_pulse),
       is_paywall_required: Map.get(args, :is_paywall_required),
       from: Map.get(args, :from),
-      to: Map.get(args, :to)
+      to: Map.get(args, :to),
+      page: page,
+      page_size: page_size
     ]
 
-    posts = Post.public_insights_by_tags(tags, page, page_size, opts)
+    posts = Post.public_insights_by_tags(tags, opts)
 
     {:ok, posts}
   end
@@ -67,10 +69,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.InsightResolver do
       is_pulse: Map.get(args, :is_pulse),
       is_paywall_required: Map.get(args, :is_paywall_required),
       from: Map.get(args, :from),
-      to: Map.get(args, :to)
+      to: Map.get(args, :to),
+      page: page,
+      page_size: page_size
     ]
 
-    posts = Post.public_insights(page, page_size, opts)
+    posts = Post.public_insights(opts)
 
     {:ok, posts}
   end

--- a/lib/sanbase_web/graphql/schema/queries/entity_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/entity_queries.ex
@@ -14,6 +14,7 @@ defmodule SanbaseWeb.Graphql.Schema.EntityQueries do
       arg(:type, :entity_type)
       arg(:page, :integer)
       arg(:page_size, :integer)
+      arg(:current_user_data_only, :boolean, default_value: false)
       arg(:cursor, :cursor_input_no_order, default_value: nil)
 
       cache_resolve(&EntityResolver.get_most_voted/3, ttl: 30, max_ttl_offset: 30)
@@ -24,6 +25,7 @@ defmodule SanbaseWeb.Graphql.Schema.EntityQueries do
       arg(:type, :entity_type)
       arg(:page, :integer)
       arg(:page_size, :integer)
+      arg(:current_user_data_only, :boolean, default_value: false)
       arg(:cursor, :cursor_input_no_order, default_value: nil)
 
       resolve(&EntityResolver.get_most_recent/3)

--- a/test/sanbase_web/graphql/insight/insight_tag_order_test.exs
+++ b/test/sanbase_web/graphql/insight/insight_tag_order_test.exs
@@ -69,12 +69,12 @@ defmodule SanbaseWeb.Graphql.InsightTagOrderTest do
     tags2 = ["third", "first", "BTC", "second"]
     mutation2 = update_insight_tags_mutation(id, tags2)
     execute_mutation(conn, mutation2)
-    assert get_insight_tags(conn, id) == tags2
+    assert get_insight_tags(conn, id) == ["first", "second", "third", "BTC"]
 
     tags3 = ["SAN", "PESH" | tags2 |> Enum.reverse()] ++ ["ASD"]
     mutation3 = update_insight_tags_mutation(id, tags3)
     execute_mutation(conn, mutation3)
-    assert get_insight_tags(conn, id) == tags3
+    assert get_insight_tags(conn, id) == ["first", "second", "third", "BTC", "SAN", "PESH", "ASD"]
   end
 
   defp create_insight_mutation(title, text, tags) do


### PR DESCRIPTION
## Changes

- Simplify Post SQL queries by reusing common parts
- Remove tag ordering as it is no longer required by the frontend but is causing a lot of issues on the backend. The FE now uses the special field `priceChartProject` that shows for which project the price chart needs to be displayed.
- Add `currentUserDataOnly` boolean argument to `getMostRecent`/`getMostVoted` that switches the behavior to return only the current user data (including private entities).

```graphql
{
      getMostVoted(
        type: INSIGHT
        page: 1
        pageSize: 10
        currentUserDataOnly: true
        cursor: { type: AFTER, datetime: "utc_now-7d" }
      ){
          insight{ id }
          watchlist{ id }
          screener{ id }
          timelineEvent{ id }
          chartConfiguration{ id }
      }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
