### PR TITLE
Add pagination featured insights

### DIFF
--- a/lib/sanbase/entity/entity.ex
+++ b/lib/sanbase/entity/entity.ex
@@ -21,6 +21,14 @@ defmodule Sanbase.Entity do
   alias Sanbase.UserList
   alias Sanbase.Timeline.TimelineEvent
 
+  def paginate(query, opts) do
+    {limit, offset} = Sanbase.Utils.Transform.opts_to_limit_offset(opts)
+
+    query
+    |> limit(^limit)
+    |> offset(^offset)
+  end
+
   def get_most_voted(entity, opts), do: do_get_most_voted(entity, opts)
 
   def get_most_recent(entity, opts), do: do_get_most_recent(entity, opts)
@@ -139,14 +147,6 @@ defmodule Sanbase.Entity do
   defp deduce_entity_module(:screener), do: UserList
   defp deduce_entity_module(:timeline_event), do: TimelineEvent
   defp deduce_entity_module(:chart_configuration), do: Chart.Configuration
-
-  defp paginate(query, opts) do
-    {limit, offset} = Sanbase.Utils.Transform.opts_to_limit_offset(opts)
-
-    query
-    |> limit(^limit)
-    |> offset(^offset)
-  end
 
   defp maybe_filter_by_cursor(query, entity_type, opts) do
     case Keyword.get(opts, :cursor) do

--- a/lib/sanbase/featured_items/featured_item.ex
+++ b/lib/sanbase/featured_items/featured_item.ex
@@ -49,14 +49,16 @@ defmodule Sanbase.FeaturedItem do
     |> check_constraint(:one_featured_item_per_row, name: :only_one_fk)
   end
 
-  def insights() do
+  def insights(opts \\ []) do
     insights_query()
     |> join(:inner, [fi], fi in assoc(fi, :post))
     |> where(
       [_fi, post],
       post.ready_state == ^Post.published() and post.state == ^Post.approved_state()
     )
-    |> select([_fi, post], post)
+    |> order_by([fi, _post], desc: fi.inserted_at, desc: fi.id)
+    |> Sanbase.Entity.paginate(opts)
+    |> select([fi, post], post)
     |> Repo.all()
     |> Repo.preload([:user, :tags])
   end

--- a/lib/sanbase_web/graphql/resolvers/featured_item_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/featured_item_resolver.ex
@@ -5,8 +5,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.FeaturedItemResolver do
 
   alias Sanbase.FeaturedItem
 
-  def insights(_root, _args, _context) do
-    {:ok, FeaturedItem.insights()}
+  def insights(_root, %{} = args, _context) do
+    {:ok, FeaturedItem.insights(page: args.page, page_size: args.page_size)}
   end
 
   def watchlists(_root, %{} = args, _context) do

--- a/lib/sanbase_web/graphql/schema/queries/featured_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/featured_queries.ex
@@ -11,6 +11,10 @@ defmodule SanbaseWeb.Graphql.Schema.FeaturedQueries do
   object :featured_queries do
     field :featured_insights, list_of(:post) do
       meta(access: :free)
+
+      arg(:page, :integer, default_value: 1)
+      arg(:page_size, :integer, default_value: 5)
+
       cache_resolve(&FeaturedItemResolver.insights/3)
     end
 

--- a/test/sanbase_web/graphql/featured_item/featured_item_api_test.exs
+++ b/test/sanbase_web/graphql/featured_item/featured_item_api_test.exs
@@ -106,6 +106,17 @@ defmodule Sanbase.FeaturedItemApiTest do
              }
     end
 
+    test "ordering and pagination of featured insights works", context do
+      insight1 = insert(:post, state: Post.approved_state(), ready_state: Post.published())
+      insight2 = insert(:post, state: Post.approved_state(), ready_state: Post.published())
+
+      :ok = FeaturedItem.update_item(insight2, true)
+      :ok = FeaturedItem.update_item(insight1, true)
+
+      query = "{featuredInsights(page: 1, page_size: 1){ id }}"
+      assert execute_query(context.conn, query, "featuredInsights") == [%{"id" => insight1.id}]
+    end
+
     test "Not published insight cannot be featured", context do
       insight = insert(:post)
       {:error, _} = FeaturedItem.update_item(insight, true)


### PR DESCRIPTION
## Changes

Add pagination for featured insights. It maybe will be useful to add for all featured entities but will be done in another PR.

<!--- Describe your changes -->

```graphql
{
featuredInsights(page: 1, page_size: 5){ id }
}
```

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
