### PR TITLE
Add nft social volume from metricshub

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/metric/metric_adapter.ex
@@ -45,7 +45,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
   @type interval :: String.t()
 
   defguard is_supported_selector(s)
-           when is_map(s) and (is_map_key(s, :slug) or is_map_key(s, :contract_address_raw))
+           when is_map(s) and is_map_key(s, :slug)
 
   @impl Sanbase.Metric.Behaviour
   def free_metrics(), do: @free_metrics

--- a/lib/sanbase/clickhouse/metric/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/metric/metric_adapter.ex
@@ -87,7 +87,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
     # FIXME: Some of the `nft` metrics need additional filter for `owner=opensea`
     # to show correct values. Remove after fixed by bigdata.
     filters =
-      if String.starts_with?(metric, "nft_") and metric not in ["nft_social_volume"] do
+      if String.starts_with?(metric, "nft_") do
         [owner: "opensea"]
       else
         Keyword.get(opts, :additional_filters, [])

--- a/lib/sanbase/clickhouse/metric/metric_files/social_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/social_metrics.json
@@ -1132,27 +1132,5 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "NFT Social volume",
-    "name": "nft_social_volume",
-    "metric": "nft_collections_social_volume",
-    "version": "2019-01-01",
-    "access": {
-      "historical": "restricted",
-      "realtime": "free"
-    },
-    "selectors": [
-      "contract_address_raw"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
   }
 ]

--- a/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
+++ b/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
@@ -368,9 +368,6 @@ defmodule Sanbase.Clickhouse.MetricAdapter.SqlQuery do
 
   defp asset_filter_value(%{slug: slug_or_slugs}), do: slug_or_slugs
 
-  defp asset_filter_value(%{contract_address_raw: address}),
-    do: Sanbase.BlockchainAddress.to_internal_format(address)
-
   defp asset_filter_value(not_supported),
     do: raise("Got unsupported selector: #{inspect(not_supported)}")
 end

--- a/lib/sanbase/metric/sql_query_helper.ex
+++ b/lib/sanbase/metric/sql_query_helper.ex
@@ -80,12 +80,6 @@ defmodule Sanbase.Metric.SqlQuery.Helper do
     "asset_id IN ( SELECT DISTINCT(asset_id) FROM asset_metadata FINAL PREWHERE name IN (?#{arg_position}) )"
   end
 
-  def asset_id_filter(%{contract_address_raw: contract}, opts) when is_binary(contract) do
-    arg_position = Keyword.fetch!(opts, :argument_position)
-
-    "asset_id IN ( SELECT asset_id FROM asset_metadata FINAL PREWHERE has(contract_addresses, ?#{arg_position}) LIMIT 1)"
-  end
-
   def metric_id_filter(metric, opts) when is_binary(metric) do
     arg_position = Keyword.fetch!(opts, :argument_position)
 

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -22,7 +22,8 @@ defmodule Sanbase.SocialData.MetricAdapter do
     "social_volume_reddit",
     "social_volume_twitter",
     "social_volume_bitcointalk",
-    "social_volume_total"
+    "social_volume_total",
+    "nft_social_volume"
   ]
 
   @community_messages_count_timeseries_metrics [
@@ -84,6 +85,30 @@ defmodule Sanbase.SocialData.MetricAdapter do
 
   @impl Sanbase.Metric.Behaviour
   def broken_data(_metric, _selector, _from, _to), do: {:ok, []}
+
+  @impl Sanbase.Metric.Behaviour
+  def timeseries_data("nft_social_volume", %{text: text} = selector, from, to, interval, _opts)
+      when is_binary(text) do
+    Sanbase.SocialData.social_volume(selector, from, to, interval, "total",
+      metric: "nft_social_volume"
+    )
+    |> transform_to_value_pairs(:mentions_count)
+  end
+
+  def timeseries_data(
+        "nft_social_volume",
+        %{contract_address: contract} = selector,
+        from,
+        to,
+        interval,
+        _opts
+      )
+      when is_binary(contract) do
+    Sanbase.SocialData.social_volume(selector, from, to, interval, "total",
+      metric: "nft_social_volume"
+    )
+    |> transform_to_value_pairs(:mentions_count)
+  end
 
   @impl Sanbase.Metric.Behaviour
   def timeseries_data(metric, selector, from, to, interval, _opts)

--- a/lib/sanbase/social_data/social_data.ex
+++ b/lib/sanbase/social_data/social_data.ex
@@ -18,6 +18,9 @@ defmodule Sanbase.SocialData do
   defdelegate social_volume(selector, from, to, interval, source),
     to: SocialVolume
 
+  defdelegate social_volume(selector, from, to, interval, source, opts),
+    to: SocialVolume
+
   defdelegate social_active_users(selector, from, to, interval),
     to: ActiveUsers
 

--- a/lib/sanbase/social_data/social_volume.ex
+++ b/lib/sanbase/social_data/social_volume.ex
@@ -23,7 +23,10 @@ defmodule Sanbase.SocialData.SocialVolume do
 
   def social_volume(%{contract_address: contract} = selector, from, to, interval, source, opts)
       when is_binary(contract) do
-    search_text = search_text_by_contract(contract)
+    search_text =
+      contract
+      |> Sanbase.BlockchainAddress.to_internal_format()
+      |> search_text_by_contract()
 
     case search_text do
       text when is_binary(text) ->

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -30,7 +30,6 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     value(:ignored_slugs)
     value(:market_segments)
     value(:contract_address)
-    value(:contract_address_raw)
     # watchlist related
     value(:watchlist_slug)
     value(:watchlist_id)
@@ -86,9 +85,6 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:label_fqn, :string)
     field(:label_fqns, list_of(:string))
     field(:holders_count, :integer)
-
-    # contract address not transformed to slug selector
-    field(:contract_address_raw, :string)
   end
 
   input_object :timeseries_metric_transform_input_object do

--- a/test/sanbase_web/graphql/metric/api_metric_metadata_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_metadata_test.exs
@@ -39,7 +39,6 @@ defmodule SanbaseWeb.Graphql.ApiMetricMetadataTest do
                    "SLUG",
                    "SLUGS",
                    "CONTRACT_ADDRESS",
-                   "CONTRACT_ADDRESS_RAW",
                    "MARKET_SEGMENTS",
                    "TEXT",
                    "LABEL",


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

```graphql
    {
      getMetric(metric: "nft_social_volume"){
        timeseriesData(
          selector: {contractAddress:"0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d"}
          from: "utc_now-5d"
          to: "utc_now"
          interval: "1d"
      	){
            datetime
            value
          }
      }
    }
```

```graphql
    {
      getMetric(metric: "nft_social_volume"){
        timeseriesData(
          selector: {text:"BAYC"}
          from: "utc_now-5d"
          to: "utc_now"
          interval: "1d"
      	){
            datetime
            value
          }
      }
    }
```

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
