### PR TITLE
Implement z_score transform for getMetric

### DIFF
--- a/lib/sanbase/accounts/statistics.ex
+++ b/lib/sanbase/accounts/statistics.ex
@@ -17,7 +17,7 @@ defmodule Sanbase.Accounts.Statistics do
     {min_stake, max_stake} = Sanbase.Math.min_max(san_balances)
 
     %{
-      "average_tokens_staked" => Math.average(san_balances),
+      "average_tokens_staked" => Math.mean(san_balances),
       "median_tokens_staked" => Math.median(san_balances),
       "tokens_staked" => Enum.sum(san_balances) |> Kernel.*(1.0) |> Float.round(2),
       "biggest_stake" => max_stake |> Kernel.*(1.0) |> Float.round(2),

--- a/lib/sanbase/alerts/trigger/settings/result_builder/transformer.ex
+++ b/lib/sanbase/alerts/trigger/settings/result_builder/transformer.ex
@@ -45,7 +45,7 @@ defmodule Sanbase.Alert.ResultBuilder.Transformer do
         %{previous: previous, current: current, previous_list: previous_list} =
           decompose_list(values, value_key)
 
-        previous_average = Sanbase.Math.average(previous_list, precision: 2)
+        previous_average = Sanbase.Math.mean(previous_list, precision: 2)
 
         Data.new(%{
           identifier: identifier,

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -210,7 +210,7 @@ defmodule Sanbase.SocialData.MetricAdapter do
           {:ok, result} ->
             value =
               Enum.map(result, & &1.value)
-              |> Sanbase.Math.average()
+              |> Sanbase.Math.mean()
 
             {:ok, %{value: value}}
 

--- a/test/sanbase/utils/math_test.exs
+++ b/test/sanbase/utils/math_test.exs
@@ -7,14 +7,14 @@ defmodule Sanbase.MathTest do
   doctest Sanbase.Math
 
   test "#average" do
-    assert Math.average([4, 6, 8, 2]) == 5.0
-    assert Math.average([]) == 0
-    assert Math.average([0.126]) == 0.13
+    assert Math.mean([4, 6, 8, 2]) == 5.0
+    assert Math.mean([]) == 0
+    assert Math.mean([0.126]) == 0.13
   end
 
   property "average is always between min and max when list of integers" do
     check all(list <- list_of(positive_integer(), min_length: 1)) do
-      average = Math.average(list)
+      average = Math.mean(list)
       min = Enum.min(list)
       max = Enum.max(list)
       assert average >= min and average <= max
@@ -26,7 +26,7 @@ defmodule Sanbase.MathTest do
     epsilon = 0.01
 
     check all(list <- list_of(float(min: 0.00), min_length: 1)) do
-      average = Math.average(list)
+      average = Math.mean(list)
       min = Enum.min(list)
       max = Enum.max(list)
       assert average >= min - epsilon and average <= max + epsilon


### PR DESCRIPTION
## Changes

```graphql
 {
  getMetric(metric: "daily_active_addresses") {
    timeseriesData(
      slug: "bitcoin"
      from: "utc_now-30d"
      to: "utc_now"
      interval: "1d"
      transform: {type: "z_score"}
    ) {
      datetime
      value
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
