### PR TITLE
Fix eth client lib content type error

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -108,7 +108,8 @@ config :waffle,
 
 config :ethereumex,
   url: "http://erigon-hz.stage.san:30250/",
-  http_options: [timeout: 25_000, recv_timeout: 25_000]
+  http_options: [timeout: 25_000, recv_timeout: 25_000],
+  http_headers: [{"Content-Type", "application/json"}]
 
 if File.exists?("config/dev.secret.exs") do
   import_config "dev.secret.exs"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -52,7 +52,8 @@ config :sanbase, SanbaseWeb.Plug.SessionPlug,
 
 config :ethereumex,
   url: "${PARITY_URL}",
-  http_options: [timeout: 25_000, recv_timeout: 25_000]
+  http_options: [timeout: 25_000, recv_timeout: 25_000],
+  http_headers: [{"Content-Type", "application/json"}]
 
 if File.exists?("config/prod.secret.exs") do
   import_config "prod.secret.exs"


### PR DESCRIPTION
## Changes

Adding `content-type: application/json` fixes the sentry errors.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
