### PR TITLE
Add moderate_featured API allowing to make entities featured

### DIFF
--- a/lib/sanbase/entity/entity.ex
+++ b/lib/sanbase/entity/entity.ex
@@ -194,6 +194,11 @@ defmodule Sanbase.Entity do
   def deduce_entity_module(:chart_configuration), do: Chart.Configuration
   def deduce_entity_module(:dashboard), do: Dashboard.Schema
 
+  def by_id(entity_type, entity_id) do
+    module = deduce_entity_module(entity_type)
+    apply(module, :by_id, [entity_id, []])
+  end
+
   @doc ~s"""
   Apply the pagination options from `opts` to `query`.
 

--- a/lib/sanbase/entity/entity_moderation.ex
+++ b/lib/sanbase/entity/entity_moderation.ex
@@ -4,17 +4,17 @@ defmodule Sanbase.Entity.Moderation do
   """
   import Ecto.Query
 
-  def set_deleted(entity_type, entity_id) do
-    set_boolean_field(entity_type, entity_id, :is_deleted, true)
+  def set_deleted(entity_type, entity_id, flag) do
+    set_boolean_field(entity_type, entity_id, :is_deleted, flag)
   end
 
-  def set_hidden(entity_type, entity_id) do
-    set_boolean_field(entity_type, entity_id, :is_hidden, true)
+  def set_hidden(entity_type, entity_id, flag) do
+    set_boolean_field(entity_type, entity_id, :is_hidden, flag)
   end
 
-  def set_featured(entity_type, entity_id) do
+  def set_featured(entity_type, entity_id, flag) do
     with {:ok, entity} <- Sanbase.Entity.by_id(entity_type, entity_id),
-         :ok <- Sanbase.FeaturedItem.update_item(entity, true) do
+         :ok <- Sanbase.FeaturedItem.update_item(entity, flag) do
       {:ok, true}
     end
   end

--- a/lib/sanbase/entity/entity_moderation.ex
+++ b/lib/sanbase/entity/entity_moderation.ex
@@ -12,6 +12,13 @@ defmodule Sanbase.Entity.Moderation do
     set_boolean_field(entity_type, entity_id, :is_hidden, true)
   end
 
+  def set_featured(entity_type, entity_id) do
+    with {:ok, entity} <- Sanbase.Entity.by_id(entity_type, entity_id),
+         :ok <- Sanbase.FeaturedItem.update_item(entity, true) do
+      {:ok, true}
+    end
+  end
+
   def unpublish_insight(insight_id) do
     case Sanbase.Insight.Post.unpublish(insight_id) do
       {:ok, _} -> {:ok, true}

--- a/lib/sanbase_web/graphql/resolvers/moderation_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/moderation_resolver.ex
@@ -1,22 +1,22 @@
 defmodule SanbaseWeb.Graphql.Resolvers.ModerationResolver do
   alias Sanbase.Entity.Moderation
 
