### PR TITLE
Simplify JSON metric files by using parameters

### DIFF
--- a/lib/sanbase/alerts/operation/operation_text.ex
+++ b/lib/sanbase/alerts/operation/operation_text.ex
@@ -16,7 +16,7 @@ defmodule Sanbase.Alert.OperationText do
 
   def merge_kvs(%{} = kv_left, %{} = kv_right) do
     Map.merge(kv_left, kv_right, fn
-      :human_readable, left, right -> Enum.uniq(left ++ right)
+      :__human_readable__, left, right -> Enum.uniq(left ++ right)
       _, _left, right -> right
     end)
   end

--- a/lib/sanbase/alerts/operation/operation_text_kv.ex
+++ b/lib/sanbase/alerts/operation/operation_text_kv.ex
@@ -13,7 +13,7 @@ defmodule Sanbase.Alert.OperationText.KV do
     kv = %{
       value: transform_fun.(value),
       previous: transform_fun.(previous),
-      human_readable: [:value, :previous]
+      __human_readable__: [:value, :previous]
     }
 
     {template, kv}
@@ -24,7 +24,7 @@ defmodule Sanbase.Alert.OperationText.KV do
     transform_fun = Keyword.get(opts, :value_transform, fn x -> x end)
 
     template = "Now: #{special_symbol}{{value}}"
-    kv = %{value: transform_fun.(value), human_readable: [:value]}
+    kv = %{value: transform_fun.(value), __human_readable__: [:value]}
     {template, kv}
   end
 
@@ -61,7 +61,7 @@ defmodule Sanbase.Alert.OperationText.KV do
     kv = %{
       op_key => transform_fun.(op_value),
       value: transform_fun.(value),
-      human_readable: [op_key, :value]
+      __human_readable__: [op_key, :value]
     }
 
     {template, kv}
@@ -89,7 +89,7 @@ defmodule Sanbase.Alert.OperationText.KV do
       lower: transform_fun.(lower),
       upper: transform_fun.(upper),
       value: transform_fun.(value),
-      human_readable: [:lower, :upper, :value]
+      __human_readable__: [:lower, :upper, :value]
     }
 
     {template, kv}
@@ -117,7 +117,7 @@ defmodule Sanbase.Alert.OperationText.KV do
       lower: transform_fun.(lower),
       upper: transform_fun.(upper),
       value: transform_fun.(value),
-      human_readable: [:lower, :upper, :value]
+      __human_readable__: [:lower, :upper, :value]
     }
 
     {template, kv}
@@ -182,7 +182,7 @@ defmodule Sanbase.Alert.OperationText.KV do
     kv = %{
       amount_change_up: transform_fun.(amount_change),
       amount_change_up_required: transform_fun.(amount_up),
-      human_readable: [:amount_change_up, :amount_change_up_required]
+      __human_readable__: [:amount_change_up, :amount_change_up_required]
     }
 
     {template, kv}
@@ -205,7 +205,7 @@ defmodule Sanbase.Alert.OperationText.KV do
     kv = %{
       amount_down_change: transform_fun.(amount_change) |> abs(),
       amount_down_change_required: transform_fun.(amount_down),
-      human_readable: [:amount_down_change, :amount_down_change_required]
+      __human_readable__: [:amount_down_change, :amount_down_change_required]
     }
 
     {template, kv}

--- a/lib/sanbase/clickhouse/metric/file_handler.ex
+++ b/lib/sanbase/clickhouse/metric/file_handler.ex
@@ -261,7 +261,10 @@ defmodule Sanbase.Clickhouse.MetricAdapter.FileHandler do
   @metrics_list @metrics_json |> Enum.map(fn %{"name" => name} -> name end)
   @metrics_mapset MapSet.new(@metrics_list)
 
-  @timebound_flag_map @metrics_json |> Map.new(&{&1["name"], &1["is_timebound"]})
+  @timebound_flag_map @metrics_json
+                      |> Map.new(fn metric ->
+                        {metric["name"], Map.get(metric, "is_timebound", false)}
+                      end)
 
   case Enum.filter(@aggregation_map, fn {_, aggr} -> aggr not in @aggregations end) do
     [] ->

--- a/lib/sanbase/clickhouse/metric/file_handler.ex
+++ b/lib/sanbase/clickhouse/metric/file_handler.ex
@@ -39,31 +39,8 @@ defmodule Sanbase.Clickhouse.MetricAdapter.FileHandler do
       [metric | duplicates]
     end
 
-    def resolve_timebound_metrics(metric_map, timebound_values) do
-      %{
-        "name" => name,
-        "metric" => metric,
-        "human_readable_name" => human_readable_name
-      } = metric_map
-
-      timebound_values
-      |> Enum.map(fn timebound ->
-        %{
-          metric_map
-          | "name" => TemplateEngine.run(name, %{timebound: timebound}),
-            "metric" => TemplateEngine.run(metric, %{timebound: timebound}),
-            "human_readable_name" =>
-              TemplateEngine.run(
-                human_readable_name,
-                %{timebound_human_readable: interval_to_str(timebound)}
-              )
-        }
-      end)
-    end
-
     def expand_patterns(metrics_json) do
       metrics_json
-      |> expand_timebound_metrics()
       |> expand_parameters_metrics()
     end
 
@@ -77,27 +54,15 @@ defmodule Sanbase.Clickhouse.MetricAdapter.FileHandler do
             %{"name" => name, "human_readable_name" => human_name, "metric" => metric} =
               metric_map
 
+            aliases = Map.get(metric_map, "aliases", [])
+
             Enum.map(parameters_list, fn parameters ->
               metric_map
               |> Map.put("name", TemplateEngine.run(name, parameters))
               |> Map.put("metric", TemplateEngine.run(metric, parameters))
               |> Map.put("human_readable_name", TemplateEngine.run(human_name, parameters))
+              |> Map.put("aliases", Enum.map(aliases, &TemplateEngine.run(&1, parameters)))
             end)
-        end
-      end)
-    end
-
-    def expand_timebound_metrics(metrics_json) do
-      put_timebound = fn list, bool -> list |> Enum.map(&Map.put(&1, "is_timebound", bool)) end
-
-      Enum.flat_map(metrics_json, fn metric ->
-        case Map.get(metric, "timebound") do
-          nil ->
-            [metric] |> put_timebound.(false)
-
-          timebound_values ->
-            resolve_timebound_metrics(metric, timebound_values)
-            |> put_timebound.(true)
         end
       end)
     end

--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -5,9 +5,7 @@
     "metric": "price_usd",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -24,9 +22,7 @@
     "metric": "daily_avg_marketcap_usd",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -43,9 +39,7 @@
     "metric": "daily_avg_price_usd",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -62,9 +56,7 @@
     "metric": "daily_closing_marketcap_usd",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -81,9 +73,7 @@
     "metric": "daily_closing_price_usd",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -100,9 +90,7 @@
     "metric": "daily_high_price_usd",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -119,9 +107,7 @@
     "metric": "daily_low_price_usd",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -138,9 +124,7 @@
     "metric": "daily_opening_price_usd",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -157,9 +141,7 @@
     "metric": "daily_trading_volume_usd",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -176,9 +158,7 @@
     "metric": "daily_active_addresses",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -195,9 +175,7 @@
     "metric": "active_addresses_30d",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -214,9 +192,7 @@
     "metric": "active_addresses_7d",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -233,9 +209,7 @@
     "metric": "active_addresses_24h",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -252,9 +226,7 @@
     "metric": "active_addresses_1h",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -271,9 +243,7 @@
     "metric": "mean_realized_price_usd_20y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -285,27 +255,26 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Mean Realized USD Price for coins that moved in the past {{timebound_human_readable}}",
+    "human_readable_name": "Mean Realized USD Price for coins that moved in the past {{timebound:human_readable}}",
     "name": "mean_realized_price_usd_{{timebound}}",
     "metric": "mean_realized_price_usd_{{timebound}}",
