### PR TITLE
Populate is_featured in Explorer API calls

### DIFF
--- a/lib/sanbase/chart/chart_configuration.ex
+++ b/lib/sanbase/chart/chart_configuration.ex
@@ -21,7 +21,6 @@ defmodule Sanbase.Chart.Configuration do
     field(:queries, :map, default: %{})
     field(:drawings, :map, default: %{})
     field(:options, :map, default: %{})
-    field(:views, :integer, virtual: true, default: 0)
 
     has_one(:featured_item, Sanbase.FeaturedItem,
       on_delete: :delete_all,
@@ -43,6 +42,10 @@ defmodule Sanbase.Chart.Configuration do
       foreign_key: :chart_configuration_for_event_id,
       where: [is_chart_event: true]
     )
+
+    # Virtual fields
+    field(:views, :integer, virtual: true, default: 0)
+    field(:is_featured, :boolean, virtual: true)
 
     timestamps()
   end
@@ -82,7 +85,7 @@ defmodule Sanbase.Chart.Configuration do
 
   @impl Sanbase.Entity.Behaviour
   def by_ids(config_ids, opts) do
-    preload = Keyword.get(opts, :preload, [:chart_events])
+    preload = Keyword.get(opts, :preload, [:chart_events, :featured_item])
 
     result =
       from(

--- a/lib/sanbase/entity/entity.ex
+++ b/lib/sanbase/entity/entity.ex
@@ -617,8 +617,18 @@ defmodule Sanbase.Entity do
       entity_module = deduce_entity_module(type)
 
       {:ok, data} = entity_module.by_ids(ids, [])
-      Enum.map(data, fn e -> %{type => e} end)
+
+      Enum.map(data, fn entity ->
+        %{type => transform_entity(entity)}
+      end)
     end)
+  end
+
+  defp transform_entity(entity) do
+    # Populate the `is_featured` boolean value from the `featured_item` assoc
+    is_featured = if entity.featured_item, do: true, else: false
+
+    %{entity | is_featured: is_featured}
   end
 
   defp rewrite_keys(list) do

--- a/lib/sanbase_web/graphql/helpers/utils.ex
+++ b/lib/sanbase_web/graphql/helpers/utils.ex
@@ -74,6 +74,7 @@ defmodule SanbaseWeb.Graphql.Helpers.Utils do
           |> Map.put(:tags, tags)
           |> Map.put(:id, ut.id)
           |> Map.put(:is_hidden, ut.is_hidden)
+          |> Map.put(:is_featured, ut.is_featured)
     }
   end
 

--- a/lib/sanbase_web/graphql/schema/types/chart_configuration_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/chart_configuration_types.ex
@@ -29,6 +29,7 @@ defmodule SanbaseWeb.Graphql.ChartConfigurationTypes do
     field(:description, :string)
     field(:is_public, non_null(:boolean))
     field(:is_hidden, non_null(:boolean))
+    field(:is_featured, :boolean)
     field(:metrics, list_of(:string))
     field(:metrics_json, :json)
     field(:anomalies, list_of(:string))

--- a/lib/sanbase_web/graphql/schema/types/insight_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/insight_types.ex
@@ -52,6 +52,7 @@ defmodule SanbaseWeb.Graphql.InsightTypes do
     field(:prediction, :string)
     field(:is_pulse, :boolean)
     field(:is_hidden, non_null(:boolean))
+    field(:is_featured, :boolean)
     field(:is_paywall_required, :boolean)
     field(:is_chart_event, :boolean)
     field(:chart_event_datetime, :datetime)

--- a/lib/sanbase_web/graphql/schema/types/user_list_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_list_types.ex
@@ -73,6 +73,7 @@ defmodule SanbaseWeb.Graphql.UserListTypes do
     field(:description, :string)
     field(:is_public, non_null(:boolean))
     field(:is_hidden, non_null(:boolean))
+    field(:is_featured, :boolean)
     field(:is_screener, non_null(:boolean))
     field(:color, :color_enum)
     field(:function, :json)

--- a/lib/sanbase_web/graphql/schema/types/user_trigger_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_trigger_types.ex
@@ -47,6 +47,7 @@ defmodule SanbaseWeb.Graphql.UserTriggerTypes do
     field(:is_active, non_null(:boolean))
     field(:is_repeating, non_null(:boolean))
     field(:is_frozen, non_null(:boolean))
+    field(:is_featured, :boolean)
   end
 
   object :alerts_stats do

--- a/test/sanbase_web/graphql/moderation/entity_moderation_api_test.exs
+++ b/test/sanbase_web/graphql/moderation/entity_moderation_api_test.exs
@@ -15,7 +15,12 @@ defmodule SanbaseWeb.Graphql.EntityModerationApiTest do
     conn = setup_jwt_auth(build_conn(), user)
     moderator_conn = setup_jwt_auth(build_conn(), moderator_user)
 
