### PR TITLE
Fix RepoReader test and reduce confusion in code

### DIFF
--- a/lib/sanbase/repo_reader/repo_reader.ex
+++ b/lib/sanbase/repo_reader/repo_reader.ex
@@ -11,7 +11,7 @@ defmodule Sanbase.RepoReader do
   alias __MODULE__.{Repository, Validator}
 
   import __MODULE__.Utils,
-    only: [clone_repo: 1, clone_repo: 2, read_files: 2, files_to_directories: 1]
+    only: [clone_repo: 2, read_files: 2, files_to_directories: 1]
 
   require Logger
 
@@ -72,7 +72,7 @@ defmodule Sanbase.RepoReader do
   # Private functions
 
   defp do_update_projects(path, changed_directories) do
-    with {:ok, %Repository{} = repo} <- clone_repo(path),
+    with {:ok, %Repository{} = repo} <- clone_repo(path, branch: "main"),
          {:ok, projects_map} <- read_files(repo, directories_to_read: changed_directories) do
       slugs = Map.keys(projects_map)
 

--- a/lib/sanbase/repo_reader/repo_reader_utils.ex
+++ b/lib/sanbase/repo_reader/repo_reader_utils.ex
@@ -11,10 +11,10 @@ defmodule Sanbase.RepoReader.Utils do
   the files in the specified path
   """
   @spec clone_repo(String.t(), Keyword.t()) :: {:ok, Repository.t()} | {:error, String.t()}
-  def clone_repo(path, opts \\ []) do
+  def clone_repo(path, opts) do
     Logger.info("Cloning reposistory #{@repository}...")
 
-    branch = Keyword.get(opts, :branch, "main")
+    branch = Keyword.fetch!(opts, :branch)
 
     case System.cmd("git", ["clone", "--branch", branch, @repository_url, path],
            stderr_to_stdout: true

--- a/test/sanbase_web/controller/repo_reader_controller_test.exs
+++ b/test/sanbase_web/controller/repo_reader_controller_test.exs
@@ -118,7 +118,7 @@ defmodule SanbaseWeb.RepoReaderControllerTest do
     alias Sanbase.Model.Project
 
     test "reader webhook with exception", context do
-      Sanbase.Mock.prepare_mock(Sanbase.RepoReader.Utils, :clone_repo, fn _ ->
+      Sanbase.Mock.prepare_mock(Sanbase.RepoReader.Utils, :clone_repo, fn _, _ ->
         raise("Some exception")
       end)
       |> Sanbase.Mock.run_with_mocks(fn ->
@@ -135,7 +135,7 @@ defmodule SanbaseWeb.RepoReaderControllerTest do
     end
 
     test "reader webhook with match error", context do
-      Sanbase.Mock.prepare_mock(Sanbase.RepoReader.Utils, :clone_repo, fn _ ->
+      Sanbase.Mock.prepare_mock(Sanbase.RepoReader.Utils, :clone_repo, fn _, _ ->
         {:error, "Some unexpected error"}
       end)
       |> Sanbase.Mock.run_with_mocks(fn ->
@@ -172,7 +172,7 @@ defmodule SanbaseWeb.RepoReaderControllerTest do
         Project.by_slug("santiment", only_preload: [:github_organizations, :contract_addresses])
 
       assert project.twitter_link == "https://twitter.com/santimentfeed"
-      assert project.discord_link == "https://discord.gg/MPH2uP5"
+      assert project.discord_link == "https://discord.com/santiment"
       assert project.github_organizations |> hd() |> Map.get(:organization) == "santiment"
 
       assert project.contract_addresses |> hd() |> Map.get(:address) ==


### PR DESCRIPTION
## Changes

The clone_repo function had 1-arity and 2-arity versions, which makes it confusing what to mock in tests.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
