### PR TITLE
Add special handling of rewriting modules for price_eth

### DIFF
--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -795,8 +795,15 @@ defmodule Sanbase.Metric do
   defp maybe_change_module(module, metric, selector, opts)
        when metric in @price_pair_metrics do
     case Keyword.get(opts, :source) || Map.get(selector, :source) do
-      "cryptocompare" -> Sanbase.PricePair.MetricAdapter
-      _ -> module
+      "cryptocompare" ->
+        Sanbase.PricePair.MetricAdapter
+
+      # NOTE: Temporary. This will be reworked and handled in a generic way
+      source when metric == "price_eth" and source != "cryptocompare" ->
+        Sanbase.Clickhouse.MetricAdapter
+
+      _ ->
+        module
     end
   end
 


### PR DESCRIPTION
## Changes
Short and dirty fix of which metric adapter module is used for `price_eth`.
The issue is that the default module for `price_usd`/`price_btc` is not the proper default module for `price_eth`.

The current fix is a temporary workaround until a proper, generic way, to handle this is implemented.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