-  def moderate_delete(_root, %{entity_type: type, entity_id: id}, %{
+  def moderate_delete(_root, %{entity_type: type, entity_id: id, flag: flag}, %{
         context: %{is_moderator: true}
       }) do
-    Moderation.set_deleted(type, id)
+    Moderation.set_deleted(type, id, flag)
   end
 
-  def moderate_hide(_root, %{entity_type: type, entity_id: id}, %{
+  def moderate_hide(_root, %{entity_type: type, entity_id: id, flag: flag}, %{
         context: %{is_moderator: true}
       }) do
-    Moderation.set_hidden(type, id)
+    Moderation.set_hidden(type, id, flag)
   end
 
-  def moderate_featured(_root, %{entity_type: type, entity_id: id}, %{
+  def moderate_featured(_root, %{entity_type: type, entity_id: id, flag: flag}, %{
         context: %{is_moderator: true}
       }) do
-    Moderation.set_featured(type, id)
+    Moderation.set_featured(type, id, flag)
   end
 
   def unpublish_insight(_root, %{insight_id: insight_id}, %{

--- a/lib/sanbase_web/graphql/resolvers/moderation_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/moderation_resolver.ex
@@ -1,19 +1,27 @@
 defmodule SanbaseWeb.Graphql.Resolvers.ModerationResolver do
+  alias Sanbase.Entity.Moderation
+
   def moderate_delete(_root, %{entity_type: type, entity_id: id}, %{
         context: %{is_moderator: true}
       }) do
-    Sanbase.Entity.Moderation.set_deleted(type, id)
+    Moderation.set_deleted(type, id)
   end
 
   def moderate_hide(_root, %{entity_type: type, entity_id: id}, %{
         context: %{is_moderator: true}
       }) do
-    Sanbase.Entity.Moderation.set_hidden(type, id)
+    Moderation.set_hidden(type, id)
+  end
+
+  def moderate_featured(_root, %{entity_type: type, entity_id: id}, %{
+        context: %{is_moderator: true}
+      }) do
+    Moderation.set_featured(type, id)
   end
 
   def unpublish_insight(_root, %{insight_id: insight_id}, %{
         context: %{is_moderator: true}
       }) do
-    Sanbase.Entity.Moderation.unpublish_insight(insight_id)
+    Moderation.unpublish_insight(insight_id)
   end
 end

--- a/lib/sanbase_web/graphql/schema/queries/moderation_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/moderation_queries.ex
@@ -11,6 +11,15 @@ defmodule SanbaseWeb.Graphql.Schema.ModerationQueries do
   end
 
   object :moderation_mutations do
+    field :moderate_featured, :boolean do
+      arg(:entity_id, non_null(:integer))
+      arg(:entity_type, non_null(:entity_type))
+
+      middleware(JWTModeratorAuth)
+
+      resolve(&ModerationResolver.moderate_featured/3)
+    end
+
     field :moderate_hide, :boolean do
       arg(:entity_id, non_null(:integer))
       arg(:entity_type, non_null(:entity_type))

--- a/lib/sanbase_web/graphql/schema/queries/moderation_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/moderation_queries.ex
@@ -15,6 +15,8 @@ defmodule SanbaseWeb.Graphql.Schema.ModerationQueries do
       arg(:entity_id, non_null(:integer))
       arg(:entity_type, non_null(:entity_type))
 
+      arg(:flag, :boolean, default_value: true)
+
       middleware(JWTModeratorAuth)
 
       resolve(&ModerationResolver.moderate_featured/3)
@@ -24,6 +26,8 @@ defmodule SanbaseWeb.Graphql.Schema.ModerationQueries do
       arg(:entity_id, non_null(:integer))
       arg(:entity_type, non_null(:entity_type))
 
+      arg(:flag, :boolean, default_value: true)
+
       middleware(JWTModeratorAuth)
 
       resolve(&ModerationResolver.moderate_hide/3)
@@ -32,6 +36,8 @@ defmodule SanbaseWeb.Graphql.Schema.ModerationQueries do
     field :moderate_delete, :boolean do
       arg(:entity_type, non_null(:entity_type))
       arg(:entity_id, non_null(:integer))
+
+      arg(:flag, :boolean, default_value: true)
 
       middleware(JWTModeratorAuth)
 


### PR DESCRIPTION
## Changes

Currently, entities (mainly insights) are made featured via the admin panel, which is cumbersome.
Add API for moderating the featured items via Sanbase (after such button is added).

```graphql
mutation{ 
  moderateFeatured(entity_type: INSIGHT, entity_id: 10)
}
```

Add `flag` boolean variable to `moderateFeatured`, `moderateHide` and `moderateDelete` that:
- if set to `true` makes the entity featured/hidden/deleted
- if set to `false` unmakes the marking of the entity as featured/hidden/deleted
By default the value of the flag is set to `true` so the existing API calls work as before.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
