### PR TITLE
Add show address with zero balance option to assets_held_by_address

### DIFF
--- a/lib/sanbase/balances/balance.ex
+++ b/lib/sanbase/balances/balance.ex
@@ -170,11 +170,11 @@ defmodule Sanbase.Balance do
   such asset return the slug and current balance. If some project is not
   in Santiment's database it is not shown.
   """
-  @spec assets_held_by_address(address) ::
+  @spec assets_held_by_address(address, Keyword.t()) ::
           {:ok, list(%{slug: slug, balance: number()})} | {:error, String.t()}
-  def assets_held_by_address(address) do
+  def assets_held_by_address(address, opts \\ []) do
     address = Sanbase.BlockchainAddress.to_internal_format(address)
-    {query, args} = assets_held_by_address_query(address)
+    {query, args} = assets_held_by_address_query(address, opts)
 
     hidden_projects_slugs = hidden_projects_slugs()
 

--- a/lib/sanbase/balances/balance_sql_query.ex
+++ b/lib/sanbase/balances/balance_sql_query.ex
@@ -478,7 +478,7 @@ defmodule Sanbase.Balance.SqlQuery do
     {query, args}
   end
 
-  def assets_held_by_address_query(address) do
+  def assets_held_by_address_query(address, opts \\ []) do
     query = """
     SELECT
       name,
@@ -500,7 +500,7 @@ defmodule Sanbase.Balance.SqlQuery do
       FROM asset_metadata FINAL
     ) USING (asset_ref_id)
     GROUP BY address, asset_ref_id, name, decimals
-    HAVING balance > 0
+    #{if Keyword.get(opts, :show_assets_with_zero_balance, false), do: "", else: "HAVING balance > 0"}
     """
 
     args = [address]

--- a/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
@@ -58,13 +58,13 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
   This can be combined with the historical balance query to see the historical
   balance of all currently owned assets
   """
-  @spec assets_held_by_address(map()) ::
+  @spec assets_held_by_address(map(), Keyword.t()) ::
           {:ok, list(map())} | {:error, String.t()}
-  def assets_held_by_address(%{infrastructure: infr, address: address}) do
+  def assets_held_by_address(%{infrastructure: infr, address: address}, opts \\ []) do
     case selector_to_args(%{infrastructure: infr}) do
       %{blockchain: blockchain}
       when balances_aggregated_blockchain?(blockchain) ->
-        Sanbase.Balance.assets_held_by_address(address)
+        Sanbase.Balance.assets_held_by_address(address, opts)
 
       %{module: module} ->
         module.assets_held_by_address(address)

--- a/lib/sanbase_web/graphql/resolvers/historical_balance_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/historical_balance_resolver.ex
@@ -11,7 +11,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.HistoricalBalanceResolver do
   def assets_held_by_address(_root, args, _resolution) do
     selector = args_to_address_selector(args)
 
-    case HistoricalBalance.assets_held_by_address(selector) do
+    case HistoricalBalance.assets_held_by_address(selector,
+           show_assets_with_zero_balance: args.show_assets_with_zero_balance
+         ) do
       {:ok, result} ->
         {:ok, result}
 

--- a/lib/sanbase_web/graphql/schema/queries/historical_balance_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/historical_balance_queries.ex
@@ -16,6 +16,7 @@ defmodule SanbaseWeb.Graphql.Schema.HistoricalBalanceQueries do
 
       arg(:selector, :address_selector_input_object)
       arg(:address, :string)
+      arg(:show_assets_with_zero_balance, :boolean, default_value: false)
 
       cache_resolve(&HistoricalBalanceResolver.assets_held_by_address/3)
     end

