### PR TITLE
Remove validation for favorite_metrics in user settings

### DIFF
--- a/lib/sanbase/accounts/settings.ex
+++ b/lib/sanbase/accounts/settings.ex
@@ -66,7 +66,6 @@ defmodule Sanbase.Accounts.Settings do
       :is_subscribed_comments_emails,
       :is_subscribed_likes_emails
     ])
-    |> validate_change(:favorite_metrics, &validate_favorite_metrics/2)
   end
 
   def get_alerts_limit_per_day(%__MODULE__{} = settings, channel) do
@@ -82,20 +81,5 @@ defmodule Sanbase.Accounts.Settings do
   def get_alerts_fired_today(%__MODULE__{} = settings, channel) do
     today_str = Date.utc_today() |> to_string()
     settings.alerts_fired[today_str][channel] |> Sanbase.Math.to_integer() || 0
-  end
-
-  defp validate_favorite_metrics(_field_name, nil), do: []
-
-  defp validate_favorite_metrics(_fiel_name, metrics) do
-    metrics
-    |> Enum.find_value([], fn metric ->
-      case Sanbase.Metric.has_metric?(metric) do
-        true ->
-          false
-
-        {:error, error} ->
-          [favorite_metrics: "Invalid metric found in the favorite metrics list. #{error}"]
-      end
-    end)
   end
 end

--- a/test/sanbase_web/graphql/user/user_settings_test.exs
+++ b/test/sanbase_web/graphql/user/user_settings_test.exs
@@ -33,15 +33,19 @@ defmodule SanbaseWeb.Graphql.UserSettingsTest do
     assert UserSettings.settings_for(user, force: true) |> Map.get(:favorite_metrics) == favorites
   end
 
-  test "change favorite metrics with invalid value", %{user: user, conn: conn} do
-    favorites = ["price_eth", "nvt", "asdfqwerty"]
+  test "favorite metrics support random non existing metrics", %{user: user, conn: conn} do
+    favorites = ["price_eth", "nvt", "non-existing-metric"]
 
     query = change_favorite_metrics_query(favorites)
     result = conn |> execute(query, "updateUserSettings")
 
-    assert result["favoriteMetrics"] == nil
+    assert result["favoriteMetrics"] == ["price_eth", "nvt", "non-existing-metric"]
 
-    assert UserSettings.settings_for(user, force: true) |> Map.get(:favorite_metrics) == []
+    assert UserSettings.settings_for(user, force: true) |> Map.get(:favorite_metrics) == [
+             "price_eth",
+             "nvt",
+             "non-existing-metric"
+           ]
   end
 
   test "toggle beta mode", %{user: user, conn: conn} do


### PR DESCRIPTION
Not checking against the list of metrics allows the FE to add custom metrics created by combining other metrics to that list.

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
