### PR TITLE
Add REST endpoint for fetching Santiment team members data

### DIFF
--- a/lib/sanbase/accounts/statistics.ex
+++ b/lib/sanbase/accounts/statistics.ex
@@ -3,7 +3,7 @@ defmodule Sanbase.Accounts.Statistics do
 
   alias Sanbase.Repo
   alias Sanbase.Math
-  alias Sanbase.Accounts.User
+  alias Sanbase.Accounts.{Role, UserRole, User}
   alias Sanbase.UserList
 
   def tokens_staked() do
@@ -25,6 +25,20 @@ defmodule Sanbase.Accounts.Statistics do
       "users_with_over_1000_san" => Enum.count(san_balances, fn balance -> balance >= 1000 end),
       "users_with_over_200_san" => Enum.count(san_balances, fn balance -> balance >= 200 end)
     }
+  end
+
+  @spec santiment_team_users() :: list(%User{})
+  def santiment_team_users() do
+    santiment_role_user_ids = Sanbase.Accounts.Role.san_team_ids()
+
+    # Get all users whose email ends with @santiment.net or they have the santiment role.
+    # There are cases where santiment members use accounts with other email domains
+    from(u in User,
+      where:
+        (like(u.email, "%@santiment.net") or u.id in ^santiment_role_user_ids) and
+          u.is_registered == true
+    )
+    |> Repo.all()
   end
 
   @doc ~s"""

--- a/lib/sanbase_web/controllers/data_controller.ex
+++ b/lib/sanbase_web/controllers/data_controller.ex
@@ -1,20 +1,53 @@
-defmodule SanbaseWeb.ProjectDataController do
+defmodule SanbaseWeb.DataController do
   use SanbaseWeb, :controller
 
   alias Sanbase.Model.Project
   alias Sanbase.Model.Project.SocialVolumeQuery
   require Logger
 
-  def data(conn, _params) do
+  # In order to access the data, the endpoint needs to know the secret.
+  # The path is https://api.santiment.net/santiment_team_members/the_real_secret
+  # This contains information about users, so it cannot be publicly freely available
+  def santiment_team_members(conn, %{"secret" => secret}) do
+    case santiment_team_members_secret() == secret do
+      true ->
+        {:ok, data} = get_santiment_team_members()
+
+        conn
+        |> put_resp_header("content-type", "application/json; charset=utf-8")
+        |> Plug.Conn.send_resp(200, data)
+
+      false ->
+        conn
+        |> send_resp(403, "Unauthorized")
+        |> halt()
+    end
+  end
+
+  def projects_data(conn, _params) do
     cache_key = {__MODULE__, __ENV__.function} |> Sanbase.Cache.hash()
-    {:ok, data} = Sanbase.Cache.get_or_store(cache_key, &get_data/0)
+    {:ok, data} = Sanbase.Cache.get_or_store(cache_key, &get_projects_data/0)
 
     conn
     |> put_resp_header("content-type", "application/json; charset=utf-8")
     |> Plug.Conn.send_resp(200, data)
   end
 
-  defp get_data() do
+  defp get_santiment_team_members() do
+    data =
+      Sanbase.Accounts.Statistics.santiment_team_users()
+      |> Enum.map(fn user ->
+        user_json =
+          %{id: user.id, email: user.email, username: user.username}
+          |> Jason.encode!()
+
+        [user_json, "\n"]
+      end)
+
+    {:ok, data}
+  end
+
+  defp get_projects_data() do
     data =
       Project.List.projects(
         preload?: true,
@@ -81,4 +114,8 @@ defmodule SanbaseWeb.ProjectDataController do
       _ -> {"", 0}
     end
   end
+
+  # On stage/prod the env var is set and is different from the default one.
+  defp santiment_team_members_secret(),
+    do: System.get_env("SANTIMENT_TEAM_MEMBERS_ENDPOINT_SECRET") || "random_secret"
 end

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -152,7 +152,8 @@ defmodule SanbaseWeb.Router do
 
   scope "/", SanbaseWeb do
     get("/api_metric_name_mapping", MetricNameController, :api_metric_name_mapping)
-    get("/projects_data", ProjectDataController, :data)
+    get("/projects_data", DataController, :projects_data)
+    get("/santiment_team_members/:secret", DataController, :santiment_team_members)
     get("/cryptocompare_asset_mapping", CryptocompareAssetMappingController, :data)
     post("/stripe_webhook", StripeController, :webhook)
   end

--- a/test/sanbase_web/controller/data_controller_test.exs
+++ b/test/sanbase_web/controller/data_controller_test.exs
@@ -1,4 +1,4 @@
-defmodule SanbaseWeb.ProjectDataControllerTest do
+defmodule SanbaseWeb.DataControllerTest do
   use SanbaseWeb.ConnCase, async: false
 
   import Sanbase.Factory


### PR DESCRIPTION
## Changes

The endpoint is accessed only if you know the secret.
The endpoint on prod will be https://api.santiment.net/santiment_team_members/replace_this_with_the_proper_secret

This is to be used to create a Clickhouse dictionary

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
