### PR TITLE
Add Dashboard.History

### DIFF
--- a/lib/sanbase/billing/invoices/download.ex
+++ b/lib/sanbase/billing/invoices/download.ex
@@ -19,14 +19,14 @@ defmodule Sanbase.Billing.Invoices.Download do
       list_invoices([], %{created: %{gte: from, lte: to}, limit: 100, status: "paid"})
       |> Enum.filter(&(&1.total > 0 or abs(&1.starting_balance) > 0))
 
-    IO.inspect(length(invoices), label: "Number of invoices for #{year}_#{month}")
+    IO.puts("Number of invoices for #{year}_#{month}: #{length(invoices)}")
 
     invoices =
       invoices
       |> Enum.map(fn inv ->
         label = if inv.starting_balance == 0, do: "fiat", else: "crypto"
         url = inv.invoice_pdf
-        IO.inspect(url, label: "#{year}_#{month} fetching url ...")
+        IO.puts("#{year}_#{month} fetching url: #{url}")
 
         response =
           HTTPoison.get!(url, [],
@@ -43,7 +43,9 @@ defmodule Sanbase.Billing.Invoices.Download do
 
     zipname = "#{year}_#{month}.zip"
     {:ok, _zipfile} = :zip.create(zipname |> to_charlist(), invoices)
-    IO.inspect(zipname, label: "***************** result zipfile")
+    IO.puts("***************** result zipfile: #{zipname}")
+
+    zipname
   end
 
   def extract_filename(response) do

--- a/lib/sanbase/dashboard/schema/dashboard_panel.ex
+++ b/lib/sanbase/dashboard/schema/dashboard_panel.ex
@@ -44,6 +44,12 @@ defmodule Sanbase.Dashboard.Panel do
     field(:sql, :map)
   end
 
+  def changeset(%__MODULE__{} = panel, attrs) do
+    panel
+    |> cast(attrs, [:name, :description, :position, :type, :size, :sql])
+    |> validate_change(:sql, &Query.changeset_valid_sql?/2)
+  end
+
   @doc ~s"""
   Create a struct from the provided arguments
 
@@ -78,17 +84,7 @@ defmodule Sanbase.Dashboard.Panel do
           args
       end
 
-    changeset =
-      panel
-      |> cast(args, [
-        :name,
-        :description,
-        :position,
-        :type,
-        :size,
-        :sql
-      ])
-      |> validate_change(:sql, &Query.changeset_valid_sql?/2)
+    changeset = changeset(panel, args)
 
     changeset =
       case Keyword.fetch!(opts, :check_required) do

--- a/lib/sanbase/dashboard/schema/dashboard_schema_history.ex
+++ b/lib/sanbase/dashboard/schema/dashboard_schema_history.ex
@@ -1,0 +1,104 @@
+defmodule Sanbase.Dashboard.History do
+  @moduledoc ~s"""
+  Dashboard database schema and CRUD functions for working
+  with it.
+
+  This module is used for creating and updating dashboard fields.
+  It also provide functions for adding/updating/removing dashboard panels
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Query
+  import Ecto.Changeset
+
+  import Sanbase.Utils.Transform, only: [opts_to_limit_offset: 1]
+
+  alias Sanbase.Repo
+  alias Sanbase.Dashboard
+
+  @type t :: %__MODULE__{
+          # Inherited from Dashboard.Schmea
+          name: String.t(),
+          description: String.t(),
+          is_public: boolean(),
+          panels: list(Dashboard.Panel.t()),
+          inserted_at: NaiveDateTime.t(),
+          updated_at: NaiveDateTime.t(),
+          #
+          dashboard_id: non_neg_integer(),
+          id: non_neg_integer(),
+          message: String.t()
+        }
+
+  @type dashboard_id :: non_neg_integer()
+
+  schema "dashboards_history" do
+    field(:name, :string)
+    field(:description, :string)
+    field(:is_public, :boolean, default: false)
+
+    embeds_many(:panels, Dashboard.Panel, on_replace: :delete)
+
+    belongs_to(:dashboard, Dashboard.Schema)
+
+    field(:message, :string)
+    field(:hash, :string)
+
+    timestamps()
+  end
+
+  def changeset(%__MODULE__{} = history, attrs) do
+    history
+    |> cast(attrs, [:name, :description, :is_public, :message, :dashboard_id, :hash])
+    |> put_embed(:panels, attrs.panels)
+  end
+
+  def commit(%Dashboard.Schema{} = dashboard, message) do
+    fields =
+      dashboard
+      |> Map.from_struct()
+      |> Map.delete(:id)
+      |> Map.put(:dashboard_id, dashboard.id)
+      |> Map.put(:message, message)
+      |> Map.put(:hash, generate_hash(dashboard, message))
+
+    %__MODULE__{}
+    |> changeset(fields)
+    |> Repo.insert()
+  end
+
+  def get_history(dashboard_id, hash) do
+    query =
+      from(dh in __MODULE__,
+        where: dh.dashboard_id == ^dashboard_id and dh.hash == ^hash
+      )
+
+    case Repo.one(query) do
+      nil -> {:error, "Dashboard History does not exist"}
+      %__MODULE__{} = dh -> {:ok, dh}
+    end
+  end
+
+  def get_history_list(dashboard_id, opts) do
+    {limit, offset} = opts_to_limit_offset(opts)
+
+    query =
+      from(dh in __MODULE__,
+        where: dh.dashboard_id == ^dashboard_id,
+        order_by: [desc: dh.inserted_at],
+        limit: ^limit,
+        offset: ^offset
+      )
+
+    {:ok, Repo.all(query)}
+  end
+
+  defp generate_hash(dashboard, message) do
+    binary_data = {dashboard, message, DateTime.utc_now()} |> :erlang.term_to_binary()
+
+    :crypto.hash(:sha256, binary_data)
+    |> Base.encode16(case: :lower)
+    |> :erlang.binary_part(0, 40)
+  end
+end

--- a/lib/sanbase_web/graphql/resolvers/user/dashboard_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/dashboard_resolver.ex
@@ -14,19 +14,19 @@ defmodule SanbaseWeb.Graphql.Resolvers.DashboardResolver do
   end
 
   def update_dashboard(_root, args, %{context: %{auth: %{current_user: user}}}) do
-    with true <- can_edit_dashboard?(args.id, user.id) do
+    with true <- is_dashboard_owner?(args.id, user.id) do
       Dashboard.update(args.id, args)
     end
   end
 
   def delete_dashboard(_root, args, %{context: %{auth: %{current_user: user}}}) do
-    with true <- can_edit_dashboard?(args.id, user.id) do
+    with true <- is_dashboard_owner?(args.id, user.id) do
       Dashboard.delete(args.id)
     end
   end
 
   def create_dashboard_panel(_root, args, %{context: %{auth: %{current_user: user}}}) do
-    with true <- can_edit_dashboard?(args.dashboard_id, user.id),
+    with true <- is_dashboard_owner?(args.dashboard_id, user.id),
          {:ok, %{} = result} <- Dashboard.create_panel(args.dashboard_id, args.panel) do
       {:ok, result.panel |> Map.put(:dashboard_id, result.dashboard.id)}
     end
@@ -35,7 +35,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.DashboardResolver do
   def remove_dashboard_panel(_root, args, %{context: %{auth: %{current_user: user}}}) do
     %{dashboard_id: dashboard_id, panel_id: panel_id} = args
 
-    with true <- can_edit_dashboard?(dashboard_id, user.id),
+    with true <- is_dashboard_owner?(dashboard_id, user.id),
          {:ok, %{} = result} <- Dashboard.remove_panel(dashboard_id, panel_id) do
       {:ok, result.panel |> Map.put(:dashboard_id, dashboard_id)}
     end
@@ -44,7 +44,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.DashboardResolver do
   def update_dashboard_panel(_root, args, %{context: %{auth: %{current_user: user}}}) do
     %{dashboard_id: dashboard_id, panel_id: panel_id, panel: panel} = args
 
-    with true <- can_edit_dashboard?(dashboard_id, user.id),
+    with true <- is_dashboard_owner?(dashboard_id, user.id),
          {:ok, %{} = result} <- Dashboard.update_panel(dashboard_id, panel_id, panel) do
       {:ok, result.panel |> Map.put(:dashboard_id, dashboard_id)}
     end
@@ -62,7 +62,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.DashboardResolver do
   def compute_and_store_dashboard_panel(_root, args, %{context: %{auth: %{current_user: user}}}) do
     %{dashboard_id: dashboard_id, panel_id: panel_id} = args
     # storing requires edit access, not just view access
-    with true <- can_edit_dashboard?(dashboard_id, user.id),
+    with true <- is_dashboard_owner?(dashboard_id, user.id),
          true <- can_run_computation?(user.id) do
       Dashboard.compute_and_store_panel(dashboard_id, panel_id)
     end
@@ -74,7 +74,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.DashboardResolver do
     compressed_rows = Dashboard.Query.rows_to_compressed_rows(panel.rows)
     panel = Map.put(panel, :compressed_rows, compressed_rows)
 
-    with true <- can_edit_dashboard?(dashboard_id, user.id),
+    with true <- is_dashboard_owner?(dashboard_id, user.id),
          %{} = query_result <- struct!(Dashboard.Query.Result, panel),
          {:ok, _} <- Dashboard.Cache.update_panel_cache(dashboard_id, panel_id, query_result) do
       panel_cache = Dashboard.Panel.Cache.from_query_result(query_result, panel_id, dashboard_id)
@@ -83,8 +83,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.DashboardResolver do
   end
 
   def get_dashboard_schema(_root, args, %{context: %{auth: %{current_user: user}}}) do
-    with true <- can_view_dashboard?(args.id, user.id) do
-      Dashboard.load_schema(args.id)
+    with true <- can_view_dashboard?(args.id, user.id),
+         {:ok, dashboard_schema} <- Dashboard.load_schema(args.id) do
+      {:ok, atomize_panel_sql_keys(dashboard_schema)}
     end
   end
 
@@ -114,6 +115,27 @@ defmodule SanbaseWeb.Graphql.Resolvers.DashboardResolver do
     end
   end
 
+  def get_dashboard_schema_history_list(_root, args, %{context: %{auth: %{current_user: user}}}) do
+    with true <- is_dashboard_owner?(args.id, user.id) do
+      opts = [page: args.page, page_size: args.page_size]
+      Dashboard.History.get_history_list(args.id, opts)
+    end
+  end
+
+  def get_dashboard_schema_history(_root, args, %{context: %{auth: %{current_user: user}}}) do
+    with true <- is_dashboard_owner?(args.id, user.id),
+         {:ok, dashboard_schema_history} <- Dashboard.History.get_history(args.id, args.hash) do
+      {:ok, atomize_panel_sql_keys(dashboard_schema_history)}
+    end
+  end
+
+  def store_dashboard_schema_history(_root, args, %{context: %{auth: %{current_user: user}}}) do
+    with true <- is_dashboard_owner?(args.id, user.id),
+         {:ok, dashboard} <- Dashboard.load_schema(args.id) do
+      Dashboard.History.commit(dashboard, args.message)
+    end
+  end
+
   def comments_count(%{id: id}, _args, %{context: %{loader: loader}}) do
     loader
     |> Dataloader.load(SanbaseDataloader, :dashboard_comments_count, id)
@@ -135,14 +157,13 @@ defmodule SanbaseWeb.Graphql.Resolvers.DashboardResolver do
     end
   end
 
-  defp can_edit_dashboard?(id, user_id) do
+  defp is_dashboard_owner?(id, user_id) do
     case Dashboard.get_is_public_and_owner(id) do
       {:ok, %{user_id: ^user_id}} ->
         true
 
       _ ->
-        {:error,
-         "Dashboard is private, does not exist or you don't have permission to execute this."}
+        {:error, "Dashboard does not exist or it's not owned by the user."}
     end
   end
 
@@ -151,5 +172,25 @@ defmodule SanbaseWeb.Graphql.Resolvers.DashboardResolver do
       true -> true
       false -> {:error, "The user with id #{user_id} has no credits left"}
     end
+  end
+
+  defp atomize_panel_sql_keys(struct) do
+    panels =
+      Enum.map(struct.panels, fn
+        %{sql: %{} = sql} = panel ->
+          sql = %{
+            query: sql["query"],
+            parameters: sql["parameters"],
+            san_query_id: sql["san_query_id"]
+          }
+
+          %{panel | sql: sql}
+
+        panel ->
+          panel
+      end)
+
+    struct
+    |> Map.put(:panels, panels)
   end
 end

--- a/lib/sanbase_web/graphql/schema/queries/dashboard_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/dashboard_queries.ex
@@ -52,6 +52,44 @@ defmodule SanbaseWeb.Graphql.Schema.DashboardQueries do
 
       resolve(&DashboardResolver.get_dashboard_cache/3)
     end
+
+    @desc ~s"""
+    Get a history revision of the dashboard schema, identified by the
+    dashboard id and hash.
+
+    The history revision contains the same fields as the dashboard schema
+    and is enriched with a comment, a computed hash that identifies the
+    revision and datetime fields indicating when it was created.
+    """
+    field :get_dashboard_schema_history, :dashboard_schema_history do
+      meta(access: :free)
+
+      arg(:id, non_null(:integer))
+      arg(:hash, non_null(:string))
+
+      middleware(JWTAuth)
+
+      resolve(&DashboardResolver.get_dashboard_schema_history/3)
+    end
+
+    @desc ~s"""
+    Get a list of all stored history revisionf of the dashboard schema, identified
+    by the dashboard id.
+
+    The returned result is a list of previews, including the hash, comment and creation
+    datetime. The hash is used to obtain the full dashboard history revision.
+    """
+    field :get_dashboard_schema_history_list, list_of(:dashboard_schema_history_preview) do
+      meta(access: :free)
+
+      arg(:id, non_null(:integer))
+      arg(:page, non_null(:integer))
+      arg(:page_size, non_null(:integer))
+
+      middleware(JWTAuth)
+
+      resolve(&DashboardResolver.get_dashboard_schema_history_list/3)
+    end
   end
 
   object :dashboard_mutations do
@@ -303,6 +341,18 @@ defmodule SanbaseWeb.Graphql.Schema.DashboardQueries do
         ttl: 10,
         max_ttl_offset: 10
       )
+    end
+
+    @desc ~s"""
+    Store the dashboard schema to allow to revisit it again in the future.
+    """
+    field :store_dashboard_schema_history, :dashboard_schema_history do
+      arg(:id, non_null(:integer))
+      arg(:message, non_null(:string))
+
+      middleware(JWTAuth)
+
+      resolve(&DashboardResolver.store_dashboard_schema_history/3)
     end
   end
 end

--- a/lib/sanbase_web/graphql/schema/types/dashboard_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/dashboard_types.ex
@@ -110,6 +110,28 @@ defmodule SanbaseWeb.Graphql.DashboardTypes do
     field :votes, :vote do
       resolve(&VoteResolver.votes/3)
     end
+
+    field(:inserted_at, :datetime)
+    field(:updated_at, :datetime)
+  end
+
+  object :dashboard_schema_history_preview do
+    field(:dashboard_id, non_null(:integer))
+    field(:hash, :string)
+    field(:message, :string)
+    field(:inserted_at, :datetime)
+  end
+
+  object :dashboard_schema_history do
+    field(:message, :string)
+    field(:hash, :string)
+
+    field(:dashboard_id, non_null(:integer))
+    field(:name, non_null(:string))
+    field(:description, :string)
+    field(:is_public, non_null(:boolean))
+    field(:panels, list_of(:panel_schema))
+    field(:inserted_at, :datetime)
   end
 
   object :dashboard_cache do

--- a/priv/repo/migrations/20220627144857_add_dashboard_history_table.exs
+++ b/priv/repo/migrations/20220627144857_add_dashboard_history_table.exs
@@ -1,0 +1,22 @@
+defmodule Sanbase.Repo.Migrations.AddDashboardHistoryTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:dashboards_history) do
+      add(:dashboard_id, references(:dashboards), on_delete: :delete_all)
+      add(:user_id, references(:users), on_delete: :delete_all)
+      add(:panels, :jsonb)
+      add(:name, :string)
+      add(:description, :text)
+      add(:is_public, :boolean)
+
+      add(:message, :text)
+      add(:hash, :text)
+
+      timestamps()
+    end
+
+    create(index(:dashboards_history, :dashboard_id))
+    create(index(:dashboards_history, :hash))
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -796,6 +796,44 @@ ALTER SEQUENCE public.dashboards_cache_id_seq OWNED BY public.dashboards_cache.i
 
 
 --
