### PR TITLE
ETH2 staking pools validators count over time with limit

### DIFF
--- a/lib/sanbase/clickhouse/metric/sql_query/metric_histogram_sql_query.ex
+++ b/lib/sanbase/clickhouse/metric/sql_query/metric_histogram_sql_query.ex
@@ -604,7 +604,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter.HistogramSqlQuery do
         from,
         to,
         interval,
-        _limit
+        limit
       ) do
     query = """
     SELECT
@@ -644,7 +644,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter.HistogramSqlQuery do
           ) USING (address)
           GROUP BY label, dt
         )
-        WHERE rank <= ?1
+        WHERE rank <= ?4
       )
       GROUP BY dt
       ORDER BY dt ASC
@@ -654,7 +654,8 @@ defmodule Sanbase.Clickhouse.MetricAdapter.HistogramSqlQuery do
     args = [
       str_to_sec(interval),
       dt_to_unix(:from, from),
-      dt_to_unix(:to, to)
+      dt_to_unix(:to, to),
+      limit
     ]
 
     {query, args}


### PR DESCRIPTION
## Changes
Add `limit` to `eth2_staking_pools_validators_count_over_time`.
The limit works by computing the top `limit` staking pools for the last day and showing the historical stats for them.
Showing top `limit` for each interval does not work as this will mean that the staking pools set will not be consistent over time.

```graphql
{
  getMetric(metric: "eth2_staking_pools_validators_count_over_time") {
    histogramData(selector: {slug: "ethereum"}, from: "utc_now-7d", to: "utc_now", limit: 5) {
      values {
        ... on Eth2StakingPoolsValidatorsCountOverTimeList {
          data {
            datetime
            value{
              stakingPool
              valuation
            }
          }
        }
      }
    }
  }
}
```

Add `limit` to `eth2_staking_pools_validators_count_over_time_delta`.
The limit works by computing the top `limit` staking pools for each day of the given interval (the rank is calculated based on the value staked for each day).

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
