### PR TITLE
Available metrics pattern

### DIFF
--- a/lib/sanbase_web/graphql/schema/queries/metric_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/metric_queries.ex
@@ -26,6 +26,13 @@ defmodule SanbaseWeb.Graphql.Schema.MetricQueries do
       arg(:plan, :plans_enum)
       arg(:has_incomplete_data, :boolean, default_value: nil)
 
+      @desc ~s"""
+      Accepts PCRE (Perl Compatible Regular Expressions) format
+
+      Example: { getAvailableMetrics(nameRegexFilter: "^mean_age_[\\d]+") }
+      """
+      arg(:name_regex_filter, :string, default_value: nil)
+
       cache_resolve(&MetricResolver.get_available_metrics/3, ttl: 300)
     end
 
@@ -33,6 +40,13 @@ defmodule SanbaseWeb.Graphql.Schema.MetricQueries do
       meta(access: :free)
 
       arg(:selector, :metric_target_selector_input_object)
+
+      @desc ~s"""
+      Accepts PCRE (Perl Compatible Regular Expressions) format
+
+      Example: { getAvailableMetrics(nameRegexFilter: "^mean_age_[\\d]+") }
+      """
+      arg(:name_regex_filter, :string, default_value: nil)
 
       cache_resolve(&MetricResolver.get_available_metrics_for_selector/3, ttl: 300)
     end


### PR DESCRIPTION
## Changes

Accept a PCRE format regexes in the getAvailableMetrics.

```graphql
{
  getAvailableMetrics(nameRegexFilter: "^mean_age_[\\d]+")
}
```

```json
{
  "data": {
    "getAvailableMetrics": [
      "mean_age_180d",
      "mean_age_2y",
      "mean_age_5y",
      "mean_age_365d",
      "mean_age_3y",
      "mean_age_90d"
    ]
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