+-- Name: dashboards_history; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.dashboards_history (
+    id bigint NOT NULL,
+    dashboard_id bigint,
+    user_id bigint,
+    panels jsonb,
+    name character varying(255),
+    description text,
+    is_public boolean,
+    message text,
+    hash text,
+    inserted_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: dashboards_history_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.dashboards_history_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: dashboards_history_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.dashboards_history_id_seq OWNED BY public.dashboards_history.id;
+
+
+--
 -- Name: dashboards_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -3922,6 +3960,13 @@ ALTER TABLE ONLY public.dashboards_cache ALTER COLUMN id SET DEFAULT nextval('pu
 
 
 --
+-- Name: dashboards_history id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.dashboards_history ALTER COLUMN id SET DEFAULT nextval('public.dashboards_history_id_seq'::regclass);
+
+
+--
 -- Name: email_login_attempts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -4594,6 +4639,14 @@ ALTER TABLE ONLY public.dashboard_comments_mapping
 
 ALTER TABLE ONLY public.dashboards_cache
     ADD CONSTRAINT dashboards_cache_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: dashboards_history dashboards_history_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.dashboards_history
+    ADD CONSTRAINT dashboards_history_pkey PRIMARY KEY (id);
 
 
 --
@@ -5430,6 +5483,20 @@ CREATE INDEX dashboard_comments_mapping_dashboard_id_index ON public.dashboard_c
 --
 
 CREATE UNIQUE INDEX dashboards_cache_dashboard_id_index ON public.dashboards_cache USING btree (dashboard_id);
+
+
+--
+-- Name: dashboards_history_dashboard_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX dashboards_history_dashboard_id_index ON public.dashboards_history USING btree (dashboard_id);
+
+
+--
+-- Name: dashboards_history_hash_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX dashboards_history_hash_index ON public.dashboards_history USING btree (hash);
 
 
 --
@@ -6466,6 +6533,22 @@ ALTER TABLE ONLY public.dashboard_comments_mapping
 
 ALTER TABLE ONLY public.dashboards_cache
     ADD CONSTRAINT dashboards_cache_dashboard_id_fkey FOREIGN KEY (dashboard_id) REFERENCES public.dashboards(id) ON DELETE CASCADE;
+
+
+--
+-- Name: dashboards_history dashboards_history_dashboard_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.dashboards_history
+    ADD CONSTRAINT dashboards_history_dashboard_id_fkey FOREIGN KEY (dashboard_id) REFERENCES public.dashboards(id);
+
+
+--
+-- Name: dashboards_history dashboards_history_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.dashboards_history
+    ADD CONSTRAINT dashboards_history_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
@@ -7688,3 +7771,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20220616131454);
 INSERT INTO public."schema_migrations" (version) VALUES (20220617112317);
 INSERT INTO public."schema_migrations" (version) VALUES (20220620132733);
 INSERT INTO public."schema_migrations" (version) VALUES (20220620143734);
+INSERT INTO public."schema_migrations" (version) VALUES (20220627144857);

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -76,6 +76,8 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           :get_coupon,
           :get_dashboard_cache,
           :get_dashboard_schema,
+          :get_dashboard_schema_history,
+          :get_dashboard_schema_history_list,
           :get_events_for_users,
           :get_full_url,
           :get_market_exchanges,


### PR DESCRIPTION
## Changes

Allow the dashboard schema to be stored and past versions of it to be browsed and inspected.

```graphql
mutation {
  storeDashboardSchemaHistory(id: 1, message: "Storing initial version"){
    message
    hash

    dashboardId
    name
    description
    panels{
      id
      sql {
        query
        parameters
      }
    }
  }
}
```

```graphql
{
  getDashboardSchemaHistoryList(id: 1, page: 1, pageSize: 10){
    message
    hash
    insertedAt
  }
}
```

```graphql
{
  getDashboardSchemaHistory(id: 1, hash: "9c9d7c048a03160671ef78344f464acec3fb3279"){
    name
    description
    panels { sql { query parameters } }
    message
    hash
    insertedAt
  }
}
```

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
