### PR TITLE
Make email, username and discord_id not null

### DIFF
--- a/lib/sanbase_web/controllers/data_controller.ex
+++ b/lib/sanbase_web/controllers/data_controller.ex
@@ -39,10 +39,15 @@ defmodule SanbaseWeb.DataController do
     data =
       Sanbase.Accounts.Statistics.santiment_team_users()
       |> Enum.map(fn user ->
-        discord_id = Map.get(email_to_discord_id_map, user.email, nil)
+        discord_id = Map.get(email_to_discord_id_map, user.email)
 
         user_json =
-          %{id: user.id, email: user.email, username: user.username, discord_id: discord_id}
+          %{
+            id: user.id,
+            email: user.email || "",
+            username: user.username || "",
+            discord_id: discord_id || ""
+          }
           |> Jason.encode!()
 
         [user_json, "\n"]
@@ -127,7 +132,9 @@ defmodule SanbaseWeb.DataController do
       {:ok, content} ->
         content
         |> Jason.decode!()
-        |> Map.new(fn %{"email" => email, "discord_id" => discord_id} -> {email, discord_id} end)
+        |> Map.new(fn %{"email" => email, "discord_id" => discord_id} ->
+          {email, discord_id}
+        end)
 
       _ ->
         %{}
@@ -136,5 +143,7 @@ defmodule SanbaseWeb.DataController do
 
   # On stage/prod the env var is set and is different from the default one.
   defp santiment_team_members_secret(),
-    do: System.get_env("SANTIMENT_TEAM_MEMBERS_ENDPOINT_SECRET") || "random_secret"
+    do:
+      System.get_env("SANTIMENT_TEAM_MEMBERS_ENDPOINT_SECRET") ||
+        "random_secret"
 end


### PR DESCRIPTION
## Changes

The endpoint is used to populate clickhouse dictionaries. They better work with non-null strings.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
