### PR TITLE
Add internal_metric to get_metric's metadata

### DIFF
--- a/lib/sanbase/blockchain_address/metric_adapter.ex
+++ b/lib/sanbase/blockchain_address/metric_adapter.ex
@@ -123,6 +123,7 @@ defmodule Sanbase.BlockchainAddress.MetricAdapter do
     {:ok,
      %{
        metric: metric,
+       internal_metric: metric,
        has_incomplete_data: has_incomplete_data?(metric),
        min_interval: "5m",
        default_aggregation: @default_aggregation,

--- a/lib/sanbase/clickhouse/github/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/github/metric_adapter.ex
@@ -193,6 +193,7 @@ defmodule Sanbase.Clickhouse.Github.MetricAdapter do
     {:ok,
      %{
        metric: metric,
+       internal_metric: metric,
        has_incomplete_data: has_incomplete_data?(metric),
        min_interval: "1m",
        default_aggregation: :sum,

--- a/lib/sanbase/clickhouse/metric/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/metric/metric_adapter.ex
@@ -37,6 +37,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
   @selectors_map FileHandler.selectors_map()
   @required_selectors_map FileHandler.required_selectors_map()
   @metric_to_names_map FileHandler.metric_to_names_map()
+  @name_to_metric_map FileHandler.name_to_metric_map()
   @deprecated_metrics_map FileHandler.deprecated_metrics_map()
   @timebound_flag_map FileHandler.timebound_flag_map()
   @default_complexity_weight 0.3
@@ -176,6 +177,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
     {:ok,
      %{
        metric: metric,
+       internal_metric: Map.get(@name_to_metric_map, metric, metric),
        has_incomplete_data: has_incomplete_data?(metric),
        min_interval: min_interval,
        default_aggregation: default_aggregation,

--- a/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
@@ -123,6 +123,7 @@ defmodule Sanbase.Clickhouse.TopHolders.MetricAdapter do
     {:ok,
      %{
        metric: metric,
+       internal_metric: metric,
        has_incomplete_data: has_incomplete_data?(metric),
        min_interval: "1d",
        default_aggregation: @default_aggregation,

--- a/lib/sanbase/clickhouse/uniswap/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/uniswap/metric_adapter.ex
@@ -102,6 +102,7 @@ defmodule Sanbase.Clickhouse.Uniswap.MetricAdapter do
     {:ok,
      %{
        metric: metric,
+       internal_metric: metric,
        has_incomplete_data: has_incomplete_data?(metric),
        min_interval: "1h",
        default_aggregation: :sum,

--- a/lib/sanbase/contract_metric/metric_adapter.ex
+++ b/lib/sanbase/contract_metric/metric_adapter.ex
@@ -102,6 +102,7 @@ defmodule Sanbase.Contract.MetricAdapter do
     {:ok,
      %{
        metric: metric,
+       internal_metric: metric,
        has_incomplete_data: has_incomplete_data?(metric),
        min_interval: "1m",
        default_aggregation: :count,

--- a/lib/sanbase/metric/behaviour.ex
+++ b/lib/sanbase/metric/behaviour.ex
@@ -26,6 +26,7 @@ defmodule Sanbase.Metric.Behaviour do
 
   @type metadata :: %{
           metric: metric,
+          internal_metric: metric,
           min_interval: interval(),
           default_aggregation: atom(),
           available_aggregations: list(atom()),

--- a/lib/sanbase/prices/metric_adapter.ex
+++ b/lib/sanbase/prices/metric_adapter.ex
@@ -77,6 +77,8 @@ defmodule Sanbase.Price.MetricAdapter do
     {:ok,
      %{
        metric: metric,
+       internal_metric: metric,
+       internal_metric: metric,
        has_incomplete_data: has_incomplete_data?(metric),
        min_interval: "5m",
        default_aggregation: @default_aggregation,

--- a/lib/sanbase/prices/price_pair/metric_adapter.ex
+++ b/lib/sanbase/prices/price_pair/metric_adapter.ex
@@ -91,6 +91,7 @@ defmodule Sanbase.PricePair.MetricAdapter do
     {:ok,
      %{
        metric: metric,
+       internal_metric: metric,
        has_incomplete_data: has_incomplete_data?(metric),
        min_interval: "1s",
        default_aggregation: @default_aggregation,

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -318,6 +318,7 @@ defmodule Sanbase.SocialData.MetricAdapter do
     {:ok,
      %{
        metric: metric,
+       internal_metric: metric,
        has_incomplete_data: has_incomplete_data?(metric),
        min_interval: "5m",
        default_aggregation: :sum,

--- a/lib/sanbase/twitter/metric_adapter.ex
+++ b/lib/sanbase/twitter/metric_adapter.ex
@@ -94,6 +94,7 @@ defmodule Sanbase.Twitter.MetricAdapter do
     {:ok,
      %{
        metric: metric,
+       internal_metric: metric,
        has_incomplete_data: has_incomplete_data?(metric),
        min_interval: "6h",
        default_aggregation: :last,

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -285,9 +285,17 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
 
   object :metric_metadata do
     @desc ~s"""
-    The name of the metric the metadata is about
+    The public name of the metric. The public name is the name that is used
+    to refer to the metric in the API.
     """
     field(:metric, non_null(:string))
+
+    @desc ~s"""
+    The internal name of the metric. The internal name is the name that is used
+    to refer to the metric internally, in the databases, etc. The public and internal
+    name can differ.
+    """
+    field(:internal_metric, non_null(:string))
 
     @desc ~s"""
     The metrics that have this flag set to true have their


### PR DESCRIPTION
## Changes

Expose the internal name of metrics in the metadata field. The internal name can only differ for the precomputed metrics stored in Clickhouse. This is useful when using the SQL editor and you don't know the proper name of the metric.

```graphql
{
  getMetric(metric: "age_consumed") {
    metadata {
      internalMetric
    }
  }
}
```

```json
{
  "data": {
    "getMetric": {
      "metadata": {
        "internalMetric": "stack_age_consumed_5min"
      }
    }
  }
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
