### PR TITLE
Add UserAuth that accepts all types of user authentication

### DIFF
--- a/lib/sanbase_web/graphql/middlewares/auth.ex
+++ b/lib/sanbase_web/graphql/middlewares/auth.ex
@@ -1,0 +1,31 @@
+defmodule SanbaseWeb.Graphql.Middlewares.UserAuth do
+  @moduledoc """
+  Authenticate that the request contains a valid user
+
+  """
+  @behaviour Absinthe.Middleware
+
+  alias Absinthe.Resolution
+  alias SanbaseWeb.Graphql.Middlewares.Helpers
+
+  @doc ~s"""
+  Decides whether the user has access or not.
+
+  The user must have accepted the privacy policy in order to access resources.
+  This allows both API key authentication and JWT authentication
+  """
+  def call(
+        %Resolution{
+          context: %{
+            auth: %{
+              current_user: current_user
+            }
+          }
+        } = resolution,
+        opts
+      ) do
+    Helpers.handle_user_access(current_user, opts, resolution)
+  end
+
+  def call(resolution, _), do: Resolution.put_result(resolution, {:error, :unauthorized})
+end

--- a/lib/sanbase_web/graphql/schema/queries/dashboard_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/dashboard_queries.ex
@@ -7,7 +7,7 @@ defmodule SanbaseWeb.Graphql.Schema.DashboardQueries do
   import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 1, cache_resolve: 2]
 
   alias SanbaseWeb.Graphql.Resolvers.DashboardResolver
-  alias SanbaseWeb.Graphql.Middlewares.JWTAuth
+  alias SanbaseWeb.Graphql.Middlewares.{UserAuth, JWTAuth}
 
   object :dashboard_queries do
     @desc ~s"""
@@ -397,6 +397,8 @@ defmodule SanbaseWeb.Graphql.Schema.DashboardQueries do
     field :compute_raw_clickhouse_query, :query_result do
       arg(:query, non_null(:string))
       arg(:parameters, non_null(:json))
+
+      middleware(UserAuth)
 
       cache_resolve(&DashboardResolver.compute_raw_clickhouse_query/3,
         ttl: 10,


### PR DESCRIPTION
## Changes

In some cases, we want to allow only authenticated users, but we don't care if the authentication is API key or JWT

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
