### PR TITLE
Add selector to getMetric and getSignal API calls

### DIFF
--- a/lib/sanbase_web/graphql/absinthe_before_send.ex
+++ b/lib/sanbase_web/graphql/absinthe_before_send.ex
@@ -30,7 +30,7 @@ defmodule SanbaseWeb.Graphql.AbsintheBeforeSend do
 
   @compile inline: [
              cache_result: 2,
-             construct_query_name: 1,
+             get_query_and_selector: 1,
              export_api_call_data: 3,
              extract_caller_data: 1,
              get_cache_key: 1,
@@ -190,10 +190,13 @@ defmodule SanbaseWeb.Graphql.AbsintheBeforeSend do
             request_id <> "_" <> (:crypto.strong_rand_bytes(6) |> Base.encode64())
         end
 
+      {query, selector} = get_query_and_selector(query)
+
       %{
         timestamp: div(now, 1_000_000_000),
         id: id,
-        query: query |> construct_query_name(),
+        query: query,
+        selector: selector,
         status_code: 200,
         has_graphql_errors: has_graphql_errors?(blueprint),
         user_id: user_id,
@@ -209,9 +212,13 @@ defmodule SanbaseWeb.Graphql.AbsintheBeforeSend do
     |> Sanbase.KafkaExporter.persist_async(:api_call_exporter)
   end
 
-  defp construct_query_name({:get_metric, metric}), do: "getMetric|#{metric}"
-  defp construct_query_name({:get_signal, signal}), do: "getSignal|#{signal}"
-  defp construct_query_name(query), do: query
+  defp get_query_and_selector({:get_metric, metric, selector}),
+    do: {"getMetric|#{metric}", selector}
+
+  defp get_query_and_selector({:get_signal, signal, selector}),
+    do: {"getSignal|#{signal}", selector}
+
+  defp get_query_and_selector(query), do: {query, nil}
 
   defp remote_ip(blueprint) do
     blueprint.execution.context.remote_ip |> IP.ip_tuple_to_string()

--- a/lib/sanbase_web/graphql/absinthe_before_send.ex
+++ b/lib/sanbase_web/graphql/absinthe_before_send.ex
@@ -190,15 +190,13 @@ defmodule SanbaseWeb.Graphql.AbsintheBeforeSend do
             request_id <> "_" <> (:crypto.strong_rand_bytes(6) |> Base.encode64())
         end
 
-      {query, selector} =
-        get_query_and_selector(query)
-        |> IO.inspect()
+      {query, selector} = get_query_and_selector(query)
 
       %{
         timestamp: div(now, 1_000_000_000),
         id: id,
         query: query,
-        selector: selector,
+        selector: Jason.encode!(selector),
         status_code: 200,
         has_graphql_errors: has_graphql_errors?(blueprint),
         user_id: user_id,

--- a/lib/sanbase_web/graphql/absinthe_before_send.ex
+++ b/lib/sanbase_web/graphql/absinthe_before_send.ex
@@ -190,7 +190,9 @@ defmodule SanbaseWeb.Graphql.AbsintheBeforeSend do
             request_id <> "_" <> (:crypto.strong_rand_bytes(6) |> Base.encode64())
         end
 
-      {query, selector} = get_query_and_selector(query)
+      {query, selector} =
+        get_query_and_selector(query)
+        |> IO.inspect()
 
       %{
         timestamp: div(now, 1_000_000_000),

--- a/lib/sanbase_web/graphql/middlewares/transform_resolution.ex
+++ b/lib/sanbase_web/graphql/middlewares/transform_resolution.ex
@@ -38,7 +38,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.TransformResolution do
     }
   end
 
-  defp do_call(query_field, resolution) do
+  defp do_call(_query_field, resolution) do
     resolution
   end
 
@@ -46,15 +46,15 @@ defmodule SanbaseWeb.Graphql.Middlewares.TransformResolution do
   defp get_selectors(resolution) do
     resolution.definition.selections
     |> Enum.map(fn %{name: name} = field ->
-      selector =
-        case Inflex.camelize(name, :lower) do
-          name when name in @fields_with_selector ->
-            argument_data_to_selector(field.argument_data)
+      case Inflex.camelize(name, :lower) do
+        name when name in @fields_with_selector ->
+          argument_data_to_selector(field.argument_data)
 
-          name ->
-            nil
-        end
+        _ ->
+          nil
+      end
     end)
+    |> Enum.reject(&is_nil/1)
   end
 
   # In some cases users can provide lists of slugs that have 50-100-200 slugs inside

--- a/lib/sanbase_web/graphql/middlewares/transform_resolution.ex
+++ b/lib/sanbase_web/graphql/middlewares/transform_resolution.ex
@@ -57,7 +57,11 @@ defmodule SanbaseWeb.Graphql.Middlewares.TransformResolution do
     end)
   end
 
+  # In some cases users can provide lists of slugs that have 50-100-200 slugs inside
+  # This would take a lot of resources to store, so it's redacted.
   defp argument_data_to_selector(%{selector: selector}), do: selector
+  defp argument_data_to_selector(%{slug: slugs}) when length(slugs) <= 5, do: %{slug: slugs}
+  defp argument_data_to_selector(%{slug: [_ | _]}), do: %{slug: "<long_slugs_list>"}
   defp argument_data_to_selector(%{slug: slug}), do: %{slug: slug}
   defp argument_data_to_selector(_), do: nil
 end

--- a/lib/sanbase_web/graphql/middlewares/transform_resolution.ex
+++ b/lib/sanbase_web/graphql/middlewares/transform_resolution.ex
@@ -18,7 +18,8 @@ defmodule SanbaseWeb.Graphql.Middlewares.TransformResolution do
 
   defp do_call(:get_metric, %{context: context} = resolution) do
     %{arguments: %{metric: metric}} = resolution
-    elem = {:get_metric, metric}
+    selectors = get_selectors(resolution)
+    elem = {:get_metric, metric, selectors}
 
     %Resolution{
       resolution
@@ -28,7 +29,8 @@ defmodule SanbaseWeb.Graphql.Middlewares.TransformResolution do
 
   defp do_call(:get_signal, %{context: context} = resolution) do
     %{arguments: %{signal: signal}} = resolution
-    elem = {:get_signal, signal}
+    selectors = get_selectors(resolution)
+    elem = {:get_signal, signal, selectors}
 
     %Resolution{
       resolution
@@ -36,5 +38,26 @@ defmodule SanbaseWeb.Graphql.Middlewares.TransformResolution do
     }
   end
 
-  defp do_call(_, resolution), do: resolution
+  defp do_call(query_field, resolution) do
+    resolution
+  end
+
+  @fields_with_selector ["timeseriesData", "timeseriesDataPerSlug", "aggregatedTimeseriesData"]
+  defp get_selectors(resolution) do
+    resolution.definition.selections
+    |> Enum.map(fn %{name: name} = field ->
+      selector =
+        case Inflex.camelize(name, :lower) do
+          name when name in @fields_with_selector ->
+            argument_data_to_selector(field.argument_data)
+
+          name ->
+            nil
+        end
+    end)
+  end
+
+  defp argument_data_to_selector(%{selector: selector}), do: selector
+  defp argument_data_to_selector(%{slug: slug}), do: %{slug: slug}
+  defp argument_data_to_selector(_), do: nil
 end

--- a/test/sanbase_web/graphql/clickhouse/api_call_data_api_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/api_call_data_api_test.exs
@@ -7,38 +7,73 @@ defmodule SanbaseWeb.Graphql.ApiCallDataApiTest do
   setup do
     user = insert(:user)
     project = insert(:random_project)
-    insert(:subscription_premium, user: user)
+    project2 = insert(:random_project)
+    insert(:subscription_pro_sanbase, user: user)
     conn = setup_jwt_auth(build_conn(), user)
-    %{conn: conn, project: project}
+    %{conn: conn, project: project, project2: project2}
   end
 
-  test "export get_metric api calls with the metric as argument", context do
-    %{conn: conn, project: project} = context
+  test "export get_metric api calls with the metric and slug as arguments", context do
+    %{conn: conn, project: %{slug: slug}, project2: %{slug: slug2}} = context
 
     Sanbase.Mock.prepare_mock2(&Sanbase.Clickhouse.MetricAdapter.timeseries_data/6, {:ok, []})
+    |> Sanbase.Mock.prepare_mock2(
+      &Sanbase.Clickhouse.MetricAdapter.timeseries_data_per_slug/6,
+      {:ok, []}
+    )
     |> Sanbase.Mock.run_with_mocks(fn ->
       from = ~U[2019-01-05 00:00:00Z]
       to = ~U[2019-01-06 00:00:00Z]
 
       Sanbase.InMemoryKafka.Producer.clear_state()
-      get_metric(conn, "mvrv_usd", project.slug, from, to, "1d")
-      get_metric(conn, "nvt", project.slug, from, to, "1d")
-      get_metric(conn, "daily_active_addresses", project.slug, from, to, "1d")
+      get_metric(conn, "mvrv_usd", slug, from, to, "1d")
+      get_metric(conn, "nvt", slug, from, to, "1d")
+      get_metric(conn, "daily_active_addresses", slug, from, to, "1d")
+
+      get_metric_timeseries_data_per_slug(conn, "nvt", [slug, slug2], from, to, "1d")
+      get_metric_timeseries_data_per_slug(conn, "mvrv_usd", [slug, slug2], from, to, "1d")
 
       # force the sending
       Sanbase.KafkaExporter.flush(:api_call_exporter)
 
       %{"sanbase_api_call_data" => api_calls} = Sanbase.InMemoryKafka.Producer.get_state()
 
-      api_calls_queries =
-        Enum.map(api_calls, fn {_, data} -> Jason.decode!(data) |> Map.get("query") end)
+      api_calls =
+        Enum.map(api_calls, fn {_, data} ->
+          data = Jason.decode!(data)
+          %{query: data["query"], selector: data["selector"]}
+        end)
 
       # There could be some test that exported api calls data and that happens async
       # so something could happend even after the `clear_state` is called
-      assert length(api_calls_queries) >= 3
-      assert "getMetric|mvrv_usd" in api_calls_queries
-      assert "getMetric|nvt" in api_calls_queries
-      assert "getMetric|daily_active_addresses" in api_calls_queries
+      assert length(api_calls) >= 5
+      slug_selector = [%{slug: slug}] |> Jason.encode!()
+      slugs_selector = [%{slugs: [slug, slug2]}] |> Jason.encode!()
+
+      assert %{
+               query: "getMetric|daily_active_addresses",
+               selector: slug_selector
+             } in api_calls
+
+      assert %{
+               query: "getMetric|nvt",
+               selector: slug_selector
+             } in api_calls
+
+      assert %{
+               query: "getMetric|mvrv_usd",
+               selector: slug_selector
+             } in api_calls
+
+      assert %{
+               query: "getMetric|nvt",
+               selector: slugs_selector
+             } in api_calls
+
+      assert %{
+               query: "getMetric|mvrv_usd",
+               selector: slugs_selector
+             } in api_calls
     end)
   end
 
@@ -49,6 +84,28 @@ defmodule SanbaseWeb.Graphql.ApiCallDataApiTest do
         timeseriesData(slug: "#{slug}", from: "#{from}", to: "#{to}", interval: "#{interval}"){
           datetime
           value
+        }
+      }
+    }
+    """
+
+    conn
+    |> post("/graphql", query_skeleton(query))
+    |> json_response(200)
+  end
+
+  defp get_metric_timeseries_data_per_slug(conn, metric, slugs, from, to, interval) do
+    slugs_str = Enum.map(slugs, &~s|"#{&1}"|) |> Enum.join(", ")
+
+    query = """
+    {
+      get_metric(metric: "#{metric}") {
+        timeseriesDataPerSlug(selector: {slugs: [#{slugs_str}]}, from: "#{from}", to: "#{to}", interval: "#{interval}"){
+          datetime
+          data{
+            slug
+            value
+          }
         }
       }
     }


### PR DESCRIPTION
## Changes

When `getMetric` or `getSignal` is called, also add the selector to the fields in the API call data.

because the following is possible:
```graphql
{
  getMetric(metric: "price_usd"){
    a: timeseriesData(slug: "bitcoin" from: "utc_now-1d" to: "utc_now"){ datetime value}
    b: timeseriesData(slug: "ethereum" from: "utc_now-1d" to: "utc_now"){ datetime value}
    c: timeseriesData(slug: "maker" from: "utc_now-1d" to: "utc_now"){ datetime value}
  }
}
```

In such case the single `getMetric` call has multiple selector. Because of this, the field is a list of maps. In the above example it will be:
```json
"[{\"slug\":\"bitcoin\"},{\"slug\":\"ethereum\"},{\"slug\":\"maker\"}]"
```

> Note: It is possible for users to provide a lot of assets (100-200 or more) in a list of slugs in the selector. It would be taking too many resources to store this, so long lists are redacted as `<long_slugs_list>`
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
