### PR TITLE
Rename plan_atom_name to plan_name. Switch plan name to string

### DIFF
--- a/lib/sanbase/accounts/user_settings.ex
+++ b/lib/sanbase/accounts/user_settings.ex
@@ -100,7 +100,7 @@ defmodule Sanbase.Accounts.UserSettings do
 
   def update_settings(user, %{is_subscribed_biweekly_report: true} = params) do
     case Subscription.current_subscription_plan(user.id, Product.product_sanbase()) do
-      pro when pro in [:pro, :pro_plus] -> settings_update(user.id, params)
+      pro when pro in ["PRO", "PRO_PLUS"] -> settings_update(user.id, params)
       _ -> {:error, "Only PRO users can subscribe to Biweekly Report"}
     end
   end

--- a/lib/sanbase/api_call_limit/api_call_limit.ex
+++ b/lib/sanbase/api_call_limit/api_call_limit.ex
@@ -251,7 +251,7 @@ defmodule Sanbase.ApiCallLimit do
 
     case subscription do
       %Subscription{plan: %{product: %{id: @product_api_id}}} ->
-        "sanapi_#{Subscription.plan_name(subscription)}"
+        "sanapi_#{Subscription.plan_name(subscription)}" |> String.downcase()
 
       %Subscription{plan: %{product: %{id: @product_sanbase_id}}} ->
         "sanbase_pro"

--- a/lib/sanbase/billing/graphql_schema.ex
+++ b/lib/sanbase/billing/graphql_schema.ex
@@ -44,7 +44,7 @@ defmodule Sanbase.Billing.GraphqlSchema do
 
   def min_plan_map() do
     # Metadata looks like this:
-    # meta(access: :restricted, min_plan: [sanapi: :pro, sanbase: :free])
+    # meta(access: :restricted, min_plan: [sanapi: "PRO", sanbase: "FREE"])
     query_min_plan_map = get_query_min_plan_map()
     metric_min_plan_map = get_metric_min_plan_map()
     signal_min_plan_map = get_signal_min_plan_map()
@@ -77,18 +77,26 @@ defmodule Sanbase.Billing.GraphqlSchema do
   end
 
   def get_all_with_access_level(level) do
+    # List of {:query, atom()}
+    queries_with_access_level =
+      get_queries_with_access_level(level)
+      |> Enum.map(&{:query, &1})
+
+    # List of {:signal, String.t()}
     signals_with_access_level =
       Sanbase.Signal.access_map()
       |> get_with_access_level(level)
       |> Enum.map(&{:signal, &1})
 
+    # List of {:metric, String.t()}
     metrics_with_access_level =
       Sanbase.Metric.access_map()
       |> get_with_access_level(level)
       |> Enum.map(&{:metric, &1})
 
-    Enum.map(get_queries_with_access_level(level), &{:query, &1}) ++
-      signals_with_access_level ++ metrics_with_access_level
+    queries_with_access_level ++
+      signals_with_access_level ++
+      metrics_with_access_level
   end
 
   def get_with_access_level(access_map, level) do
@@ -117,12 +125,12 @@ defmodule Sanbase.Billing.GraphqlSchema do
       {query, kw_list} when is_list(kw_list) ->
         {{:query, query},
          %{
-           "SANAPI" => Keyword.get(kw_list, :sanapi, :free),
-           "SANBASE" => Keyword.get(kw_list, :sanbase, :free)
+           "SANAPI" => Keyword.get(kw_list, :sanapi, "FREE"),
+           "SANBASE" => Keyword.get(kw_list, :sanbase, "FREE")
          }}
 
       {query, _} ->
-        {{:query, query}, %{"SANAPI" => :free, "SANBASE" => :free}}
+        {{:query, query}, %{"SANAPI" => "FREE", "SANBASE" => "FREE"}}
     end)
   end
 
@@ -133,7 +141,7 @@ defmodule Sanbase.Billing.GraphqlSchema do
         {{:metric, metric}, product_plan_map}
 
       {metric, _} ->
-        {{:metric, metric}, %{"SANAPI" => :free, "SANBASE" => :free}}
+        {{:metric, metric}, %{"SANAPI" => "FREE", "SANBASE" => "FREE"}}
     end)
   end
 
@@ -144,7 +152,7 @@ defmodule Sanbase.Billing.GraphqlSchema do
         {{:signal, signal}, product_plan_map}
 
       {signal, _} ->
-        {{:signal, signal}, %{"SANAPI" => :free, "SANBASE" => :free}}
+        {{:signal, signal}, %{"SANAPI" => "FREE", "SANBASE" => "FREE"}}
     end)
   end
 

--- a/lib/sanbase/billing/plan.ex
+++ b/lib/sanbase/billing/plan.ex
@@ -55,25 +55,17 @@ defmodule Sanbase.Billing.Plan do
     %__MODULE__{name: "FREE"}
   end
 
-  def plan_atom_name(%__MODULE__{} = plan) do
+  @plan_same_name ["FREE", "BASIC", "PRO", "PRO_PLUS", "PREMIUM", "CUSTOM", "EXTENSION"]
+  def plan_name(%__MODULE__{} = plan) do
     case plan do
-      %{name: "FREE"} -> :free
-      %{name: "BASIC"} -> :basic
-      # should be renamed to basic in the DB
-      %{name: "ESSENTIAL"} -> :basic
-      %{name: "PRO"} -> :pro
-      %{name: "PRO_PLUS"} -> :pro_plus
-      %{name: "PREMIUM"} -> :premium
-      %{name: "CUSTOM"} -> :custom
-      %{name: "ENTERPRISE"} -> :custom
-      %{name: "ENTERPRISE_BASIC"} -> :custom
-      %{name: "ENTERPRISE_PLUS"} -> :custom
-      %{name: "EXTENSION"} -> :extension
-      %{name: name} -> String.downcase(name) |> String.to_existing_atom()
+      %{name: name} when name in @plan_same_name -> name
+      %{name: "ESSENTIAL"} -> "BASIC"
+      %{name: "ENTERPRISE" <> _rest} -> "CUSTOM"
+      %{name: "CUSTOM_" <> _ = name} -> name
     end
   end
 
-  def plan_atom_name(_), do: :free
+  def plan_name(_), do: "FREE"
 
   def plan_full_name(plan) do
     plan = plan |> Repo.preload(:product)

