### PR TITLE
Limit dashboard stored size

### DIFF
--- a/lib/sanbase/dashboard/schema/dashboard_cache.ex
+++ b/lib/sanbase/dashboard/schema/dashboard_cache.ex
@@ -152,13 +152,19 @@ defmodule Sanbase.Dashboard.Cache do
   # can be executed and fill the database with lots of data.
   @allowed_kb_size 500
   defp query_result_size_allowed?(query_result) do
-    case byte_size(query_result.compressed_rows) / 1024 do
+    kb_size = byte_size(query_result.compressed_rows) / 1024
+    kb_size = Float.round(kb_size, 2)
+
+    case kb_size do
       size when size <= @allowed_kb_size ->
         true
 
       size ->
-        {:error, "Cannot cache the panel because its compressed size is #{size}KB \
-         which is over the limit of #{@allowed_kb_size}KB"}
+        {:error,
+         """
+         Cannot cache the panel because its compressed size is #{size}KB \
+         which is over the limit of #{@allowed_kb_size}KB
+         """}
     end
   end
 end

--- a/lib/sanbase/dashboard/schema/dashboard_cache.ex
+++ b/lib/sanbase/dashboard/schema/dashboard_cache.ex
@@ -70,18 +70,19 @@ defmodule Sanbase.Dashboard.Cache do
   @spec update_panel_cache(non_neg_integer(), String.t(), Dashboad.Query.Result.t()) ::
           {:ok, t()} | {:error, any()}
   def update_panel_cache(dashboard_id, panel_id, query_result) do
-    {:ok, cache} = by_dashboard_id(dashboard_id)
+    with true <- query_result_size_allowed?(query_result),
+         {:ok, cache} <- by_dashboard_id(dashboard_id) do
+      panel_cache =
+        Dashboard.Panel.Cache.from_query_result(query_result, panel_id, dashboard_id)
+        |> Map.from_struct()
+        |> Map.drop([:rows])
 
-    panel_cache =
-      Dashboard.Panel.Cache.from_query_result(query_result, panel_id, dashboard_id)
-      |> Map.from_struct()
-      |> Map.drop([:rows])
+      panels = Map.update(cache.panels, panel_id, panel_cache, fn _ -> panel_cache end)
 
-    panels = Map.update(cache.panels, panel_id, panel_cache, fn _ -> panel_cache end)
-
-    cache
-    |> change(%{panels: panels})
-    |> Repo.update()
+      cache
+      |> change(%{panels: panels})
+      |> Repo.update()
+    end
   end
 
   @doc ~s"""
@@ -144,5 +145,20 @@ defmodule Sanbase.Dashboard.Cache do
       end)
 
     {:ok, transformed_rows}
+  end
+
+  # The byte size of the compressed rows should not exceed the allowed limit.
+  # Otherwise simple queries like `select * from intraday_metircs limit 9999999`
+  # can be executed and fill the database with lots of data.
+  @allowed_kb_size 500
+  defp query_result_size_allowed?(query_result) do
+    case byte_size(query_result.compressed_rows) / 1024 do
+      size when size <= @allowed_kb_size ->
+        true
+
+      size ->
+        {:error, "Cannot cache the panel because its compressed size is #{size}KB \
+         which is over the limit of #{@allowed_kb_size}KB"}
+    end
   end
 end


### PR DESCRIPTION
## Changes

Allow storing a cached version of a panel only if it's gzip compressed size is less than 500KB.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
