### PR TITLE
Fix get_metric's metadata caching

### DIFF
--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -627,7 +627,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     end
 
     field :metadata, :metric_metadata do
-      cache_resolve(&MetricResolver.get_metadata/3)
+      cache_resolve(&MetricResolver.get_metadata/3, include_subscription_in_key: true)
     end
 
     @desc ~s"""


### PR DESCRIPTION
## Changes

Some fields like restricted_from and restricted_to need to be different for users with different subscription plans. In order to implement this without completely removing the caching, introduce the add support for the :include_subscription_in_key flag in the cache_resolve/1,2 macro. When set to true, the current user's plan and product used will be included in the cache key.

Previously, if an anonymous user first fetched some metadata fields and they were cached, then a PRO user will see the same result in the metadata, which is not correct. The GraphQL query below has that problem and it is fixed by this PR.

```graphql
{
  getMetric(metric: "mvrv_usd_30d"){
    metadata{
      isAccessible
      restrictedFrom
      restrictedTo
      isTimebound
    }
  }
}
```


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
