### PR TITLE
Hide hidden entities from moderators in explorer

### DIFF
--- a/lib/sanbase/entity/entity_query.ex
+++ b/lib/sanbase/entity/entity_query.ex
@@ -56,8 +56,11 @@ defmodule Sanbase.Entity.Query do
 
   @spec maybe_filter_is_hidden(Ecto.Query.t(), Sanbase.Entity.opts()) :: Ecto.Query.t()
   def maybe_filter_is_hidden(query, opts) do
-    default_value =
-      if Keyword.get(opts, :is_moderator), do: :hidden_and_not_hidden, else: :only_not_hidden
+    default_value = Keyword.get(opts, :show_hidden_option, :only_not_hidden)
+
+    # Use this when we introduce a special tab that will be seen by moderators
+    # and will be used to undo these actions
+    # default_value = if Keyword.get(opts, :is_moderator), do: :hidden_and_not_hidden, else: :only_not_hidden
 
     case Keyword.get(opts, :show_hidden_entities, default_value) do
       :only_not_hidden ->

--- a/test/sanbase_web/graphql/moderation/entity_moderation_api_test.exs
+++ b/test/sanbase_web/graphql/moderation/entity_moderation_api_test.exs
@@ -274,18 +274,12 @@ defmodule SanbaseWeb.Graphql.EntityModerationApiTest do
       SanbaseWeb.Graphql.Cache.clear_all()
 
       assert %{
-               "data" => [
-                 %{
-                   "userTrigger" => %{
-                     "trigger" => %{"id" => ^user_trigger_id, "isHidden" => true}
-                   }
-                 }
-               ],
+               "data" => [],
                "stats" => %{
                  "currentPage" => 1,
                  "currentPageSize" => 10,
-                 "totalEntitiesCount" => 1,
-                 "totalPagesCount" => 1
+                 "totalEntitiesCount" => 0,
+                 "totalPagesCount" => 0
                }
              } = get_most_recent(moderator_conn, :user_trigger)
 


### PR DESCRIPTION
## Changes

Currently moderators see hidden entities. After this change they will no longer see them.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
