### PR TITLE
Improve CH query speed when asset is not present in CH

### DIFF
--- a/lib/sanbase/metric/sql_query_helper.ex
+++ b/lib/sanbase/metric/sql_query_helper.ex
@@ -119,7 +119,7 @@ defmodule Sanbase.Metric.SqlQuery.Helper do
   def asset_id_filter(%{slug: slug}, opts) when is_binary(slug) do
     arg_position = Keyword.fetch!(opts, :argument_position)
 
-    "asset_id = ( SELECT asset_id FROM asset_metadata FINAL PREWHERE name = ?#{arg_position} LIMIT 1 )"
+    "asset_id IN ( SELECT asset_id FROM asset_metadata FINAL PREWHERE name = ?#{arg_position} LIMIT 1 )"
   end
 
   def asset_id_filter(%{slug: slugs}, opts) when is_list(slugs) do
@@ -132,7 +132,7 @@ defmodule Sanbase.Metric.SqlQuery.Helper do
       when is_binary(contract_address) do
     arg_position = Keyword.fetch!(opts, :argument_position)
 
-    "asset_id = ( SELECT asset_id FROM asset_metadata FINAL PREWHERE has(contract_addresses, ?#{arg_position}) LIMIT 1 )"
+    "asset_id IN ( SELECT asset_id FROM asset_metadata FINAL PREWHERE has(contract_addresses, ?#{arg_position}) LIMIT 1 )"
   end
 
   def asset_id_filter(_, opts) do


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
The change seems to behave better when asset is not present in the asset_metadata in CH. 

The query with `asset_id = ` takes a lot of time to complete when asset is not present while the one with `asset_id IN ` finishes fast. There is no difference in the execution plan between both.
Here is example of the slow query:
```sql
SELECT
    toUnixTimestamp(intDiv(toUInt32(toDateTime(dt)), 600) * 600) AS t,
    sumKahan(value)
FROM
(
    SELECT
        dt,
        argMax(value, computed_at) AS value
    FROM intraday_metrics
    PREWHERE (dt >= toDateTime(1651598800)) AND (dt < toDateTime(1663928371)) AND (asset_id = (
        SELECT asset_id
        FROM asset_metadata
        FINAL
        PREWHERE name IN ('diamond-launch')
        LIMIT 1
    )) AND (metric_id = (
        SELECT metric_id
        FROM metric_metadata
        FINAL
        PREWHERE name = 'social_volume'
        LIMIT 1
    ))
    GROUP BY
        asset_id,
        dt
)
WHERE (value IS NOT NULL) AND (NOT isNaN(value))
GROUP BY t
ORDER BY t ASC
FORMAT JSONCompact
```

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
