### PR TITLE
Rework getMostUsed API

### DIFF
--- a/lib/sanbase/chart/chart_configuration.ex
+++ b/lib/sanbase/chart/chart_configuration.ex
@@ -95,10 +95,9 @@ defmodule Sanbase.Chart.Configuration do
     {:ok, result}
   end
 
-  @impl Sanbase.Entity.Behaviour
-  def public_entity_ids_query(opts) do
+  # The base of all the entity queries
+  defp base_entity_ids_query(opts) do
     base_query()
-    |> where([config], config.is_public == true)
     |> maybe_apply_projects_filter(opts)
     |> Sanbase.Entity.Query.maybe_filter_is_hidden(opts)
     |> Sanbase.Entity.Query.maybe_filter_is_featured_query(opts, :chart_configuration_id)
@@ -108,13 +107,21 @@ defmodule Sanbase.Chart.Configuration do
   end
 
   @impl Sanbase.Entity.Behaviour
+  def public_and_user_entity_ids_query(user_id, opts) do
+    base_entity_ids_query(opts)
+    |> where([config], config.is_public == true or config.user_id == ^user_id)
+  end
+
+  @impl Sanbase.Entity.Behaviour
+  def public_entity_ids_query(opts) do
+    base_entity_ids_query(opts)
+    |> where([config], config.is_public == true)
+  end
+
+  @impl Sanbase.Entity.Behaviour
   def user_entity_ids_query(user_id, opts) do
-    base_query()
+    base_entity_ids_query(opts)
     |> where([config], config.user_id == ^user_id)
-    |> Sanbase.Entity.Query.maybe_filter_is_hidden(opts)
-    |> Sanbase.Entity.Query.maybe_filter_is_featured_query(opts, :chart_configuration_id)
-    |> Sanbase.Entity.Query.maybe_filter_by_cursor(:inserted_at, opts)
-    |> select([config], config.id)
   end
 
   def is_public?(%__MODULE__{is_public: is_public}), do: is_public

--- a/lib/sanbase/dashboard/dashboard_schema.ex
+++ b/lib/sanbase/dashboard/dashboard_schema.ex
@@ -93,10 +93,9 @@ defmodule Sanbase.Dashboard.Schema do
   @impl Sanbase.Entity.Behaviour
   def by_ids!(ids, opts \\ []), do: by_ids(ids, opts) |> to_bang()
 
-  @impl Sanbase.Entity.Behaviour
-  def public_entity_ids_query(opts) do
+  # The base of all the entity queries
+  defp base_entity_ids_query(opts) do
     base_query()
-    |> where([d], d.is_public == true)
     |> Sanbase.Entity.Query.maybe_filter_is_hidden(opts)
     |> Sanbase.Entity.Query.maybe_filter_is_featured_query(opts, :dashboard_id)
     |> Sanbase.Entity.Query.maybe_filter_by_users(opts)
@@ -105,13 +104,24 @@ defmodule Sanbase.Dashboard.Schema do
   end
 
   @impl Sanbase.Entity.Behaviour
+  def public_and_user_entity_ids_query(user_id, opts) do
+    base_entity_ids_query(opts)
+    |> where([d], d.is_public == true or d.user_id == ^user_id)
+  end
+
+  @impl Sanbase.Entity.Behaviour
+  def public_entity_ids_query(opts) do
+    base_entity_ids_query(opts)
+    |> where([d], d.is_public == true)
+  end
+
+  @impl Sanbase.Entity.Behaviour
   def user_entity_ids_query(user_id, opts) do
-    base_query()
+    # Disable the filter by users
+    opts = Keyword.put(opts, :user_ids, nil)
+
+    base_entity_ids_query(opts)
     |> where([ul], ul.user_id == ^user_id)
-    |> Sanbase.Entity.Query.maybe_filter_is_hidden(opts)
-    |> Sanbase.Entity.Query.maybe_filter_is_featured_query(opts, :dashboard_id)
-    |> Sanbase.Entity.Query.maybe_filter_by_cursor(:inserted_at, opts)
-    |> select([ul], ul.id)
   end
 
   def is_public?(%__MODULE__{is_public: is_public}), do: is_public

--- a/lib/sanbase/entity/entity_behaviour.ex
+++ b/lib/sanbase/entity/entity_behaviour.ex
@@ -12,4 +12,5 @@ defmodule Sanbase.Entity.Behaviour do
 
   @callback public_entity_ids_query(opts) :: Ecto.Query.t()
   @callback user_entity_ids_query(user_id :: non_neg_integer(), opts) :: Ecto.Query.t()
