### PR TITLE
Add available_projects field to get_metric's metadata

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric_resolver.ex
@@ -56,6 +56,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   def get_available_slugs(_root, _args, %{source: %{metric: metric}}),
     do: Metric.available_slugs(metric)
 
+  def get_available_projects(_root, _args, %{source: %{metric: metric}}) do
+    with {:ok, slugs} <- Metric.available_slugs(metric) do
+      {:ok, Sanbase.Model.Project.List.by_slugs(slugs)}
+    end
+  end
+
   def get_human_readable_name(_root, _args, %{source: %{metric: metric}}),
     do: Metric.human_readable_name(metric)
 

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -299,8 +299,11 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     the metric.
     """
     field :available_slugs, list_of(:string) do
-      arg(:selector, :aggregated_timeseries_data_selector_input_object)
       cache_resolve(&MetricResolver.get_available_slugs/3, ttl: 300)
+    end
+
+    field :available_projects, list_of(:project) do
+      cache_resolve(&MetricResolver.get_available_projects/3, ttl: 300)
     end
 
     @desc ~s"""


### PR DESCRIPTION
## Changes
```graphql
{
  getMetric(metric: "mvrv_usd_intraday") {
    metadata {
      availableProjects {
        slug
        ticker
      }
    }
  }
}
```

```json
{
  "data": {
    "getMetric": {
      "metadata": {
        "availableProjects": [
          {
            "slug": "compound",
            "ticker": "COMP"
          },
          {
            "slug": "chiliz",
            "ticker": "CHZ"
          },
          {
            "slug": "crypto-com-coin",
            "ticker": "CRO"
          },
          {
            "slug": "fantom",
            "ticker": "FTM"
          },
          {
            "slug": "ankr",
            "ticker": "ANKR"
          },
          {
            "slug": "ftx-token",
            "ticker": "FTT"
          },
          {
            "slug": "huobi-token",
            "ticker": "HT"
          },
          {
            "slug": "ren",
            "ticker": "REN"
          },
          {
            "slug": "bancor",
            "ticker": "BNT"
          },
          {
            "slug": "bitcoin-cash",
            "ticker": "BCH"
          },
          {
            "slug": "chainlink",
            "ticker": "LINK"
          },
          {
            "slug": "unus-sed-leo",
            "ticker": "LEO"
          },
          {
            "slug": "0x",
            "ticker": "ZRX"
          },
          {
            "slug": "decentraland",
            "ticker": "MANA"
          },
          {
            "slug": "omisego",
            "ticker": "OMG"
          },
          {
            "slug": "enjin-coin",
            "ticker": "ENJ"
          },
          {
            "slug": "nexo",
            "ticker": "NEXO"
          },
          {
            "slug": "bitcoin",
            "ticker": "BTC"
          },
          {
            "slug": "litecoin",
            "ticker": "LTC"
          },
          {
            "slug": "loopring",
            "ticker": "LRC"
          },
          {
            "slug": "ethereum",
            "ticker": "ETH"
          },
          {
            "slug": "holo",
            "ticker": "HOT"
          },
          {
            "slug": "basic-attention-token",
            "ticker": "BAT"
          },
          {
            "slug": "kyber-network",
            "ticker": "KNC"
          },
          {
            "slug": "the-sandbox",
            "ticker": "SAND"
          },
          {
            "slug": "okb",
            "ticker": "OKB"
          },
          {
            "slug": "ripple",
            "ticker": "XRP"
          },
          {
            "slug": "matic-network",
            "ticker": "MATIC"
          },
          {
            "slug": "swissborg",
            "ticker": "CHSB"
          },
          {
            "slug": "skale-network",
            "ticker": "SKL"
          },
          {
            "slug": "reserve-rights",
            "ticker": "RSR"
          },
          {
            "slug": "celsius",
            "ticker": "CEL"
          },
          {
            "slug": "wrapped-bitcoin",
            "ticker": "WBTC"
          },
          {
            "slug": "synthetix-network-token",
            "ticker": "SNX"
          },
          {
            "slug": "balancer",
            "ticker": "BAL"
          },
          {
            "slug": "sushi",
            "ticker": "SUSHI"
          },
          {
            "slug": "uma",
            "ticker": "UMA"
          },
          {
            "slug": "livepeer",
            "ticker": "LPT"
          },
          {
            "slug": "curve",
            "ticker": "CRV"
          },
          {
            "slug": "uniswap",
            "ticker": "UNI"
          },
          {
            "slug": "aave",
            "ticker": "AAVE"
          },
          {
            "slug": "santiment",
            "ticker": "SAN"
          },
          {
            "slug": "binance-coin",
            "ticker": "BNB"
          },
          {
            "slug": "cardano",
            "ticker": "ADA"
          },
          {
            "slug": "maker",
            "ticker": "MKR"
          },
          {
            "slug": "alpha-finance-lab",
            "ticker": "ALPHA"
          },
          {
            "slug": "the-graph",
            "ticker": "GRT"
          },
          {
            "slug": "1inch",
            "ticker": "1INCH"
          },
          {
            "slug": "dogecoin",
            "ticker": "DOGE"
          },
          {
            "slug": "zkswap",
            "ticker": "ZKS"
          },
          {
            "slug": "axie-infinity",
            "ticker": "AXS"
          },
          {
            "slug": "amp",
            "ticker": "AMP"
          },
          {
            "slug": "yearn-finance",
            "ticker": "YFI"
          },
          {
            "slug": "gala",
            "ticker": "GALA"
          }
        ]
      }
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