--- a/lib/sanbase/billing/plan/access_checker.ex
+++ b/lib/sanbase/billing/plan/access_checker.ex
@@ -9,7 +9,7 @@ defmodule Sanbase.Billing.Plan.AccessChecker do
   The subscription plan needed for a given query is given in the query definition
     ```
     field :network_growth, list_of(:network_growth) do
-        meta(access: :restricted, min_plan: [sanapi: :pro, sanbase: :free])
+        meta(access: :restricted, min_plan: [sanapi: "PRO", sanbase: "FREE"])
         ...
     end
     ```
@@ -27,6 +27,7 @@ defmodule Sanbase.Billing.Plan.AccessChecker do
   as we have different restrictions.
   """
 
+  @type plan :: String.t()
   alias Sanbase.Billing.{Product, GraphqlSchema}
   alias Sanbase.Billing.Plan.{CustomAccess, ApiAccessChecker, SanbaseAccessChecker}
 
@@ -85,7 +86,7 @@ defmodule Sanbase.Billing.Plan.AccessChecker do
       require Sanbase.Break, as: Break
 
       Break.break("""
-      There are queries with access level `:free` that are defined in the
+      There are queries with access level `FREE` that are defined in the
       CustomAccess module. These queries custom access logic will never be
       executed.
 
@@ -104,26 +105,26 @@ defmodule Sanbase.Billing.Plan.AccessChecker do
     do: query_or_argument not in @free_query_or_argument_mapset
 
   @spec plan_has_access?(plan, product, query_or_argument) :: boolean()
-        when plan: atom(), product: binary()
+        when plan: plan, product: binary()
   def plan_has_access?(plan, product, query_or_argument) do
     case min_plan(product, query_or_argument) do
-      :free -> true
-      :basic -> plan != :free
-      :pro -> plan not in [:free, :basic]
-      :premium -> plan not in [:free, :basic, :pro]
-      :custom -> plan == :custom
+      "FREE" -> true
+      "BASIC" -> plan != "FREE"
+      "PRO" -> plan not in ["FREE", "BASIC"]
+      "PREMIUM" -> plan not in ["FREE", "BASIC", "PRO"]
+      "CUSTOM" -> plan == "CUSTOM"
       # extensions plans can be with other plan. They're handled separately
       _ -> true
     end
   end
 
-  @spec min_plan(product, query_or_argument) :: atom() when product: binary()
+  @spec min_plan(product, query_or_argument) :: plan when product: binary()
   def min_plan(product, query_or_argument) do
-    @min_plan_map[query_or_argument][product] || :free
+    @min_plan_map[query_or_argument][product] || "FREE"
   end
 
   @spec get_available_metrics_for_plan(product, plan, restriction_type) :: list(binary())
-        when plan: atom(), product: binary(), restriction_type: atom()
+        when plan: plan(), product: binary(), restriction_type: atom()
   def get_available_metrics_for_plan(product, plan, restriction_type \\ :all) do
     case restriction_type do
       :free -> @free_query_or_argument

--- a/lib/sanbase/billing/plan/api_access_checker.ex
+++ b/lib/sanbase/billing/plan/api_access_checker.ex
@@ -32,21 +32,21 @@ defmodule Sanbase.Billing.Plan.ApiAccessChecker do
 
   def historical_data_in_days(plan, _query) do
     case plan do
-      :free -> @free_plan_stats[:historical_data_in_days]
-      :basic -> @basic_plan_stats[:historical_data_in_days]
-      :pro -> @pro_plan_stats[:historical_data_in_days]
-      :premium -> @premium_plan_stats[:historical_data_in_days]
-      :custom -> @custom_plan_stats[:historical_data_in_days]
+      "FREE" -> @free_plan_stats[:historical_data_in_days]
+      "BASIC" -> @basic_plan_stats[:historical_data_in_days]
+      "PRO" -> @pro_plan_stats[:historical_data_in_days]
+      "PREMIUM" -> @premium_plan_stats[:historical_data_in_days]
+      "CUSTOM" -> @custom_plan_stats[:historical_data_in_days]
     end
   end
 
   def realtime_data_cut_off_in_days(plan, _query) do
     case plan do
-      :free -> @free_plan_stats[:realtime_data_cut_off_in_days]
-      :basic -> @basic_plan_stats[:realtime_data_cut_off_in_days]
-      :pro -> @pro_plan_stats[:realtime_data_cut_off_in_days]
-      :premium -> @premium_plan_stats[:realtime_data_cut_off_in_days]
-      :custom -> @premium_plan_stats[:realtime_data_cut_off_in_days]
+      "FREE" -> @free_plan_stats[:realtime_data_cut_off_in_days]
+      "BASIC" -> @basic_plan_stats[:realtime_data_cut_off_in_days]
+      "PRO" -> @pro_plan_stats[:realtime_data_cut_off_in_days]
+      "PREMIUM" -> @premium_plan_stats[:realtime_data_cut_off_in_days]
+      "CUSTOM" -> @premium_plan_stats[:realtime_data_cut_off_in_days]
     end
   end
 end

--- a/lib/sanbase/billing/plan/custom_access.ex
+++ b/lib/sanbase/billing/plan/custom_access.ex
@@ -33,8 +33,8 @@ defmodule Sanbase.Billing.Plan.CustomAccess do
       {:metric, "realized_value_usd"}
     ],
     plan_access: %{
-      free: %{realtime_data_cut_off_in_days: 30, historical_data_in_days: 365},
-      basic: %{realtime_data_cut_off_in_days: 14, historical_data_in_days: 2 * 365}
+      "FREE" => %{realtime_data_cut_off_in_days: 30, historical_data_in_days: 365},
+      "BASIC" => %{realtime_data_cut_off_in_days: 14, historical_data_in_days: 2 * 365}
     }
   }
 
@@ -42,7 +42,7 @@ defmodule Sanbase.Billing.Plan.CustomAccess do
   @metric %{
     metric_name: [{:query, :token_age_consumed}, {:query, :burn_rate}, {:metric, "age_destroyed"}],
     plan_access: %{
-      free: %{realtime_data_cut_off_in_days: 30}
+      "FREE" => %{realtime_data_cut_off_in_days: 30}
     }
   }
 

--- a/lib/sanbase/billing/plan/sanbase_access_checker.ex
+++ b/lib/sanbase/billing/plan/sanbase_access_checker.ex
@@ -50,19 +50,20 @@ defmodule Sanbase.Billing.Plan.SanbaseAccessChecker do
 
   def can_access_paywalled_insights?(subscription) do
     subscription.plan
-    |> Plan.plan_atom_name()
+    |> Plan.plan_name()
     |> plan_stats()
     |> Map.get(:access_paywalled_insights, false)
   end
 
   defp plan_stats(plan) do
     case plan do
