### PR TITLE
Add GraphiQL advanced interface on /graphiql_advanced endpoint

### DIFF
--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -101,6 +101,24 @@ defmodule SanbaseWeb.Router do
       log_level: :info,
       before_send: {SanbaseWeb.Graphql.AbsintheBeforeSend, :before_send}
     )
+
+    forward(
+      "/graphiql_advanced",
+      # Use own version of the plug with fixed XSS vulnerability
+      Absinthe.Plug.GraphiQL,
+      json_codec: Jason,
+      schema: SanbaseWeb.Graphql.Schema,
+      socket: SanbaseWeb.UserSocket,
+      document_providers: [
+        SanbaseWeb.Graphql.DocumentProvider,
+        Absinthe.Plug.DocumentProvider.Default
+      ],
+      analyze_complexity: true,
+      max_complexity: 50_000,
+      interface: :advanced,
+      log_level: :info,
+      before_send: {SanbaseWeb.Graphql.AbsintheBeforeSend, :before_send}
+    )
   end
 
   scope "/", SanbaseWeb do


### PR DESCRIPTION
## Changes

Add `/advanced_graphiql` endpoint.

Keep the original `/graphiql` endpoint as-is due to backwards compatibility reasons. The new endpoint allows users to set custom headers. This is needed when API-only clients want to explore the API via graphiql. In order to do so, the Authorization header needs to be set:

<img width="643" alt="image" src="https://user-images.githubusercontent.com/6518376/193786305-54206bfa-5e23-47aa-8c87-c859a34d43a4.png">

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
