### PR TITLE
Add two more intervals for active addresses metrics

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -190,6 +190,44 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Active Addresses for the last 30 days",
+    "name": "active_addresses_30d",
+    "metric": "active_addresses_30d",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Active Addresses for the last 7 days",
+    "name": "active_addresses_7d",
+    "metric": "active_addresses_7d",
+    "version": "2019-01-01",
+    "access": "free",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
     "human_readable_name": "Active Addresses for the last 24 hours",
     "name": "active_addresses_24h",
     "metric": "active_addresses_24h",

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -354,6 +354,8 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
 
     expected_free_metrics =
       [
+        "active_addresses_30d",
+        "active_addresses_7d",
         "active_addresses_24h",
         "active_addresses_1h",
         "circulation",


### PR DESCRIPTION
## Changes
Add two active addresses metrics that were missing in the API 
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
