### PR TITLE
Temporarily add a JSON field to the dashboard

### DIFF
--- a/lib/sanbase_web/graphql/schema/queries/dashboard_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/dashboard_queries.ex
@@ -138,6 +138,7 @@ defmodule SanbaseWeb.Graphql.Schema.DashboardQueries do
       arg(:name, non_null(:string))
       arg(:description, :string)
       arg(:is_public, :boolean)
+      arg(:temp_json, :json)
 
       middleware(JWTAuth)
 
@@ -157,6 +158,7 @@ defmodule SanbaseWeb.Graphql.Schema.DashboardQueries do
       arg(:name, :string)
       arg(:description, :string)
       arg(:is_public, :boolean)
+      arg(:temp_json, :json)
 
       middleware(JWTAuth)
 

--- a/lib/sanbase_web/graphql/schema/types/dashboard_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/dashboard_types.ex
@@ -180,6 +180,8 @@ defmodule SanbaseWeb.Graphql.DashboardTypes do
     field(:name, non_null(:string))
     field(:description, :string)
     field(:is_public, non_null(:boolean))
+    @desc "Temporary field. Will be removed"
+    field(:temp_json, non_null(:json))
     field(:panels, list_of(:panel_schema))
 
     field :user, non_null(:public_user) do

--- a/priv/repo/migrations/20220718125615_add_temp_dashboard_field.exs
+++ b/priv/repo/migrations/20220718125615_add_temp_dashboard_field.exs
@@ -1,0 +1,9 @@
+defmodule Sanbase.Repo.Migrations.AddTempDashboardField do
+  use Ecto.Migration
+
+  def change do
+    alter table(:dashboards) do
+      add(:temp_json, :map, default: "{}")
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 12.3
--- Dumped by pg_dump version 12.3
+-- Dumped from database version 14.2
+-- Dumped by pg_dump version 14.2
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -763,7 +763,8 @@ CREATE TABLE public.dashboards (
     inserted_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     is_deleted boolean DEFAULT false,
-    is_hidden boolean DEFAULT false
+    is_hidden boolean DEFAULT false,
+    temp_json jsonb DEFAULT '{}'::jsonb
 );
 
 
@@ -7042,6 +7043,7 @@ ALTER TABLE ONLY public.signals_historical_activity
 ALTER TABLE ONLY public.signals_historical_activity
     ADD CONSTRAINT signals_historical_activity_user_trigger_id_fkey FOREIGN KEY (user_trigger_id) REFERENCES public.user_triggers(id) ON DELETE CASCADE;
 
+
 --
 -- Name: source_slug_mappings source_slug_mappings_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
@@ -7777,3 +7779,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20220620143734);
 INSERT INTO public."schema_migrations" (version) VALUES (20220627144857);
 INSERT INTO public."schema_migrations" (version) VALUES (20220630123257);
 INSERT INTO public."schema_migrations" (version) VALUES (20220712122954);
+INSERT INTO public."schema_migrations" (version) VALUES (20220718125615);


### PR DESCRIPTION
## Changes

The FE temporarily needs a JSON field in the dashboard schema until design/FE reworks are made.

Add `tempJson` argument to `createDashboard` and `updateDashboard`.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
