### PR TITLE
Fix default aggregation of change metrics to be LAST

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/change_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/change_metrics.json
@@ -1624,7 +1624,7 @@
       "SANAPI": "free",
       "SANBASE": "free"
     },
-    "aggregation": "sum",
+    "aggregation": "last",
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
@@ -1646,7 +1646,7 @@
       "SANAPI": "pro",
       "SANBASE": "free"
     },
-    "aggregation": "sum",
+    "aggregation": "last",
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": true,
@@ -1668,7 +1668,7 @@
       "SANAPI": "pro",
       "SANBASE": "free"
     },
-    "aggregation": "sum",
+    "aggregation": "last",
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": true,


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
