### PR TITLE
Remove unsupported slugs from the get_metrics' avialable_slugs response

### DIFF
--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -475,7 +475,19 @@ defmodule Sanbase.Metric do
       module when is_atom(module) ->
         module = maybe_change_module(module, metric, %{}, opts)
 
-        module.available_slugs(metric)
+        case module.available_slugs(metric) do
+          {:ok, slugs} ->
+            supported_slugs = Sanbase.Model.Project.List.projects_slugs()
+
+            slugs =
+              MapSet.intersection(MapSet.new(slugs), MapSet.new(supported_slugs))
+              |> Enum.to_list()
+
+            {:ok, slugs}
+
+          error ->
+            error
+        end
     end
   end
 


### PR DESCRIPTION
## Changes

If there is data for an asset that is no longer supported in the API, this asset needs to be removed from the result.
This also happens after an asset is marked as hidden - it should be removed from the avilable slugs response.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
