### PR TITLE
Add extra clearing of ETS records before updating the quota

### DIFF
--- a/lib/sanbase/api_call_limit/api_call_limit.ex
+++ b/lib/sanbase/api_call_limit/api_call_limit.ex
@@ -173,12 +173,14 @@ defmodule Sanbase.ApiCallLimit do
   end
 
   defp get_by_and_lock(:user, user) do
-    from(acl in __MODULE__,
-      where: acl.user_id == ^user.id,
-      lock: "FOR UPDATE"
-    )
-    |> Repo.one()
-    |> case do
+    result =
+      from(acl in __MODULE__,
+        where: acl.user_id == ^user.id,
+        lock: "FOR UPDATE"
+      )
+      |> Repo.one()
+
+    case result do
       nil ->
         # Ensure that the result we get back has a lock. This is making more
         # DB calls, but it should be executed only once per user/remote_ip and

--- a/test/sanbase_web/api_call_limit/api_call_limit_api_test.exs
+++ b/test/sanbase_web/api_call_limit/api_call_limit_api_test.exs
@@ -270,7 +270,7 @@ defmodule SanbaseWeb.ApiCallLimitTest do
 
       api_calls_made = Enum.max(Map.values(acl.api_calls))
 
-      allowed_difference = max_quota
+      allowed_difference = max_quota * 2
       real_api_calls_made = (iterations - days_in_old_month) * api_calls_per_iteration
 
       assert api_calls_made >= real_api_calls_made - allowed_difference
@@ -334,7 +334,7 @@ defmodule SanbaseWeb.ApiCallLimitTest do
 
       api_calls_made = Enum.max(Map.values(acl.api_calls))
 
-      allowed_difference = max_quota
+      allowed_difference = max_quota * 2
 
       # The amount stored should never exceed the real amount of api calls
       assert iterations * api_calls_per_iteration >= api_calls_made
@@ -403,7 +403,7 @@ defmodule SanbaseWeb.ApiCallLimitTest do
 
       api_calls_made = Enum.max(Map.values(acl.api_calls))
 
-      allowed_difference = max_quota
+      allowed_difference = max_quota * 2
 
       # The amount stored should never exceed the real amount of api calls
       assert iterations * api_calls_per_iteration >= api_calls_made

--- a/test/sanbase_web/api_call_limit/api_call_limit_api_test.exs
+++ b/test/sanbase_web/api_call_limit/api_call_limit_api_test.exs
@@ -270,10 +270,7 @@ defmodule SanbaseWeb.ApiCallLimitTest do
 
       api_calls_made = Enum.max(Map.values(acl.api_calls))
 
-      # The quota size in test env is between 10 and 20. I would expect
-      # a max difference of 20 with the DB stored calls - at most `max_quota`
-      # There are some API calls lost (I don't know why) so there is +10 extra
-      allowed_difference = max_quota * 2
+      allowed_difference = max_quota
       real_api_calls_made = (iterations - days_in_old_month) * api_calls_per_iteration
 
       assert api_calls_made >= real_api_calls_made - allowed_difference
@@ -337,10 +334,7 @@ defmodule SanbaseWeb.ApiCallLimitTest do
 
       api_calls_made = Enum.max(Map.values(acl.api_calls))
 
-      # The quota size in test env is between 10 and 20. I would expect
-      # a max difference of 20 with the DB stored calls - at most `max_quota`
-      # There are some API calls lost (I don't know why) so there is +10 extra
-      allowed_difference = max_quota * 2
+      allowed_difference = max_quota
 
       # The amount stored should never exceed the real amount of api calls
       assert iterations * api_calls_per_iteration >= api_calls_made
@@ -409,10 +403,7 @@ defmodule SanbaseWeb.ApiCallLimitTest do
 
       api_calls_made = Enum.max(Map.values(acl.api_calls))
 
-      # The quota size in test env is between 10 and 20. I would expect
-      # a max difference of 20 with the DB stored calls - at most `max_quota`
-      # There are some API calls lost (I don't know why) so there is +10 extra
-      allowed_difference = max_quota * 2
+      allowed_difference = max_quota
 
       # The amount stored should never exceed the real amount of api calls
       assert iterations * api_calls_per_iteration >= api_calls_made


### PR DESCRIPTION
## Changes

Adding clearing of the ETS record before fetching a new quota and
putting it in the ETS help alleviate the situation where the quota
fetching fails. This way the ETS record is cleared and the usage
cannot be recorded twice in the database.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
