### PR TITLE
Look for logged in user in source

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/user/linked_user_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/linked_user_resolver.ex
@@ -22,6 +22,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.LinkedUserResolver do
     LinkedUser.get_primary_user(user.id)
   end
 
+  def primary_user_sanbase_subscription(_root, _args, %{source: %{user: user}}) do
+    Subscription.get_user_subscription(user.id, Product.product_sanbase())
+  end
+
   def primary_user_sanbase_subscription(_root, _args, %{context: %{auth: %{current_user: user}}}) do
     Subscription.get_user_subscription(user.id, Product.product_sanbase())
   end


### PR DESCRIPTION
## Changes
In case the primary_user_sanbase_subscription function is called from within email verify graphql mutation, the authenticated user is not in the context. The user can be fetched by the result of the top-level query.

`primary_user_sanbase_subscription` can be called from `emailLoginVerify`, which returned:
```elixir
{:ok,
  %{
    user: user,
    token: jwt_tokens_map.access_token,
    access_token: jwt_tokens_map.access_token,
    refresh_token: jwt_tokens_map.refresh_token
  }}
```

In such case, the whole map is accessible under `resolution.resource`


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
