### PR TITLE
Support realtime ETH price from asset_price_pairs_only table

### DIFF
--- a/lib/sanbase/prices/price_pair/metric_adapter.ex
+++ b/lib/sanbase/prices/price_pair/metric_adapter.ex
@@ -5,7 +5,7 @@ defmodule Sanbase.PricePair.MetricAdapter do
   @aggregations [:any, :sum, :avg, :min, :max, :last, :first, :median, :ohlc]
   @default_aggregation :last
 
-  @timeseries_metrics ["price_usd", "price_usdt", "price_btc"]
+  @timeseries_metrics ["price_usd", "price_eth", "price_usdt", "price_btc"]
   @histogram_metrics []
   @table_metrics []
 
@@ -109,6 +109,7 @@ defmodule Sanbase.PricePair.MetricAdapter do
       "price_usd" -> {:ok, "Price in USD"}
       "price_btc" -> {:ok, "Price in BTC"}
       "price_usdt" -> {:ok, "Price in USDT"}
+      "price_eth" -> {:ok, "Price in ETH"}
     end
   end
 
@@ -145,7 +146,8 @@ defmodule Sanbase.PricePair.MetricAdapter do
         metrics =
           if("BTC" in quote_assets, do: ["price_btc"], else: []) ++
             if("USD" in quote_assets, do: ["price_usd"], else: []) ++
-            if("USDT" in quote_assets, do: ["price_usdt"], else: [])
+            if("USDT" in quote_assets, do: ["price_usdt"], else: []) ++
+            if("ETH" in quote_assets, do: ["price_eth"], else: [])
 
         {:ok, metrics}
 
@@ -193,4 +195,5 @@ defmodule Sanbase.PricePair.MetricAdapter do
   defp metric_to_quote_asset("price_btc"), do: "BTC"
   defp metric_to_quote_asset("price_usd"), do: "USD"
   defp metric_to_quote_asset("price_usdt"), do: "USDT"
+  defp metric_to_quote_asset("price_eth"), do: "ETH"
 end


### PR DESCRIPTION
## Changes

```graphql
{

  getMetric(metric: "price_eth"){
    timeseriesData(
      selector: {slug: "green-metaverse-token" source: "cryptocompare"}
      from: "utc_now-10m"
      to: "utc_now"
      interval: "60s"){
        datetime
        value
    }
  } 
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
