### PR TITLE
Add locking to dashboard database queries

### DIFF
--- a/lib/sanbase/comments/comment.ex
+++ b/lib/sanbase/comments/comment.ex
@@ -5,13 +5,22 @@ defmodule Sanbase.Comment do
   A comment is represented by its:
   - author
   - content
-  - subcomments & subcomments_count
-  - parent_id - The id of the comment to which this comment is a direct subcomment.
-    The parent of the subcomment in the tree this comment is part of (if not nil)
-  - root_parent_id - The top-level comment id in the chain of subcomments.
-    The root of the tree this comment is part of (if not nil)
+  - Relationship to other comments in a tree hierarchy:
+    - parent_id - The id of the comment to which this comment is a direct subcomment.
+      The parent of the subcomment in the tree this comment is part of (if not nil)
+    - root_parent_id - The top-level comment id in the chain of subcomments.
+      The root of the tree this comment is part of (if not nil)
+    - subcomments_count
   - timestamp fields
 
+  The comment itself does not belong to any entity (post, chart configuration, etc.).
+  The comments live independently of all these entities - join_through tables are
+  used to build a relationship between entities and comments. One such example table
+  is `post_comments_mapping` which maps comments to posts. Comments of an entity
+  can be viewed as a collection of comment trees - the "top-level" comments are those
+  without parent_id/root_parent_id, which can be ordered by `inserted_at`. Every
+  subcomment in such a tree has parent_id and root_parent_id, where the root_parent_id
+  is the said top-level comment
 
   The EntityComment module is used to interact with comments and is
   invisible to the outside world

--- a/lib/sanbase/dashboard/dashboard_query.ex
+++ b/lib/sanbase/dashboard/dashboard_query.ex
@@ -31,7 +31,7 @@ defmodule Sanbase.Dashboard.Query do
       {:ok, map} ->
         {:ok,
          %Query.Result{
-           san_query_id: san_query_id || "<unknown>",
+           san_query_id: san_query_id,
            clickhouse_query_id: map.query_id,
            summary: map.summary,
            rows: map.rows,

--- a/lib/sanbase/dashboard/dashboard_query.ex
+++ b/lib/sanbase/dashboard/dashboard_query.ex
@@ -31,7 +31,7 @@ defmodule Sanbase.Dashboard.Query do
       {:ok, map} ->
         {:ok,
          %Query.Result{
-           san_query_id: san_query_id,
+           san_query_id: san_query_id || "<unknown>",
            clickhouse_query_id: map.query_id,
            summary: map.summary,
            rows: map.rows,

--- a/lib/sanbase_web/admin/model/project_market_segment.ex
+++ b/lib/sanbase_web/admin/model/project_market_segment.ex
@@ -2,7 +2,7 @@ defmodule SanbaseWeb.ExAdmin.ProjectMarketSegment do
   use ExAdmin.Register
 
   alias Sanbase.Project
-  alias Sanbase.ModelMarketSegment
+  alias Sanbase.Model.MarketSegment
 
   register_resource Sanbase.Project.ProjectMarketSegment do
     show market_segment do


### PR DESCRIPTION
## Changes

Fix a few issues:

- Add a row-level lock: When the frontend stores/updates a dashboard, it emits multiple `updateDashboardPanel` and `createDashboardPanel` queries. These queries need to lock the row that they work on in order to avoid race conditions.
- Fix when ids are added to panels. Make it possible to work when the `san_query_id` is not available.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
