### PR TITLE
Send the change email link to the new email not the old

### DIFF
--- a/lib/sanbase/accounts/user/user_email.ex
+++ b/lib/sanbase/accounts/user/user_email.ex
@@ -126,7 +126,7 @@ defmodule Sanbase.Accounts.User.Email do
     verify_link = SanbaseWeb.Endpoint.verify_url(user.email_candidate_token, user.email_candidate)
     template = Sanbase.Email.Template.verification_email_template()
 
-    Sanbase.TemplateMailer.send(user.email, template, %{verify_link: verify_link})
+    Sanbase.TemplateMailer.send(user.email_candidate, template, %{verify_link: verify_link})
   end
 
   defp do_send_login_email(user, origin_host_parts, args) do

--- a/lib/sanbase_web/graphql/resolvers/user/auth_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/auth_resolver.ex
@@ -154,8 +154,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.AuthResolver do
          {:ok, %EmailLoginAttempt{}} <- EmailLoginAttempt.create(user, remote_ip) do
       {:ok, %{success: true}}
     else
-      {:error, _} ->
-        {:error, message: "Can't change current user's email to #{email_candidate}"}
+      {:error, error} ->
+        error_msg = "Can't change current user's email to #{email_candidate}"
+        Logger.info(error_msg <> ". Reason: #{inspect(error)}")
+        {:error, message: error_msg}
     end
   end
 


### PR DESCRIPTION
## Changes

When attempting to change email, the email must be send to the new email, not the old one. The old one might not even exists if the user is registered via metamask.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
