### PR TITLE
Improve handling of Clickhouse errors

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -11,7 +11,7 @@
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},
   "cidr": {:hex, :cidr, "1.1.0", "77ab79e3d694d6d315c2e7dea1c66710623488ab7595316d3e2987aebe0def25", [:mix], [], "hexpm", "155c26559b27be49a446e13a9e12bf50d62bf9231c548e7743263e75fa61dc91"},
   "clickhouse_ecto": {:git, "https://github.com/santiment/clickhouse_ecto.git", "9518142275534f040edb19c61646fc3aed889040", [branch: "migrate-ecto-3"]},
-  "clickhousex": {:git, "https://github.com/santiment/clickhousex.git", "78ca1b3c43e2e7ee5db0281192f153ee07676dfb", []},
+  "clickhousex": {:git, "https://github.com/santiment/clickhousex.git", "41d0b49c719e97fd591996b9be16f2fcc377aef1", []},
   "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm", "1b1dbc1790073076580d0d1d64e42eae2366583e7aecd455d1215b0d16f2451b"},
   "con_cache": {:hex, :con_cache, "1.0.0", "6405e2bd5d5005334af72939432783562a8c35a196c2e63108fe10bb97b366e6", [:mix], [], "hexpm", "4d1f5cb1a67f3c1a468243dc98d10ac83af7f3e33b7e7c15999dc2c9bc0a551e"},
   "connection": {:hex, :connection, "1.1.0", "ff2a49c4b75b6fb3e674bfc5536451607270aac754ffd1bdfe175abe4a6d7a68", [:mix], [], "hexpm", "722c1eb0a418fbe91ba7bd59a47e28008a189d47e37e0e7bb85585a016b2869c"},

--- a/test/sanbase_web/graphql/clickhouse/historical_balance/historical_balances_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/historical_balance/historical_balances_test.exs
@@ -190,7 +190,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
           assert historical_balance == nil
         end)
 
-      assert log =~ inspect(error)
+      assert log =~ error
 
       assert log =~
                ~s|Can't fetch Historical Balances for selector #{inspect(selector)}|


### PR DESCRIPTION
## Changes

- Update Clickhousex to handle erros that don't have the :reason key in it
- Extract the error from the %Clickhousex.Error{} struct instead of only from `__STACKTRACE__`

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
