### PR TITLE
Exclude deleted comments from the feed

### DIFF
--- a/lib/sanbase/comments/entity_comment.ex
+++ b/lib/sanbase/comments/entity_comment.ex
@@ -195,9 +195,12 @@ defmodule Sanbase.Comments.EntityComment do
       |> union_all(^from(pc in ShortUrlComment, select: pc.comment_id))
       |> union_all(^from(pc in ChartConfigurationComment, select: pc.comment_id))
 
+    # Exclude deleted comments
+    anonymous_user_id = Sanbase.Accounts.User.anonymous_user_id()
+
     from(
       c in Comment,
-      where: c.id in subquery(comment_ids_query),
+      where: c.id in subquery(comment_ids_query) and c.user_id != ^anonymous_user_id,
       preload: ^@comments_feed_entities
     )
   end

--- a/test/sanbase_web/graphql/comments/comments_feed_api_test.exs
+++ b/test/sanbase_web/graphql/comments/comments_feed_api_test.exs
@@ -7,6 +7,8 @@ defmodule SanbaseWeb.Graphql.Comments.CommentsFeedApiTest do
   alias Sanbase.Comments.EntityComment
 
   setup do
+    insert(:insights_fallback_user)
+
     user = insert(:user)
     watchlist = insert(:watchlist)
 


### PR DESCRIPTION
## Changes

The deleted comments have text `This comment has been deleted` and their user is set to the anonymous user.
These comments should be excluded from the feed.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