-      :free -> @free_plan_stats
-      :basic -> @basic_plan_stats
-      :pro -> @pro_plan_stats
-      :pro_plus -> @pro_plus_plan_stats
-      :premium -> @custom_plan_stats
-      :custom -> @custom_plan_stats
+      "FREE" -> @free_plan_stats
+      "BASIC" -> @basic_plan_stats
+      "PRO" -> @pro_plan_stats
+      "PRO_PLUS" -> @pro_plus_plan_stats
+      "PREMIUM" -> @custom_plan_stats
+      "CUSTOM" -> @custom_plan_stats
+      "CUSTOM_" <> _ -> @custom_plan_stats
     end
   end
 end

--- a/lib/sanbase/billing/subscription/subscription.ex
+++ b/lib/sanbase/billing/subscription/subscription.ex
@@ -386,8 +386,8 @@ defmodule Sanbase.Billing.Subscription do
     current_subscription(user_id, product_id) |> plan_name()
   end
 
-  def plan_name(nil), do: :free
-  def plan_name(%__MODULE__{plan: plan}), do: plan |> Plan.plan_atom_name()
+  def plan_name(nil), do: "FREE"
+  def plan_name(%__MODULE__{plan: plan}), do: plan |> Plan.plan_name()
 
   # Private functions
 

--- a/lib/sanbase/blockchain_address/metric_adapter.ex
+++ b/lib/sanbase/blockchain_address/metric_adapter.ex
@@ -16,12 +16,15 @@ defmodule Sanbase.BlockchainAddress.MetricAdapter do
 
   @metrics @histogram_metrics ++ @timeseries_metrics ++ @table_metrics
 
+  # plan related - the plan is upcase string
+  @min_plan_map Enum.into(@metrics, %{}, fn metric -> {metric, "FREE"} end)
+
+  # restriction related - the restriction is atom :free or :restricted
   @access_map Enum.into(@metrics, %{}, fn metric -> {metric, :free} end)
-  @min_plan_map Enum.into(@metrics, %{}, fn metric -> {metric, :free} end)
 
   @free_metrics Enum.filter(@access_map, fn {_, level} -> level == :free end)
                 |> Enum.map(&elem(&1, 0))
-  @restricted_metrics Enum.filter(@access_map, fn {_, level} -> level == :restricted end)
+  @restricted_metrics Enum.filter(@access_map, fn {_, level} -> level == :free end)
                       |> Enum.map(&elem(&1, 0))
 
   @required_selectors Enum.into(@metrics, %{}, &{&1, [[:blockchain_address], [:slug]]})

--- a/lib/sanbase/chart/shared_access_token.ex
+++ b/lib/sanbase/chart/shared_access_token.ex
@@ -86,7 +86,7 @@ defmodule Sanbase.Chart.Configuration.SharedAccessToken do
              shared_access_token: %__MODULE__{},
              metrics: list(),
              queries: list(),
-             plan: atom(),
+             plan: String.t(),
              product_id: integer(),
              product: String.t()
            }}
@@ -105,7 +105,7 @@ defmodule Sanbase.Chart.Configuration.SharedAccessToken do
             shared_access_token: token,
             metrics: metrics,
             queries: queries,
-            plan: :pro,
+            plan: "PRO",
             product_id: Sanbase.Billing.Product.product_sanbase(),
             product: "SANBASE"
           }

--- a/lib/sanbase/clickhouse/github/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/github/metric_adapter.ex
@@ -28,8 +28,11 @@ defmodule Sanbase.Clickhouse.Github.MetricAdapter do
 
   @metrics @histogram_metrics ++ @timeseries_metrics ++ @table_metrics
 
+  # plan related - the plan is upcase string
+  @min_plan_map Enum.into(@metrics, %{}, fn metric -> {metric, "FREE"} end)
+
+  # restriction related - the restriction is atom :free or :restricted
   @access_map Enum.into(@metrics, %{}, fn metric -> {metric, :free} end)
-  @min_plan_map Enum.into(@metrics, %{}, fn metric -> {metric, :free} end)
 
   @free_metrics @metrics
   @restricted_metrics []

--- a/lib/sanbase/clickhouse/metric/file_handler.ex
+++ b/lib/sanbase/clickhouse/metric/file_handler.ex
@@ -191,7 +191,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter.FileHandler do
   @min_interval_map Helper.name_to_field_map(@metrics_json, "min_interval")
   @min_plan_map Helper.name_to_field_map(@metrics_json, "min_plan",
                   transform_fn: fn plan_map ->
-                    Enum.into(plan_map, %{}, fn {k, v} -> {k, String.to_atom(v)} end)
+                    Enum.into(plan_map, %{}, fn {k, v} -> {k, String.upcase(v)} end)
                   end
                 )
 

--- a/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
@@ -42,11 +42,13 @@ defmodule Sanbase.Clickhouse.TopHolders.MetricAdapter do
 
   @metrics @histogram_metrics ++ @timeseries_metrics ++ @table_metrics
 
-  @access_map Enum.into(@metrics, %{}, fn metric -> {metric, :restricted} end)
+  # plan related - the plan is upcase string
   @min_plan_map Enum.into(@metrics, %{}, fn metric ->
-                  {metric, %{"SANAPI" => :free, "SANBASE" => :free}}
+                  {metric, %{"SANAPI" => "FREE", "SANBASE" => "FREE"}}
                 end)
 
+  # restriction related - the restriction is atom :free or :restricted
+  @access_map Enum.into(@metrics, %{}, fn metric -> {metric, :restricted} end)
   @free_metrics Enum.filter(@access_map, fn {_, level} -> level == :free end)
                 |> Enum.map(&elem(&1, 0))
   @restricted_metrics Enum.filter(@access_map, fn {_, level} -> level == :restricted end)

--- a/lib/sanbase/clickhouse/uniswap/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/uniswap/metric_adapter.ex
@@ -17,9 +17,11 @@ defmodule Sanbase.Clickhouse.Uniswap.MetricAdapter do
 
   @metrics @histogram_metrics ++ @timeseries_metrics ++ @table_metrics
 
-  @access_map Enum.into(@metrics, %{}, fn metric -> {metric, :restricted} end)
-  @min_plan_map Enum.into(@metrics, %{}, fn metric -> {metric, :free} end)
+  # plan related - the plan is upcase string
+  @min_plan_map Enum.into(@metrics, %{}, fn metric -> {metric, "FREE"} end)
 
