### PR TITLE
Change wallet signature verification

### DIFF
--- a/lib/sanbase/internal_services/ethauth.ex
+++ b/lib/sanbase/internal_services/ethauth.ex
@@ -42,17 +42,18 @@ defmodule Sanbase.InternalServices.Ethauth do
   @doc ~s"""
   Verify that a user that claims to own a given Ethereum address acttually owns it.
   """
-  @spec verify_signature(any(), any(), any()) :: boolean() | {:error, String.t()}
-  def verify_signature(signature, address, message_hash) do
+  @spec is_valid_signature?(any(), any()) :: boolean() | {:error, String.t()}
+  def is_valid_signature?(address, signature) do
     Logger.info(["[Ethauth] Verify signature"])
 
+    message = "Login in Santiment with address #{address}"
+
     with {:ok, %Tesla.Env{status: 200, body: body}} <-
-           get(client(), "recover",
-             query: [sign: signature, hash: message_hash],
+           get(client(), "verify",
+             query: [signer: address, signature: signature, message: message],
              opts: @tesla_opts
-           ),
-         {:ok, %{"recovered" => recovered}} <- Jason.decode(body) do
-      String.downcase(address) == String.downcase(recovered)
+           ) do
+      body == "true"
     else
       {:ok, %Tesla.Env{status: status}} ->
         {:error, "Error veryfing signature for address. #{address}. Status: #{status}"}

--- a/lib/sanbase/internal_services/ethauth.ex
+++ b/lib/sanbase/internal_services/ethauth.ex
@@ -52,8 +52,9 @@ defmodule Sanbase.InternalServices.Ethauth do
            get(client(), "verify",
              query: [signer: address, signature: signature, message: message],
              opts: @tesla_opts
-           ) do
-      body == "true"
+           ),
+         {:ok, %{"is_valid" => is_valid}} <- Jason.decode(body) do
+      is_valid
     else
       {:ok, %Tesla.Env{status: status}} ->
         {:error, "Error veryfing signature for address. #{address}. Status: #{status}"}

--- a/lib/sanbase_web/graphql/resolvers/user/auth_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/auth_resolver.ex
@@ -48,8 +48,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.AuthResolver do
       ) do
     event_args = %{login_origin: :eth_login}
 
