### PR TITLE
Add is_timebound to get_metric's metadata

### DIFF
--- a/lib/sanbase/blockchain_address/metric_adapter.ex
+++ b/lib/sanbase/blockchain_address/metric_adapter.ex
@@ -130,6 +130,7 @@ defmodule Sanbase.BlockchainAddress.MetricAdapter do
        available_selectors: [:blockchain_address, :slug],
        required_selectors: Map.get(@required_selectors, metric, []),
        data_type: :timeseries,
+       is_timebound: false,
        complexity_weight: @default_complexity_weight
      }}
   end

--- a/lib/sanbase/clickhouse/github/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/github/metric_adapter.ex
@@ -199,6 +199,7 @@ defmodule Sanbase.Clickhouse.Github.MetricAdapter do
        available_aggregations: @aggregations,
        available_selectors: [:slug],
        data_type: :timeseries,
+       is_timebound: false,
        complexity_weight: @default_complexity_weight
      }}
   end

--- a/lib/sanbase/clickhouse/metric/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/metric/metric_adapter.ex
@@ -38,6 +38,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
   @required_selectors_map FileHandler.required_selectors_map()
   @metric_to_names_map FileHandler.metric_to_names_map()
   @deprecated_metrics_map FileHandler.deprecated_metrics_map()
+  @timebound_flag_map FileHandler.timebound_flag_map()
   @default_complexity_weight 0.3
 
   @incomplete_metrics Enum.filter(@incomplete_data_map, &(elem(&1, 1) == true))
@@ -182,6 +183,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
        available_selectors: Map.get(@selectors_map, metric),
        required_selectors: Map.get(@required_selectors_map, metric, []),
        data_type: Map.get(@metrics_data_type_map, metric),
+       is_timebound: Map.get(@timebound_flag_map, metric),
        complexity_weight: @default_complexity_weight
      }}
   end

--- a/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
@@ -130,6 +130,7 @@ defmodule Sanbase.Clickhouse.TopHolders.MetricAdapter do
        available_selectors: [:slug, :holders_count],
        required_selectors: [:slug],
        data_type: data_type,
+       is_timebound: false,
        complexity_weight: @default_complexity_weight
      }}
   end

--- a/lib/sanbase/clickhouse/uniswap/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/uniswap/metric_adapter.ex
@@ -109,6 +109,7 @@ defmodule Sanbase.Clickhouse.Uniswap.MetricAdapter do
        available_selectors: [:slug],
        required_selectors: [:slug],
        data_type: :timeseries,
+       is_timebound: false,
        complexity_weight: @default_complexity_weight
      }}
   end

--- a/lib/sanbase/contract_metric/metric_adapter.ex
+++ b/lib/sanbase/contract_metric/metric_adapter.ex
@@ -109,6 +109,7 @@ defmodule Sanbase.Contract.MetricAdapter do
        available_selectors: [:contract_address],
        required_selectors: [:contract_address],
        data_type: :timeseries,
+       is_timebound: false,
        complexity_weight: @default_complexity_weight
      }}
   end

--- a/lib/sanbase/prices/metric_adapter.ex
+++ b/lib/sanbase/prices/metric_adapter.ex
@@ -84,6 +84,7 @@ defmodule Sanbase.Price.MetricAdapter do
        available_selectors: [:slug],
        required_selectors: [:slug],
        data_type: :timeseries,
+       is_timebound: false,
        complexity_weight: @default_complexity_weight
      }}
   end

--- a/lib/sanbase/prices/price_pair/metric_adapter.ex
+++ b/lib/sanbase/prices/price_pair/metric_adapter.ex
@@ -96,7 +96,9 @@ defmodule Sanbase.PricePair.MetricAdapter do
        default_aggregation: @default_aggregation,
        available_aggregations: @aggregations,
        available_selectors: [:slug],
+       required_selectors: [:slug],
        data_type: :timeseries,
+       is_timebound: false,
        complexity_weight: @default_complexity_weight
      }}
   end

--- a/lib/sanbase/signal/signal_adapter.ex
+++ b/lib/sanbase/signal/signal_adapter.ex
@@ -86,6 +86,7 @@ defmodule Sanbase.Signal.SignalAdapter do
        available_aggregations: @aggregations,
        available_selectors: Map.get(@selectors_map, signal),
        data_type: Map.get(@data_type_map, signal),
+       is_timebound: false,
        complexity_weight: 0.3
      }}
   end

--- a/lib/sanbase/twitter/metric_adapter.ex
+++ b/lib/sanbase/twitter/metric_adapter.ex
@@ -101,6 +101,7 @@ defmodule Sanbase.Twitter.MetricAdapter do
        available_selectors: [:slug],
        required_selectors: [:slug],
        data_type: :timeseries,
+       is_timebound: false,
        complexity_weight: @default_complexity_weight
      }}
   end

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -368,6 +368,8 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     """
     field(:data_type, :metric_data_type)
 
+    field(:is_timebound, :boolean)
+
     field(:is_accessible, :boolean)
 
     field(:is_restricted, :boolean)

--- a/test/sanbase_web/graphql/metric/api_metric_metadata_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_metadata_test.exs
@@ -103,6 +103,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricMetadataTest do
           dataType
           metric
           humanReadableName
+          isTimebound
           isRestricted
           restrictedFrom
           restrictedTo


### PR DESCRIPTION
## Changes
Add `isTimebound` flag to the metadata. Some metrics have names that can be confused for timebound: `active_addresses_7d` or the change metrics that end in `_30d`, `_60d`, etc.
```graphql
{
  getMetric(metric: "mvrv_usd_30d"){
    metadata{
      isTimebound
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