+  # restriction related - the restriction is atom :free or :restricted
+  @access_map Enum.into(@metrics, %{}, fn metric -> {metric, :restricted} end)
   @free_metrics Enum.filter(@access_map, &match?({_, :free}, &1)) |> Enum.map(&elem(&1, 0))
   @restricted_metrics Enum.filter(@access_map, &match?({_, :restricted}, &1))
                       |> Enum.map(&elem(&1, 0))

--- a/lib/sanbase/contract_metric/metric_adapter.ex
+++ b/lib/sanbase/contract_metric/metric_adapter.ex
@@ -17,12 +17,14 @@ defmodule Sanbase.Contract.MetricAdapter do
   @histogram_metrics []
   @table_metrics []
 
+  # plan related - the plan is upcase string
+  @min_plan_map Enum.into(@metrics, %{}, fn metric -> {metric, "FREE"} end)
+
+  # restriction related - the restriction is atom :free or :restricted
   @access_map Enum.into(@metrics, %{}, fn metric -> {metric, :restricted} end)
   @free_metrics Enum.filter(@access_map, &match?({_, :free}, &1)) |> Enum.map(&elem(&1, 0))
   @restricted_metrics Enum.filter(@access_map, &match?({_, :restricted}, &1))
                       |> Enum.map(&elem(&1, 0))
-
-  @min_plan_map Enum.into(@metrics, %{}, fn metric -> {metric, :free} end)
 
   @required_selectors Enum.into(@metrics, %{}, &{&1, [[:contract_address]]})
   @default_complexity_weight 1.0

--- a/lib/sanbase/metric/helper.ex
+++ b/lib/sanbase/metric/helper.ex
@@ -115,7 +115,7 @@ defmodule Sanbase.Metric.Helper do
     restrictions when is_map(restrictions) ->
       restrictions
 
-    restriction when restriction in [:restricted, :free] ->
+    restriction when restriction in [:free, :restricted] ->
       %{"historical" => restriction, "realtime" => restriction}
   end
 

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -666,7 +666,7 @@ defmodule Sanbase.Metric do
   """
   @spec is_historical_data_allowed?(metric) :: boolean
   def is_historical_data_allowed?(metric) do
-    get_in(@access_map, [metric, "historical"]) == :free
+    get_in(@access_map, [metric, "historical"]) == "FREE"
   end
 
   @doc ~s"""
@@ -674,7 +674,7 @@ defmodule Sanbase.Metric do
   """
   @spec is_realtime_data_allowed?(metric) :: boolean
   def is_realtime_data_allowed?(metric) do
-    get_in(@access_map, [metric, "realtime"]) == :free
+    get_in(@access_map, [metric, "realtime"]) == "FREE"
   end
 
   @doc ~s"""

--- a/lib/sanbase/prices/metric_adapter.ex
+++ b/lib/sanbase/prices/metric_adapter.ex
@@ -11,8 +11,11 @@ defmodule Sanbase.Price.MetricAdapter do
 
   @metrics @histogram_metrics ++ @timeseries_metrics ++ @table_metrics
 
+  # plan related - the plan is upcase string
+  @min_plan_map Enum.into(@metrics, %{}, fn metric -> {metric, "FREE"} end)
+
+  # restriction related - the restriction is atom :free or :restricted
   @access_map Enum.into(@metrics, %{}, fn metric -> {metric, :free} end)
-  @min_plan_map Enum.into(@metrics, %{}, fn metric -> {metric, :free} end)
 
   @free_metrics Enum.filter(@access_map, fn {_, level} -> level == :free end)
                 |> Enum.map(&elem(&1, 0))

--- a/lib/sanbase/prices/price_pair/metric_adapter.ex
+++ b/lib/sanbase/prices/price_pair/metric_adapter.ex
@@ -11,8 +11,11 @@ defmodule Sanbase.PricePair.MetricAdapter do
 
   @metrics @histogram_metrics ++ @timeseries_metrics ++ @table_metrics
 
+  # plan related - the plan is upcase string
+  @min_plan_map Enum.into(@metrics, %{}, fn metric -> {metric, "FREE"} end)
+
+  # restriction related - the restriction is atom :free or :restricted
   @access_map Enum.into(@metrics, %{}, fn metric -> {metric, :free} end)
-  @min_plan_map Enum.into(@metrics, %{}, fn metric -> {metric, :free} end)
 
   @free_metrics Enum.filter(@access_map, fn {_, level} -> level == :free end)
                 |> Enum.map(&elem(&1, 0))

--- a/lib/sanbase/reports/report.ex
+++ b/lib/sanbase/reports/report.ex
@@ -16,7 +16,7 @@ defmodule Sanbase.Report do
 
   @type get_reports_opts :: %{
           required(:is_logged_in) => boolean(),
-          optional(:plan_atom_name) => atom()
+          optional(:plan_name) => atom()
         }
 
   schema "reports" do
@@ -127,7 +127,7 @@ defmodule Sanbase.Report do
     Enum.map(reports, fn report -> %{report | url: nil} end)
   end
 
-  defp show_only_preview_fields?(reports, %{is_logged_in: true, plan_atom_name: :free}) do
+  defp show_only_preview_fields?(reports, %{is_logged_in: true, plan_name: "FREE"}) do
     reports
     |> Enum.map(fn
       %__MODULE__{is_pro: true} = report ->
@@ -138,8 +138,7 @@ defmodule Sanbase.Report do
     end)
   end
 
-  defp show_only_preview_fields?(reports, %{is_logged_in: true, plan_atom_name: plan})
-       when plan != :free do
+  defp show_only_preview_fields?(reports, %{is_logged_in: true}) do
     reports
   end
 

--- a/lib/sanbase/signal/file_handler.ex
+++ b/lib/sanbase/signal/file_handler.ex
@@ -88,7 +88,7 @@ defmodule Sanbase.Signal.FileHandler do
 
     def resolve_access_level(access) when is_map(access) do
       case access do
-        %{"historical" => :free, "realtime" => :free} -> :free
+        %{"historical" => "FREE", "realtime" => "FREE"} -> "FREE"
         _ -> :restricted
       end
     end
@@ -131,7 +131,7 @@ defmodule Sanbase.Signal.FileHandler do
   @signals_mapset MapSet.new(@signals_list)
   @min_plan_map Helper.name_to_field_map(@signals_json, "min_plan",
                   transform_fn: fn plan_map ->
-                    Enum.into(plan_map, %{}, fn {k, v} -> {k, String.to_atom(v)} end)
+                    Enum.into(plan_map, %{}, fn {k, v} -> {k, String.upcase(v)} end)
                   end
                 )
 