-    with true <- address_message_hash(address) == message_hash,
-         true <- Ethauth.verify_signature(signature, address, message_hash),
+    with true <- Ethauth.is_valid_signature?(address, signature),
          {:ok, user} <- fetch_user(args, EthAccount.by_address(address)),
          {:ok, %{} = jwt_tokens_map} <-
            SanbaseWeb.Guardian.get_jwt_tokens(user,
@@ -147,12 +146,5 @@ defmodule SanbaseWeb.Graphql.Resolvers.AuthResolver do
   defp fetch_user(_args, %EthAccount{user_id: user_id}) do
     # Existing EthAccount, login as the user of EthAccount
     User.by_id(user_id)
-  end
-
-  defp address_message_hash(address) do
-    message = "Login in Santiment with address #{address}"
-    full_message = "\x19Ethereum Signed Message:\n" <> "#{String.length(message)}" <> message
-    hash = ExKeccak.hash_256(full_message)
-    "0x" <> Base.encode16(hash, case: :lower)
   end
 end

--- a/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
@@ -192,10 +192,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserResolver do
 
   def add_user_eth_address(
         _root,
-        %{signature: signature, address: address, message_hash: message_hash},
+        %{signature: signature, address: address, message_hash: _message_hash},
         %{context: %{auth: %{auth_method: :user_token, current_user: user}}}
       ) do
-    with true <- Ethauth.verify_signature(signature, address, message_hash),
+    with true <- Ethauth.is_valid_signature?(address, signature),
          {:ok, _} <- User.add_eth_account(user, address) do
       {:ok, user}
     else

--- a/test/sanbase_web/graphql/auth/eth_login_api_test.exs
+++ b/test/sanbase_web/graphql/auth/eth_login_api_test.exs
@@ -8,13 +8,13 @@ defmodule SanbaseWeb.Graphql.EthLoginApiTest do
   test "first eth login success - create user and eth account", context do
     # This address is an unused address on the Ropsten testnet. It is not a mainnet
     # address holding any coins. The signature is not a real signature as the
-    # call to verify_signature/3 will be mocked
+    # call to is_valid_signature?/2 will be mocked
     address = "0x9024d48cc7be15343dfd76ef051fa5264cfbf7a9"
     message_hash = "0xff8ca2965b505cabd1156342c1dfa72c11e7c5e00ff839a12af71e8a7d231731"
     signature = "0xeba4d1a091ca6e7cb0_signature_check_will_be_mocked"
 
     # Mock the external call to Ethauth. Mock the call to trial subscription creation.
-    Sanbase.Mock.prepare_mock2(&Sanbase.InternalServices.Ethauth.verify_signature/3, true)
+    Sanbase.Mock.prepare_mock2(&Sanbase.InternalServices.Ethauth.is_valid_signature?/3, true)
     |> Sanbase.Mock.prepare_mock2(&Sanbase.Accounts.EthAccount.san_staked_address/2, 0.0)
     |> Sanbase.Mock.run_with_mocks(fn ->
       result =
@@ -35,13 +35,13 @@ defmodule SanbaseWeb.Graphql.EthLoginApiTest do
   test "eth login success - existing user", context do
     # This address is an unused address on the Ropsten testnet. It is not a mainnet
     # address holding any coins. The signature is not a real signature as the
-    # call to verify_signature/3 will be mocked
+    # call to is_valid_signature?/2 will be mocked
     address = "0x9024d48cc7be15343dfd76ef051fa5264cfbf7a9"
     message_hash = "0xff8ca2965b505cabd1156342c1dfa72c11e7c5e00ff839a12af71e8a7d231731"
     signature = "0xeba4d1a091ca6e7cb0_signature_check_will_be_mocked"
 
     # Mock the external call to Ethauth. Mock the call to trial subscription creation.
-    Sanbase.Mock.prepare_mock2(&Sanbase.InternalServices.Ethauth.verify_signature/3, true)
+    Sanbase.Mock.prepare_mock2(&Sanbase.InternalServices.Ethauth.is_valid_signature?/2, true)
     |> Sanbase.Mock.prepare_mock2(&Sanbase.Accounts.EthAccount.san_staked_address/2, 0.0)
     |> Sanbase.Mock.run_with_mocks(fn ->
       _ = eth_login(context.conn, address, signature, message_hash)
@@ -64,13 +64,13 @@ defmodule SanbaseWeb.Graphql.EthLoginApiTest do
   test "eth login works after changing username", context do
     # This address is an unused address on the Ropsten testnet. It is not a mainnet
     # address holding any coins. The signature is not a real signature as the
-    # call to verify_signature/3 will be mocked
+    # call to is_valid_signature?/2 will be mocked
     address = "0x9024d48cc7be15343dfd76ef051fa5264cfbf7a9"
     message_hash = "0xff8ca2965b505cabd1156342c1dfa72c11e7c5e00ff839a12af71e8a7d231731"
     signature = "0xeba4d1a091ca6e7cb0_signature_check_will_be_mocked"
 
     # Mock the external call to Ethauth. Mock the call to trial subscription creation.
-    Sanbase.Mock.prepare_mock2(&Sanbase.InternalServices.Ethauth.verify_signature/3, true)
+    Sanbase.Mock.prepare_mock2(&Sanbase.InternalServices.Ethauth.is_valid_signature?/3, true)
     |> Sanbase.Mock.prepare_mock2(&Sanbase.Accounts.EthAccount.san_staked_address/2, 0.0)
     |> Sanbase.Mock.run_with_mocks(fn ->
       user_id =
@@ -97,7 +97,7 @@ defmodule SanbaseWeb.Graphql.EthLoginApiTest do
     signature = "0xeba4d1a091ca6e7cb0_signature_check_will_be_mocked"
 
     # Mock the external call to Ethauth
-    Sanbase.Mock.prepare_mock2(&Sanbase.InternalServices.Ethauth.verify_signature/3, true)
+    Sanbase.Mock.prepare_mock2(&Sanbase.InternalServices.Ethauth.is_valid_signature?/3, true)
     |> Sanbase.Mock.run_with_mocks(fn ->
       log =
         capture_log(fn ->

--- a/test/sanbase_web/graphql/auth/eth_login_api_test.exs
+++ b/test/sanbase_web/graphql/auth/eth_login_api_test.exs
@@ -14,7 +14,7 @@ defmodule SanbaseWeb.Graphql.EthLoginApiTest do
     signature = "0xeba4d1a091ca6e7cb0_signature_check_will_be_mocked"
 
     # Mock the external call to Ethauth. Mock the call to trial subscription creation.
-    Sanbase.Mock.prepare_mock2(&Sanbase.InternalServices.Ethauth.is_valid_signature?/3, true)
+    Sanbase.Mock.prepare_mock2(&Sanbase.InternalServices.Ethauth.is_valid_signature?/2, true)
     |> Sanbase.Mock.prepare_mock2(&Sanbase.Accounts.EthAccount.san_staked_address/2, 0.0)
     |> Sanbase.Mock.run_with_mocks(fn ->
       result =
@@ -70,7 +70,7 @@ defmodule SanbaseWeb.Graphql.EthLoginApiTest do
     signature = "0xeba4d1a091ca6e7cb0_signature_check_will_be_mocked"
 
     # Mock the external call to Ethauth. Mock the call to trial subscription creation.
-    Sanbase.Mock.prepare_mock2(&Sanbase.InternalServices.Ethauth.is_valid_signature?/3, true)
+    Sanbase.Mock.prepare_mock2(&Sanbase.InternalServices.Ethauth.is_valid_signature?/2, true)
     |> Sanbase.Mock.prepare_mock2(&Sanbase.Accounts.EthAccount.san_staked_address/2, 0.0)
     |> Sanbase.Mock.run_with_mocks(fn ->
       user_id =
@@ -97,7 +97,7 @@ defmodule SanbaseWeb.Graphql.EthLoginApiTest do
     signature = "0xeba4d1a091ca6e7cb0_signature_check_will_be_mocked"
 
     # Mock the external call to Ethauth
-    Sanbase.Mock.prepare_mock2(&Sanbase.InternalServices.Ethauth.is_valid_signature?/3, true)
+    Sanbase.Mock.prepare_mock2(&Sanbase.InternalServices.Ethauth.is_valid_signature?/2, true)
     |> Sanbase.Mock.run_with_mocks(fn ->
       log =
         capture_log(fn ->

--- a/test/sanbase_web/graphql/user/user_eth_account_api_test.exs
+++ b/test/sanbase_web/graphql/user/user_eth_account_api_test.exs
@@ -94,7 +94,7 @@ defmodule SanbaseWeb.Graphql.UserEthAccountApiTest do
 
   defp add_eth_address(conn, address) do
     mock(fn %{method: :get} ->
-      {:ok, %Tesla.Env{status: 200, body: %{"recovered" => address} |> Jason.encode!()}}
+      {:ok, %Tesla.Env{status: 200, body: %{"is_valid" => true} |> Jason.encode!()}}
     end)
 
     mutation = """


### PR DESCRIPTION
## Changes

Newer version  of `ethers` recover uses the plain text message instead of the hash of the message for verification.
Use new interface in `ethauth` internal lib for both `recover` and eip1271 verification.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