--- a/test/sanbase/clickhouse/historical_balance/assets_held_by_address_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/assets_held_by_address_test.exs
@@ -28,7 +28,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.AssetsHeldByAdderssTest do
 
   test "clickhouse returns list of results", context do
     Sanbase.Mock.prepare_mock2(
-      &Sanbase.Balance.assets_held_by_address/1,
+      &Sanbase.Balance.assets_held_by_address/2,
       {:ok,
        [
          %{balance: 1000.0, slug: context.eth_project.slug},
@@ -48,7 +48,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.AssetsHeldByAdderssTest do
   end
 
   test "clickhouse returns no results", _context do
-    Sanbase.Mock.prepare_mock2(&Sanbase.Balance.assets_held_by_address/1, {:ok, []})
+    Sanbase.Mock.prepare_mock2(&Sanbase.Balance.assets_held_by_address/2, {:ok, []})
     |> Sanbase.Mock.run_with_mocks(fn ->
       assert HistoricalBalance.assets_held_by_address(%{address: "0x123", infrastructure: "BTC"}) ==
                {:ok, []}
@@ -57,7 +57,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.AssetsHeldByAdderssTest do
 
   test "clickhouse returns error", _context do
     Sanbase.Mock.prepare_mock2(
-      &Sanbase.Balance.assets_held_by_address/1,
+      &Sanbase.Balance.assets_held_by_address/2,
       {:error, "Something went wrong"}
     )
     |> Sanbase.Mock.run_with_mocks(fn ->

--- a/test/sanbase_web/graphql/clickhouse/historical_balance/assets_held_by_address_api_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/historical_balance/assets_held_by_address_api_test.exs
@@ -30,7 +30,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
 
     ethereum_usd_price = 1300
 
-    Sanbase.Mock.prepare_mock2(&Sanbase.Balance.assets_held_by_address/1, {:ok, data})
+    Sanbase.Mock.prepare_mock2(&Sanbase.Balance.assets_held_by_address/2, {:ok, data})
     |> Sanbase.Mock.prepare_mock2(
       &Sanbase.Metric.aggregated_timeseries_data/5,
       # Ethereum's price usd
@@ -65,7 +65,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
     bitcoin_usd_price = 30_000
     data_btc = [%{balance: 200.0, slug: btc_project.slug}]
 
-    Sanbase.Mock.prepare_mock2(&Sanbase.Balance.assets_held_by_address/1, {:ok, data_btc})
+    Sanbase.Mock.prepare_mock2(&Sanbase.Balance.assets_held_by_address/2, {:ok, data_btc})
     |> Sanbase.Mock.prepare_mock2(
       &Sanbase.Metric.aggregated_timeseries_data/5,
       # Bitcoin's price in usd
@@ -98,7 +98,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
 
     data_btc = [%{balance: 200.0, slug: btc_project.slug}]
 
-    Sanbase.Mock.prepare_mock2(&Sanbase.Balance.assets_held_by_address/1, {:ok, data_btc})
+    Sanbase.Mock.prepare_mock2(&Sanbase.Balance.assets_held_by_address/2, {:ok, data_btc})
     |> Sanbase.Mock.prepare_mock2(&Sanbase.Metric.aggregated_timeseries_data/5, {:ok, %{}})
     |> Sanbase.Mock.run_with_mocks(fn ->
       query = assets_held_by_address_query("0x123", "BTC")
@@ -123,7 +123,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
   end
 
   test "historical balances returns empty list", context do
-    Sanbase.Mock.prepare_mock2(&Sanbase.Balance.assets_held_by_address/1, {:ok, []})
+    Sanbase.Mock.prepare_mock2(&Sanbase.Balance.assets_held_by_address/2, {:ok, []})
     |> Sanbase.Mock.run_with_mocks(fn ->
       address = "0x123"
 


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

Add `showAssetsWithZeroBalance`  option.

```graphql
query assetsHeldByAddress($address: String!, $infrastructure: String!) {
  assetsHeldByAddress(
    selector: {address: $address, infrastructure: $infrastructure}
    showAssetsWithZeroBalance:true
  ) {
    slug
    balance
    balanceUsd
    __typename
  }
}
```

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
