### PR TITLE
Fix caching dashboards with more than one panel

### DIFF
--- a/lib/sanbase/dashboard/discord_dashboard.ex
+++ b/lib/sanbase/dashboard/discord_dashboard.ex
@@ -121,12 +121,10 @@ defmodule Sanbase.Dashboard.DiscordDashboard do
   def create(user_id, query, params) do
     args = Map.put(params, :user_id, user_id)
 
+    create_panel_args = %{name: params.name, sql: %{parameters: %{}, query: query}}
+
     with {:ok, dashboard} <- Dashboard.create(%{name: params.name}, user_id),
-         {:ok, %{panel: panel}} <-
-           Dashboard.create_panel(dashboard.id, %{
-             name: params.name,
-             sql: %{parameters: %{}, query: query}
-           }),
+         {:ok, %{panel: panel}} <- Dashboard.create_panel(dashboard.id, create_panel_args),
          {:ok, %__MODULE__{}} <-
            do_create(Map.merge(args, %{dashboard_id: dashboard.id, panel_id: panel.id})),
          {:ok, result} <-


### PR DESCRIPTION
## Changes

When dashboard panel cache was updated, the existing cache panels were first loaded and transformed by decompressing `compressed_rows` into `rows`. Then this transformed cache was written back to the database.
Fix by not transforming the existing cached panels.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
