### PR TITLE
Support functions in interval type

### DIFF
--- a/lib/sanbase/utils/datetime/datetime_utils.ex
+++ b/lib/sanbase/utils/datetime/datetime_utils.ex
@@ -143,6 +143,22 @@ defmodule Sanbase.DateTimeUtils do
     datetime
   end
 
+  @supported_interval_functions Sanbase.Metric.SqlQuery.Helper.supported_interval_functions()
+  @interval_function_to_equal_interval Sanbase.Metric.SqlQuery.Helper.interval_function_to_equal_interval()
+
+  def maybe_str_to_sec(interval) do
+    case interval in @supported_interval_functions do
+      true -> interval
+      false -> str_to_sec(interval)
+    end
+  end
+
+  # If interval_function is 'toStartOfWeek', 'toStartOfMonth', etc.
+  def str_to_sec(interval_function) when interval_function in @supported_interval_functions do
+    Map.get(@interval_function_to_equal_interval, interval_function)
+    |> str_to_sec()
+  end
+
   def str_to_sec(interval) do
     {int_interval, duration_index} =
       case Integer.parse(interval) do

--- a/lib/sanbase_web/graphql/schema/custom_types/interval.ex
+++ b/lib/sanbase_web/graphql/schema/custom_types/interval.ex
@@ -30,9 +30,16 @@ defmodule SanbaseWeb.Graphql.CustomTypes.Interval do
     parse(&decode/1)
   end
 
+  @supported_interval_functions Sanbase.Metric.SqlQuery.Helper.supported_interval_functions()
+
   @spec decode(Absinthe.Blueprint.Input.String.t()) :: {:ok, term()} | :error
   @spec decode(Absinthe.Blueprint.Input.Null.t()) :: {:ok, nil}
   defp decode(%Absinthe.Blueprint.Input.String{value: ""}), do: {:ok, ""}
+
+  defp decode(%Absinthe.Blueprint.Input.String{value: value})
+       when value in @supported_interval_functions do
+    {:ok, value}
+  end
 
   defp decode(%Absinthe.Blueprint.Input.String{value: value}) do
     case Sanbase.DateTimeUtils.valid_compound_duration?(value) do


### PR DESCRIPTION
## Changes

Introduce the new interval type handling for `getMetric`'s timeseries-data fields.

The `interval` so far has been a fixed time window. This does not work well when trying to align data to months (28-31 days) or when the date needs to be a specific day in the week (Monday or Sunday as start of week). 
To improve this, add support for functions in the interval type. Now, instead of values like `5m`, `1h`, `7d`, etc. support the following functions as well:
- toStartOfDay
- toStartOfWeek
- toStartOfMonth
- toStartOfQuarter
- toStartOfYear
- toMonday
- toStartOfHour

```graphql
{
  getMetric(metric: "daily_active_addresses"){
    timeseriesData(
      slug: "bitcoin"
      from: "2021-01-01T00:00:00Z"
      to: "2021-12-31T23:59:59Z"
      interval: "toMonday"){
        datetime
        value
    }
  }
}
```

