### PR TITLE
Add min_title_length and min_description_length to explorer

### DIFF
--- a/lib/sanbase/chart/chart_configuration.ex
+++ b/lib/sanbase/chart/chart_configuration.ex
@@ -101,6 +101,8 @@ defmodule Sanbase.Chart.Configuration do
     base_query()
     |> maybe_apply_projects_filter(opts)
     |> Sanbase.Entity.Query.maybe_filter_is_hidden(opts)
+    |> Sanbase.Entity.Query.maybe_filter_min_title_length(opts, :title)
+    |> Sanbase.Entity.Query.maybe_filter_min_description_length(opts, :description)
     |> Sanbase.Entity.Query.maybe_filter_is_featured_query(opts, :chart_configuration_id)
     |> Sanbase.Entity.Query.maybe_filter_by_users(opts)
     |> Sanbase.Entity.Query.maybe_filter_by_cursor(:inserted_at, opts)

--- a/lib/sanbase/dashboard/dashboard_schema.ex
+++ b/lib/sanbase/dashboard/dashboard_schema.ex
@@ -101,6 +101,8 @@ defmodule Sanbase.Dashboard.Schema do
     |> Sanbase.Entity.Query.maybe_filter_is_featured_query(opts, :dashboard_id)
     |> Sanbase.Entity.Query.maybe_filter_by_users(opts)
     |> Sanbase.Entity.Query.maybe_filter_by_cursor(:inserted_at, opts)
+    |> Sanbase.Entity.Query.maybe_filter_min_title_length(opts, :name)
+    |> Sanbase.Entity.Query.maybe_filter_min_description_length(opts, :description)
     |> select([ul], ul.id)
   end
 

--- a/lib/sanbase/entity/entity.ex
+++ b/lib/sanbase/entity/entity.ex
@@ -658,7 +658,15 @@ defmodule Sanbase.Entity do
 
   # Which of the provided by the API opts are passed to the entity modules.
 
-  @passed_opts [:filter, :cursor, :user_ids, :is_featured_data_only, :is_moderator]
+  @passed_opts [
+    :filter,
+    :cursor,
+    :user_ids,
+    :is_featured_data_only,
+    :is_moderator,
+    :min_title_length,
+    :min_description_length
+  ]
 
   defp entity_ids_query(:insight, opts) do
     # `ordered?: false` is important otherwise the default order will be applied

--- a/lib/sanbase/entity/entity_query.ex
+++ b/lib/sanbase/entity/entity_query.ex
@@ -73,6 +73,28 @@ defmodule Sanbase.Entity.Query do
     end
   end
 
+  def maybe_filter_min_title_length(query, opts, column) do
+    case Keyword.get(opts, :min_title_length) do
+      len when is_integer(len) and len > 0 ->
+        query
+        |> where([elem], fragment("LENGTH(?)", field(elem, ^column)) >= ^len)
+
+      _ ->
+        query
+    end
+  end
+
+  def maybe_filter_min_description_length(query, opts, column) do
+    case Keyword.get(opts, :min_description_length) do
+      len when is_integer(len) and len > 0 ->
+        query
+        |> where([elem], fragment("LENGTH(?)", field(elem, ^column)) >= ^len)
+
+      _ ->
+        query
+    end
+  end
+
   defmacro entity_id_selection() do
     quote do
       fragment("""

--- a/lib/sanbase/user_lists/user_list.ex
+++ b/lib/sanbase/user_lists/user_list.ex
@@ -138,6 +138,8 @@ defmodule Sanbase.UserList do
     |> Sanbase.Entity.Query.maybe_filter_is_featured_query(opts, :user_list_id)
     |> Sanbase.Entity.Query.maybe_filter_by_users(opts)
     |> Sanbase.Entity.Query.maybe_filter_by_cursor(:inserted_at, opts)
+    |> Sanbase.Entity.Query.maybe_filter_min_title_length(opts, :name)
+    |> Sanbase.Entity.Query.maybe_filter_min_description_length(opts, :description)
     |> select([ul], ul.id)
   end
 

--- a/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
@@ -147,6 +147,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.EntityResolver do
     |> maybe_add_user_option(:current_user_voted_for_only, args, resolution)
     |> maybe_add_value_option(:user_role_data_only, args)
     |> maybe_add_value_option(:is_featured_data_only, args)
+    |> maybe_add_value_option(:min_title_length, args)
+    |> maybe_add_value_option(:min_description_length, args)
     |> add_is_moderator_option(resolution)
   end
 

--- a/lib/sanbase_web/graphql/schema/queries/entity_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/entity_queries.ex
@@ -24,6 +24,9 @@ defmodule SanbaseWeb.Graphql.Schema.EntityQueries do
       arg(:cursor, :cursor_input_no_order, default_value: nil)
       arg(:filter, :entity_filter)
 
+      arg(:min_title_length, :integer, default_value: 0)
+      arg(:min_description_length, :integer, default_value: 0)
+
       cache_resolve(&EntityResolver.get_most_voted/3,
         ttl: 30,
         max_ttl_offset: 30,
@@ -44,6 +47,11 @@ defmodule SanbaseWeb.Graphql.Schema.EntityQueries do
       arg(:cursor, :cursor_input_no_order, default_value: nil)
       arg(:filter, :entity_filter)
 
+      # Set the default values to 3/20. This can be reverted once the
+      # frontend sets the limits
+      arg(:min_title_length, :integer, default_value: 3)
+      arg(:min_description_length, :integer, default_value: 20)
+
       cache_resolve(&EntityResolver.get_most_recent/3,
         ttl: 30,
         max_ttl_offset: 30,
@@ -62,6 +70,9 @@ defmodule SanbaseWeb.Graphql.Schema.EntityQueries do
       arg(:user_role_data_only, :user_role)
       arg(:cursor, :cursor_input_no_order, default_value: nil)
       arg(:filter, :entity_filter)
+
+      arg(:min_title_length, :integer, default_value: 0)
+      arg(:min_description_length, :integer, default_value: 0)
 
       middleware(JWTAuth)
 

--- a/test/sanbase_web/graphql/moderation/entity_moderation_api_test.exs
+++ b/test/sanbase_web/graphql/moderation/entity_moderation_api_test.exs
@@ -314,6 +314,8 @@ defmodule SanbaseWeb.Graphql.EntityModerationApiTest do
         |> Keyword.put_new(:page, 1)
         |> Keyword.put_new(:page_size, 10)
         |> Keyword.put_new(:types, List.wrap(entity_or_entities))
+        |> Keyword.put_new(:min_title_length, 0)
+        |> Keyword.put_new(:min_description_length, 0)
 
       query = """
       {


### PR DESCRIPTION
## Changes
Entities with short title and description or no description at all can be considered noise as they are hard to understand.

```graphql
{
  getMostRecent(
    types: [CHART_CONFIGURATION, PROJECT_WATCHLIST, SCREENER]
    page: 1
    pageSize: 20
    minTitleLength: 10
    minDescriptionLength: 20
   ) {
    stats {
      totalPagesCount
    }
    data {
      projectWatchlist {
        id
        title: name
        description
        insertedAt
      }
      screener {
        id
        title: name
        description
        insertedAt
      }
      chartConfiguration {
        id
        title
        description
        insertedAt
      }
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