-    "timebound": [
-      "1d",
-      "7d",
-      "30d",
-      "60d",
-      "90d",
-      "180d",
-      "365d",
-      "2y",
-      "3y",
-      "5y",
-      "10y"
+    "parameters": [
+      { "timebound": "1d" },
+      { "timebound": "7d" },
+      { "timebound": "30d" },
+      { "timebound": "60d" },
+      { "timebound": "90d" },
+      { "timebound": "180d" },
+      { "timebound": "365d" },
+      { "timebound": "2y" },
+      { "timebound": "3y" },
+      { "timebound": "5y" },
+      { "timebound": "10y" }
     ],
+    "is_timebound": true,
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -322,9 +291,7 @@
     "metric": "mvrv_usd_long_short_diff",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -341,9 +308,7 @@
     "metric": "mvrv_usd_20y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -355,27 +320,26 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "MVRV for coins that moved in the past {{timebound_human_readable}}",
+    "human_readable_name": "MVRV for coins that moved in the past {{timebound:human_readable}}",
     "name": "mvrv_usd_{{timebound}}",
     "metric": "mvrv_usd_{{timebound}}",
-    "timebound": [
-      "1d",
-      "7d",
-      "30d",
-      "60d",
-      "90d",
-      "180d",
-      "365d",
-      "2y",
-      "3y",
-      "5y",
-      "10y"
+    "parameters": [
+      { "timebound": "1d" },
+      { "timebound": "7d" },
+      { "timebound": "30d" },
+      { "timebound": "60d" },
+      { "timebound": "90d" },
+      { "timebound": "180d" },
+      { "timebound": "365d" },
+      { "timebound": "2y" },
+      { "timebound": "3y" },
+      { "timebound": "5y" },
+      { "timebound": "10y" }
     ],
+    "is_timebound": true,
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -392,9 +356,7 @@
     "metric": "mvrv_usd_intraday_20y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -406,27 +368,26 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "MVRV Intraday for coins that moved in the past {{timebound_human_readable}}",
+    "human_readable_name": "MVRV Intraday for coins that moved in the past {{timebound:human_readable}}",
     "name": "mvrv_usd_intraday_{{timebound}}",
     "metric": "mvrv_usd_intraday_{{timebound}}",
-    "timebound": [
-      "1d",
-      "7d",
-      "30d",
-      "60d",
-      "90d",
-      "180d",
-      "365d",
-      "2y",
-      "3y",
-      "5y",
-      "10y"
+    "parameters": [
+      { "timebound": "1d" },
+      { "timebound": "7d" },
+      { "timebound": "30d" },
+      { "timebound": "60d" },
+      { "timebound": "90d" },
+      { "timebound": "180d" },
+      { "timebound": "365d" },
+      { "timebound": "2y" },
+      { "timebound": "3y" },
+      { "timebound": "5y" },
+      { "timebound": "10y" }
     ],
+    "is_timebound": true,
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -443,9 +404,7 @@
     "metric": "stack_circulation_20y",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -457,27 +416,26 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Circulation for coins that moved in the past {{timebound_human_readable}}",
+    "human_readable_name": "Circulation for coins that moved in the past {{timebound:human_readable}}",
     "name": "circulation_{{timebound}}",
     "metric": "stack_circulation_{{timebound}}",
-    "timebound": [
-      "1d",
-      "7d",
-      "30d",
-      "60d",
-      "90d",
-      "180d",
-      "365d",
-      "2y",
-      "3y",
-      "5y",
-      "10y"
+    "parameters": [
+      { "timebound": "1d" },
+      { "timebound": "7d" },
+      { "timebound": "30d" },
+      { "timebound": "60d" },
+      { "timebound": "90d" },
+      { "timebound": "180d" },
+      { "timebound": "365d" },
+      { "timebound": "2y" },
+      { "timebound": "3y" },
+      { "timebound": "5y" },
+      { "timebound": "10y" }
     ],
+    "is_timebound": true,
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -494,9 +452,7 @@
     "metric": "dormant_circulation_10y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -513,9 +469,7 @@
     "metric": "dormant_circulation_5y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -532,9 +486,7 @@
     "metric": "dormant_circulation_3y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -551,9 +503,7 @@
     "metric": "dormant_circulation_2y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -570,9 +520,7 @@
     "metric": "dormant_circulation_365d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -589,9 +537,7 @@
     "metric": "dormant_circulation_180d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -608,9 +554,7 @@
     "metric": "dormant_circulation_90d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -627,9 +571,7 @@
     "metric": "stack_mean_age_days",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -647,9 +589,7 @@
     "metric": "stack_mean_age_dollar_days",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -667,9 +607,7 @@
     "metric": "stack_realized_cap_usd_20y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -681,27 +619,26 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Realized Value for coins that moved in the past {{timebound_human_readable}}",
+    "human_readable_name": "Realized Value for coins that moved in the past {{timebound:human_readable}}",
     "name": "realized_value_usd_{{timebound}}",
     "metric": "stack_realized_cap_usd_{{timebound}}",
-    "timebound": [
-      "1d",
-      "7d",
-      "30d",
-      "60d",
-      "90d",
-      "180d",
-      "365d",
-      "2y",
-      "3y",
-      "5y",
-      "10y"
+    "parameters": [
+      { "timebound": "1d" },
+      { "timebound": "7d" },
+      { "timebound": "30d" },
+      { "timebound": "60d" },
+      { "timebound": "90d" },
+      { "timebound": "180d" },
+      { "timebound": "365d" },
+      { "timebound": "2y" },
+      { "timebound": "3y" },
+      { "timebound": "5y" },
+      { "timebound": "10y" }
     ],
+    "is_timebound": true,
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -718,9 +655,7 @@
     "metric": "token_velocity",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -737,9 +672,7 @@
     "metric": "transaction_volume_5min",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -756,9 +689,7 @@
     "metric": "transaction_volume_usd",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -772,15 +703,11 @@
   {
     "human_readable_name": "Age Consumed",
     "name": "age_destroyed",
-    "aliases": [
-      "age_consumed"
-    ],
+    "aliases": ["age_consumed"],
     "metric": "stack_age_consumed_5min",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -797,9 +724,7 @@
     "metric": "nvt",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -816,9 +741,7 @@
     "metric": "nvt_transaction_volume",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -835,9 +758,7 @@
     "metric": "network_growth",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -854,9 +775,7 @@
     "metric": "active_deposits",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -873,9 +792,7 @@
     "metric": "deposit_transactions",
     "version": "2020-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -892,9 +809,7 @@
     "metric": "active_withdrawals",
     "version": "2020-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -911,9 +826,7 @@
     "metric": "withdrawal_transactions",
     "version": "2020-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -930,9 +843,7 @@
     "metric": "dev_activity",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -949,9 +860,7 @@
     "metric": "stock_to_flow_ratio",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -968,9 +877,7 @@
     "metric": "payment_count",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -987,9 +894,7 @@
     "metric": "transaction_count",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1006,9 +911,7 @@
     "metric": "fees",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1025,9 +928,7 @@
     "metric": "fees_usd",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1044,9 +945,7 @@
     "metric": "fees_intraday",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1063,9 +962,7 @@
     "metric": "fees_usd_intraday",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1082,9 +979,7 @@
     "metric": "avg_fees_usd",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1101,9 +996,7 @@
     "metric": "median_fees_usd",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1120,9 +1013,7 @@
     "metric": "network_circulation_usd_1d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1139,9 +1030,7 @@
     "metric": "fees_to_network_circulation_usd_1d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1158,9 +1047,7 @@
     "metric": "daa_divergence",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1177,9 +1064,7 @@
     "metric": "adjusted_daa_divergence",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1196,9 +1081,7 @@
     "metric": "avg_gas",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1215,9 +1098,7 @@
     "metric": "network_profit_loss",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1234,9 +1115,7 @@
     "metric": "total_supply_in_profit",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1253,9 +1132,7 @@
     "metric": "percent_of_total_supply_in_profit",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1272,9 +1149,7 @@
     "metric": "active_deposits_5min",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1291,9 +1166,7 @@
     "metric": "deposit_transactions_5min",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1310,9 +1183,7 @@
     "metric": "active_withdrawals_5min",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1329,9 +1200,7 @@
     "metric": "withdrawal_transactions_5min",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1348,9 +1217,7 @@
     "metric": "avg_fees_usd_intraday",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1367,9 +1234,7 @@
     "metric": "median_fees_usd_intraday",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1386,9 +1251,7 @@
     "metric": "average_transfer_5min",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1405,9 +1268,7 @@
     "metric": "median_transfer_5min",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1424,9 +1285,7 @@
     "metric": "whale_transaction_count_more_than_100k_usd_5min",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1443,9 +1302,7 @@
     "metric": "whale_transaction_count_more_than_1m_usd_5min",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1462,9 +1319,7 @@
     "metric": "price_eth",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1481,9 +1336,7 @@
     "metric": "mvrv_z",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1497,15 +1350,11 @@
   {
     "human_readable_name": "Total Supply",
     "name": "total_supply",
-    "aliases": [
-      "mcd_erc20_supply"
-    ],
+    "aliases": ["mcd_erc20_supply"],
     "metric": "total_supply",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1522,9 +1371,7 @@
     "metric": "miner_supply",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1541,9 +1388,7 @@
     "metric": "rank",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1560,9 +1405,7 @@
     "metric": "nvt_intraday",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1579,9 +1422,7 @@
     "metric": "percent_of_whale_total_supply",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1596,14 +1437,10 @@
     "human_readable_name": "Binance Exchange Funding Rates (USDT)",
     "name": "usdt_bnb_funding_rates",
     "metric": "usdt_bnb_funding_rates",
-    "aliases": [
-      "usdt_binance_funding_rate"
-    ],
+    "aliases": ["usdt_binance_funding_rate"],
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1618,14 +1455,10 @@
     "human_readable_name": "Binance Exchange Funding Rates (BUSD)",
     "name": "busd_bnb_funding_rates",
     "metric": "busd_bnb_funding_rates",
-    "aliases": [
-      "busd_binance_funding_rate"
-    ],
+    "aliases": ["busd_binance_funding_rate"],
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1642,9 +1475,7 @@
     "metric": "ftx_funding_rates",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1661,9 +1492,7 @@
     "metric": "bitfinex_funding_rates",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1680,9 +1509,7 @@
     "metric": "dydx_funding_rates",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1699,9 +1526,7 @@
     "metric": "deribit_funding_rates",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1716,14 +1541,10 @@
     "human_readable_name": "Binance USDT Exchange Open Interest",
     "name": "usdt_bnb_open_interest",
     "metric": "usdt_bnb_open_interest",
-    "aliases": [
-      "usdt_binance_open_interest"
-    ],
+    "aliases": ["usdt_binance_open_interest"],
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1738,14 +1559,10 @@
     "human_readable_name": "Binance USDT Exchange Open Value",
     "name": "usdt_bnb_open_value",
     "metric": "usdt_bnb_open_value",
-    "aliases": [
-      "usdt_binance_open_value"
-    ],
+    "aliases": ["usdt_binance_open_value"],
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1760,14 +1577,10 @@
     "human_readable_name": "Binance BUSD Exchange Open Interest",
     "name": "busd_bnb_open_interest",
     "metric": "busd_bnb_open_interest",
-    "aliases": [
-      "busd_binance_open_interest"
-    ],
+    "aliases": ["busd_binance_open_interest"],
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1782,14 +1595,10 @@
     "human_readable_name": "Binance BUSD Exchange Open Value",
     "name": "busd_bnb_open_value",
     "metric": "busd_bnb_open_value",
-    "aliases": [
-      "busd_binance_open_value"
-    ],
+    "aliases": ["busd_binance_open_value"],
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1806,9 +1615,7 @@
     "metric": "huobi_funding_rates",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1825,9 +1632,7 @@
     "metric": "ftx_open_interest",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1844,9 +1649,7 @@
     "metric": "transaction_volume_profit",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -1863,9 +1666,7 @@
     "metric": "transaction_volume_loss",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -1882,9 +1683,7 @@
     "metric": "transaction_volume_profit_loss_ratio",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -1901,9 +1700,7 @@
     "metric": "spent_coins_age_band_0d_to_1d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1920,9 +1717,7 @@
     "metric": "spent_coins_age_band_1d_to_7d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -1939,9 +1734,7 @@
     "metric": "spent_coins_age_band_7d_to_30d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -1958,9 +1751,7 @@
     "metric": "spent_coins_age_band_30d_to_60d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -1977,9 +1768,7 @@
     "metric": "spent_coins_age_band_60d_to_90d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -1996,9 +1785,7 @@
     "metric": "spent_coins_age_band_90d_to_180d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2015,9 +1802,7 @@
     "metric": "spent_coins_age_band_180d_to_365d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2034,9 +1819,7 @@
     "metric": "spent_coins_age_band_365d_to_2y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2053,9 +1836,7 @@
     "metric": "spent_coins_age_band_2y_to_3y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2072,9 +1853,7 @@
     "metric": "spent_coins_age_band_3y_to_5y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2091,9 +1870,7 @@
     "metric": "spent_coins_age_band_5y_to_7y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2110,9 +1887,7 @@
     "metric": "spent_coins_age_band_7y_to_10y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2129,9 +1904,7 @@
     "metric": "spent_coins_age_band_10y_to_inf",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2148,9 +1921,7 @@
     "metric": "percent_of_spent_coins_age_band_0d_to_1d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -2167,9 +1938,7 @@
     "metric": "percent_of_spent_coins_age_band_1d_to_7d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2186,9 +1955,7 @@
     "metric": "percent_of_spent_coins_age_band_7d_to_30d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2205,9 +1972,7 @@
     "metric": "percent_of_spent_coins_age_band_30d_to_60d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2224,9 +1989,7 @@
     "metric": "percent_of_spent_coins_age_band_60d_to_90d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2243,9 +2006,7 @@
     "metric": "percent_of_spent_coins_age_band_90d_to_180d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2262,9 +2023,7 @@
     "metric": "percent_of_spent_coins_age_band_180d_to_365d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2281,9 +2040,7 @@
     "metric": "percent_of_spent_coins_age_band_365d_to_2y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2300,9 +2057,7 @@
     "metric": "percent_of_spent_coins_age_band_2y_to_3y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2319,9 +2074,7 @@
     "metric": "percent_of_spent_coins_age_band_3y_to_5y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2338,9 +2091,7 @@
     "metric": "percent_of_spent_coins_age_band_5y_to_7y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2357,9 +2108,7 @@
     "metric": "percent_of_spent_coins_age_band_7y_to_10y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2376,9 +2125,7 @@
     "metric": "percent_of_spent_coins_age_band_10y_to_inf",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2395,9 +2142,7 @@
     "metric": "realized_cap_hodl_waves_0d_to_1d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -2414,9 +2159,7 @@
     "metric": "realized_cap_hodl_waves_1d_to_7d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2433,9 +2176,7 @@
     "metric": "realized_cap_hodl_waves_7d_to_30d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2452,9 +2193,7 @@
     "metric": "realized_cap_hodl_waves_30d_to_60d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2471,9 +2210,7 @@
     "metric": "realized_cap_hodl_waves_60d_to_90d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2490,9 +2227,7 @@
     "metric": "realized_cap_hodl_waves_90d_to_180d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2509,9 +2244,7 @@
     "metric": "realized_cap_hodl_waves_180d_to_365d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2528,9 +2261,7 @@
     "metric": "realized_cap_hodl_waves_365d_to_2y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2547,9 +2278,7 @@
     "metric": "realized_cap_hodl_waves_2y_to_3y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2566,9 +2295,7 @@
     "metric": "realized_cap_hodl_waves_3y_to_5y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2585,9 +2312,7 @@
     "metric": "realized_cap_hodl_waves_5y_to_10y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2604,9 +2329,7 @@
     "metric": "realized_cap_hodl_waves_10y_to_20y",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -2890,22 +2613,21 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Mean Age in days for the past {{timebound_human_readable}}",
+    "human_readable_name": "Mean Age in days for the past {{timebound:human_readable}}",
     "name": "mean_age_{{timebound}}",
     "metric": "stack_mean_age_days_{{timebound}}",
-    "timebound": [
-      "90d",
-      "180d",
-      "365d",
-      "2y",
-      "3y",
-      "5y"
+    "parameters": [
+      { "timebound": "90d" },
+      { "timebound": "180d" },
+      { "timebound": "365d" },
+      { "timebound": "2y" },
+      { "timebound": "3y" },
+      { "timebound": "5y" }
     ],
+    "is_timebound": true,
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -2918,22 +2640,21 @@
     "unit": "days"
   },
   {
-    "human_readable_name": "Mean Dollar Invested Age in days for the past {{timebound_human_readable}}",
+    "human_readable_name": "Mean Dollar Invested Age in days for the past {{timebound:human_readable}}",
     "name": "mean_dollar_invested_age_{{timebound}}",
     "metric": "stack_mean_age_dollar_days_{{timebound}}",
-    "timebound": [
-      "90d",
-      "180d",
-      "365d",
-      "2y",
-      "3y",
-      "5y"
+    "parameters": [
+      { "timebound": "90d" },
+      { "timebound": "180d" },
+      { "timebound": "365d" },
+      { "timebound": "2y" },
+      { "timebound": "3y" },
+      { "timebound": "5y" }
     ],
+    "is_timebound": true,
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"

--- a/lib/sanbase/clickhouse/metric/metric_files/change_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/change_metrics.json
@@ -1,12 +1,15 @@
 [
   {
-    "human_readable_name": "Trading Volume Change (1d)",
-    "name": "volume_usd_change_1d",
-    "metric": "trading_volume_change_1d",
+    "human_readable_name": "Trading Volume Change ({{interval}})",
+    "name": "volume_usd_change_{{interval}}",
+    "metric": "trading_volume_change_{{interval}}",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -19,13 +22,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Trading Volume Change (7d)",
-    "name": "volume_usd_change_7d",
-    "metric": "trading_volume_change_7d",
+    "human_readable_name": "Price in USD Change ({{interval}})",
+    "name": "price_usd_change_{{interval}}",
+    "metric": "price_change_{{interval}}",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -38,13 +44,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Trading Volume Change (30d)",
-    "name": "volume_usd_change_30d",
-    "metric": "trading_volume_change_30d",
+    "human_readable_name": "Active Addresses For The Last 24h Change ({{interval}})",
+    "name": "active_addresses_24h_change_{{interval}}",
+    "metric": "active_addresses_24h_change_{{interval}}",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -57,128 +66,13 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Price in USD Change (1d)",
-    "name": "price_usd_change_1d",
-    "metric": "price_change_1d",
+    "human_readable_name": "30 Days Moving Average Of Development Activity Change ({{interval}})",
+    "name": "30d_moving_avg_dev_activity_change_{{interval}}",
+    "metric": "30_day_moving_avg_dev_activity_change_{{interval}}",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Price in USD Change (7d)",
-    "name": "price_usd_change_7d",
-    "metric": "price_change_7d",
-    "version": "2019-01-01",
-    "access": "free",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Price in USD Change (30d)",
-    "name": "price_usd_change_30d",
-    "metric": "price_change_30d",
-    "version": "2019-01-01",
-    "access": "free",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Active Addresses For The Last 24h Change (1d)",
-    "name": "active_addresses_24h_change_1d",
-    "metric": "active_addresses_24h_change_1d",
-    "version": "2019-01-01",
-    "access": "free",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Active Addresses For The Last 24h Change (7d)",
-    "name": "active_addresses_24h_change_7d",
-    "metric": "active_addresses_24h_change_7d",
-    "version": "2019-01-01",
-    "access": "free",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Active Addresses For The Last 24h Change (30d)",
-    "name": "active_addresses_24h_change_30d",
-    "metric": "active_addresses_24h_change_30d",
-    "version": "2019-01-01",
-    "access": "free",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "30 Days Moving Average Of Development Activity 1 Day Change",
-    "name": "30d_moving_avg_dev_activity_change_1d",
-    "metric": "30_day_moving_avg_dev_activity_change_1d",
-    "version": "2019-01-01",
-    "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
+    "parameters": [{ "interval": "1d" }],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -190,13 +84,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Development activity Change (1d)",
-    "name": "dev_activity_change_1d",
-    "metric": "dev_activity_change_1d",
+    "human_readable_name": "Development activity Change ({{interval}})",
+    "name": "dev_activity_change_{{interval}}",
+    "metric": "dev_activity_change_{{interval}}",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -208,52 +105,18 @@
     "has_incomplete_data": true,
     "data_type": "timeseries"
   },
+
   {
-    "human_readable_name": "Development activity Change (7d)",
-    "name": "dev_activity_change_7d",
-    "metric": "dev_activity_change_7d",
+    "human_readable_name": "Market Capitalization Change ({{interval}})",
+    "name": "marketcap_usd_change_{{interval}}",
+    "metric": "marketcap_usd_change_{{interval}}",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": true,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Development activity Change (30d)",
-    "name": "dev_activity_change_30d",
-    "metric": "dev_activity_change_30d",
-    "version": "2019-01-01",
-    "access": "free",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": true,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Market Capitalization Change (1d)",
-    "name": "marketcap_usd_change_1d",
-    "metric": "marketcap_usd_change_1d",
-    "version": "2019-01-01",
-    "access": "free",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -266,51 +129,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Market Capitalization Change (7d)",
-    "name": "marketcap_usd_change_7d",
-    "metric": "marketcap_usd_change_7d",
-    "version": "2019-01-01",
-    "access": "free",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Market Capitalization Change (30d)",
-    "name": "marketcap_usd_change_30d",
-    "metric": "marketcap_usd_change_30d",
-    "version": "2019-01-01",
-    "access": "free",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Network Growth Change (1d)",
-    "name": "network_growth_change_1d",
-    "metric": "network_growth_change_1d",
+    "human_readable_name": "Network Growth Change ({{interval}})",
+    "name": "network_growth_change_{{interval}}",
+    "metric": "network_growth_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -323,51 +151,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Network Growth Change (7d)",
-    "name": "network_growth_change_7d",
-    "metric": "network_growth_change_7d",
+    "human_readable_name": "Exchange Inflow Change ({{interval}})",
+    "name": "exchange_inflow_change_{{interval}}",
+    "metric": "exchange_inflow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Network Growth Change (30d)",
-    "name": "network_growth_change_30d",
-    "metric": "network_growth_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Exchange Inflow Change (1d)",
-    "name": "exchange_inflow_change_1d",
-    "metric": "exchange_inflow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -380,13 +173,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Exchange Inflow Change (7d)",
-    "name": "exchange_inflow_change_7d",
-    "metric": "exchange_inflow_change_7d",
+    "human_readable_name": "Exchange Outflow Change ({{interval}})",
+    "name": "exchange_outflow_change_{{interval}}",
+    "metric": "exchange_outflow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -399,13 +195,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Exchange Inflow Change (30d)",
-    "name": "exchange_inflow_change_30d",
-    "metric": "exchange_inflow_change_30d",
+    "human_readable_name": "Exchange Balance (Inflow - Outflow) Change ({{interval}})",
+    "name": "exchange_balance_change_{{interval}}",
+    "metric": "exchange_balance_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -418,127 +217,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Exchange Outflow Change (1d)",
-    "name": "exchange_outflow_change_1d",
-    "metric": "exchange_outflow_change_1d",
+    "human_readable_name": "On-Chain Transaction Volume Change ({{interval}})",
+    "name": "transaction_volume_change_{{interval}}",
+    "metric": "transaction_volume_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Exchange Outflow Change (7d)",
-    "name": "exchange_outflow_change_7d",
-    "metric": "exchange_outflow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Exchange Outflow Change (30d)",
-    "name": "exchange_outflow_change_30d",
-    "metric": "exchange_outflow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Exchange Balance (Inflow - Outflow) Change (1d)",
-    "name": "exchange_balance_change_1d",
-    "metric": "exchange_balance_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Exchange Balance (Inflow - Outflow) Change (7d)",
-    "name": "exchange_balance_change_7d",
-    "metric": "exchange_balance_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Exchange Balance (Inflow - Outflow) Change (30d)",
-    "name": "exchange_balance_change_30d",
-    "metric": "exchange_balance_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "On-Chain Transaction Volume Change (1d)",
-    "name": "transaction_volume_change_1d",
-    "metric": "transaction_volume_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -551,13 +239,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "On-Chain Transaction Volume Change (7d)",
-    "name": "transaction_volume_change_7d",
-    "metric": "transaction_volume_change_7d",
+    "human_readable_name": "On-Chain Transaction Volume in USD Change ({{interval}})",
+    "name": "transaction_volume_usd_change_{{interval}}",
+    "metric": "transaction_volume_usd_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -570,13 +261,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "On-Chain Transaction Volume Change (30d)",
-    "name": "transaction_volume_change_30d",
-    "metric": "transaction_volume_change_30d",
+    "human_readable_name": "Circulation for coins that have not moved in the past 1 year Change ({{interval}})",
+    "name": "dormant_circulation_365d_change_{{interval}}",
+    "metric": "dormant_circulation_365d_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -588,14 +282,18 @@
     "has_incomplete_data": false,
     "data_type": "timeseries"
   },
+
   {
-    "human_readable_name": "On-Chain Transaction Volume in USD Change (1d)",
-    "name": "transaction_volume_usd_change_1d",
-    "metric": "transaction_volume_usd_change_1d",
+    "human_readable_name": "Circulation for coins that moved in the past 180 days Change ({{interval}})",
+    "name": "circulation_180d_change_{{interval}}",
+    "metric": "stack_circulation_180d_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -607,14 +305,18 @@
     "has_incomplete_data": false,
     "data_type": "timeseries"
   },
+
   {
-    "human_readable_name": "On-Chain Transaction Volume in USD Change (7d)",
-    "name": "transaction_volume_usd_change_7d",
-    "metric": "transaction_volume_usd_change_7d",
+    "human_readable_name": "Circulation Change ({{interval}})",
+    "name": "circulation_change_{{interval}}",
+    "metric": "stack_circulation_20y_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -626,204 +328,18 @@
     "has_incomplete_data": false,
     "data_type": "timeseries"
   },
+
   {
-    "human_readable_name": "On-Chain Transaction Volume in USD Change (30d)",
-    "name": "transaction_volume_usd_change_30d",
-    "metric": "transaction_volume_usd_change_30d",
+    "human_readable_name": "Bitmex Perpetual Funding Rate Change ({{interval}})",
+    "name": "bitmex_perpetual_funding_rate_change_{{interval}}",
+    "metric": "bitmex_perpetual_funding_rate_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Circulation for coins that have not moved in the past 1 year Change (1d)",
-    "name": "dormant_circulation_365d_change_1d",
-    "metric": "dormant_circulation_365d_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Circulation for coins that have not moved in the past 1 year Change (7d)",
-    "name": "dormant_circulation_365d_change_7d",
-    "metric": "dormant_circulation_365d_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Circulation for coins that have not moved in the past 1 year Change (30d)",
-    "name": "dormant_circulation_365d_change_30d",
-    "metric": "dormant_circulation_365d_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Circulation for coins that moved in the past 180 days Change (1d)",
-    "name": "circulation_180d_change_1d",
-    "metric": "stack_circulation_180d_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Circulation for coins that moved in the past 180 days Change (7d)",
-    "name": "circulation_180d_change_7d",
-    "metric": "stack_circulation_180d_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Circulation for coins that moved in the past 180 days Change (30d)",
-    "name": "circulation_180d_change_30d",
-    "metric": "stack_circulation_180d_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Circulation Change (1d)",
-    "name": "circulation_change_1d",
-    "metric": "stack_circulation_20y_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Circulation Change (7d)",
-    "name": "circulation_change_7d",
-    "metric": "stack_circulation_20y_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Circulation Change (30d)",
-    "name": "circulation_change_30d",
-    "metric": "stack_circulation_20y_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Bitmex Perpetual Funding Rate Change (1d)",
-    "name": "bitmex_perpetual_funding_rate_change_1d",
-    "metric": "bitmex_perpetual_funding_rate_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -835,52 +351,87 @@
     "has_incomplete_data": false,
     "data_type": "timeseries"
   },
+
   {
-    "human_readable_name": "Bitmex Perpetual Funding Rate Change (7d)",
-    "name": "bitmex_perpetual_funding_rate_change_7d",
-    "metric": "bitmex_perpetual_funding_rate_change_7d",
+    "human_readable_name": "MVRV for coins that moved in the past 7 days Change ({{interval}})",
+    "name": "mvrv_usd_7d_change_{{interval}}",
+    "metric": "mvrv_usd_7d_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "last",
-    "min_interval": "8h",
+    "min_interval": "1d",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries"
   },
+
   {
-    "human_readable_name": "Bitmex Perpetual Funding Rate Change (30d)",
-    "name": "bitmex_perpetual_funding_rate_change_30d",
-    "metric": "bitmex_perpetual_funding_rate_change_30d",
+    "human_readable_name": "MVRV for coins that moved in the past 60 days Change ({{interval}})",
+    "name": "mvrv_usd_60d_change_{{interval}}",
+    "metric": "mvrv_usd_60d_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
     },
     "aggregation": "last",
-    "min_interval": "8h",
+    "min_interval": "1d",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries"
   },
+
   {
-    "human_readable_name": "MVRV for coins that moved in the past 7 days Change (1d)",
-    "name": "mvrv_usd_7d_change_1d",
-    "metric": "mvrv_usd_7d_change_1d",
+    "human_readable_name": "MVRV for coins that moved in the past 90 days Change ({{interval}})",
+    "name": "mvrv_usd_90d_change_{{interval}}",
+    "metric": "mvrv_usd_90d_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
+    ],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+
+  {
+    "human_readable_name": "MVRV for coins that moved in the past 30 days Change ({{interval}})",
+    "name": "mvrv_usd_30d_change_{{interval}}",
+    "metric": "mvrv_usd_30d_change_{{interval}}",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -893,13 +444,39 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "MVRV for coins that moved in the past 7 days Change (7d)",
-    "name": "mvrv_usd_7d_change_7d",
-    "metric": "mvrv_usd_7d_change_7d",
+    "human_readable_name": "MVRV for coins that moved in the past 180 days Change ({{interval}})",
+    "name": "mvrv_usd_180d_change_{{interval}}",
+    "metric": "mvrv_usd_180d_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
+    ],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "1d",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+
+  {
+    "human_readable_name": "MVRV for coins that moved in the past 1 year Change ({{interval}})",
+    "name": "mvrv_usd_365d_change_{{interval}}",
+    "metric": "mvrv_usd_365d_change_{{interval}}",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -912,13 +489,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "MVRV for coins that moved in the past 7 days Change (30d)",
-    "name": "mvrv_usd_7d_change_30d",
-    "metric": "mvrv_usd_7d_change_30d",
+    "human_readable_name": "MVRV Change ({{interval}})",
+    "name": "mvrv_usd_change_{{interval}}",
+    "metric": "mvrv_usd_20y_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -931,13 +511,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "MVRV for coins that moved in the past 60 days Change (1d)",
-    "name": "mvrv_usd_60d_change_1d",
-    "metric": "mvrv_usd_60d_change_1d",
+    "human_readable_name": "Mean Dollar Invested Age in days for coins that moved Change ({{interval}})",
+    "name": "mean_dollar_invested_age_change_{{interval}}",
+    "metric": "stack_mean_age_dollar_days_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -950,397 +533,18 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "MVRV for coins that moved in the past 60 days Change (7d)",
-    "name": "mvrv_usd_60d_change_7d",
-    "metric": "mvrv_usd_60d_change_7d",
+    "human_readable_name": "Age Consumed Change ({{interval}})",
+    "name": "age_destroyed_change_{{interval}}",
+    "metric": "stack_age_consumed_5min_chang{{interval}}1d",
+    "aliases": ["age_consumed_change_{{interval}}"],
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "MVRV for coins that moved in the past 60 days Change (30d)",
-    "name": "mvrv_usd_60d_change_30d",
-    "metric": "mvrv_usd_60d_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "MVRV for coins that moved in the past 90 days Change (1d)",
-    "name": "mvrv_usd_90d_change_1d",
-    "metric": "mvrv_usd_90d_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "MVRV for coins that moved in the past 90 days Change (7d)",
-    "name": "mvrv_usd_90d_change_7d",
-    "metric": "mvrv_usd_90d_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "MVRV for coins that moved in the past 90 days Change (30d)",
-    "name": "mvrv_usd_90d_change_30d",
-    "metric": "mvrv_usd_90d_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "MVRV for coins that moved in the past 30 days Change (1d)",
-    "name": "mvrv_usd_30d_change_1d",
-    "metric": "mvrv_usd_30d_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "MVRV for coins that moved in the past 30 days Change (7d)",
-    "name": "mvrv_usd_30d_change_7d",
-    "metric": "mvrv_usd_30d_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "MVRV for coins that moved in the past 30 days Change (30d)",
-    "name": "mvrv_usd_30d_change_30d",
-    "metric": "mvrv_usd_30d_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "MVRV for coins that moved in the past 180 days Change (1d)",
-    "name": "mvrv_usd_180d_change_1d",
-    "metric": "mvrv_usd_180d_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "MVRV for coins that moved in the past 180 days Change (7d)",
-    "name": "mvrv_usd_180d_change_7d",
-    "metric": "mvrv_usd_180d_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "MVRV for coins that moved in the past 180 days Change (30d)",
-    "name": "mvrv_usd_180d_change_30d",
-    "metric": "mvrv_usd_180d_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "MVRV for coins that moved in the past 1 year Change (1d)",
-    "name": "mvrv_usd_365d_change_1d",
-    "metric": "mvrv_usd_365d_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "MVRV for coins that moved in the past 1 year Change (7d)",
-    "name": "mvrv_usd_365d_change_7d",
-    "metric": "mvrv_usd_365d_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "MVRV for coins that moved in the past 1 year Change (30d)",
-    "name": "mvrv_usd_365d_change_30d",
-    "metric": "mvrv_usd_365d_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "MVRV Change (1d)",
-    "name": "mvrv_usd_change_1d",
-    "metric": "mvrv_usd_20y_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "MVRV Change (7d)",
-    "name": "mvrv_usd_change_7d",
-    "metric": "mvrv_usd_20y_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "MVRV Change (30d)",
-    "name": "mvrv_usd_change_30d",
-    "metric": "mvrv_usd_20y_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Mean Dollar Invested Age in days for coins that moved Change (1d)",
-    "name": "mean_dollar_invested_age_change_1d",
-    "metric": "stack_mean_age_dollar_days_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Mean Dollar Invested Age in days for coins that moved Change (7d)",
-    "name": "mean_dollar_invested_age_change_7d",
-    "metric": "stack_mean_age_dollar_days_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Mean Dollar Invested Age in days for coins that moved Change (30d)",
-    "name": "mean_dollar_invested_age_change_30d",
-    "metric": "stack_mean_age_dollar_days_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Age Consumed Change (1d)",
-    "name": "age_destroyed_change_1d",
-    "metric": "stack_age_consumed_5min_change_1d",
-    "aliases": [
-      "age_consumed_change_1d"
-    ],
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1352,95 +556,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Age Consumed Change (7d)",
-    "name": "age_destroyed_change_7d",
-    "metric": "stack_age_consumed_5min_change_7d",
-    "aliases": [
-      "age_consumed_change_7d"
-    ],
+    "human_readable_name": "Percent Of Total Supply On Exchanges Change ({{interval}})",
+    "name": "percent_of_total_supply_on_exchanges_change_{{interval}}",
+    "metric": "percent_of_total_supply_on_exchanges_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Age Consumed Change (30d)",
-    "name": "age_destroyed_change_30d",
-    "metric": "stack_age_consumed_5min_change_30d",
-    "aliases": [
-      "age_consumed_change_30d"
-    ],
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Percent Of Total Supply On Exchanges Change (1d)",
-    "name": "percent_of_total_supply_on_exchanges_change_1d",
-    "metric": "percent_of_total_supply_on_exchanges_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Percent Of Total Supply On Exchanges Change (7d)",
-    "name": "percent_of_total_supply_on_exchanges_change_7d",
-    "metric": "percent_of_total_supply_on_exchanges_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Percent Of Total Supply On Exchanges Change (30d)",
-    "name": "percent_of_total_supply_on_exchanges_change_30d",
-    "metric": "percent_of_total_supply_on_exchanges_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -1458,9 +583,7 @@
     "metric": "stack_circulation_usd_180d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1472,51 +595,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Circulation for coins that moved in the past 180 days in USD Change (1d)",
-    "name": "circulation_usd_180d_change_1d",
-    "metric": "stack_circulation_usd_180d_change_1d",
+    "human_readable_name": "Circulation for coins that moved in the past 180 days in USD Change ({{interval}})",
+    "name": "circulation_usd_180d_change_{{interval}}",
+    "metric": "stack_circulation_usd_180d_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": true,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Circulation for coins that moved in the past 180 days in USD Change (7d)",
-    "name": "circulation_usd_180d_change_7d",
-    "metric": "stack_circulation_usd_180d_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": true,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Circulation for coins that moved in the past 180 days in USD Change (30d)",
-    "name": "circulation_usd_180d_change_30d",
-    "metric": "stack_circulation_usd_180d_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -1534,9 +622,7 @@
     "metric": "dormant_circulation_usd_180d",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1548,51 +634,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Circulation for coins that have not moved in the past 180 days in USD Change (1d)",
-    "name": "dormant_circulation_usd_180d_change_1d",
-    "metric": "dormant_circulation_usd_180d_change_1d",
+    "human_readable_name": "Circulation for coins that have not moved in the past 180 days in USD Change ({{interval}})",
+    "name": "dormant_circulation_usd_180d_change_{{interval}}",
+    "metric": "dormant_circulation_usd_180d_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": true,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Circulation for coins that have not moved in the past 180 days in USD Change (7d)",
-    "name": "dormant_circulation_usd_180d_change_7d",
-    "metric": "dormant_circulation_usd_180d_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": true,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Circulation for coins that have not moved in the past 180 days in USD Change (30d)",
-    "name": "dormant_circulation_usd_180d_change_30d",
-    "metric": "dormant_circulation_usd_180d_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -1610,9 +661,7 @@
     "metric": "exchange_inflow_usd",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1624,51 +673,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Exchange Inflow in USD Change (1d)",
-    "name": "exchange_inflow_usd_change_1d",
-    "metric": "exchange_inflow_usd_change_1d",
+    "human_readable_name": "Exchange Inflow in USD Change ({{interval}})",
+    "name": "exchange_inflow_usd_change_{{interval}}",
+    "metric": "exchange_inflow_usd_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Exchange Inflow in USD Change (7d)",
-    "name": "exchange_inflow_usd_change_7d",
-    "metric": "exchange_inflow_usd_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Exchange Inflow in USD Change (30d)",
-    "name": "exchange_inflow_usd_change_30d",
-    "metric": "exchange_inflow_usd_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -1686,9 +700,7 @@
     "metric": "exchange_outflow_usd",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1700,13 +712,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Exchange Outflow in USD Change (1d)",
-    "name": "exchange_outflow_usd_change_1d",
-    "metric": "exchange_outflow_usd_change_1d",
+    "human_readable_name": "Exchange Outflow in USD Change ({{interval}})",
+    "name": "exchange_outflow_usd_change_{{interval}}",
+    "metric": "exchange_outflow_usd_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -1719,13 +734,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Exchange Outflow in USD Change (7d)",
-    "name": "exchange_outflow_usd_change_7d",
-    "metric": "exchange_outflow_usd_change_7d",
+    "human_readable_name": "Social Volume Change ({{interval}})",
+    "name": "social_volume_total_change_{{interval}}",
+    "metric": "social_volume_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -1738,1383 +756,18 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Exchange Outflow in USD Change (30d)",
-    "name": "exchange_outflow_usd_change_30d",
-    "metric": "exchange_outflow_usd_change_30d",
+    "human_readable_name": "DEX Traders to DEXes Flow Change ({{interval}})",
+    "name": "dex_traders_to_dexes_flow_change_{{interval}}",
+    "metric": "dex_traders_to_dexes_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Social Volume Change (1d)",
-    "name": "social_volume_total_change_1d",
-    "metric": "social_volume_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Social Volume Change (7d)",
-    "name": "social_volume_total_change_7d",
-    "metric": "social_volume_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Social Volume Change (30d)",
-    "name": "social_volume_total_change_30d",
-    "metric": "social_volume_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX Traders to DEXes Flow Change (1d)",
-    "name": "dex_traders_to_dexes_flow_change_1d",
-    "metric": "dex_traders_to_dexes_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX Traders to DEXes Flow Change (7d)",
-    "name": "dex_traders_to_dexes_flow_change_7d",
-    "metric": "dex_traders_to_dexes_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX Traders to DEXes Flow Change (30d)",
-    "name": "dex_traders_to_dexes_flow_change_30d",
-    "metric": "dex_traders_to_dexes_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX Traders to CEXes Flow Change (1d)",
-    "name": "dex_traders_to_cexes_flow_change_1d",
-    "metric": "dex_traders_to_cexes_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX Traders to CEXes Flow Change (7d)",
-    "name": "dex_traders_to_cexes_flow_change_7d",
-    "metric": "dex_traders_to_cexes_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX Traders to CEXes Flow Change (30d)",
-    "name": "dex_traders_to_cexes_flow_change_30d",
-    "metric": "dex_traders_to_cexes_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX Traders to DeFi Flow Change (1d)",
-    "name": "dex_traders_to_defi_flow_change_1d",
-    "metric": "dex_traders_to_defi_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX Traders to DeFi Flow Change (7d)",
-    "name": "dex_traders_to_defi_flow_change_7d",
-    "metric": "dex_traders_to_defi_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX Traders to DeFi Flow Change (30d)",
-    "name": "dex_traders_to_defi_flow_change_30d",
-    "metric": "dex_traders_to_defi_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX Traders to Whale Flow Change (1d)",
-    "name": "dex_traders_to_whale_flow_change_1d",
-    "metric": "dex_traders_to_whale_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX Traders to Whale Flow Change (7d)",
-    "name": "dex_traders_to_whale_flow_change_7d",
-    "metric": "dex_traders_to_whale_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX Traders to Whale Flow Change (30d)",
-    "name": "dex_traders_to_whale_flow_change_30d",
-    "metric": "dex_traders_to_whale_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX Traders to Other Flow Change (1d)",
-    "name": "dex_traders_to_other_flow_change_1d",
-    "metric": "dex_traders_to_other_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX Traders to Other Flow Change (7d)",
-    "name": "dex_traders_to_other_flow_change_7d",
-    "metric": "dex_traders_to_other_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX Traders to Other Flow Change (30d)",
-    "name": "dex_traders_to_other_flow_change_30d",
-    "metric": "dex_traders_to_other_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEXes to DEX Traders Flow Change (1d)",
-    "name": "dexes_to_dex_traders_flow_change_1d",
-    "metric": "dexes_to_dex_traders_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEXes to DEX Traders Flow Change (7d)",
-    "name": "dexes_to_dex_traders_flow_change_7d",
-    "metric": "dexes_to_dex_traders_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEXes to DEX Traders Flow Change (30d)",
-    "name": "dexes_to_dex_traders_flow_change_30d",
-    "metric": "dexes_to_dex_traders_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX to CEXes Flow Change (1d)",
-    "name": "dex_to_cexes_flow_change_1d",
-    "metric": "dex_to_cexes_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX to CEXes Flow Change (7d)",
-    "name": "dex_to_cexes_flow_change_7d",
-    "metric": "dex_to_cexes_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEX to CEXes Flow Change (30d)",
-    "name": "dex_to_cexes_flow_change_30d",
-    "metric": "dex_to_cexes_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEXes to DeFi Flow Change (1d)",
-    "name": "dexes_to_defi_flow_change_1d",
-    "metric": "dexes_to_defi_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEXes to DeFi Flow Change (7d)",
-    "name": "dexes_to_defi_flow_change_7d",
-    "metric": "dexes_to_defi_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEXes to DeFi Flow Change (30d)",
-    "name": "dexes_to_defi_flow_change_30d",
-    "metric": "dexes_to_defi_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEXes to Whale Flow Change (1d)",
-    "name": "dexes_to_whale_flow_change_1d",
-    "metric": "dexes_to_whale_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEXes to Whale Flow Change (7d)",
-    "name": "dexes_to_whale_flow_change_7d",
-    "metric": "dexes_to_whale_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEXes to Whale Flow Change (30d)",
-    "name": "dexes_to_whale_flow_change_30d",
-    "metric": "dexes_to_whale_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEXes to Other Flow Change (1d)",
-    "name": "dexes_to_other_flow_change_1d",
-    "metric": "dexes_to_other_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEXes to Other Flow Change (7d)",
-    "name": "dexes_to_other_flow_change_7d",
-    "metric": "dexes_to_other_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DEXes to Other Flow Change (30d)",
-    "name": "dexes_to_other_flow_change_30d",
-    "metric": "dexes_to_other_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "CEXes to DEX Traders Flow Change (1d)",
-    "name": "cexes_to_dex_traders_flow_change_1d",
-    "metric": "cexes_to_dex_traders_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "CEXes to DEX Traders Flow Change (7d)",
-    "name": "cexes_to_dex_traders_flow_change_7d",
-    "metric": "cexes_to_dex_traders_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "CEXes to DEX Traders Flow Change (30d)",
-    "name": "cexes_to_dex_traders_flow_change_30d",
-    "metric": "cexes_to_dex_traders_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "CEXes to DEX Flow Change (1d)",
-    "name": "cexes_to_dex_flow_change_1d",
-    "metric": "cexes_to_dex_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "CEXes to DEX Flow Change (7d)",
-    "name": "cexes_to_dex_flow_change_7d",
-    "metric": "cexes_to_dex_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "CEXes to DEX Flow Change (30d)",
-    "name": "cexes_to_dex_flow_change_30d",
-    "metric": "cexes_to_dex_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "CEXes to DeFi Flow Change (1d)",
-    "name": "cexes_to_defi_flow_change_1d",
-    "metric": "cexes_to_defi_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "CEXes to DeFi Flow Change (7d)",
-    "name": "cexes_to_defi_flow_change_7d",
-    "metric": "cexes_to_defi_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "CEXes to DeFi Flow Change (30d)",
-    "name": "cexes_to_defi_flow_change_30d",
-    "metric": "cexes_to_defi_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "CEXes to Whale Flow Change (1d)",
-    "name": "cexes_to_whale_flow_change_1d",
-    "metric": "cexes_to_whale_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "CEXes to Whale Flow Change (7d)",
-    "name": "cexes_to_whale_flow_change_7d",
-    "metric": "cexes_to_whale_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "CEXes to Whale Flow Change (30d)",
-    "name": "cexes_to_whale_flow_change_30d",
-    "metric": "cexes_to_whale_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "CEXes to Other Flow Change (1d)",
-    "name": "cexes_to_other_flow_change_1d",
-    "metric": "cexes_to_other_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "CEXes to Other Flow Change (7d)",
-    "name": "cexes_to_other_flow_change_7d",
-    "metric": "cexes_to_other_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "CEXes to Other Flow Change (30d)",
-    "name": "cexes_to_other_flow_change_30d",
-    "metric": "cexes_to_other_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DeFi to DEX Traders Flow Change (1d)",
-    "name": "defi_to_dex_traders_flow_change_1d",
-    "metric": "defi_to_dex_traders_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DeFi to DEX Traders Flow Change (7d)",
-    "name": "defi_to_dex_traders_flow_change_7d",
-    "metric": "defi_to_dex_traders_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DeFi to DEX Traders Flow Change (30d)",
-    "name": "defi_to_dex_traders_flow_change_30d",
-    "metric": "defi_to_dex_traders_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DeFi to DEXes Flow Change (1d)",
-    "name": "defi_to_dexes_flow_change_1d",
-    "metric": "defi_to_dexes_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DeFi to DEXes Flow Change (7d)",
-    "name": "defi_to_dexes_flow_change_7d",
-    "metric": "defi_to_dexes_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DeFi to DEXes Flow Change (30d)",
-    "name": "defi_to_dexes_flow_change_30d",
-    "metric": "defi_to_dexes_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DeFi to CEXes Flow Change (1d)",
-    "name": "defi_to_cexes_flow_change_1d",
-    "metric": "defi_to_cexes_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DeFi to CEXes Flow Change (7d)",
-    "name": "defi_to_cexes_flow_change_7d",
-    "metric": "defi_to_cexes_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DeFi to CEXes Flow Change (30d)",
-    "name": "defi_to_cexes_flow_change_30d",
-    "metric": "defi_to_cexes_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DeFi to Whale Flow Change (1d)",
-    "name": "defi_to_whale_flow_change_1d",
-    "metric": "defi_to_whale_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DeFi to Whale Flow Change (7d)",
-    "name": "defi_to_whale_flow_change_7d",
-    "metric": "defi_to_whale_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DeFi to Whale Flow Change (30d)",
-    "name": "defi_to_whale_flow_change_30d",
-    "metric": "defi_to_whale_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DeFi to Other Flow Change (1d)",
-    "name": "defi_to_other_flow_change_1d",
-    "metric": "defi_to_other_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DeFi to Other Flow Change (7d)",
-    "name": "defi_to_other_flow_change_7d",
-    "metric": "defi_to_other_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "DeFi to Other Flow Change (30d)",
-    "name": "defi_to_other_flow_change_30d",
-    "metric": "defi_to_other_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Whale to DEX Traders Flow Change (1d)",
-    "name": "whale_to_dex_traders_flow_change_1d",
-    "metric": "whale_to_dex_traders_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Whale to DEX Traders Flow Change (7d)",
-    "name": "whale_to_dex_traders_flow_change_7d",
-    "metric": "whale_to_dex_traders_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Whale to DEX Traders Flow Change (30d)",
-    "name": "whale_to_dex_traders_flow_change_30d",
-    "metric": "whale_to_dex_traders_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Whale to DEXes Flow Change (1d)",
-    "name": "whale_to_dexes_flow_change_1d",
-    "metric": "whale_to_dexes_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Whale to DEXes Flow Change (7d)",
-    "name": "whale_to_dexes_flow_change_7d",
-    "metric": "whale_to_dexes_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Whale to DEXes Flow Change (30d)",
-    "name": "whale_to_dexes_flow_change_30d",
-    "metric": "whale_to_dexes_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Whale to CEXes Flow Change (1d)",
-    "name": "whale_to_cexes_flow_change_1d",
-    "metric": "whale_to_cexes_flow_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Whale to CEXes Flow Change (7d)",
-    "name": "whale_to_cexes_flow_change_7d",
-    "metric": "whale_to_cexes_flow_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Whale to CEXes Flow Change (30d)",
-    "name": "whale_to_cexes_flow_change_30d",
-    "metric": "whale_to_cexes_flow_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
     },
@@ -3125,13 +778,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Whale to DeFi Flow Change (1d)",
-    "name": "whale_to_defi_flow_change_1d",
-    "metric": "whale_to_defi_flow_change_1d",
+    "human_readable_name": "DEX Traders to CEXes Flow Change ({{interval}})",
+    "name": "dex_traders_to_cexes_flow_change_{{interval}}",
+    "metric": "dex_traders_to_cexes_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3144,13 +800,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Whale to DeFi Flow Change (7d)",
-    "name": "whale_to_defi_flow_change_7d",
-    "metric": "whale_to_defi_flow_change_7d",
+    "human_readable_name": "DEX Traders to DeFi Flow Change ({{interval}})",
+    "name": "dex_traders_to_defi_flow_change_{{interval}}",
+    "metric": "dex_traders_to_defi_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3163,13 +822,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Whale to DeFi Flow Change (30d)",
-    "name": "whale_to_defi_flow_change_30d",
-    "metric": "whale_to_defi_flow_change_30d",
+    "human_readable_name": "DEX Traders to Whale Flow Change ({{interval}})",
+    "name": "dex_traders_to_whale_flow_change_{{interval}}",
+    "metric": "dex_traders_to_whale_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3182,13 +844,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Whale to Other Flow Change (1d)",
-    "name": "whale_to_other_flow_change_1d",
-    "metric": "whale_to_other_flow_change_1d",
+    "human_readable_name": "DEX Traders to Other Flow Change ({{interval}})",
+    "name": "dex_traders_to_other_flow_change_{{interval}}",
+    "metric": "dex_traders_to_other_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3201,13 +866,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Whale to Other Flow Change (7d)",
-    "name": "whale_to_other_flow_change_7d",
-    "metric": "whale_to_other_flow_change_7d",
+    "human_readable_name": "DEXes to DEX Traders Flow Change ({{interval}})",
+    "name": "dexes_to_dex_traders_flow_change_{{interval}}",
+    "metric": "dexes_to_dex_traders_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3220,13 +888,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Whale to Other Flow Change (30d)",
-    "name": "whale_to_other_flow_change_30d",
-    "metric": "whale_to_other_flow_change_30d",
+    "human_readable_name": "DEX to CEXes Flow Change ({{interval}})",
+    "name": "dex_to_cexes_flow_change_{{interval}}",
+    "metric": "dex_to_cexes_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3239,13 +910,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to DEX Traders Flow Change (1d)",
-    "name": "other_to_dex_traders_flow_change_1d",
-    "metric": "other_to_dex_traders_flow_change_1d",
+    "human_readable_name": "DEXes to DeFi Flow Change ({{interval}})",
+    "name": "dexes_to_defi_flow_change_{{interval}}",
+    "metric": "dexes_to_defi_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3258,13 +932,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to DEX Traders Flow Change (7d)",
-    "name": "other_to_dex_traders_flow_change_7d",
-    "metric": "other_to_dex_traders_flow_change_7d",
+    "human_readable_name": "DEXes to Whale Flow Change ({{interval}})",
+    "name": "dexes_to_whale_flow_change_{{interval}}",
+    "metric": "dexes_to_whale_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3277,13 +954,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to DEX Traders Flow Change (30d)",
-    "name": "other_to_dex_traders_flow_change_30d",
-    "metric": "other_to_dex_traders_flow_change_30d",
+    "human_readable_name": "DEXes to Other Flow Change ({{interval}})",
+    "name": "dexes_to_other_flow_change_{{interval}}",
+    "metric": "dexes_to_other_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3296,13 +976,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to DEXes Flow Change (1d)",
-    "name": "other_to_dexes_flow_change_1d",
-    "metric": "other_to_dexes_flow_change_1d",
+    "human_readable_name": "CEXes to DEX Traders Flow Change ({{interval}})",
+    "name": "cexes_to_dex_traders_flow_change_{{interval}}",
+    "metric": "cexes_to_dex_traders_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3315,13 +998,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to DEXes Flow Change (7d)",
-    "name": "other_to_dexes_flow_change_7d",
-    "metric": "other_to_dexes_flow_change_7d",
+    "human_readable_name": "CEXes to DEX Flow Change ({{interval}})",
+    "name": "cexes_to_dex_flow_change_{{interval}}",
+    "metric": "cexes_to_dex_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3334,13 +1020,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to DEXes Flow Change (30d)",
-    "name": "other_to_dexes_flow_change_30d",
-    "metric": "other_to_dexes_flow_change_30d",
+    "human_readable_name": "CEXes to DeFi Flow Change ({{interval}})",
+    "name": "cexes_to_defi_flow_change_{{interval}}",
+    "metric": "cexes_to_defi_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3353,13 +1042,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to CEXes Flow Change (1d)",
-    "name": "other_to_cexes_flow_change_1d",
-    "metric": "other_to_cexes_flow_change_1d",
+    "human_readable_name": "CEXes to Whale Flow Change ({{interval}})",
+    "name": "cexes_to_whale_flow_change_{{interval}}",
+    "metric": "cexes_to_whale_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3372,13 +1064,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to CEXes Flow Change (7d)",
-    "name": "other_to_cexes_flow_change_7d",
-    "metric": "other_to_cexes_flow_change_7d",
+    "human_readable_name": "CEXes to Other Flow Change ({{interval}})",
+    "name": "cexes_to_other_flow_change_{{interval}}",
+    "metric": "cexes_to_other_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3391,13 +1086,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to CEXes Flow Change (30d)",
-    "name": "other_to_cexes_flow_change_30d",
-    "metric": "other_to_cexes_flow_change_30d",
+    "human_readable_name": "DeFi to DEX Traders Flow Change ({{interval}})",
+    "name": "defi_to_dex_traders_flow_change_{{interval}}",
+    "metric": "defi_to_dex_traders_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3410,13 +1108,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to DeFi Flow Change (1d)",
-    "name": "other_to_defi_flow_change_1d",
-    "metric": "other_to_defi_flow_change_1d",
+    "human_readable_name": "DeFi to DEXes Flow Change ({{interval}})",
+    "name": "defi_to_dexes_flow_change_{{interval}}",
+    "metric": "defi_to_dexes_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3429,13 +1130,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to DeFi Flow Change (7d)",
-    "name": "other_to_defi_flow_change_7d",
-    "metric": "other_to_defi_flow_change_7d",
+    "human_readable_name": "DeFi to CEXes Flow Change ({{interval}})",
+    "name": "defi_to_cexes_flow_change_{{interval}}",
+    "metric": "defi_to_cexes_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3448,13 +1152,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to DeFi Flow Change (30d)",
-    "name": "other_to_defi_flow_change_30d",
-    "metric": "other_to_defi_flow_change_30d",
+    "human_readable_name": "DeFi to Whale Flow Change ({{interval}})",
+    "name": "defi_to_whale_flow_change_{{interval}}",
+    "metric": "defi_to_whale_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3467,13 +1174,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to Whale Flow Change (1d)",
-    "name": "other_to_whale_flow_change_1d",
-    "metric": "other_to_whale_flow_change_1d",
+    "human_readable_name": "DeFi to Other Flow Change ({{interval}})",
+    "name": "defi_to_other_flow_change_{{interval}}",
+    "metric": "defi_to_other_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3486,13 +1196,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to Whale Flow Change (7d)",
-    "name": "other_to_whale_flow_change_7d",
-    "metric": "other_to_whale_flow_change_7d",
+    "human_readable_name": "Whale to DEX Traders Flow Change ({{interval}})",
+    "name": "whale_to_dex_traders_flow_change_{{interval}}",
+    "metric": "whale_to_dex_traders_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3505,13 +1218,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to Whale Flow Change (30d)",
-    "name": "other_to_whale_flow_change_30d",
-    "metric": "other_to_whale_flow_change_30d",
+    "human_readable_name": "Whale to DEXes Flow Change ({{interval}})",
+    "name": "whale_to_dexes_flow_change_{{interval}}",
+    "metric": "whale_to_dexes_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3524,13 +1240,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Traders to Other Flow Change (1d)",
-    "name": "traders_to_other_flow_change_1d",
-    "metric": "traders_to_other_flow_change_1d",
+    "human_readable_name": "Whale to CEXes Flow Change ({{interval}})",
+    "name": "whale_to_cexes_flow_change_{{interval}}",
+    "metric": "whale_to_cexes_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3543,13 +1262,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Traders to Other Flow Change (7d)",
-    "name": "traders_to_other_flow_change_7d",
-    "metric": "traders_to_other_flow_change_7d",
+    "human_readable_name": "Whale to DeFi Flow Change ({{interval}})",
+    "name": "whale_to_defi_flow_change_{{interval}}",
+    "metric": "whale_to_defi_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3562,13 +1284,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Traders to Other Flow Change (30d)",
-    "name": "traders_to_other_flow_change_30d",
-    "metric": "traders_to_other_flow_change_30d",
+    "human_readable_name": "Whale to Other Flow Change ({{interval}})",
+    "name": "whale_to_other_flow_change_{{interval}}",
+    "metric": "whale_to_other_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3581,13 +1306,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to Traders Flow Change (1d)",
-    "name": "other_to_traders_flow_change_1d",
-    "metric": "other_to_traders_flow_change_1d",
+    "human_readable_name": "Other to DEX Traders Flow Change ({{interval}})",
+    "name": "other_to_dex_traders_flow_change_{{interval}}",
+    "metric": "other_to_dex_traders_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3600,13 +1328,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to Traders Flow Change (7d)",
-    "name": "other_to_traders_flow_change_7d",
-    "metric": "other_to_traders_flow_change_7d",
+    "human_readable_name": "Other to DEXes Flow Change ({{interval}})",
+    "name": "other_to_dexes_flow_change_{{interval}}",
+    "metric": "other_to_dexes_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3619,13 +1350,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Other to Traders Flow Change (30d)",
-    "name": "other_to_traders_flow_change_30d",
-    "metric": "other_to_traders_flow_change_30d",
+    "human_readable_name": "Other to CEXes Flow Change ({{interval}})",
+    "name": "other_to_cexes_flow_change_{{interval}}",
+    "metric": "other_to_cexes_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3638,13 +1372,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Whale to Traders Flow Change (1d)",
-    "name": "whale_to_traders_flow_change_1d",
-    "metric": "whale_to_traders_flow_change_1d",
+    "human_readable_name": "Other to DeFi Flow Change ({{interval}})",
+    "name": "other_to_defi_flow_change_{{interval}}",
+    "metric": "other_to_defi_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3657,13 +1394,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Whale to Traders Flow Change (7d)",
-    "name": "whale_to_traders_flow_change_7d",
-    "metric": "whale_to_traders_flow_change_7d",
+    "human_readable_name": "Other to Whale Flow Change ({{interval}})",
+    "name": "other_to_whale_flow_change_{{interval}}",
+    "metric": "other_to_whale_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3676,13 +1416,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Whale to Traders Flow Change (30d)",
-    "name": "whale_to_traders_flow_change_30d",
-    "metric": "whale_to_traders_flow_change_30d",
+    "human_readable_name": "Traders to Other Flow Change ({{interval}})",
+    "name": "traders_to_other_flow_change_{{interval}}",
+    "metric": "traders_to_other_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3695,13 +1438,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Traders to Whale Flow Change (1d)",
-    "name": "traders_to_whale_flow_change_1d",
-    "metric": "traders_to_whale_flow_change_1d",
+    "human_readable_name": "Other to Traders Flow Change ({{interval}})",
+    "name": "other_to_traders_flow_change_{{interval}}",
+    "metric": "other_to_traders_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3714,13 +1460,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Traders to Whale Flow Change (7d)",
-    "name": "traders_to_whale_flow_change_7d",
-    "metric": "traders_to_whale_flow_change_7d",
+    "human_readable_name": "Whale to Traders Flow Change ({{interval}})",
+    "name": "whale_to_traders_flow_change_{{interval}}",
+    "metric": "whale_to_traders_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3733,13 +1482,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Traders to Whale Flow Change (30d)",
-    "name": "traders_to_whale_flow_change_30d",
-    "metric": "traders_to_whale_flow_change_30d",
+    "human_readable_name": "Traders to Whale Flow Change ({{interval}})",
+    "name": "traders_to_whale_flow_change_{{interval}}",
+    "metric": "traders_to_whale_flow_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -3752,13 +1504,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Social Dominance Change (1d)",
-    "name": "social_dominance_total_change_1d",
-    "metric": "social_dominance_change_1d",
+    "human_readable_name": "Social Dominance Change ({{interval}})",
+    "name": "social_dominance_total_change_{{interval}}",
+    "metric": "social_dominance_change_{{interval}}",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -3771,13 +1526,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Social Dominance Change (7d)",
-    "name": "social_dominance_total_change_7d",
-    "metric": "social_dominance_change_7d",
+    "human_readable_name": "Sentiment Balance Change ({{interval}})",
+    "name": "sentiment_balance_total_change_{{interval}}",
+    "metric": "sentiment_balance_change_{{interval}}",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -3790,127 +1548,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Social Dominance Change (30d)",
-    "name": "social_dominance_total_change_30d",
-    "metric": "social_dominance_change_30d",
-    "version": "2020-07-31",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Sentiment Balance Change (1d)",
-    "name": "sentiment_balance_total_change_1d",
-    "metric": "sentiment_balance_change_1d",
-    "version": "2020-07-31",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Sentiment Balance Change (7d)",
-    "name": "sentiment_balance_total_change_7d",
-    "metric": "sentiment_balance_change_7d",
-    "version": "2020-07-31",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Sentiment Balance Change (30d)",
-    "name": "sentiment_balance_total_change_30d",
-    "metric": "sentiment_balance_change_30d",
-    "version": "2020-07-31",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Price in ETH Change (1d)",
-    "name": "price_eth_change_1d",
-    "metric": "price_eth_change_1d",
+    "human_readable_name": "Price in ETH Change ({{interval}})",
+    "name": "price_eth_change_{{interval}}",
+    "metric": "price_eth_change_{{interval}}",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Price in ETH Change (7d)",
-    "name": "price_eth_change_7d",
-    "metric": "price_eth_change_7d",
-    "version": "2019-01-01",
-    "access": "free",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Price in ETH Change (30d)",
-    "name": "price_eth_change_30d",
-    "metric": "price_eth_change_30d",
-    "version": "2019-01-01",
-    "access": "free",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -3928,9 +1575,7 @@
     "metric": "price_change_1h",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -3942,13 +1587,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Price in BTC Change (1d)",
-    "name": "price_btc_change_1d",
-    "metric": "price_btc_change_1d",
+    "human_readable_name": "Price in BTC Change ({{interval}})",
+    "name": "price_btc_change_{{interval}}",
+    "metric": "price_btc_change_{{interval}}",
     "version": "2019-01-01",
     "access": "free",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -3961,51 +1609,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Price in BTC Change (7d)",
-    "name": "price_btc_change_7d",
-    "metric": "price_btc_change_7d",
-    "version": "2019-01-01",
-    "access": "free",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Price in BTC Change (30d)",
-    "name": "price_btc_change_30d",
-    "metric": "price_btc_change_30d",
-    "version": "2019-01-01",
-    "access": "free",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Network Realized Profit or Loss in USD Change (1d)",
-    "name": "network_profit_loss_change_1d",
-    "metric": "network_profit_loss_change_1d",
+    "human_readable_name": "Network Realized Profit or Loss in USD Change ({{interval}})",
+    "name": "network_profit_loss_change_{{interval}}",
+    "metric": "network_profit_loss_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -4018,51 +1631,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Network Realized Profit or Loss in USD Change (7d)",
-    "name": "network_profit_loss_change_7d",
-    "metric": "network_profit_loss_change_7d",
+    "human_readable_name": "Number of Transactions Transferring More Than 100k USD Change ({{interval}})",
+    "name": "whale_transaction_count_100k_usd_to_inf_change_{{interval}}",
+    "metric": "whale_transaction_count_more_than_100k_usd_5min_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "sum",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Network Realized Profit or Loss in USD Change (30d)",
-    "name": "network_profit_loss_change_30d",
-    "metric": "network_profit_loss_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "sum",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Number of Transactions Transferring More Than 100k USD Change (1d)",
-    "name": "whale_transaction_count_100k_usd_to_inf_change_1d",
-    "metric": "whale_transaction_count_more_than_100k_usd_5min_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -4075,13 +1653,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Number of Transactions Transferring More Than 100k USD Change (7d)",
-    "name": "whale_transaction_count_100k_usd_to_inf_change_7d",
-    "metric": "whale_transaction_count_more_than_100k_usd_5min_change_7d",
+    "human_readable_name": "Number of Transactions Transferring More Than 1 million USD Change ({{interval}})",
+    "name": "whale_transaction_count_1m_usd_to_inf_change_{{interval}}",
+    "metric": "whale_transaction_count_more_than_1m_usd_5min_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "pro",
@@ -4094,89 +1675,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Number of Transactions Transferring More Than 100k USD Change (30d)",
-    "name": "whale_transaction_count_100k_usd_to_inf_change_30d",
-    "metric": "whale_transaction_count_more_than_100k_usd_5min_change_30d",
+    "human_readable_name": "1h Moving Average Of Social Dominance Change ({{interval}})",
+    "name": "social_dominance_total_1h_moving_average_change_{{interval}}",
+    "metric": "social_dominance_1h_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "sum",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": true,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Number of Transactions Transferring More Than 1 million USD Change (1d)",
-    "name": "whale_transaction_count_1m_usd_to_inf_change_1d",
-    "metric": "whale_transaction_count_more_than_1m_usd_5min_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "sum",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": true,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Number of Transactions Transferring More Than 1 million USD Change (7d)",
-    "name": "whale_transaction_count_1m_usd_to_inf_change_7d",
-    "metric": "whale_transaction_count_more_than_1m_usd_5min_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "sum",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": true,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Number of Transactions Transferring More Than 1 million USD Change (30d)",
-    "name": "whale_transaction_count_1m_usd_to_inf_change_30d",
-    "metric": "whale_transaction_count_more_than_1m_usd_5min_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "pro",
-      "SANBASE": "free"
-    },
-    "aggregation": "sum",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": true,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "1h Moving Average Of Social Dominance Change (1d)",
-    "name": "social_dominance_total_1h_moving_average_change_1d",
-    "metric": "social_dominance_1h_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -4189,13 +1697,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "1h Moving Average Of Social Dominance Change (7d)",
-    "name": "social_dominance_total_1h_moving_average_change_7d",
-    "metric": "social_dominance_1h_change_7d",
+    "human_readable_name": "24h Moving Average Of Social Dominance Change ({{interval}})",
+    "name": "social_dominance_total_24h_moving_average_change_{{interval}}",
+    "metric": "social_dominance_24h_change_{{interval}}",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",
@@ -4208,127 +1719,16 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "1h Moving Average Of Social Dominance Change (30d)",
-    "name": "social_dominance_total_1h_moving_average_change_30d",
-    "metric": "social_dominance_1h_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "24h Moving Average Of Social Dominance Change (1d)",
-    "name": "social_dominance_total_24h_moving_average_change_1d",
-    "metric": "social_dominance_24h_change_1d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "24h Moving Average Of Social Dominance Change (7d)",
-    "name": "social_dominance_total_24h_moving_average_change_7d",
-    "metric": "social_dominance_24h_change_7d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "24h Moving Average Of Social Dominance Change (30d)",
-    "name": "social_dominance_total_24h_moving_average_change_30d",
-    "metric": "social_dominance_24h_change_30d",
-    "version": "2019-01-01",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "5m",
-    "table": "intraday_metrics",
-    "has_incomplete_data": false,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Sentiment Volume Consumed Total Change (1d)",
-    "name": "sentiment_volume_consumed_total_change_1d",
-    "metric": "sentiment_volume_consumed_1d_change_1d",
+    "human_readable_name": "Sentiment Volume Consumed Total Change ({{interval}})",
+    "name": "sentiment_volume_consumed_total_change_{{interval}}",
+    "metric": "sentiment_volume_consumed_1d_change_{{interval}}",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": true,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Sentiment Volume Consumed Total Change (7d)",
-    "name": "sentiment_volume_consumed_total_change_7d",
-    "metric": "sentiment_volume_consumed_1d_change_7d",
-    "version": "2020-07-31",
-    "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
-    "min_plan": {
-      "SANAPI": "free",
-      "SANBASE": "free"
-    },
-    "aggregation": "last",
-    "min_interval": "1d",
-    "table": "intraday_metrics",
-    "has_incomplete_data": true,
-    "data_type": "timeseries"
-  },
-  {
-    "human_readable_name": "Sentiment Volume Consumed Total Change (30d)",
-    "name": "sentiment_volume_consumed_total_change_30d",
-    "metric": "sentiment_volume_consumed_1d_change_30d",
-    "version": "2020-07-31",
-    "access": "restricted",
-    "selectors": [
-      "slug"
+    "selectors": ["slug"],
+    "parameters": [
+      { "interval": "1d" },
+      { "interval": "7d" },
+      { "interval": "30d" }
     ],
     "min_plan": {
       "SANAPI": "free",

--- a/lib/sanbase/template_engine/template_engine.ex
+++ b/lib/sanbase/template_engine/template_engine.ex
@@ -4,6 +4,15 @@ defmodule Sanbase.TemplateEngine do
   All occurances in the template that are enclosed in double braces are replaced
   with the corersponding values from KV enumerable.
 
+  There are two ways to transform a value into its human readable variant.
+
+  The first way is to provide an :__human_readable__ key inside the kv argument which
+  is a list of the keys that need to be transformed.
+
+  The second way is to replace the `{{key}}` in the template with `{{key:human_readable}}`.
+  This way is more flexible as it allows to make only enable transformation into
+  human readable only for parts of the template.
+
   Example:
     iex> Sanbase.TemplateEngine.run("My name is {{name}}", %{name: "San"})
     "My name is San"
@@ -17,34 +26,42 @@ defmodule Sanbase.TemplateEngine do
     iex> Sanbase.TemplateEngine.run("MediumNum: {{medium_num}}", %{medium_num: 100000})
     "MediumNum: 100000"
 
-    iex> Sanbase.TemplateEngine.run("Human Readable MediumNum: {{medium_num}}", %{medium_num: 100000, human_readable: [:medium_num]})
+    iex> Sanbase.TemplateEngine.run("Human Readable MediumNum: {{medium_num}}", %{medium_num: 100000, __human_readable__: [:medium_num]})
     "Human Readable MediumNum: 100,000.00"
 
     iex> Sanbase.TemplateEngine.run("BigNum: {{big_num}}", %{big_num: 999999999999})
     "BigNum: 999999999999"
 
-
-    iex> Sanbase.TemplateEngine.run("Human Readable BigNum: {{big_num}}", %{big_num: 999999999999, human_readable: [:big_num]})
+    iex> Sanbase.TemplateEngine.run("Human Readable BigNum: {{big_num}}", %{big_num: 999999999999, __human_readable__: [:big_num]})
     "Human Readable BigNum: 1,000.00 Billion"
+
+    iex> Sanbase.TemplateEngine.run("{{timebound}} has human readable value {{timebound:human_readable}}", %{timebound: "3d"})
+    "3d has human readable value 3 days"
   """
 
   @spec run(String.t(), map) :: String.t()
   def run(template, kv) do
-    {human_readable_map, kv} = Map.split(kv, [:human_readable])
+    {human_readable_map, kv} = Map.split(kv, [:__human_readable__])
 
     human_readable_mapset =
-      Map.get(human_readable_map, :human_readable, [])
+      Map.get(human_readable_map, :__human_readable__, [])
       |> MapSet.new()
 
     Enum.reduce(kv, template, fn {key, value}, acc ->
-      replace(acc, key, value, human_readable_mapset)
+      # Support `key:human_readable` to convert the value to human readable even
+      # if it's not part of the :__human_readable))
+      human_readalbe_key = "#{key}:human_readable"
+
+      acc
+      |> replace(key, value, human_readable_mapset)
+      |> replace(human_readalbe_key, value, MapSet.put(human_readable_mapset, human_readalbe_key))
     end)
   end
 
   defp replace(string, key, value, human_readable_mapset) do
     String.replace(string, "{{#{key}}}", fn _ ->
       case key in human_readable_mapset do
-        true -> value |> human_readable |> to_string()
+        true -> value |> human_readable() |> to_string()
         false -> value |> to_string()
       end
     end)
@@ -60,21 +77,26 @@ defmodule Sanbase.TemplateEngine do
            when is_number(num) and (num > low and num < high)
 
   defp human_readable(data) do
-    case data do
-      num when is_number_outside_range_inclusive(num, -1_000_000, 1_000_000) ->
-        Number.Human.number_to_human(num)
+    cond do
+      # Transform interval to human readable interval
+      true == Sanbase.DateTimeUtils.valid_interval?(data) ->
+        Sanbase.DateTimeUtils.interval_to_str(data)
 
-      num when is_number_outside_range_inclusive(num, -1000, 1000) ->
-        Number.Delimit.number_to_delimited(num)
+      # Transform numbers to human readable number
+      is_number_outside_range_inclusive(data, -1_000_000, 1_000_000) ->
+        Number.Human.number_to_human(data)
 
-      num when is_number_inside_range_exclusive(num, -1, 1) ->
-        Number.Delimit.number_to_delimited(num, precision: 8)
+      is_number_outside_range_inclusive(data, -1000, 1000) ->
+        Number.Delimit.number_to_delimited(data)
 
-      num when is_float(num) ->
-        Number.Delimit.number_to_delimited(num, precision: 2)
+      is_number_inside_range_exclusive(data, -1, 1) ->
+        Number.Delimit.number_to_delimited(data, precision: 8)
 
-      num when is_integer(num) ->
-        Integer.to_string(num)
+      is_float(data) ->
+        Number.Delimit.number_to_delimited(data, precision: 2)
+
+      is_integer(data) ->
+        Integer.to_string(data)
     end
   end
 end

--- a/lib/sanbase/utils/datetime/datetime_utils.ex
+++ b/lib/sanbase/utils/datetime/datetime_utils.ex
@@ -174,6 +174,7 @@ defmodule Sanbase.DateTimeUtils do
       "h" -> int_interval * 60 * 60
       "d" -> int_interval * 24 * 60 * 60
       "w" -> int_interval * 7 * 24 * 60 * 60
+      "y" -> int_interval * 365 * 24 * 60 * 60
     end
   end
 
@@ -197,7 +198,7 @@ defmodule Sanbase.DateTimeUtils do
       "w" -> "#{int_interval} week"
       "y" -> "#{int_interval} year"
     end
-    |> maybe_append_s(int_interval)
+    |> maybe_pluralize_interval(int_interval)
   end
 
   def valid_compound_duration?(value) do
@@ -241,16 +242,11 @@ defmodule Sanbase.DateTimeUtils do
 
   def time_from_8601!(%Time{} = time), do: time
 
-  def valid_interval_string?(interval_string) when not is_binary(interval_string) do
-    {:error, "The provided string #{interval_string} is not a valid string interval"}
-  end
-
-  def valid_interval_string?(interval_string) when is_binary(interval_string) do
-    if Regex.match?(~r/^\d+[smhdw]{1}$/, interval_string) do
-      true
-    else
-      {:error, "The provided string #{interval_string} is not a valid string interval"}
-    end
+  def valid_interval?(interval) do
+    _ = str_to_sec(interval)
+    true
+  rescue
+    _ -> false
   end
 
   @doc ~s"""
@@ -283,6 +279,6 @@ defmodule Sanbase.DateTimeUtils do
   end
 
   # Private
-  defp maybe_append_s(str, 1), do: str
-  defp maybe_append_s(str, _), do: str <> "s"
+  defp maybe_pluralize_interval(str, 1), do: str
+  defp maybe_pluralize_interval(str, _), do: str <> "s"
 end


### PR DESCRIPTION
## Changes
- Rework the custom handled `timebound` field in the JSON metrics file with the generic `parameters` field 
- Rework the change metrics to use parametrization. Usually the change metrics are available with 1d, 7d and 30d intervals, so this cuts off around 2/3 of the definitions.
- Properly handle aliases of metrics.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