-    %{conn: conn, moderator_conn: moderator_conn, user: user, moderator_user: moderator_user}
+    %{
+      conn: conn,
+      moderator_conn: moderator_conn,
+      user: user,
+      moderator_user: moderator_user
+    }
   end
 
   describe "set deleted" do
@@ -243,7 +248,9 @@ defmodule SanbaseWeb.Graphql.EntityModerationApiTest do
              } = get_most_recent(conn, :insight)
     end
 
-    test "moderators can still see hidden content", %{moderator_conn: moderator_conn} do
+    test "moderators can still see hidden content", %{
+      moderator_conn: moderator_conn
+    } do
       # The hidden content is visible to moderators, so hidding it results only
       # in setting the `is_hidden` flag to `true`
 
@@ -256,7 +263,10 @@ defmodule SanbaseWeb.Graphql.EntityModerationApiTest do
                "data" => [
                  %{
                    "userTrigger" => %{
-                     "trigger" => %{"id" => ^user_trigger_id, "isHidden" => false}
+                     "trigger" => %{
+                       "id" => ^user_trigger_id,
+                       "isHidden" => false
+                     }
                    }
                  }
                ],
@@ -301,42 +311,12 @@ defmodule SanbaseWeb.Graphql.EntityModerationApiTest do
       |> post("/graphql", mutation_skeleton(mutation))
       |> json_response(200)
     end
-
-    defp get_most_recent(conn, entity_or_entities, opts \\ []) do
-      opts =
-        opts
-        |> Keyword.put_new(:page, 1)
-        |> Keyword.put_new(:page_size, 10)
-        |> Keyword.put_new(:types, List.wrap(entity_or_entities))
-        |> Keyword.put_new(:min_title_length, 0)
-        |> Keyword.put_new(:min_description_length, 0)
-
-      query = """
-      {
-        getMostRecent(#{map_to_args(Map.new(opts))}){
-          stats { currentPage currentPageSize totalPagesCount totalEntitiesCount }
-          data {
-            insight{ id isHidden }
-            projectWatchlist{ id isHidden }
-            addressWatchlist{ id isHidden }
-            screener{ id isHidden }
-            chartConfiguration{ id isHidden }
-            userTrigger{ trigger{ id isHidden } }
-          }
-        }
-      }
-      """
-
-      conn
-      |> post("/graphql", query_skeleton(query))
-      |> json_response(200)
-      |> get_in(["data", "getMostRecent"])
-    end
   end
 
   describe "set featured" do
     test "insight", %{moderator_conn: moderator_conn} do
       insight = insert(:published_post)
+      insight_id = insight.id
 
       featured_insights = fn ->
         query = "{ featuredInsights{ id } }"
@@ -349,15 +329,28 @@ defmodule SanbaseWeb.Graphql.EntityModerationApiTest do
 
       assert featured_insights.() == []
 
+      assert %{
+               "data" => [
+                 %{"insight" => %{"id" => ^insight_id, "isFeatured" => false}}
+               ]
+             } = get_most_recent(moderator_conn, :insight)
+
       assert moderate_featured(moderator_conn, :insight, insight.id) == true
 
       SanbaseWeb.Graphql.Cache.clear_all()
+
+      assert %{
+               "data" => [
+                 %{"insight" => %{"id" => ^insight_id, "isFeatured" => true}}
+               ]
+             } = get_most_recent(moderator_conn, :insight)
 
       assert featured_insights.() == [%{"id" => insight.id}]
     end
 
     test "watchlist", %{moderator_conn: moderator_conn} do
       watchlist = insert(:watchlist, is_public: true, type: :project)
+      watchlist_id = watchlist.id |> to_string()
 
       featured_watchlists = fn ->
         query = "{ featuredWatchlists(type: PROJECT){ id } }"
@@ -370,15 +363,39 @@ defmodule SanbaseWeb.Graphql.EntityModerationApiTest do
 
       assert featured_watchlists.() == []
 
-      assert moderate_featured(moderator_conn, :project_watchlist, watchlist.id) == true
+      assert %{
+               "data" => [
+                 %{
+                   "projectWatchlist" => %{
+                     "id" => ^watchlist_id,
+                     "isFeatured" => false
+                   }
+                 }
+               ]
+             } = get_most_recent(moderator_conn, :project_watchlist)
+
+      assert moderate_featured(moderator_conn, :project_watchlist, watchlist.id) ==
+               true
 
       SanbaseWeb.Graphql.Cache.clear_all()
+
+      assert %{
+               "data" => [
+                 %{
+                   "projectWatchlist" => %{
+                     "id" => ^watchlist_id,
+                     "isFeatured" => true
+                   }
+                 }
+               ]
+             } = get_most_recent(moderator_conn, :project_watchlist)
 
       assert featured_watchlists.() == [%{"id" => "#{watchlist.id}"}]
     end
 
     test "chart configuration", %{moderator_conn: moderator_conn} do
       config = insert(:chart_configuration, is_public: true)
