### PR TITLE
Rework user entity interaction to 1 interaction per 10 seconds

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -23,7 +23,9 @@ config :sanbase, Sanbase.ApiCallLimit,
   quota_size: 10,
   quota_size_max_offset: 10
 
-config :sanbase, Sanbase.Accounts.Interaction, interaction_cooldown_seconds: 0
+config :sanbase, Sanbase.Accounts.Interaction,
+  interaction_cooldown_seconds: 0,
+  datetime_module: Sanbase.Interaction.DateTime
 
 # Test adapter that allows mocking
 config :tesla, adapter: Tesla.Mock

--- a/config/test.exs
+++ b/config/test.exs
@@ -23,6 +23,8 @@ config :sanbase, Sanbase.ApiCallLimit,
   quota_size: 10,
   quota_size_max_offset: 10
 
+config :sanbase, Sanbase.Accounts.Interaction, interaction_cooldown_seconds: 0
+
 # Test adapter that allows mocking
 config :tesla, adapter: Tesla.Mock
 

--- a/lib/sanbase/accounts/interaction/interaction.ex
+++ b/lib/sanbase/accounts/interaction/interaction.ex
@@ -23,6 +23,12 @@ defmodule Sanbase.Accounts.Interaction do
                                   10
                                 )
 
+  @datetime_module Application.compile_env(
+                     :sanbase,
+                     [__MODULE__, :datetime_module],
+                     DateTime
+                   )
+
   @supported_entity_types [
     :address_watchlist,
     :chart_configuration,
@@ -87,12 +93,12 @@ defmodule Sanbase.Accounts.Interaction do
           {:ok, t()} | {:error, Ecto.Changeset.t()}
   def store_user_interaction(user_id, args) do
     inserted_at =
-      DateTime.utc_now()
+      @datetime_module.utc_now()
       |> Sanbase.DateTimeUtils.round_datetime(
         second: @interaction_cooldown_seconds,
         rounding: :down
       )
-      |> DateTime.to_naive()
+      |> @datetime_module.to_naive()
 
     args =
       args

--- a/lib/sanbase/accounts/interaction/interaction.ex
+++ b/lib/sanbase/accounts/interaction/interaction.ex
@@ -8,6 +8,21 @@ defmodule Sanbase.Accounts.Interaction do
   """
   use Ecto.Schema
 
+  import Ecto.Query
+  import Ecto.Changeset
+
+  alias Sanbase.Accounts.User
+  # The same [:user_id, :entity_id, :entity_type, :interaction_type] cannot be stored
+  # more than once per coooldown period. This helps avoid storing the same interaction
+  # multiple times in case of browser reload, opening the entity in multiple tabs, etc.
+  # This value is set to 0 in test env, so the interactions can be stored without mocking
+  # the DateTime module.
+  @interaction_cooldown_seconds Application.compile_env(
+                                  :sanbase,
+                                  [__MODULE__, :interaction_cooldown_seconds],
+                                  10
+                                )
+
   @supported_entity_types [
     :address_watchlist,
     :chart_configuration,
@@ -35,11 +50,6 @@ defmodule Sanbase.Accounts.Interaction do
           updated_at: NaiveDateTime.t()
         }
 
-  import Ecto.Query
-  import Ecto.Changeset
-
-  alias Sanbase.Accounts.User
-
   schema "user_entity_interactions" do
     field(:entity_id, :integer)
     field(:entity_type, :string)
@@ -52,7 +62,17 @@ defmodule Sanbase.Accounts.Interaction do
 
   def changeset(%__MODULE__{} = interaction, args) do
     interaction
-    |> cast(args, [:entity_id, :entity_type, :interaction_type, :user_id])
+    # cast the `:inserted_at` and `:updated_at` as the datetime is rounded
+    # so the same interaction cannot be submitted multiple times in the span of
+    # a few seconds (browser reload, open the same entity in multiple tabs fast, etc.)
+    |> cast(args, [
+      :entity_id,
+      :entity_type,
+      :interaction_type,
+      :user_id,
+      :inserted_at,
+      :updated_at
+    ])
     |> validate_change(:entity_type, &validate_entity_type/2)
     |> validate_change(:interaction_type, &validate_interaction_type/2)
   end
@@ -66,15 +86,27 @@ defmodule Sanbase.Accounts.Interaction do
   @spec store_user_interaction(non_neg_integer(), Map.t()) ::
           {:ok, t()} | {:error, Ecto.Changeset.t()}
   def store_user_interaction(user_id, args) do
+    inserted_at =
+      DateTime.utc_now()
+      |> Sanbase.DateTimeUtils.round_datetime(
+        second: @interaction_cooldown_seconds,
+        rounding: :down
+      )
+      |> DateTime.to_naive()
+
     args =
       args
-      |> Map.put(:user_id, user_id)
-      |> Map.put(:interaction_type, to_string(args.interaction_type))
-      |> Map.put(:entity_type, deduce_entity_column_name(args.entity_type))
+      |> Map.merge(%{
+        user_id: user_id,
+        inserted_at: inserted_at,
+        updated_at: inserted_at,
+        interaction_type: to_string(args.interaction_type),
+        entity_type: deduce_entity_column_name(args.entity_type)
+      })
 
     %__MODULE__{}
     |> changeset(args)
-    |> Sanbase.Repo.insert()
+    |> Sanbase.Repo.insert(on_conflict: :nothing)
   end
 
   @doc ~s"""

--- a/lib/sanbase/utils/datetime/datetime_utils.ex
+++ b/lib/sanbase/utils/datetime/datetime_utils.ex
@@ -245,20 +245,25 @@ defmodule Sanbase.DateTimeUtils do
   datetime, usable in cache key construction
   """
   def round_datetime(datetime, opts \\ []) do
-    seconds = Keyword.get(opts, :second, 300)
-    rounding = Keyword.get(opts, :rounding, :down)
-    datetime_unix = DateTime.to_unix(datetime)
+    case Keyword.get(opts, :second, 300) do
+      0 ->
+        datetime
 
-    datetime_unix =
-      case rounding do
-        :up -> datetime_unix + seconds
-        :down -> datetime_unix
-      end
+      seconds ->
+        rounding = Keyword.get(opts, :rounding, :down)
+        datetime_unix = DateTime.to_unix(datetime)
 
-    datetime_unix
-    |> div(seconds)
-    |> Kernel.*(seconds)
-    |> DateTime.from_unix!()
+        datetime_unix =
+          case rounding do
+            :up -> datetime_unix + seconds
+            :down -> datetime_unix
+          end
+
+        datetime_unix
+        |> div(seconds)
+        |> Kernel.*(seconds)
+        |> DateTime.from_unix!()
+    end
   end
 
   # Private

--- a/priv/repo/migrations/20220727072726_add_user_entity_interaction_unique_index.exs
+++ b/priv/repo/migrations/20220727072726_add_user_entity_interaction_unique_index.exs
@@ -1,0 +1,17 @@
+defmodule Sanbase.Repo.Migrations.AddUserEntityInteractionUniqueIndex do
+  use Ecto.Migration
+
+  # Do not store the same interaction again multiple times. The code that stores
+  # the interaction also rounds the
+  def change do
+    create(
+      unique_index(:user_entity_interactions, [
+        :user_id,
+        :entity_type,
+        :entity_id,
+        :interaction_type,
+        :inserted_at
+      ])
+    )
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -6114,6 +6114,13 @@ CREATE INDEX user_entity_interactions_interaction_type_index ON public.user_enti
 
 
 --
+-- Name: user_entity_interactions_user_id_entity_type_entity_id_interact; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX user_entity_interactions_user_id_entity_type_entity_id_interact ON public.user_entity_interactions USING btree (user_id, entity_type, entity_id, interaction_type, inserted_at);
+
+
+--
 -- Name: user_entity_interactions_user_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7780,3 +7787,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20220627144857);
 INSERT INTO public."schema_migrations" (version) VALUES (20220630123257);
 INSERT INTO public."schema_migrations" (version) VALUES (20220712122954);
 INSERT INTO public."schema_migrations" (version) VALUES (20220718125615);
+INSERT INTO public."schema_migrations" (version) VALUES (20220727072726);

--- a/test/sanbase_web/graphql/entity/get_most_used_api_test.exs
+++ b/test/sanbase_web/graphql/entity/get_most_used_api_test.exs
@@ -44,11 +44,11 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
     insight4 = insert(:published_post)
     _unused = insert(:published_post)
 
-    for index <- 1..50 do
-      if rem(index, 5) == 0, do: create_interaction_api(conn, :insight, insight1.id)
-      if rem(index, 4) == 0, do: create_interaction_api(conn, :insight, insight2.id)
-      if rem(index, 3) == 0, do: create_interaction_api(conn, :insight, insight3.id)
-      if rem(index, 2) == 0, do: create_interaction_api(conn, :insight, insight4.id)
+    for index <- 1..10 do
+      if rem(index, 4) == 0, do: create_interaction_api(conn, :insight, insight1.id)
+      if rem(index, 3) == 0, do: create_interaction_api(conn, :insight, insight2.id)
+      if rem(index, 2) == 0, do: create_interaction_api(conn, :insight, insight3.id)
+      if rem(index, 1) == 0, do: create_interaction_api(conn, :insight, insight4.id)
     end
 
     result = get_most_used(conn, :insight)
@@ -78,11 +78,11 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
     dashboard4 = insert(:dashboard, is_public: true)
     _unused = insert(:dashboard, is_public: true)
 
-    for index <- 1..50 do
-      if rem(index, 5) == 0, do: create_interaction_api(conn, :dashboard, dashboard1.id)
-      if rem(index, 4) == 0, do: create_interaction_api(conn, :dashboard, dashboard4.id)
-      if rem(index, 3) == 0, do: create_interaction_api(conn, :dashboard, dashboard3.id)
-      if rem(index, 2) == 0, do: create_interaction_api(conn, :dashboard, dashboard2.id)
+    for i <- 1..10 do
+      if rem(i, 4) == 0, do: create_interaction_api(conn, :dashboard, dashboard1.id)
+      if rem(i, 3) == 0, do: create_interaction_api(conn, :dashboard, dashboard4.id)
+      if rem(i, 2) == 0, do: create_interaction_api(conn, :dashboard, dashboard3.id)
+      if rem(i, 1) == 0, do: create_interaction_api(conn, :dashboard, dashboard2.id)
     end
 
     result = get_most_used(conn, :dashboard)
@@ -113,11 +113,11 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
     screener4 = insert(:screener, is_public: false, user: context.user)
     _unused = insert(:screener, is_public: true)
 
-    for index <- 1..50 do
-      if rem(index, 5) == 0, do: create_interaction_api(conn, :screener, screener1.id)
-      if rem(index, 4) == 0, do: create_interaction_api(conn, :screener, screener4.id)
-      if rem(index, 3) == 0, do: create_interaction_api(conn, :screener, screener3.id)
-      if rem(index, 2) == 0, do: create_interaction_api(conn, :screener, screener2.id)
+    for i <- 1..10 do
+      if rem(i, 4) == 0, do: create_interaction_api(conn, :screener, screener1.id)
+      if rem(i, 3) == 0, do: create_interaction_api(conn, :screener, screener4.id)
+      if rem(i, 2) == 0, do: create_interaction_api(conn, :screener, screener3.id)
+      if rem(i, 1) == 0, do: create_interaction_api(conn, :screener, screener2.id)
     end
 
     result = get_most_used(conn, :screener)
@@ -142,18 +142,18 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
     %{conn: conn} = context
 
     # The screener should not be in the result
-    watchlist1 = insert(:watchlist, type: :project, is_public: false, user: context.user)
-    watchlist2 = insert(:watchlist, type: :project, is_public: true)
-    watchlist3 = insert(:watchlist, type: :project, is_public: false, user: context.user)
+    w1 = insert(:watchlist, type: :project, is_public: false, user: context.user)
+    w2 = insert(:watchlist, type: :project, is_public: true)
+    w3 = insert(:watchlist, type: :project, is_public: false, user: context.user)
     _screener = insert(:screener, type: :project, is_public: true)
-    watchlist4 = insert(:watchlist, type: :project, is_public: true)
+    w4 = insert(:watchlist, type: :project, is_public: true)
     _unused = insert(:watchlist, type: :project, is_public: true)
 
-    for index <- 1..50 do
-      if rem(index, 5) == 0, do: create_interaction_api(conn, :project_watchlist, watchlist2.id)
-      if rem(index, 4) == 0, do: create_interaction_api(conn, :project_watchlist, watchlist3.id)
-      if rem(index, 3) == 0, do: create_interaction_api(conn, :project_watchlist, watchlist1.id)
-      if rem(index, 2) == 0, do: create_interaction_api(conn, :project_watchlist, watchlist4.id)
+    for i <- 1..10 do
+      if rem(i, 4) == 0, do: create_interaction_api(conn, :project_watchlist, w2.id)
+      if rem(i, 3) == 0, do: create_interaction_api(conn, :project_watchlist, w3.id)
+      if rem(i, 2) == 0, do: create_interaction_api(conn, :project_watchlist, w1.id)
+      if rem(i, 1) == 0, do: create_interaction_api(conn, :project_watchlist, w4.id)
     end
 
     result = get_most_used(conn, :project_watchlist)
@@ -168,34 +168,28 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
            } = stats
 
     assert length(data) == 4
-    assert Enum.at(data, 0)["projectWatchlist"]["id"] |> String.to_integer() == watchlist4.id
-    assert Enum.at(data, 1)["projectWatchlist"]["id"] |> String.to_integer() == watchlist1.id
-    assert Enum.at(data, 2)["projectWatchlist"]["id"] |> String.to_integer() == watchlist3.id
-    assert Enum.at(data, 3)["projectWatchlist"]["id"] |> String.to_integer() == watchlist2.id
+    assert Enum.at(data, 0)["projectWatchlist"]["id"] |> String.to_integer() == w4.id
+    assert Enum.at(data, 1)["projectWatchlist"]["id"] |> String.to_integer() == w1.id
+    assert Enum.at(data, 2)["projectWatchlist"]["id"] |> String.to_integer() == w3.id
+    assert Enum.at(data, 3)["projectWatchlist"]["id"] |> String.to_integer() == w2.id
   end
 
   test "get most used address watchlist", context do
     %{conn: conn} = context
 
     # The screener should not be in the result
-    watchlist1 = insert(:watchlist, type: :blockchain_address, is_public: true)
-
-    watchlist2 =
-      insert(:watchlist, type: :blockchain_address, is_public: false, user: context.user)
-
-    watchlist3 = insert(:watchlist, type: :blockchain_address, is_public: true)
+    w1 = insert(:watchlist, type: :blockchain_address, is_public: true)
+    w2 = insert(:watchlist, type: :blockchain_address, is_public: false, user: context.user)
+    w3 = insert(:watchlist, type: :blockchain_address, is_public: true)
     _screener = insert(:screener, type: :blockchain_address, is_public: true)
-
-    watchlist4 =
-      insert(:watchlist, type: :blockchain_address, is_public: false, user: context.user)
-
+    w4 = insert(:watchlist, type: :blockchain_address, is_public: false, user: context.user)
     _unused = insert(:watchlist, type: :blockchain_address, is_public: true)
 
-    for index <- 1..50 do
-      if rem(index, 5) == 0, do: create_interaction_api(conn, :address_watchlist, watchlist2.id)
-      if rem(index, 4) == 0, do: create_interaction_api(conn, :address_watchlist, watchlist3.id)
-      if rem(index, 3) == 0, do: create_interaction_api(conn, :address_watchlist, watchlist1.id)
-      if rem(index, 2) == 0, do: create_interaction_api(conn, :address_watchlist, watchlist4.id)
+    for i <- 1..10 do
+      if rem(i, 4) == 0, do: create_interaction_api(conn, :address_watchlist, w2.id)
+      if rem(i, 3) == 0, do: create_interaction_api(conn, :address_watchlist, w3.id)
+      if rem(i, 2) == 0, do: create_interaction_api(conn, :address_watchlist, w1.id)
+      if rem(i, 1) == 0, do: create_interaction_api(conn, :address_watchlist, w4.id)
     end
 
     result = get_most_used(conn, :address_watchlist)
@@ -210,10 +204,10 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
            } = stats
 
     assert length(data) == 4
-    assert Enum.at(data, 0)["addressWatchlist"]["id"] |> String.to_integer() == watchlist4.id
-    assert Enum.at(data, 1)["addressWatchlist"]["id"] |> String.to_integer() == watchlist1.id
-    assert Enum.at(data, 2)["addressWatchlist"]["id"] |> String.to_integer() == watchlist3.id
-    assert Enum.at(data, 3)["addressWatchlist"]["id"] |> String.to_integer() == watchlist2.id
+    assert Enum.at(data, 0)["addressWatchlist"]["id"] |> String.to_integer() == w4.id
+    assert Enum.at(data, 1)["addressWatchlist"]["id"] |> String.to_integer() == w1.id
+    assert Enum.at(data, 2)["addressWatchlist"]["id"] |> String.to_integer() == w3.id
+    assert Enum.at(data, 3)["addressWatchlist"]["id"] |> String.to_integer() == w2.id
   end
 
   test "get most used chart configuration", context do
@@ -224,18 +218,11 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
     c4 = insert(:chart_configuration, is_public: true)
     _unused = insert(:chart_configuration, is_public: true)
 
-    for index <- 1..50 do
-      if rem(index, 5) == 0,
-        do: create_interaction_api(conn, :chart_configuration, c2.id)
-
-      if rem(index, 4) == 0,
-        do: create_interaction_api(conn, :chart_configuration, c1.id)
-
-      if rem(index, 3) == 0,
-        do: create_interaction_api(conn, :chart_configuration, c4.id)
-
-      if rem(index, 2) == 0,
-        do: create_interaction_api(conn, :chart_configuration, c3.id)
+    for i <- 1..10 do
+      if rem(i, 4) == 0, do: create_interaction_api(conn, :chart_configuration, c2.id)
+      if rem(i, 3) == 0, do: create_interaction_api(conn, :chart_configuration, c1.id)
+      if rem(i, 2) == 0, do: create_interaction_api(conn, :chart_configuration, c4.id)
+      if rem(i, 1) == 0, do: create_interaction_api(conn, :chart_configuration, c3.id)
     end
 
     result = get_most_used(conn, :chart_configuration)
@@ -259,24 +246,17 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
   test "get most used user trigger", context do
     %{conn: conn} = context
 
-    user_trigger1 = insert(:user_trigger, is_public: false, user: context.user)
-    user_trigger2 = insert(:user_trigger, is_public: true)
-    user_trigger3 = insert(:user_trigger, is_public: false, user: context.user)
-    user_trigger4 = insert(:user_trigger, is_public: true)
+    ut1 = insert(:user_trigger, is_public: false, user: context.user)
+    ut2 = insert(:user_trigger, is_public: true)
+    ut3 = insert(:user_trigger, is_public: false, user: context.user)
+    ut4 = insert(:user_trigger, is_public: true)
     _unused = insert(:user_trigger, is_public: true)
 
-    for index <- 1..50 do
-      if rem(index, 5) == 0,
-        do: create_interaction_api(conn, :user_trigger, user_trigger2.id)
-
-      if rem(index, 4) == 0,
-        do: create_interaction_api(conn, :user_trigger, user_trigger1.id)
-
-      if rem(index, 3) == 0,
-        do: create_interaction_api(conn, :user_trigger, user_trigger3.id)
-
-      if rem(index, 2) == 0,
-        do: create_interaction_api(conn, :user_trigger, user_trigger4.id)
+    for i <- 1..10 do
+      if rem(i, 4) == 0, do: create_interaction_api(conn, :user_trigger, ut2.id)
+      if rem(i, 3) == 0, do: create_interaction_api(conn, :user_trigger, ut1.id)
+      if rem(i, 2) == 0, do: create_interaction_api(conn, :user_trigger, ut3.id)
+      if rem(i, 1) == 0, do: create_interaction_api(conn, :user_trigger, ut4.id)
     end
 
     result = get_most_used(conn, :user_trigger)
@@ -291,28 +271,28 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
            } = stats
 
     assert length(data) == 4
-    assert Enum.at(data, 0)["userTrigger"]["trigger"]["id"] == user_trigger4.id
-    assert Enum.at(data, 1)["userTrigger"]["trigger"]["id"] == user_trigger3.id
-    assert Enum.at(data, 2)["userTrigger"]["trigger"]["id"] == user_trigger1.id
-    assert Enum.at(data, 3)["userTrigger"]["trigger"]["id"] == user_trigger2.id
+    assert Enum.at(data, 0)["userTrigger"]["trigger"]["id"] == ut4.id
+    assert Enum.at(data, 1)["userTrigger"]["trigger"]["id"] == ut3.id
+    assert Enum.at(data, 2)["userTrigger"]["trigger"]["id"] == ut1.id
+    assert Enum.at(data, 3)["userTrigger"]["trigger"]["id"] == ut2.id
   end
 
   test "get most used combined", context do
     %{conn: conn} = context
     ut = insert(:user_trigger, is_public: false, user: context.user)
-    i = insert(:published_post)
+    p = insert(:published_post)
     c = insert(:chart_configuration, is_public: true)
     s = insert(:screener, is_public: true)
     w = insert(:watchlist, type: :project, is_public: true)
     d = insert(:dashboard, is_public: true)
 
-    for index <- 1..50 do
-      if rem(index, 7) == 0, do: create_interaction_api(conn, :dashboard, d.id)
-      if rem(index, 6) == 0, do: create_interaction_api(conn, :user_trigger, ut.id)
-      if rem(index, 5) == 0, do: create_interaction_api(conn, :chart_configuration, c.id)
-      if rem(index, 4) == 0, do: create_interaction_api(conn, :project_watchlist, w.id)
-      if rem(index, 3) == 0, do: create_interaction_api(conn, :screener, s.id)
-      if rem(index, 2) == 0, do: create_interaction_api(conn, :insight, i.id)
+    for i <- 1..20 do
+      if rem(i, 6) == 0, do: create_interaction_api(conn, :dashboard, d.id)
+      if rem(i, 5) == 0, do: create_interaction_api(conn, :user_trigger, ut.id)
+      if rem(i, 4) == 0, do: create_interaction_api(conn, :chart_configuration, c.id)
+      if rem(i, 3) == 0, do: create_interaction_api(conn, :project_watchlist, w.id)
+      if rem(i, 2) == 0, do: create_interaction_api(conn, :screener, s.id)
+      if rem(i, 1) == 0, do: create_interaction_api(conn, :insight, p.id)
     end
 
     # Get with default page = 1 and pageSize = 10, all entities are returned
@@ -338,7 +318,7 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
 
     assert length(data) == 6
 
-    assert Enum.at(data, 0)["insight"]["id"] == i.id
+    assert Enum.at(data, 0)["insight"]["id"] == p.id
     assert Enum.at(data, 1)["screener"]["id"] |> String.to_integer() == s.id
     assert Enum.at(data, 2)["projectWatchlist"]["id"] |> String.to_integer() == w.id
     assert Enum.at(data, 3)["chartConfiguration"]["id"] == c.id
@@ -374,20 +354,15 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
     a1 = create_alert(context.user, p1)
     a2 = create_alert(context.user, p2)
 
-    for index <- 1..60 do
-      if rem(index, 10) == 0, do: create_interaction_api(conn, :insight, i2.id)
-      if rem(index, 7) == 0, do: create_interaction_api(conn, :insight, i1.id)
-      if rem(index, 5) == 0, do: create_interaction_api(conn, :user_trigger, a1.id)
-      if rem(index, 5) == 0, do: create_interaction_api(conn, :user_trigger, a2.id)
-
-      if rem(index, 4) == 0,
-        do: create_interaction_api(conn, :chart_configuration, c2.id)
-
-      if rem(index, 4) == 0,
-        do: create_interaction_api(conn, :chart_configuration, c1.id)
-
-      if rem(index, 3) == 0, do: create_interaction_api(conn, :project_watchlist, w1.id)
-      if rem(index, 2) == 0, do: create_interaction_api(conn, :project_watchlist, w2.id)
+    for i <- 1..60 do
+      if rem(i, 10) == 0, do: create_interaction_api(conn, :insight, i2.id)
+      if rem(i, 7) == 0, do: create_interaction_api(conn, :insight, i1.id)
+      if rem(i, 5) == 0, do: create_interaction_api(conn, :user_trigger, a1.id)
+      if rem(i, 5) == 0, do: create_interaction_api(conn, :user_trigger, a2.id)
+      if rem(i, 4) == 0, do: create_interaction_api(conn, :chart_configuration, c2.id)
+      if rem(i, 4) == 0, do: create_interaction_api(conn, :chart_configuration, c1.id)
+      if rem(i, 3) == 0, do: create_interaction_api(conn, :project_watchlist, w1.id)
+      if rem(i, 2) == 0, do: create_interaction_api(conn, :project_watchlist, w2.id)
     end
 
     result =
@@ -456,11 +431,11 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
     s4 = insert(:screener, is_public: true, function: function.(["price_usd", "price_btc"]))
     _unused = insert(:screener, is_public: true, function: function.(["price_usd", "price_btc"]))
 
-    for index <- 1..60 do
-      if rem(index, 20) == 0, do: create_interaction_api(conn, :screener, s2.id)
-      if rem(index, 10) == 0, do: create_interaction_api(conn, :screener, s1.id)
-      if rem(index, 8) == 0, do: create_interaction_api(conn, :screener, s3.id)
-      if rem(index, 5) == 0, do: create_interaction_api(conn, :screener, s4.id)
+    for i <- 1..10 do
+      if rem(i, 4) == 0, do: create_interaction_api(conn, :screener, s2.id)
+      if rem(i, 3) == 0, do: create_interaction_api(conn, :screener, s1.id)
+      if rem(i, 2) == 0, do: create_interaction_api(conn, :screener, s3.id)
+      if rem(i, 1) == 0, do: create_interaction_api(conn, :screener, s4.id)
     end
 
     result = get_most_used(conn, [:screener], filter: %{metrics: ["price_usd"]})
@@ -493,13 +468,13 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
     :ok = Sanbase.FeaturedItem.update_item(i2, true)
     :ok = Sanbase.FeaturedItem.update_item(c1, true)
 
-    for index <- 1..60 do
-      if rem(index, 20) == 0, do: create_interaction_api(conn, :project_watchlist, w1.id)
-      if rem(index, 20) == 0, do: create_interaction_api(conn, :screener, s1.id)
-      if rem(index, 10) == 0, do: create_interaction_api(conn, :insight, i1.id)
-      if rem(index, 10) == 0, do: create_interaction_api(conn, :insight, i2.id)
-      if rem(index, 5) == 0, do: create_interaction_api(conn, :chart_configuration, c1.id)
-      if rem(index, 5) == 0, do: create_interaction_api(conn, :chart_configuration, c2.id)
+    for i <- 1..60 do
+      if rem(i, 20) == 0, do: create_interaction_api(conn, :project_watchlist, w1.id)
+      if rem(i, 20) == 0, do: create_interaction_api(conn, :screener, s1.id)
+      if rem(i, 10) == 0, do: create_interaction_api(conn, :insight, i1.id)
+      if rem(i, 10) == 0, do: create_interaction_api(conn, :insight, i2.id)
+      if rem(i, 5) == 0, do: create_interaction_api(conn, :chart_configuration, c1.id)
+      if rem(i, 5) == 0, do: create_interaction_api(conn, :chart_configuration, c2.id)
     end
 
     result =

--- a/test/sanbase_web/graphql/entity/get_most_used_api_test.exs
+++ b/test/sanbase_web/graphql/entity/get_most_used_api_test.exs
@@ -4,6 +4,11 @@ defmodule SanbaseWeb.Graphql.GetMostUsedApiTest do
   import SanbaseWeb.Graphql.TestHelpers
   import Sanbase.Factory
 
+  # Note: There cannot be more than 1 interaction for the same user, type and entity
+  # in a predefined time window. This option is disabled in test env by adding
+  # `config :sanbase, Sanbase.Accounts.Interaction, interaction_cooldown_seconds: 0`
+  # to test.exs config.
+
   setup do
     _role = insert(:role_san_family)
 

--- a/test/support/interaction_datetime_module.ex
+++ b/test/support/interaction_datetime_module.ex
@@ -1,0 +1,30 @@
+defmodule Sanbase.Interaction.DateTime do
+  @ets_table :unique_interaction_datetime_counter
+
+  def start_ets() do
+    spawn(fn ->
+      :ets.new(@ets_table, [
+        :set,
+        :public,
+        :named_table
+      ])
+
+      # Infinite sleep so the process does not die and the ETS table lives
+      # throughout the test
+      Process.sleep(:infinity)
+    end)
+
+    # Wait until the table is ready
+    for _ <- 1..5, do: if(:ets.whereis(@ets_table) == :undefined, do: Process.sleep(100))
+  end
+
+  def utc_now() do
+    if :ets.whereis(@ets_table) == :undefined, do: start_ets()
+
+    counter = :ets.update_counter(@ets_table, :counter, {2, 1}, {:counter, 1})
+
+    DateTime.add(DateTime.utc_now(), -counter)
+  end
+
+  def to_naive(dt), do: DateTime.to_naive(dt)
+end


### PR DESCRIPTION
## Changes

Add a unique index so an interaction for a user of a given type and
specific entity cannot be stored more than once per 5 seconds. This
reduces the number of interactions when opening the same entity in
multiple browser tabs, fast reloading, etc.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
