### PR TITLE
Support multiple types to getMostRecent/getMostVoted

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
@@ -1,6 +1,6 @@
 defmodule SanbaseWeb.Graphql.Resolvers.EntityResolver do
   def get_most_voted(_root, args, _resolution) do
-    type = Map.get(args, :type)
+    types = Map.get(args, :types) || [Map.get(args, :type)]
 
     opts = [
       page: Map.get(args, :page, 1),
@@ -8,11 +8,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.EntityResolver do
       cursor: Map.get(args, :cursor)
     ]
 
-    Sanbase.Entity.get_most_voted(type, opts)
+    execute_for_types(types, &Sanbase.Entity.get_most_voted(&1, opts))
   end
 
   def get_most_recent(_root, args, _resolution) do
-    type = Map.get(args, :type)
+    types = Map.get(args, :types) || [Map.get(args, :type)]
 
     opts = [
       page: Map.get(args, :page, 1),
@@ -20,6 +20,15 @@ defmodule SanbaseWeb.Graphql.Resolvers.EntityResolver do
       cursor: Map.get(args, :cursor)
     ]
 
-    Sanbase.Entity.get_most_recent(type, opts)
+    execute_for_types(types, &Sanbase.Entity.get_most_recent(&1, opts))
+  end
+
+  defp execute_for_types(types, function) do
+    Enum.reduce_while(types, {:ok, []}, fn type, {:ok, acc} ->
+      case function.(type) do
+        {:ok, result} -> {:cont, {:ok, result ++ acc}}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
   end
 end

--- a/lib/sanbase_web/graphql/schema/queries/entity_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/entity_queries.ex
@@ -12,6 +12,7 @@ defmodule SanbaseWeb.Graphql.Schema.EntityQueries do
     field :get_most_voted, list_of(:entity_result) do
       meta(access: :free)
       arg(:type, :entity_type)
+      arg(:types, list(:entity_type))
       arg(:page, :integer)
       arg(:page_size, :integer)
       arg(:cursor, :cursor_input_no_order, default_value: nil)
@@ -22,6 +23,7 @@ defmodule SanbaseWeb.Graphql.Schema.EntityQueries do
     field :get_most_recent, list_of(:entity_result) do
       meta(access: :free)
       arg(:type, :entity_type)
+      arg(:types, list(:entity_type))
       arg(:page, :integer)
       arg(:page_size, :integer)
       arg(:cursor, :cursor_input_no_order, default_value: nil)


### PR DESCRIPTION
## Changes

```graphql
{
      getMostVoted(
        types: [WATCHLIST, CHART_CONFIGURATION, INSIGHT]
        page: 1
        pageSize: 10
        cursor: { type: AFTER, datetime: "utc_now-7d" }
      ){
          insight{ id }
          watchlist{ id }
          screener{ id }
          timelineEvent{ id }
          chartConfiguration{ id }
      }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