+      config_id = config.id
 
       featured_configs = fn ->
         query = "{ featuredChartConfigurations{ id } }"
@@ -391,15 +408,39 @@ defmodule SanbaseWeb.Graphql.EntityModerationApiTest do
 
       assert featured_configs.() == []
 
-      assert moderate_featured(moderator_conn, :chart_configuration, config.id) == true
+      assert %{
+               "data" => [
+                 %{
+                   "chartConfiguration" => %{
+                     "id" => ^config_id,
+                     "isFeatured" => false
+                   }
+                 }
+               ]
+             } = get_most_recent(moderator_conn, :chart_configuration)
+
+      assert moderate_featured(moderator_conn, :chart_configuration, config.id) ==
+               true
 
       SanbaseWeb.Graphql.Cache.clear_all()
+
+      assert %{
+               "data" => [
+                 %{
+                   "chartConfiguration" => %{
+                     "id" => ^config_id,
+                     "isFeatured" => true
+                   }
+                 }
+               ]
+             } = get_most_recent(moderator_conn, :chart_configuration)
 
       assert featured_configs.() == [%{"id" => config.id}]
     end
 
     test "user trigger", %{moderator_conn: moderator_conn} do
       user_trigger = insert(:user_trigger, is_public: true)
+      user_trigger_id = user_trigger.id
 
       featured_triggers = fn ->
         query = "{ featuredUserTriggers{ trigger{ id } } }"
@@ -412,11 +453,40 @@ defmodule SanbaseWeb.Graphql.EntityModerationApiTest do
 
       assert featured_triggers.() == []
 
-      assert moderate_featured(moderator_conn, :user_trigger, user_trigger.id) == true
+      assert %{
+               "data" => [
+                 %{
+                   "userTrigger" => %{
+                     "trigger" => %{
+                       "id" => ^user_trigger_id,
+                       "isFeatured" => false
+                     }
+                   }
+                 }
+               ]
+             } = get_most_recent(moderator_conn, :user_trigger)
+
+      assert moderate_featured(moderator_conn, :user_trigger, user_trigger.id) ==
+               true
 
       SanbaseWeb.Graphql.Cache.clear_all()
 
-      assert featured_triggers.() == [%{"trigger" => %{"id" => user_trigger.id}}]
+      assert %{
+               "data" => [
+                 %{
+                   "userTrigger" => %{
+                     "trigger" => %{
+                       "id" => ^user_trigger_id,
+                       "isFeatured" => true
+                     }
+                   }
+                 }
+               ]
+             } = get_most_recent(moderator_conn, :user_trigger)
+
+      assert featured_triggers.() == [
+               %{"trigger" => %{"id" => user_trigger.id}}
+             ]
     end
 
     defp moderate_featured(conn, entity_type, entity_id) do
@@ -435,5 +505,36 @@ defmodule SanbaseWeb.Graphql.EntityModerationApiTest do
       |> json_response(200)
       |> get_in(["data", "moderateFeatured"])
     end
+  end
+
+  defp get_most_recent(conn, entity_or_entities, opts \\ []) do
+    opts =
+      opts
+      |> Keyword.put_new(:page, 1)
+      |> Keyword.put_new(:page_size, 10)
+      |> Keyword.put_new(:types, List.wrap(entity_or_entities))
+      |> Keyword.put_new(:min_title_length, 0)
+      |> Keyword.put_new(:min_description_length, 0)
+
+    query = """
+    {
+      getMostRecent(#{map_to_args(Map.new(opts))}){
+        stats { currentPage currentPageSize totalPagesCount totalEntitiesCount }
+        data {
+          insight{ id isHidden isFeatured }
+          projectWatchlist{ id isHidden isFeatured }
+          addressWatchlist{ id isHidden isFeatured }
+          screener{ id isHidden isFeatured }
+          chartConfiguration{ id isHidden isFeatured }
+          userTrigger{ trigger{ id isHidden isFeatured } }
+        }
+      }
+    }
+    """
+
+    conn
+    |> post("/graphql", query_skeleton(query))
+    |> json_response(200)
+    |> get_in(["data", "getMostRecent"])
   end
 end


### PR DESCRIPTION
## Changes

Add `isFeatured` field in the entities that are returned in the Explorer. Populate these fields in the `getMost*` API calls.

```graphql
{
  getMostRecent(
    types: [CHART_CONFIGURATION, PROJECT_WATCHLIST, SCREENER]
    page: 1
    pageSize: 20
    minTitleLength: 10
    minDescriptionLength: 20
   ) {
    stats {
      totalPagesCount
    }
    data {
      projectWatchlist {
        isFeatured
        id
        title: name
        description
        insertedAt
      }
      screener {
        isFeatured
        id
        title: name
        description
        insertedAt
      }
      chartConfiguration {
        isFeatured
        id
        title
        description
        insertedAt
      }
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
