### PR TITLE
Add social dominance list of words

### DIFF
--- a/lib/sanbase/social_data/social_dominance.ex
+++ b/lib/sanbase/social_data/social_dominance.ex
@@ -62,7 +62,8 @@ defmodule Sanbase.SocialData.SocialDominance do
     end
   end
 
-  def social_dominance_words(words) do
+  def words_social_dominance(word_or_words) do
+    words = List.wrap(word_or_words)
     to = Timex.now()
     from = Timex.shift(to, hours: -@hours_back_ensure_has_data)
     interval = "1h"
@@ -77,7 +78,7 @@ defmodule Sanbase.SocialData.SocialDominance do
 
       total_mentions = List.last(total_volume).mentions_count
 
-      words_dominance_map =
+      words_dominance =
         words_volume_map
         |> Enum.map(fn {word, mentions} ->
           %{
@@ -85,6 +86,8 @@ defmodule Sanbase.SocialData.SocialDominance do
             social_dominance: Sanbase.Math.percent_of(mentions, total_mentions) || 0.0
           }
         end)
+
+      {:ok, words_dominance}
     else
       {:ok, []} -> {:ok, nil}
       error -> {:ok, nil}

--- a/lib/sanbase_web/graphql/resolvers/social_data_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/social_data_resolver.ex
@@ -98,6 +98,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.SocialDataResolver do
     SocialData.social_volume(selector, from, to, interval, :total)
   end
 
+  def words_social_dominance(
+        _root,
+        %{selector: %{words: words}},
+        _resolution
+      ) do
+    SocialData.SocialDominance.words_social_dominance(words)
+  end
+
   def words_context(
         _root,
         %{selector: %{word: word}, source: source, size: size, from: from, to: to},

--- a/lib/sanbase_web/graphql/schema/queries/social_data_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/social_data_queries.ex
@@ -200,6 +200,14 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
       cache_resolve(&SocialDataResolver.words_social_volume/3, ttl: 600, max_ttl_offset: 240)
     end
 
+    field :words_social_dominance, list_of(:words_social_dominance) do
+      meta(access: :free)
+
+      arg(:selector, :word_selector_input_object)
+
+      cache_resolve(&SocialDataResolver.words_social_dominance/3, ttl: 600, max_ttl_offset: 240)
+    end
+
     @desc ~s"""
     Returns a list of mentions count for a given project and time interval.
 

--- a/lib/sanbase_web/graphql/schema/types/social_data_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/social_data_types.ex
@@ -115,6 +115,11 @@ defmodule SanbaseWeb.Graphql.SocialDataTypes do
     field(:timeseries_data, list_of(:social_volume))
   end
 
+  object :words_social_dominance do
+    field(:word, non_null(:string))
+    field(:social_dominance, non_null(:float))
+  end
+
   object :top_social_gainers_losers do
     field(:datetime, non_null(:datetime))
     field(:projects, list_of(:projects_change))

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -148,7 +148,8 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           :usd_value_address_change,
           :user_list,
           :watchlist,
-          :watchlist_by_slug
+          :watchlist_by_slug,
+          :words_social_dominance
         ]
         |> Enum.sort()
 


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

```graphql
{
  wordsSocialDominance(selector:{words:["market", "referring", "inflation", "giveaway", "klaytn", "metamask", "sec",
 "kwon", "cones", "cone"]}) {
  	word
  	socialDominance
	}
}
```

![image](https://user-images.githubusercontent.com/122794/191224869-0ae9b77a-f931-43fe-91e7-55dbfe5ca89a.png)


## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