--- a/lib/sanbase/signal/signal_adapter.ex
+++ b/lib/sanbase/signal/signal_adapter.ex
@@ -200,7 +200,7 @@ defmodule Sanbase.Signal.SignalAdapter do
     Enum.into(restrictions, %{}, fn {k, v} -> {k, String.to_existing_atom(v)} end)
   end
 
-  defp resolve_restrictions(restriction) when restriction in [:restricted, :free] do
+  defp resolve_restrictions(restriction) when restriction in [:free, :restriction] do
     %{"historical" => restriction, "realtime" => restriction}
   end
 end

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -64,18 +64,23 @@ defmodule Sanbase.SocialData.MetricAdapter do
   @table_metrics []
 
   @metrics @histogram_metrics ++ @timeseries_metrics ++ @table_metrics
+
+  # plan related - the plan is upcase string
+  @min_plan_map Enum.reduce(@metrics, %{}, fn metric, acc -> Map.put(acc, metric, "FREE") end)
+
+  # restriction related - the restriction is atom :free or :restricted
   @social_volume_metrics_access_map @social_volume_timeseries_metrics
                                     |> Enum.into(
                                       %{},
                                       &{&1, %{"historical" => :restricted, "realtime" => :free}}
                                     )
+
   @access_map (@metrics -- @social_volume_timeseries_metrics)
               |> Enum.reduce(%{}, fn metric, acc ->
                 Map.put(acc, metric, :restricted)
               end)
               |> Map.merge(@social_volume_metrics_access_map)
 
-  @min_plan_map Enum.reduce(@metrics, %{}, fn metric, acc -> Map.put(acc, metric, :free) end)
   @required_selectors Enum.into(@metrics, %{}, &{&1, []})
                       |> Map.put("social_active_users", [[:source]])
 

--- a/lib/sanbase/twitter/metric_adapter.ex
+++ b/lib/sanbase/twitter/metric_adapter.ex
@@ -10,8 +10,11 @@ defmodule Sanbase.Twitter.MetricAdapter do
 
   @metrics @histogram_metrics ++ @timeseries_metrics ++ @table_metrics
 
+  # plan related - the plan is upcase string
+  @min_plan_map Enum.into(@metrics, %{}, fn metric -> {metric, "FREE"} end)
+
+  # restriction related - the restriction is atom :free or :restricted
   @access_map Enum.into(@metrics, %{}, fn metric -> {metric, :free} end)
-  @min_plan_map Enum.into(@metrics, %{}, fn metric -> {metric, :free} end)
 
   @free_metrics Enum.filter(@access_map, fn {_, level} -> level == :free end)
                 |> Enum.map(&elem(&1, 0))

--- a/lib/sanbase/webinars/webinar.ex
+++ b/lib/sanbase/webinars/webinar.ex
@@ -59,8 +59,8 @@ defmodule Sanbase.Webinar do
     |> show_only_preview_fields?(opts)
   end
 
-  defp show_only_preview_fields?(webinars, %{plan_atom_name: plan})
-       when plan in [:pro, :pro_plus] do
+  defp show_only_preview_fields?(webinars, %{plan_name: plan})
+       when plan in ["PRO", "PRO_PLUS"] do
     webinars
   end
 

--- a/lib/sanbase_web/graphql/complexity/complexity.ex
+++ b/lib/sanbase_web/graphql/complexity/complexity.ex
@@ -36,13 +36,14 @@ defmodule SanbaseWeb.Graphql.Complexity do
       when not is_nil(subscription) do
     complexity = calculate_complexity(args, child_complexity, struct)
 
-    case Sanbase.Billing.Plan.plan_atom_name(subscription.plan) do
-      :free -> complexity
-      :basic -> div(complexity, 4)
-      :pro -> div(complexity, 5)
-      :pro_plus -> div(complexity, 5)
-      :premium -> div(complexity, 6)
-      :custom -> div(complexity, 7)
+    case Sanbase.Billing.Plan.plan_name(subscription.plan) do
+      "FREE" -> complexity
+      "BASIC" -> div(complexity, 4)
+      "PRO" -> div(complexity, 5)
+      "PRO_PLUS" -> div(complexity, 5)
+      "PREMIUM" -> div(complexity, 6)
+      "CUSTOM" -> div(complexity, 7)
+      "CUSTOM_" <> _ -> div(complexity, 7)
     end
   end
 

--- a/lib/sanbase_web/graphql/resolvers/access_control_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/access_control_resolver.ex
@@ -3,7 +3,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.AccessControlResolver do
   alias SanbaseWeb.Graphql.Cache
 
   def get_access_restrictions(_root, args, %{context: context}) do
-    plan = Map.get(args, :plan) || context[:auth][:plan] || :free
+    plan = Map.get(args, :plan) || context[:auth][:plan] || "FREE"
+    plan = plan |> to_string() |> String.upcase()
 
     product_id =
       Product.id_by_code(Map.get(args, :product)) || context[:product_id] || Product.product_api()

--- a/lib/sanbase_web/graphql/resolvers/discord_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/discord_resolver.ex
@@ -4,7 +4,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.DiscordResolver do
   def add_to_pro_role_in_discord(_root, args, %{
         context: %{auth: %{subscription: subscription, plan: plan}}
       }) do
-    case subscription.status == :active and plan in [:pro, :pro_plus] do
+    case subscription.status == :active and plan in ["PRO", "PRO_PLUS"] do
       true -> Bot.add_pro_role(args.discord_username)
       false -> {:error, "Please, upgrade to Sanbase PRO plan or higher!"}
     end

--- a/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
@@ -27,7 +27,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
 
   def get_available_metrics(_root, %{product: product, plan: plan} = args, _resolution) do
     product = product |> Atom.to_string() |> String.upcase()
+    plan = plan |> to_string() |> String.upcase()
     metrics = AccessChecker.get_available_metrics_for_plan(product, plan)
+
     metrics = maybe_filter_incomplete_metrics(metrics, args[:has_incomplete_data])
     {:ok, metrics}
   end

--- a/lib/sanbase_web/graphql/resolvers/report_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/report_resolver.ex
@@ -18,7 +18,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ReportResolver do
   def get_reports(_root, _args, %{context: %{auth: %{current_user: user}}}) do
     plan = Subscription.current_subscription_plan(user.id, @product_sanbase)
 
-    reports = Report.get_published_reports(%{is_logged_in: true, plan_atom_name: plan})
+    reports = Report.get_published_reports(%{is_logged_in: true, plan_name: plan})
 
     {:ok, reports}
   end
