### PR TITLE
Add get_dashboard_panel_cache API

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/user/dashboard_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/dashboard_resolver.ex
@@ -152,6 +152,15 @@ defmodule SanbaseWeb.Graphql.Resolvers.DashboardResolver do
     end
   end
 
+  def get_dashboard_panel_cache(_root, args, resolution) do
+    user_id_or_nil = resolution_to_user_id_or_nil(resolution)
+
+    with true <- can_view_dashboard?(args.dashboard_id, user_id_or_nil),
+         {:ok, panel_cache} <- Dashboard.load_panel_cache(args.dashboard_id, args.panel_id) do
+      {:ok, panel_cache}
+    end
+  end
+
   def compute_raw_clickhouse_query(_root, args, %{context: %{auth: %{current_user: user}}}) do
     san_query_id = UUID.uuid4()
 

--- a/lib/sanbase_web/graphql/schema/queries/dashboard_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/dashboard_queries.ex
@@ -63,6 +63,20 @@ defmodule SanbaseWeb.Graphql.Schema.DashboardQueries do
     end
 
     @desc ~s"""
+    Get the last computed version of a Dashboard Cache.
+
+    This API returns a single Dashboard Panel Cache, the same
+    as the one returned by getDashboardCache
+    """
+    field :get_dashboard_panel_cache, :panel_cache do
+      meta(access: :free)
+      arg(:dashboard_id, non_null(:integer))
+      arg(:panel_id, non_null(:string))
+
+      resolve(&DashboardResolver.get_dashboard_panel_cache/3)
+    end
+
+    @desc ~s"""
     Get a history revision of the dashboard schema, identified by the
     dashboard id and hash.
 

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -77,6 +77,7 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           :get_clickhouse_query_execution_stats,
           :get_coupon,
           :get_dashboard_cache,
+          :get_dashboard_panel_cache,
           :get_dashboard_schema,
           :get_dashboard_schema_history,
           :get_dashboard_schema_history_list,


### PR DESCRIPTION
## Changes

```graphql
{
  getDashboardPanelCache(dashboardId: 41, panelId: "ada4e6eb-0929-483a-a920-45372feeeb51") {
    id
    columns
  }
}
```

```json
{
  "data": {
    "getDashboardPanelCache": {
      "columns": [
        "table",
        "name",
        "type"
      ],
      "id": "ada4e6eb-0929-483a-a920-45372feeeb51"
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
