### PR TITLE
Add migration for deleting price volume diff alerts

### DIFF
--- a/priv/repo/migrations/20220617151459_delete_price_volume_diff_alerts.exs
+++ b/priv/repo/migrations/20220617151459_delete_price_volume_diff_alerts.exs
@@ -1,0 +1,17 @@
+defmodule Sanbase.Repo.Migrations.DeletePriceVolumeDiffAlerts do
+  use Ecto.Migration
+
+  import Ecto.Query
+  import Sanbase.Alert.TriggerQuery, only: [trigger_type_is: 1]
+
+  def up do
+    from(ut in Sanbase.Alert.UserTrigger,
+      where: trigger_type_is("price_volume_difference")
+    )
+    |> Sanbase.Repo.delete_all()
+  end
+
+  def down do
+    :ok
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -7686,5 +7686,6 @@ INSERT INTO public."schema_migrations" (version) VALUES (20220615122849);
 INSERT INTO public."schema_migrations" (version) VALUES (20220615135946);
 INSERT INTO public."schema_migrations" (version) VALUES (20220616131454);
 INSERT INTO public."schema_migrations" (version) VALUES (20220617112317);
+INSERT INTO public."schema_migrations" (version) VALUES (20220617151459);
 INSERT INTO public."schema_migrations" (version) VALUES (20220620132733);
 INSERT INTO public."schema_migrations" (version) VALUES (20220620143734);


### PR DESCRIPTION
## Changes

Price-Volume Difference is no longer supported and used. Remove the
alerts that are using this metric

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