@@ -30,7 +30,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ReportResolver do
   def get_reports_by_tags(_root, %{tags: tags}, %{context: %{auth: %{current_user: user}}}) do
     plan = Subscription.current_subscription_plan(user.id, @product_sanbase)
 
-    reports = Report.get_by_tags(tags, %{is_logged_in: true, plan_atom_name: plan})
+    reports = Report.get_by_tags(tags, %{is_logged_in: true, plan_name: plan})
 
     {:ok, reports}
   end

--- a/lib/sanbase_web/graphql/resolvers/sheets_template_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/sheets_template_resolver.ex
@@ -11,7 +11,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.SheetsTemplateResolver do
       Subscription.current_subscription(user, @product_sanbase)
       |> Subscription.plan_name()
 
-    {:ok, SheetsTemplate.get_all(%{is_logged_in: true, plan_atom_name: plan})}
+    {:ok, SheetsTemplate.get_all(%{is_logged_in: true, plan_name: plan})}
   end
 
   def get_sheets_templates(_root, _args, _resolution) do

--- a/lib/sanbase_web/graphql/resolvers/signals/user_trigger_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/signals/user_trigger_resolver.ex
@@ -39,7 +39,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserTriggerResolver do
   def create_trigger(_root, args, %{
         context: %{auth: %{current_user: current_user} = auth}
       }) do
-    # Can be :free, :pro or :pro_plus. If we reach here then the
+    # Can be "FREE", "PRO" or "PRO_PLUS. If we reach here then the
     # authentication has been done via the JWT token, using the
     # JWTAuth middleware, so the plan is a sanbase plan
     sanbase_plan = auth[:plan]
@@ -54,17 +54,18 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserTriggerResolver do
     triggers_count = UserTrigger.triggers_count_for(user.id)
 
     cond do
-      sanbase_plan == :free and triggers_count >= SanbaseAccessChecker.alerts_limit(:free) ->
+      sanbase_plan == "FREE" and triggers_count >= SanbaseAccessChecker.alerts_limit("FREE") ->
         {:error,
-         "Sanbase FREE plan has a limit of #{SanbaseAccessChecker.alerts_limit(:free)} alerts."}
+         "Sanbase FREE plan has a limit of #{SanbaseAccessChecker.alerts_limit("FREE")} alerts."}
 
-      sanbase_plan == :pro and triggers_count >= SanbaseAccessChecker.alerts_limit(:pro) ->
+      sanbase_plan == "PRO" and triggers_count >= SanbaseAccessChecker.alerts_limit("PRO") ->
         {:error,
-         "Sanbase PRO plan has a limit of #{SanbaseAccessChecker.alerts_limit(:pro)} alerts."}
+         "Sanbase PRO plan has a limit of #{SanbaseAccessChecker.alerts_limit("PRO")} alerts."}
 
-      sanbase_plan == :pro_plus and triggers_count >= SanbaseAccessChecker.alerts_limit(:pro_plus) ->
+      sanbase_plan == "PRO_PLUS" and
+          triggers_count >= SanbaseAccessChecker.alerts_limit("PRO_PLUS") ->
         {:error,
-         "Sanbase PRO+ plan has a limit of #{triggers_count >= SanbaseAccessChecker.alerts_limit(:pro_plus)} alerts."}
+         "Sanbase PRO+ plan has a limit of #{triggers_count >= SanbaseAccessChecker.alerts_limit("PRO_PLUS")} alerts."}
 
       true ->
         true

--- a/lib/sanbase_web/graphql/resolvers/webinar_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/webinar_resolver.ex
@@ -12,7 +12,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.WebinarResolver do
       Subscription.current_subscription(user, @product_sanbase)
       |> Subscription.plan_name()
 
-    {:ok, Webinar.get_all(%{is_logged_in: true, plan_atom_name: plan})}
+    {:ok, Webinar.get_all(%{is_logged_in: true, plan_name: plan})}
   end
 
   def get_webinars(_root, _args, _resolution) do

--- a/lib/sanbase_web/graphql/schema/queries/historical_balance_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/historical_balance_queries.ex
@@ -110,7 +110,7 @@ defmodule SanbaseWeb.Graphql.Schema.HistoricalBalanceQueries do
     Currently only ETH is supported.
     """
     field :miners_balance, list_of(:miners_balance) do
-      meta(access: :restricted, min_plan: [sanapi: :pro, sanbase: :free])
+      meta(access: :restricted, min_plan: [sanapi: "PRO", sanbase: "FREE"])
 
       arg(:slug, :string, default_value: "ethereum")
       arg(:from, non_null(:datetime))

--- a/lib/sanbase_web/graphql/schema/queries/metric_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/metric_queries.ex
@@ -43,7 +43,7 @@ defmodule SanbaseWeb.Graphql.Schema.MetricQueries do
       It will be deprecated once Websocket Subscriptions are added
       """)
 
-      meta(access: :restricted, min_plan: [sanapi: :pro, sanbase: :pro])
+      meta(access: :restricted, min_plan: [sanapi: "PRO", sanbase: "PRO"])
 
       arg(:selector, :metric_target_selector_input_object)
       arg(:metrics, list_of(:string))

--- a/lib/sheets_templates/sheets_template.ex
+++ b/lib/sheets_templates/sheets_template.ex
@@ -66,7 +66,7 @@ defmodule Sanbase.SheetsTemplate do
     Enum.map(sheets_templates, fn sheets_template -> %{sheets_template | url: nil} end)
   end
 
-  defp show_only_preview_fields?(sheets_templates, %{is_logged_in: true, plan_atom_name: :free}) do
+  defp show_only_preview_fields?(sheets_templates, %{is_logged_in: true, plan_name: "FREE"}) do
     sheets_templates
     |> Enum.map(fn
       %__MODULE__{is_pro: true} = sheets_template ->
@@ -77,8 +77,8 @@ defmodule Sanbase.SheetsTemplate do
     end)
   end
 
-  defp show_only_preview_fields?(sheets_templates, %{is_logged_in: true, plan_atom_name: plan})
-       when plan != :free do
+  defp show_only_preview_fields?(sheets_templates, %{is_logged_in: true, plan_name: plan})
+       when plan != "FREE" do
     sheets_templates
   end
 end

--- a/test/sanbase/alerts/trigger_restrictions_test.exs
+++ b/test/sanbase/alerts/trigger_restrictions_test.exs
@@ -55,7 +55,7 @@ defmodule Sanbase.Alert.TriggerRestrictionsTest do
     user = insert(:user)
     conn = setup_jwt_auth(build_conn(), user)
 
