### PR TITLE
Add eth2 staking pools metric to API

### DIFF
--- a/lib/sanbase/clickhouse/metric/histogram_metric.ex
+++ b/lib/sanbase/clickhouse/metric/histogram_metric.ex
@@ -11,7 +11,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter.HistogramMetric do
     "eth2_staked_amount_per_label",
     "eth2_staked_address_count_per_label",
     "eth2_unlabeled_staker_inflow_sources",
-    "eth2_staking_address"
+    "eth2_staking_pools"
   ]
 
   @eth2_string_address_string_label_float_value_metrics [

--- a/lib/sanbase/clickhouse/metric/histogram_metric.ex
+++ b/lib/sanbase/clickhouse/metric/histogram_metric.ex
@@ -10,7 +10,8 @@ defmodule Sanbase.Clickhouse.MetricAdapter.HistogramMetric do
   @eth2_string_label_float_value_metrics [
     "eth2_staked_amount_per_label",
     "eth2_staked_address_count_per_label",
-    "eth2_unlabeled_staker_inflow_sources"
+    "eth2_unlabeled_staker_inflow_sources",
+    "eth2_staking_address"
   ]
 
   @eth2_string_address_string_label_float_value_metrics [

--- a/lib/sanbase/clickhouse/metric/metric_files/histogram_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/histogram_metrics.json
@@ -159,5 +159,24 @@
     "table": "eth2_staking_transfers_v2",
     "has_incomplete_data": false,
     "data_type": "histogram"
+  },
+  {
+    "human_readable_name": "ETH2 Staking Pools",
+    "name": "eth2_staking_pools",
+    "metric": "eth2_staking_pools",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "eth2_staking_transfers_v2",
+    "has_incomplete_data": false,
+    "data_type": "histogram"
   }
 ]

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -420,6 +420,7 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "eth2_staked_address_count_per_label",
         "eth2_unlabeled_staker_inflow_sources",
         "eth2_top_stakers",
+        "eth2_staking_pools",
         "price_usd_change_1h",
         "price_eth_change_1d",
         "price_eth_change_7d",


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Add eth2 staking pools metric to API 

## Ticket

<!--- Issue to which the pull request is related -->
Percentage of staked coins from each staking pool (https://www.notion.so/santiment/Percentage-of-staked-coins-from-each-staking-pool-81cd25eab1614f489836178a4ce7daba)

## API

```graphql
{
  getMetric(metric: "eth2_staking_pools") {
    histogramData(
      selector: {slug: "ethereum"}
      from: "utc_now-70d"
      to:"utc_now"
      limit: 10
    ){
      values{
        __typename
        ... on StringLabelFloatValueList{
        data{
            label
            value
          }
      	}
      }
    }
  }
}
```
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
