### PR TITLE
Bring included_applications back

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule Sanbase.Mixfile do
         :os_mon,
         :event_bus
       ],
-      included_applications: [:kaffe, :ueberauth_twitter]
+      included_applications: [:kaffe, :brod, :ueberauth_twitter]
     ]
   end
 
@@ -63,6 +63,7 @@ defmodule Sanbase.Mixfile do
       {:absinthe_phoenix, "~> 2.0"},
       {:absinthe_plug, "~> 1.5"},
       {:absinthe, "~> 1.5"},
+      {:brod, "~> 3.8", runtime: false},
       {:browser, "~> 0.4.4"},
       {:cachex, "~> 3.4"},
       {:cidr, "~> 1.1"},
@@ -113,7 +114,7 @@ defmodule Sanbase.Mixfile do
       {:inch_ex, github: "rrrene/inch_ex", only: [:dev, :test]},
       {:inflex, "~> 2.0", override: true},
       {:jason, "~> 1.2"},
-      {:kaffe, github: "santiment/kaffe", override: true},
+      {:kaffe, github: "santiment/kaffe", branch: "remove-brod-as-applications", override: true},
       {:kafka_protocol,
        github: "santiment/kafka_protocol", branch: "working-version", override: true},
       {:libcluster, "~> 3.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -74,7 +74,7 @@
   "jason": {:hex, :jason, "1.3.0", "fa6b82a934feb176263ad2df0dbd91bf633d4a46ebfdffea0c8ae82953714946", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "53fc1f51255390e0ec7e50f9cb41e751c260d065dcba2bf0d08dc51a4002c2ac"},
   "jose": {:hex, :jose, "1.11.2", "f4c018ccf4fdce22c71e44d471f15f723cb3efab5d909ab2ba202b5bf35557b3", [:mix, :rebar3], [], "hexpm", "98143fbc48d55f3a18daba82d34fe48959d44538e9697c08f34200fa5f0947d2"},
   "jumper": {:hex, :jumper, "1.0.1", "3c00542ef1a83532b72269fab9f0f0c82bf23a35e27d278bfd9ed0865cecabff", [:mix], [], "hexpm", "318c59078ac220e966d27af3646026db9b5a5e6703cb2aa3e26bcfaba65b7433"},
-  "kaffe": {:git, "https://github.com/santiment/kaffe.git", "ffe4a70657865950aca6cd7642d22f3b55a3ca49", []},
+  "kaffe": {:git, "https://github.com/santiment/kaffe.git", "cd57c3f58ad1346422434575669b3d2bace2fbe4", [branch: "remove-brod-as-applications"]},
   "kaffy": {:git, "https://github.com/santiment/kaffy.git", "e790a98aa03aca8422097446b4cea1966b358047", []},
   "kafka_protocol": {:git, "https://github.com/santiment/kafka_protocol.git", "0e498daca1f380ccd4e4d70c5d475a57299a41d2", [branch: "working-version"]},
   "libcluster": {:hex, :libcluster, "3.3.1", "e7a4875cd1290cee7a693d6bd46076863e9e433708b01339783de6eff5b7f0aa", [:mix], [{:jason, "~> 1.1", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "b575ca63c1cd84e01f3fa0fc45e6eb945c1ee7ae8d441d33def999075e9e5398"},


### PR DESCRIPTION
For some time the Elixir main branch had a regression where optional dependencies were not handled properly. This fixes it.

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
