### PR TITLE
Add public user to the user trigger graphql type

### DIFF
--- a/lib/sanbase_web/graphql/schema/types/user_trigger_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_trigger_types.ex
@@ -1,13 +1,21 @@
 defmodule SanbaseWeb.Graphql.UserTriggerTypes do
   use Absinthe.Schema.Notation
 
-  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1]
+  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1, cache_resolve: 2]
 
   alias SanbaseWeb.Graphql.Resolvers.UserTriggerResolver
   alias SanbaseWeb.Graphql.Resolvers.VoteResolver
 
   object :user_trigger do
     field(:user_id, :integer)
+
+    field :user, :public_user do
+      cache_resolve(&SanbaseWeb.Graphql.Resolvers.UserResolver.user_no_preloads/3,
+        ttl: 60,
+        max_ttl: 60
+      )
+    end
+
     field(:trigger, :trigger)
 
     field :voted_at, :datetime do

--- a/test/sanbase_web/graphql/alerts/triggers_api_test.exs
+++ b/test/sanbase_web/graphql/alerts/triggers_api_test.exs
@@ -232,6 +232,7 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
 
     assert trigger["settings"] == trigger_settings
     assert trigger["id"] == trigger_id
+    assert result["data"]["getTriggerById"]["user"]["id"] == "#{user.id}"
   end
 
   test "can get other user public trigger", %{conn: conn} do
@@ -639,10 +640,11 @@ defmodule SanbaseWeb.Graphql.TriggersApiTest do
     query = """
     query {
       getTriggerById(id: #{id}) {
-          trigger{
-            id
-            settings
-            lastTriggeredDatetime
+        user{ id }
+        trigger{
+          id
+          settings
+          lastTriggeredDatetime
         }
       }
     }


### PR DESCRIPTION
## Changes
```graphql
    query {
      getTriggerById(id: 1) {
        userId # still supported
        user{ id } # new public user object is provided in this PR
        trigger{
          id
          settings
          lastTriggeredDatetime
        }
      }
    }
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