-    assert Sanbase.Billing.Plan.SanbaseAccessChecker.alerts_limit(:free) == 3
+    assert Sanbase.Billing.Plan.SanbaseAccessChecker.alerts_limit("FREE") == 3
 
     for _ <- 1..3 do
       assert %{"data" => %{"createTrigger" => _}} = create_trigger(conn)
@@ -70,7 +70,7 @@ defmodule Sanbase.Alert.TriggerRestrictionsTest do
     _ = insert(:subscription_pro_sanbase, user: user)
     conn = setup_jwt_auth(build_conn(), user)
 
-    assert Sanbase.Billing.Plan.SanbaseAccessChecker.alerts_limit(:pro) == 20
+    assert Sanbase.Billing.Plan.SanbaseAccessChecker.alerts_limit("PRO") == 20
 
     for _ <- 1..20 do
       assert %{"data" => %{"createTrigger" => _}} = create_trigger(conn)
@@ -85,7 +85,7 @@ defmodule Sanbase.Alert.TriggerRestrictionsTest do
     _ = insert(:subscription_pro_sanbase, user: user)
     conn = setup_jwt_auth(build_conn(), user)
 
-    assert Sanbase.Billing.Plan.SanbaseAccessChecker.alerts_limit(:pro_plus) == 1000
+    assert Sanbase.Billing.Plan.SanbaseAccessChecker.alerts_limit("PRO_PLUS") == 1000
 
     # Creating 1000 would be too slow
     for _ <- 1..30 do

--- a/test/sanbase_web/graphql/auth/linked_user_api_test.exs
+++ b/test/sanbase_web/graphql/auth/linked_user_api_test.exs
@@ -97,7 +97,7 @@ defmodule SanbaseWeb.Graphql.LinkedUserApiTest do
   test "secondary user gets access to metrics", context do
     %{"errors" => [%{"message" => error_msg}]} = get_pro_metric(context.conn)
     assert error_msg =~ "parameters are outside the allowed interval"
-    assert error_msg =~ "current subscription SANBASE free"
+    assert error_msg =~ "current subscription SANBASE FREE"
 
     token = generate_linked_user_token(context.pro_conn, context.user)
     true = confirm_linked_user_token(context.conn, token)

--- a/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_product_access_test.exs
+++ b/test/sanbase_web/graphql/billing/timeframe_access_restrictions/api_product_access_test.exs
@@ -62,7 +62,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
 
     test "cannot access RESTRICTED metrics for over 2 years", context do
       {from, to} = from_to(2 * 365 + 1, 31)
-      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :free)
+      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, "FREE")
       slug = context.project.slug
       selector = %{slug: slug}
       query = metric_query(metric, selector, from, to)
@@ -93,7 +93,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
 
     test "can access RESTRICTED metrics within 2 years and 30 days interval", context do
       {from, to} = from_to(2 * 365, 31)
-      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :free)
+      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, "FREE")
       slug = context.project.slug
       selector = %{slug: slug}
       query = metric_query(metric, selector, from, to)
@@ -251,7 +251,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
 
     # test "can't access signal with min plan PRO", context do
     #   {from, to} = from_to(2 * 365 - 1, 2 * 365 - 2)
-    #   signal = restricted_signal_for_plan(context.next_integer.(), @product, :pro)
+    #   signal = restricted_signal_for_plan(context.next_integer.(), @product, "PRO")
     #   slug = context.project.slug
     #   query = signal_query(signal, slug, from, to)
     #   error_message = execute_query_with_error(context.conn, query, "getSignal")
@@ -320,7 +320,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
 
     test "can access RESTRICTED metrics for less than 7 years", context do
       {from, to} = from_to(7 * 365 - 1, 7 * 365 - 2)
-      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :pro)
+      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, "PRO")
       slug = context.project.slug
       selector = %{slug: slug}
       query = metric_query(metric, selector, from, to)
@@ -332,7 +332,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
 
     # test "can access RESTRICTED signals for less than 7 years", context do
     #   {from, to} = from_to(7 * 365 - 1, 7 * 365 - 2)
-    #   signal = restricted_signal_for_plan(context.next_integer.(), @product, :pro)
+    #   signal = restricted_signal_for_plan(context.next_integer.(), @product, "PRO")
     #   slug = context.project.slug
     #   query = signal_query(signal, slug, from, to)
     #   result = execute_query(context.conn, query, "getSignal")
@@ -352,7 +352,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
 
     test "can access RESTRICTED metrics for over 7 years", context do
       {from, to} = from_to(7 * 365 + 1, 7 * 365 - 1)
-      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :pro)
+      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, "PRO")
       slug = context.project.slug
       selector = %{slug: slug}
       query = metric_query(metric, selector, from, to)
@@ -364,7 +364,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
 
     # test "can access RESTRICTED signals for over 7 years", context do
     #   {from, to} = from_to(7 * 365 + 1, 7 * 365 - 1)
-    #   signal = restricted_signal_for_plan(context.next_integer.(), @product, :pro)
+    #   signal = restricted_signal_for_plan(context.next_integer.(), @product, "PRO")
     #   slug = context.project.slug
     #   query = signal_query(signal, slug, from, to)
     #   result = execute_query(context.conn, query, "getSignal")
@@ -384,7 +384,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
 
     test "can access RESTRICTED metrics realtime", context do
       {from, to} = from_to(10, 0)
-      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :pro)
+      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, "PRO")
       slug = context.project.slug
       selector = %{slug: slug}
       query = metric_query(metric, selector, from, to)
@@ -405,7 +405,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
 
     # test "can access RESTRICTED signals realtime", context do
     #   {from, to} = from_to(10, 0)
-    #   signal = restricted_signal_for_plan(context.next_integer.(), @product, :pro)
+    #   signal = restricted_signal_for_plan(context.next_integer.(), @product, "PRO")
     #   slug = context.project.slug
     #   query = signal_query(signal, slug, from, to)
     #   result = execute_query(context.conn, query, "getSignal")
@@ -465,7 +465,7 @@ defmodule Sanbase.Billing.ApiProductAccessTest do
 
     test "can access RESTRICTED metrics for all time & realtime", context do
       {from, to} = from_to(2500, 0)
-      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :custom)
+      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, "CUSTOM")
       slug = context.project.slug
       selector = %{slug: slug}
       query = metric_query(metric, selector, from, to)

--- a/test/sanbase_web/graphql/billing/timeframe_access_restrictions/sanbase_product_access_test.exs
+++ b/test/sanbase_web/graphql/billing/timeframe_access_restrictions/sanbase_product_access_test.exs
@@ -72,7 +72,7 @@ defmodule Sanbase.Billing.SanbaseProductAccessTest do
     test "cannot access RESTRICTED metrics for over 2 years", context do
       {from, to} = from_to(2 * 365 + 1, 31)
       slug = context.project.slug
