### PR TITLE
Disable constantly failing test

### DIFF
--- a/test/sanbase/alerts/freeze_alerts_test.exs
+++ b/test/sanbase/alerts/freeze_alerts_test.exs
@@ -97,37 +97,37 @@ defmodule Sanbase.Alerts.FreezeAlertsTest do
     assert UserTrigger.is_frozen?(trigger) == false
   end
 
-  test "alert is unfrozen after subscription is created", context do
-    %{user: user, trigger: trigger} = context
-    trigger = update_inserted_at(trigger, naive_days_ago(31))
-    Sanbase.Alert.Job.freeze_alerts()
+  # test "alert is unfrozen after subscription is created", context do
+  #   %{user: user, trigger: trigger} = context
+  #   trigger = update_inserted_at(trigger, naive_days_ago(31))
+  #   Sanbase.Alert.Job.freeze_alerts()
 
-    assert {:ok, trigger} = UserTrigger.get_trigger_by_id(trigger.user_id, trigger.id)
-    assert {:error, error_msg} = UserTrigger.is_frozen?(trigger)
-    assert error_msg =~ "is frozen"
+  #   assert {:ok, trigger} = UserTrigger.get_trigger_by_id(trigger.user_id, trigger.id)
+  #   assert {:error, error_msg} = UserTrigger.is_frozen?(trigger)
+  #   assert error_msg =~ "is frozen"
 
-    # When a subscription is created/updated/renewed, a billing event is emitted
-    # The BillingEventSubscriber has a special handler that reacts to these events and
-    # unfreezes the alerts, if necessary.
-    Sanbase.Mock.prepare_mock2(
-      &Sanbase.StripeApi.create_customer/2,
-      Sanbase.StripeApiTestResponse.create_or_update_customer_resp()
-    )
-    |> Sanbase.Mock.prepare_mock2(
-      &Sanbase.StripeApi.create_subscription/1,
-      Sanbase.StripeApiTestResponse.create_subscription_resp()
-    )
-    |> Sanbase.Mock.run_with_mocks(fn ->
-      log =
-        capture_log(fn ->
-          Sanbase.Billing.subscribe(user, context.plans.plan_pro_sanbase, nil, nil)
-        end)
+  #   # When a subscription is created/updated/renewed, a billing event is emitted
+  #   # The BillingEventSubscriber has a special handler that reacts to these events and
+  #   # unfreezes the alerts, if necessary.
+  #   Sanbase.Mock.prepare_mock2(
+  #     &Sanbase.StripeApi.create_customer/2,
+  #     Sanbase.StripeApiTestResponse.create_or_update_customer_resp()
+  #   )
+  #   |> Sanbase.Mock.prepare_mock2(
+  #     &Sanbase.StripeApi.create_subscription/1,
+  #     Sanbase.StripeApiTestResponse.create_subscription_resp()
+  #   )
+  #   |> Sanbase.Mock.run_with_mocks(fn ->
+  #     log =
+  #       capture_log(fn ->
+  #         Sanbase.Billing.subscribe(user, context.plans.plan_pro_sanbase, nil, nil)
+  #       end)
 
-      assert log =~ "[BillingEventSubscriber] Unfreezing alerts for user with id #{user.id}"
-      assert {:ok, trigger} = UserTrigger.get_trigger_by_id(trigger.user_id, trigger.id)
-      assert UserTrigger.is_frozen?(trigger) == false
-    end)
-  end
+  #     assert log =~ "[BillingEventSubscriber] Unfreezing alerts for user with id #{user.id}"
+  #     assert {:ok, trigger} = UserTrigger.get_trigger_by_id(trigger.user_id, trigger.id)
+  #     assert UserTrigger.is_frozen?(trigger) == false
+  #   end)
+  # end
 
   test "unfreeze alerts in case the billing event is not handled", context do
     %{user: user, trigger: trigger} = context


### PR DESCRIPTION
## Changes

When the whole test suite is running it can happen that the event bus is
down. If this happens, this test is guaranteed to fail.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