```json
{
  "data": {
    "getMetric": {
      "timeseriesData": [
        {
          "datetime": "2021-01-04T00:00:00Z",
          "value": 1236990.857142857
        },
        {
          "datetime": "2021-01-11T00:00:00Z",
          "value": 1153610.4285714286
        },
        {
          "datetime": "2021-01-18T00:00:00Z",
          "value": 1083057.142857143
        },
        {
          "datetime": "2021-01-25T00:00:00Z",
          "value": 1124766.5714285714
        },
        {
          "datetime": "2021-02-01T00:00:00Z",
          "value": 1168387
        },
        {
          "datetime": "2021-02-08T00:00:00Z",
          "value": 1165267.857142857
        },
        {
          "datetime": "2021-02-15T00:00:00Z",
          "value": 1127095.142857143
        },
        {
          "datetime": "2021-02-22T00:00:00Z",
          "value": 1136578.857142857
        },
        {
          "datetime": "2021-03-01T00:00:00Z",
          "value": 1111440.5714285714
        },
        {
          "datetime": "2021-03-08T00:00:00Z",
          "value": 1139343.857142857
        },
        {
          "datetime": "2021-03-15T00:00:00Z",
          "value": 1151291.2857142857
        },
        {
          "datetime": "2021-03-22T00:00:00Z",
          "value": 1151795.5714285714
        },
        {
          "datetime": "2021-03-29T00:00:00Z",
          "value": 1116863.7142857143
        },
        {
          "datetime": "2021-04-05T00:00:00Z",
          "value": 1169356
        },
        {
          "datetime": "2021-04-12T00:00:00Z",
          "value": 1090666.7142857143
        },
        {
          "datetime": "2021-04-19T00:00:00Z",
          "value": 1046076.1428571428
        },
        {
          "datetime": "2021-04-26T00:00:00Z",
          "value": 1079090.2857142857
        },
        {
          "datetime": "2021-05-03T00:00:00Z",
          "value": 1228441
        },
        {
          "datetime": "2021-05-10T00:00:00Z",
          "value": 1144609
        },
        {
          "datetime": "2021-05-17T00:00:00Z",
          "value": 944484.4285714285
        },
        {
          "datetime": "2021-05-24T00:00:00Z",
          "value": 940047.7142857143
        },
        {
          "datetime": "2021-05-31T00:00:00Z",
          "value": 914202.4285714285
        },
        {
          "datetime": "2021-06-07T00:00:00Z",
          "value": 908991.8571428572
        },
        {
          "datetime": "2021-06-14T00:00:00Z",
          "value": 844526.4285714285
        },
        {
          "datetime": "2021-06-21T00:00:00Z",
          "value": 770754.1428571428
        },
        {
          "datetime": "2021-06-28T00:00:00Z",
          "value": 839631.2857142857
        },
        {
          "datetime": "2021-07-05T00:00:00Z",
          "value": 803541.5714285715
        },
        {
          "datetime": "2021-07-12T00:00:00Z",
          "value": 761744.2857142857
        },
        {
          "datetime": "2021-07-19T00:00:00Z",
          "value": 777795.4285714285
        },
        {
          "datetime": "2021-07-26T00:00:00Z",
          "value": 836673.8571428572
        },
        {
          "datetime": "2021-08-02T00:00:00Z",
          "value": 826809.8571428572
        },
        {
          "datetime": "2021-08-09T00:00:00Z",
          "value": 846861.5714285715
        },
        {
          "datetime": "2021-08-16T00:00:00Z",
          "value": 882922
        },
        {
          "datetime": "2021-08-23T00:00:00Z",
          "value": 840473.7142857143
        },
        {
          "datetime": "2021-08-30T00:00:00Z",
          "value": 907713.5714285715
        },
        {
          "datetime": "2021-09-06T00:00:00Z",
          "value": 883162.5714285715
        },
        {
          "datetime": "2021-09-13T00:00:00Z",
          "value": 906021.2857142857
        },
        {
          "datetime": "2021-09-20T00:00:00Z",
          "value": 862812.2857142857
        },
        {
          "datetime": "2021-09-27T00:00:00Z",
          "value": 919392.4285714285
        },
        {
          "datetime": "2021-10-04T00:00:00Z",
          "value": 984315.2857142857
        },
        {
          "datetime": "2021-10-11T00:00:00Z",
          "value": 963607.5714285715
        },
        {
          "datetime": "2021-10-18T00:00:00Z",
          "value": 957999.4285714285
        },
        {
          "datetime": "2021-10-25T00:00:00Z",
          "value": 980434
        },
        {
          "datetime": "2021-11-01T00:00:00Z",
          "value": 982198
        },
        {
          "datetime": "2021-11-08T00:00:00Z",
          "value": 979300.5714285715
        },
        {
          "datetime": "2021-11-15T00:00:00Z",
          "value": 965849.1428571428
        },
        {
          "datetime": "2021-11-22T00:00:00Z",
          "value": 929566.2857142857
        },
        {
          "datetime": "2021-11-29T00:00:00Z",
          "value": 1019358.7142857143
        },
        {
          "datetime": "2021-12-06T00:00:00Z",
          "value": 937956.8571428572
        },
        {
          "datetime": "2021-12-13T00:00:00Z",
          "value": 922527.4285714285
        },
        {
          "datetime": "2021-12-20T00:00:00Z",
          "value": 946112.2857142857
        },
        {
          "datetime": "2021-12-27T00:00:00Z",
          "value": 1054822.6
        }
      ]
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