-      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :free)
+      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, "FREE")
       selector = %{slug: slug}
       query = metric_query(metric, selector, from, to)
 
@@ -98,7 +98,7 @@ defmodule Sanbase.Billing.SanbaseProductAccessTest do
     test "cannot access RESTRICTED metrics for the past 30 days", context do
       {from, to} = from_to(32, 28)
       slug = context.project.slug
-      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :free)
+      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, "FREE")
       selector = %{slug: slug}
       query = metric_query(metric, selector, from, to)
 
@@ -113,7 +113,7 @@ defmodule Sanbase.Billing.SanbaseProductAccessTest do
       {from, to} = from_to(20, 10)
       slug = context.project.slug
 
-      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :free)
+      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, "FREE")
 
       selector = %{slug: slug}
       query = metric_query(metric, selector, from, to)
@@ -161,7 +161,7 @@ defmodule Sanbase.Billing.SanbaseProductAccessTest do
     test "can access RESTRICTED metrics within 2 years and 30 day ago interval", context do
       {from, to} = from_to(2 * 365 - 1, 31)
       slug = context.project.slug
-      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :free)
+      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, "FREE")
       selector = %{slug: slug}
       query = metric_query(metric, selector, from, to)
 
@@ -217,7 +217,7 @@ defmodule Sanbase.Billing.SanbaseProductAccessTest do
     test "can access RESTRICTED metrics for all time", context do
       {from, to} = from_to(4000, 10)
       slug = context.project.slug
-      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, :pro)
+      metric = v2_restricted_metric_for_plan(context.next_integer.(), @product, "PRO")
       selector = %{slug: slug}
       query = metric_query(metric, selector, from, to)
 
@@ -230,7 +230,7 @@ defmodule Sanbase.Billing.SanbaseProductAccessTest do
     # test "can access RESTRICTED signals for all time", context do
     #   {from, to} = from_to(4000, 10)
     #   slug = context.project.slug
-    #   signal = restricted_signal_for_plan(context.next_integer.(), @product, :pro)
+    #   signal = restricted_signal_for_plan(context.next_integer.(), @product, "PRO")
     #   query = signal_query(signal, slug, from, to)
 
     #   result = execute_query(context.conn, query, "getSignal")

--- a/test/sanbase_web/graphql/context_plug_test.exs
+++ b/test/sanbase_web/graphql/context_plug_test.exs
@@ -32,7 +32,7 @@ defmodule SanbaseWeb.Graphql.ContextPlugTest do
              auth_method: :user_token,
              current_user: user,
              subscription: Subscription.free_subscription(),
-             plan: :free
+             plan: "FREE"
            }
 
     assert conn_context.remote_ip == {127, 0, 0, 1}
@@ -62,7 +62,7 @@ defmodule SanbaseWeb.Graphql.ContextPlugTest do
 
     assert Map.has_key?(conn_context, :auth)
     assert conn_context.auth.auth_method == :none
-    assert conn_context.auth.plan == :free
+    assert conn_context.auth.plan == "FREE"
     assert conn_context.remote_ip == {127, 0, 0, 1}
     assert conn_context.permissions == User.Permissions.no_permissions()
   end
@@ -144,7 +144,7 @@ defmodule SanbaseWeb.Graphql.ContextPlugTest do
 
     assert Map.has_key?(conn_context, :auth)
     assert conn_context.auth.auth_method == :none
-    assert conn_context.auth.plan == :free
+    assert conn_context.auth.plan == "FREE"
     assert conn_context.remote_ip == {127, 0, 0, 1}
     assert conn_context.permissions == User.Permissions.no_permissions()
   end
@@ -164,7 +164,7 @@ defmodule SanbaseWeb.Graphql.ContextPlugTest do
 
     assert Map.has_key?(conn_context, :auth)
     assert conn_context.auth.auth_method == :none
-    assert conn_context.auth.plan == :free
+    assert conn_context.auth.plan == "FREE"
     assert conn_context.remote_ip == {127, 0, 0, 1}
     assert conn_context.permissions == User.Permissions.no_permissions()
   end
@@ -180,7 +180,7 @@ defmodule SanbaseWeb.Graphql.ContextPlugTest do
 
     assert Map.has_key?(conn_context, :auth)
     assert conn_context.auth.auth_method == :none
-    assert conn_context.auth.plan == :free
+    assert conn_context.auth.plan == "FREE"
     assert conn_context.remote_ip == {127, 0, 0, 1}
     assert conn_context.permissions == User.Permissions.no_permissions()
   end

--- a/test/sanbase_web/graphql/dashboard/dashboard_comment_api_test.exs
+++ b/test/sanbase_web/graphql/dashboard/dashboard_comment_api_test.exs
@@ -1,4 +1,4 @@
-defmodule SanbaseWeb.Graphql.ShortUrlCommentApiTest do
+defmodule SanbaseWeb.Graphql.DashboardCommentApiTest do
   use SanbaseWeb.ConnCase, async: false
 
   import Sanbase.Factory

--- a/test/support/graphql_test_helpers.ex
+++ b/test/support/graphql_test_helpers.ex
@@ -49,8 +49,8 @@ defmodule SanbaseWeb.Graphql.TestHelpers do
   defp free_timeseries_elements(product, :metric) do
     Metric.min_plan_map()
     |> Enum.filter(fn
-      {_, :free} -> true
-      {_, %{^product => :free}} -> true
+      {_, "FREE"} -> true
+      {_, %{^product => "FREE"}} -> true
       _ -> false
     end)
     |> Enum.map(fn {metric, _} -> metric end)
@@ -62,8 +62,8 @@ defmodule SanbaseWeb.Graphql.TestHelpers do
   defp free_timeseries_elements(product, :signal) do
     Signal.min_plan_map()
     |> Enum.filter(fn
-      {_, :free} -> true
-      {_, %{^product => :free}} -> true
+      {_, "FREE"} -> true
+      {_, %{^product => "FREE"}} -> true
       _ -> false
     end)
     |> Enum.map(fn {signal, _} -> signal end)


### PR DESCRIPTION
## Changes

Switch how the plan names are handled in code - they are no longer represented as atoms, but as strings.

This is needed so the future introduction of more than 1 custom plan can be made easily.
The idea is that these plans' names will be `CUSTOM_<something>` so we can pattern match for that prefix and dispatch to the custom plan module.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