+  @callback public_and_user_entity_ids_query(user_id :: non_neg_integer(), opts) :: Ecto.Query.t()
 end

--- a/lib/sanbase/timeline/timeline_event.ex
+++ b/lib/sanbase/timeline/timeline_event.ex
@@ -2,7 +2,6 @@ defmodule Sanbase.Timeline.TimelineEvent do
   @moduledoc ~s"""
   Persisting events on create/update insights, watchlists and triggers
   """
-  @behaviour Sanbase.Entity.Behaviour
 
   use Ecto.Schema
 
@@ -80,10 +79,8 @@ defmodule Sanbase.Timeline.TimelineEvent do
 
   @by_id_preloads [:user_trigger, [post: :tags], :user_list, :user, :votes]
 
-  @impl Sanbase.Entity.Behaviour
   def by_id!(id, opts), do: by_id(id, opts) |> to_bang()
 
-  @impl Sanbase.Entity.Behaviour
   def by_id(id, _opts) when is_integer(id) do
     from(te in TimelineEvent,
       where: te.id == ^id,
@@ -96,10 +93,8 @@ defmodule Sanbase.Timeline.TimelineEvent do
     end
   end
 
-  @impl Sanbase.Entity.Behaviour
   def by_ids!(ids, opts) when is_list(ids), do: by_ids(ids, opts) |> to_bang()
 
-  @impl Sanbase.Entity.Behaviour
   def by_ids(ids, _opts) when is_list(ids) do
     result =
       from(te in TimelineEvent,
@@ -110,22 +105,6 @@ defmodule Sanbase.Timeline.TimelineEvent do
       |> Repo.all()
 
     {:ok, result}
-  end
-
-  @impl Sanbase.Entity.Behaviour
-  def public_entity_ids_query(opts) do
-    from(te in __MODULE__)
-    |> Query.events_with_public_entities_query()
-    |> Sanbase.Entity.Query.maybe_filter_by_cursor(:inserted_at, opts)
-    |> select([te], te.id)
-  end
-
-  @impl Sanbase.Entity.Behaviour
-  def user_entity_ids_query(user_id, opts) do
-    from(te in __MODULE__)
-    |> where([te], te.user_id == ^user_id)
-    |> Sanbase.Entity.Query.maybe_filter_by_cursor(:inserted_at, opts)
-    |> select([te], te.id)
   end
 
   @doc """

--- a/test/sanbase_web/graphql/entity/get_most_used_api_test.exs
+++ b/test/sanbase_web/graphql/entity/get_most_used_api_test.exs
@@ -66,11 +66,10 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
 
   test "get most used dashboard", context do
     %{conn: conn} = context
-    dashboard1 = insert(:dashboard, is_public: true)
+    dashboard1 = insert(:dashboard, is_public: false, user: context.user)
     dashboard2 = insert(:dashboard, is_public: true)
-    dashboard3 = insert(:dashboard, is_public: true)
-    _private = insert(:dashboard, is_public: false)
-    _private = insert(:dashboard, is_public: false)
+    dashboard3 = insert(:dashboard, is_public: false, user: context.user)
+    _unused = insert(:dashboard, is_public: false)
     dashboard4 = insert(:dashboard, is_public: true)
     _unused = insert(:dashboard, is_public: true)
 
@@ -103,11 +102,10 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
     %{conn: conn} = context
     _not_screener = insert(:watchlist, is_public: true)
     screener1 = insert(:screener, is_public: true)
-    screener2 = insert(:screener, is_public: true)
+    screener2 = insert(:screener, is_public: false, user: context.user)
     screener3 = insert(:screener, is_public: true)
-    _private = insert(:screener, is_public: false)
-    _private = insert(:screener, is_public: false)
-    screener4 = insert(:screener, is_public: true)
+    _unused = insert(:screener, is_public: false)
+    screener4 = insert(:screener, is_public: false, user: context.user)
     _unused = insert(:screener, is_public: true)
 
     for index <- 1..50 do
@@ -139,11 +137,9 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
     %{conn: conn} = context
 
     # The screener should not be in the result
-    watchlist1 = insert(:watchlist, type: :project, is_public: true)
-    _private = insert(:watchlist, type: :project, is_public: false)
-    _private = insert(:watchlist, type: :project, is_public: false)
+    watchlist1 = insert(:watchlist, type: :project, is_public: false, user: context.user)
     watchlist2 = insert(:watchlist, type: :project, is_public: true)
-    watchlist3 = insert(:watchlist, type: :project, is_public: true)
+    watchlist3 = insert(:watchlist, type: :project, is_public: false, user: context.user)
     _screener = insert(:screener, type: :project, is_public: true)
     watchlist4 = insert(:watchlist, type: :project, is_public: true)
     _unused = insert(:watchlist, type: :project, is_public: true)
@@ -178,12 +174,16 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
 
     # The screener should not be in the result
     watchlist1 = insert(:watchlist, type: :blockchain_address, is_public: true)
-    _private = insert(:watchlist, type: :blockchain_address, is_public: false)
-    _private = insert(:watchlist, type: :blockchain_address, is_public: false)
-    watchlist2 = insert(:watchlist, type: :blockchain_address, is_public: true)
+
+    watchlist2 =
+      insert(:watchlist, type: :blockchain_address, is_public: false, user: context.user)
+
     watchlist3 = insert(:watchlist, type: :blockchain_address, is_public: true)
     _screener = insert(:screener, type: :blockchain_address, is_public: true)
-    watchlist4 = insert(:watchlist, type: :blockchain_address, is_public: true)
+
+    watchlist4 =
+      insert(:watchlist, type: :blockchain_address, is_public: false, user: context.user)
+
     _unused = insert(:watchlist, type: :blockchain_address, is_public: true)
 
     for index <- 1..50 do
@@ -214,9 +214,7 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
   test "get most used chart configuration", context do
     %{conn: conn} = context
     c1 = insert(:chart_configuration, is_public: true)
-    c2 = insert(:chart_configuration, is_public: true)
-    _private = insert(:chart_configuration, is_public: false)
-    _private = insert(:chart_configuration, is_public: false)
+    c2 = insert(:chart_configuration, is_public: false, user: context.user)
     c3 = insert(:chart_configuration, is_public: true)
     c4 = insert(:chart_configuration, is_public: true)
     _unused = insert(:chart_configuration, is_public: true)
@@ -256,11 +254,9 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
   test "get most used user trigger", context do
     %{conn: conn} = context
 
-    user_trigger1 = insert(:user_trigger, is_public: true)
+    user_trigger1 = insert(:user_trigger, is_public: false, user: context.user)
     user_trigger2 = insert(:user_trigger, is_public: true)
-    _private = insert(:user_trigger, is_public: false)
-    _private = insert(:user_trigger, is_public: false)
-    user_trigger3 = insert(:user_trigger, is_public: true)
+    user_trigger3 = insert(:user_trigger, is_public: false, user: context.user)
     user_trigger4 = insert(:user_trigger, is_public: true)
     _unused = insert(:user_trigger, is_public: true)
 
@@ -298,7 +294,7 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
 
   test "get most used combined", context do
     %{conn: conn} = context
-    ut = insert(:user_trigger, is_public: true)
+    ut = insert(:user_trigger, is_public: false, user: context.user)
     i = insert(:published_post)
     c = insert(:chart_configuration, is_public: true)
     s = insert(:screener, is_public: true)
@@ -443,7 +439,14 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
     end
 
     s1 = insert(:screener, is_public: true, function: function.(["price_usd"]))
-    s2 = insert(:screener, is_public: true, function: function.(["social_volume_total"]))
+
+    s2 =
+      insert(:screener,
+        is_public: false,
+        function: function.(["social_volume_total"]),
+        user: context.user
+      )
+
     s3 = insert(:screener, is_public: true, function: function.(["price_usd", "price_btc"]))
     s4 = insert(:screener, is_public: true, function: function.(["price_usd", "price_btc"]))
     _unused = insert(:screener, is_public: true, function: function.(["price_usd", "price_btc"]))
@@ -475,11 +478,11 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
   test "get most used featured entities", context do
     %{conn: conn} = context
     w1 = insert(:watchlist, type: :project, is_public: true)
-    s1 = insert(:screener, type: :project, is_public: true)
+    s1 = insert(:screener, type: :project, is_public: false, user: context.user)
     i1 = insert(:published_post)
     i2 = insert(:published_post)
     c1 = insert(:chart_configuration, is_public: true)
-    c2 = insert(:chart_configuration, is_public: true)
+    c2 = insert(:chart_configuration, is_public: false, user: context.user)
 
     :ok = Sanbase.FeaturedItem.update_item(w1, true)
     :ok = Sanbase.FeaturedItem.update_item(i2, true)


### PR DESCRIPTION
## Changes

- Rework `getMostUsed` API so it also takes into account user's own private entities. This is required as the most used chart layout/watchlist/screener/etc. of a user can be private and should not be excluded. The result is seen only by the user.
- Extend the `Sanbase.Entity.Behaviour` to accommodate these changes and reduce duplication of code
- Rework the tests according to the changes.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
