### PR TITLE
Allow overriding parameters in compute_dashboard_panel

### DIFF
--- a/lib/sanbase/dashboard/dashboard.ex
+++ b/lib/sanbase/dashboard/dashboard.ex
@@ -116,11 +116,11 @@ defmodule Sanbase.Dashboard do
   @doc ~s"""
   Trigger computation of a single panel of the dashboard
   """
-  @spec compute_panel(dashboard_id(), panel_id(), user_id()) ::
+  @spec compute_panel(dashboard_id(), panel_id(), user_id(), Keyword.t()) ::
           {:ok, Dashboard.Query.Result.t()} | {:error, String.t()}
-  def compute_panel(dashboard_id, panel_id, querying_user_id) do
+  def compute_panel(dashboard_id, panel_id, querying_user_id, opts) do
     with {:ok, dashboard} <- Dashboard.Schema.by_id(dashboard_id),
-         {:ok, query_result} <- do_compute_panel(dashboard, panel_id, querying_user_id) do
+         {:ok, query_result} <- do_compute_panel(dashboard, panel_id, querying_user_id, opts) do
       Task.Supervisor.async_nolink(Sanbase.TaskSupervisor, fn ->
         Dashboard.QueryExecution.store_execution(querying_user_id, query_result)
       end)
@@ -179,10 +179,10 @@ defmodule Sanbase.Dashboard do
   end
 
   # Compute the dashboard by computing every panel in it.
-  defp do_compute_panel(%Dashboard.Schema{} = dashboard, panel_id, querying_user_id) do
+  defp do_compute_panel(%Dashboard.Schema{} = dashboard, panel_id, querying_user_id, opts \\ []) do
     case Enum.find(dashboard.panels, &(&1.id == panel_id)) do
       nil -> {:error, "Dashboard panel with id #{panel_id} does not exist"}
-      panel -> Sanbase.Dashboard.Panel.compute(panel, querying_user_id)
+      panel -> Sanbase.Dashboard.Panel.compute(panel, querying_user_id, opts)
     end
   end
 end

--- a/lib/sanbase/dashboard/dashboard_panel.ex
+++ b/lib/sanbase/dashboard/dashboard_panel.ex
@@ -102,10 +102,20 @@ defmodule Sanbase.Dashboard.Panel do
   The SQL query and arguments are taken from the panel and are executed.
   The result is transformed by converting the Date and NaiveDateTime types to DateTime.
   """
-  @spec compute(t(), non_neg_integer()) :: {:ok, Query.Result.t()} | {:error, String.t()}
-  def compute(%__MODULE__{} = panel, querying_user_id) do
+  @spec compute(t(), non_neg_integer(), Keyword.t()) ::
+          {:ok, Query.Result.t()} | {:error, String.t()}
+  def compute(%__MODULE__{} = panel, querying_user_id, opts) do
     %{sql: %{"query" => query, "parameters" => parameters, "san_query_id" => san_query_id}} =
       panel
+
+    # If the opts contain parameters, override the default parameters during computing.
+    # It allows for only some parameters to be provided. They will override the existing
+    # ones and the rest will remain the same.
+    parameters =
+      case Keyword.get(opts, :parameters) do
+        nil -> parameters
+        overridden_parameters -> Map.merge(parameters, overridden_parameters)
+      end
 
     Query.run(query, parameters, san_query_id, querying_user_id)
   end

--- a/lib/sanbase_web/graphql/resolvers/dashboard_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/dashboard_resolver.ex
@@ -72,10 +72,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.DashboardResolver do
 
   def compute_dashboard_panel(_root, args, %{context: %{auth: %{current_user: user}}}) do
     %{dashboard_id: dashboard_id, panel_id: panel_id} = args
+    parameters = Map.get(args, :parameters, nil)
+    opts = [parameters: parameters]
 
     with true <- can_view_dashboard?(dashboard_id, user.id),
          true <- can_run_computation?(user.id) do
-      Dashboard.compute_panel(dashboard_id, panel_id, user.id)
+      Dashboard.compute_panel(dashboard_id, panel_id, user.id, opts)
     end
   end
 

--- a/lib/sanbase_web/graphql/schema/queries/dashboard_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/dashboard_queries.ex
@@ -298,6 +298,11 @@ defmodule SanbaseWeb.Graphql.Schema.DashboardQueries do
       arg(:dashboard_id, non_null(:integer))
       arg(:panel_id, non_null(:string))
 
+      @desc ~s"""
+      Docs about this arg
+      """
+      arg(:parameters, :json, default_value: nil)
+
       middleware(JWTAuth)
 
       resolve(&DashboardResolver.compute_dashboard_panel/3)


### PR DESCRIPTION
## Changes

Allow overriding the stored parameters of a panel when computing it.
This allows users who do not own the dashboard to be able to execute it with a different set of parameters to see how it will look like.

It allows only a subset of the parameters to be provided. They will override the existing parameters with that name and the rest of the parameters will be reused.

```graphql
mutation {
  computeDashboardPanel(dashboardId: 1408, panelId: "2809f57e-575d-40b9-b555-bd518e93cdb5", parameters: "{\"slug\":\"ethereum\"}"){
    id
    name
    description
    user{ id }
    panels { id }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
