### PR TITLE
Rework login/registration state and events

### DIFF
--- a/lib/sanbase/accounts/accounts.ex
+++ b/lib/sanbase/accounts/accounts.ex
@@ -2,6 +2,9 @@ defmodule Sanbase.Accounts do
   alias Sanbase.Repo
   alias __MODULE__.{User, EthAccount}
 
+  import Ecto.Query
+  import Sanbase.Accounts.User.Ecto, only: [registration_state_equals: 1]
+
   def get_user(user_id_or_ids) do
     User.by_id(user_id_or_ids)
   end
@@ -10,6 +13,47 @@ defmodule Sanbase.Accounts do
     case User.by_id(user_id_or_ids) do
       {:ok, user} -> user
       {:error, error} -> raise(error)
+    end
+  end
+
+  @doc ~s"""
+  Evolve the registration state by performing `action` and storing `data`.
+
+  The registration state is a JSON map with `state` and `data` fields. Actions
+  can be:
+    - send_login_email
+    - google_oauth
+    - twitter_oauth
+    - eth_login
+    - email_login_verify
+    - login
+
+  Performing an action either moves the state to a different state or keep the same
+  state. The state is kept when it is already `finished`, then any action is noop,
+  as the registration has been finished.
+
+  The `data` field keeps values like `origin_url`, `login_origin`, etc. that can be
+  used in events emitting after the state reaches a given value after some transition.
+  For example, `send_email_login` can put `origin_url`, but only after performing
+  `email_login_verify` the `:register_user` event can be emitted, containing the
+  URL stored before.
+  """
+  @spec forward_registration(User.t(), String.t(), Map.t()) ::
+          {:ok, :evolve_state | :keep_state, User.t()} | no_return()
+  def forward_registration(%User{} = user, action, data) do
+    %{registration_state: %{"state" => current_state}} = user
+
+    case User.RegistrationState.forward(user, action, data) do
+      :keep_state ->
+        {:ok, :keep_state, user}
+
+      {:next_state, state, data} ->
+        registration_state = %{"state" => state, "data" => data}
+
+        case atomic_update(user.id, current_state, registration_state) do
+          {1, [user]} -> {:ok, :evolve_state, user}
+          {0, _} -> {:ok, :keep_state, user}
+        end
     end
   end
 
@@ -34,5 +78,17 @@ defmodule Sanbase.Accounts do
       {:error, _, reason, _} ->
         {:error, reason}
     end
+  end
+
+  defp atomic_update(user_id, old_state, new_registration_state) do
+    # Atomic update. If the same code is execute from multiple processes or nodes
+    # only one of them should succeed
+    from(
+      user in User,
+      where: user.id == ^user_id and registration_state_equals(old_state),
+      update: [set: [registration_state: ^new_registration_state]],
+      select: user
+    )
+    |> Repo.update_all([])
   end
 end

--- a/lib/sanbase/accounts/accounts_event_emitter.ex
+++ b/lib/sanbase/accounts/accounts_event_emitter.ex
@@ -11,12 +11,12 @@ defmodule Sanbase.Accounts.EventEmitter do
     |> notify()
   end
 
-  def handle_event({:ok, user}, :register_user, %{login_origin: _} = args) do
+  def handle_event({:ok, user}, :register_user, %{} = args) do
     Map.merge(%{event_type: :register_user, user_id: user.id}, args)
     |> notify()
   end
 
-  def handle_event({:ok, user}, :login_user, %{login_origin: _} = args) do
+  def handle_event({:ok, user}, :login_user, %{} = args) do
     Map.merge(%{event_type: :login_user, user_id: user.id}, args)
     |> notify()
   end
@@ -56,7 +56,7 @@ defmodule Sanbase.Accounts.EventEmitter do
     |> notify()
   end
 
-  def handle_event({:ok, user_follower}, event_type, _extra_args)
+  def handle_event({:ok, user_follower}, event_type, _args)
       when event_type in [:follow_user, :unfollow_user] do
     %{
       event_type: event_type,

--- a/lib/sanbase/accounts/statistics.ex
+++ b/lib/sanbase/accounts/statistics.ex
@@ -1,6 +1,6 @@
 defmodule Sanbase.Accounts.Statistics do
   import Ecto.Query
-
+  import Sanbase.Accounts.User.Ecto, only: [is_registered: 0]
   alias Sanbase.Repo
   alias Sanbase.Math
   alias Sanbase.Accounts.User
@@ -36,7 +36,7 @@ defmodule Sanbase.Accounts.Statistics do
     from(u in User,
       where:
         (like(u.email, "%@santiment.net") or u.id in ^santiment_role_user_ids) and
-          u.is_registered == true
+          is_registered()
     )
     |> Repo.all()
   end

--- a/lib/sanbase/accounts/user/user_ecto.ex
+++ b/lib/sanbase/accounts/user/user_ecto.ex
@@ -1,0 +1,16 @@
+defmodule Sanbase.Accounts.User.Ecto do
+  defmacro registration_state_equals(state) do
+    quote do
+      fragment(
+        "registration_state->'state' = ?",
+        ^unquote(state)
+      )
+    end
+  end
+
+  defmacro is_registered() do
+    quote do
+      fragment("registration_state->'state' = 'finished'")
+    end
+  end
+end

--- a/lib/sanbase/accounts/user/user_registration_state.ex
+++ b/lib/sanbase/accounts/user/user_registration_state.ex
@@ -1,0 +1,89 @@
+defmodule Sanbase.Accounts.User.RegistrationState do
+  @moduledoc ~s"""
+  The Registration State is a JSON field of the User that holds the current
+  state of the registration process along with some metadata.
+
+  The state is evolved like a state machine - given the current state and some
+  action, the state can either evolve to a new state or be kept the same.
+  """
+
+  alias Sanbase.Accounts.EventEmitter
+  alias Sanbase.Accounts.User
+  alias __MODULE__.StateMachine
+
+  @doc ~s"""
+  Take a step forward in the registration progress by executing the given `action`.
+
+  The new data is merged with the old data and this is stored in the map as well,
+  so it can be used later.
+
+  In some of the cases emit events like:
+  If the state changes from not finished to finish, emit :register_user event
+  """
+  def forward(%User{registration_state: registration_state} = user, action, data) do
+    current_state = Map.fetch!(registration_state, "state")
+
+    old_data =
+      Map.get(registration_state, "data", %{})
+      |> Map.new(fn {k, v} -> {String.to_existing_atom(k), v} end)
+
+    merged_data = Map.merge(old_data, data)
+
+    case StateMachine.forward(current_state, action) do
+      :keep_state ->
+        :keep_state
+
+      {:next_state, next_state} ->
+        {:next_state, next_state, merged_data}
+    end
+    |> emit_event(user)
+  end
+
+  def is_registered(%User{registration_state: registration_state}) do
+    registration_state["state"] == "finished"
+  end
+
+  def is_first_login(%User{registration_state: registration_state}, action)
+      when action in ["eth_login", "email_login_verify"] do
+    %{"state" => current_state} = registration_state
+
+    # This is going to be used in case of eth_login and email_login_verify actions
+    # In these cases, if this action is performed and the state is not finished, but
+    # moves to `finished` after performing the action, then this can be treated
+    # as first_login: true`
+    current_state != "finished" and
+      match?({:next_state, "finished"}, StateMachine.forward(current_state, action))
+  end
+
+  def login_to_finish_registration?(%User{registration_state: registration_state}) do
+    registration_state["state"] == "wait_login_to_finish_registration"
+  end
+
+  defp emit_event(:keep_state, _), do: :keep_state
+
+  defp emit_event({:next_state, "login_email_sent", data} = result, user) do
+    EventEmitter.emit_event({:ok, user}, :send_email_login_link, data)
+
+    result
+  end
+
+  defp emit_event({:next_state, "finished", data} = result, user) do
+    EventEmitter.emit_event({:ok, user}, :register_user, data)
+
+    result
+  end
+
+  defp emit_event(result, _user), do: result
+
+  defmodule StateMachine do
+    # In case the user is already registered, do nothing.
+    def forward("finished", _), do: :keep_state
+
+    def forward(_, "send_login_email"), do: {:next_state, "login_email_sent"}
+    def forward(_, "google_oauth"), do: {:next_state, "wait_login_to_finish_registration"}
+    def forward(_, "twitter_oauth"), do: {:next_state, "wait_login_to_finish_registration"}
+    def forward(_, "eth_login"), do: {:next_state, "finished"}
+    def forward(_, "email_login_verify"), do: {:next_state, "finished"}
+    def forward("wait_login_to_finish_registration", "login"), do: {:next_state, "finished"}
+  end
+end

--- a/lib/sanbase/event_bus/event_validation.ex
+++ b/lib/sanbase/event_bus/event_validation.ex
@@ -21,7 +21,7 @@ defmodule Sanbase.EventBus.EventValidation do
     do: valid_integer_id?(id) and is_binary(email)
 
   def valid?(%{event_type: :register_user, user_id: id, login_origin: login_origin}),
-    do: valid_integer_id?(id) and is_atom(login_origin)
+    do: valid_integer_id?(id) and (is_atom(login_origin) or is_binary(login_origin))
 
   def valid?(%{event_type: event_type, user_id: user_id, follower_id: follower_id})
       when event_type in [:follow_user, :unfollow_user] do
@@ -29,7 +29,7 @@ defmodule Sanbase.EventBus.EventValidation do
   end
 
   def valid?(%{event_type: :login_user, user_id: id, login_origin: login_origin}),
-    do: valid_integer_id?(id) and is_atom(login_origin)
+    do: valid_integer_id?(id) and (is_atom(login_origin) or is_binary(login_origin))
 
   def valid?(%{event_type: :send_email_login_link, user_id: id}),
     do: valid_integer_id?(id)

--- a/lib/sanbase/intercom/intercom.ex
+++ b/lib/sanbase/intercom/intercom.ex
@@ -4,6 +4,7 @@ defmodule Sanbase.Intercom do
   """
 
   import Ecto.Query
+  import Sanbase.Accounts.User.Ecto, only: [is_registered: 0]
 
   alias Sanbase.Utils.Config
   alias Sanbase.Accounts.{User, Statistics}
@@ -95,7 +96,7 @@ defmodule Sanbase.Intercom do
   end
 
   def fetch_new_registrations_since(dt) do
-    from(u in User, where: u.is_registered and u.inserted_at > ^dt, select: u.id)
+    from(u in User, where: is_registered() and u.inserted_at > ^dt, select: u.id)
     |> Repo.all()
   end
 
@@ -409,7 +410,7 @@ defmodule Sanbase.Intercom do
   end
 
   def signed_up_at(user) do
-    case user.is_registered do
+    case User.RegistrationState.is_registered(user) do
       true -> DateTime.from_naive!(user.inserted_at, "Etc/UTC") |> DateTime.to_unix()
       false -> 0
     end

--- a/lib/sanbase_web/controllers/bot_login_controller.ex
+++ b/lib/sanbase_web/controllers/bot_login_controller.ex
@@ -18,11 +18,7 @@ defmodule SanbaseWeb.BotLoginController do
   defp send_response(user, conn) do
     device_data = SanbaseWeb.Guardian.device_data(conn)
 
-    {:ok, jwt_tokens} =
-      SanbaseWeb.Guardian.get_jwt_tokens(user,
-        platform: device_data.platform,
-        client: device_data.platform
-      )
+    {:ok, jwt_tokens} = SanbaseWeb.Guardian.get_jwt_tokens(user, device_data)
 
     conn
     |> SanbaseWeb.Guardian.add_jwt_tokens_to_conn_session(jwt_tokens)

--- a/lib/sanbase_web/graphql/schema/queries/auth_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/auth_queries.ex
@@ -109,7 +109,7 @@ defmodule SanbaseWeb.Graphql.Schema.AuthQueries do
       arg(:consent, :string)
       arg(:subscribe_to_weekly_newsletter, :boolean)
 
-      resolve(&AuthResolver.email_login/2)
+      resolve(&AuthResolver.send_email_login_email/2)
     end
 
     @desc ~s"""

--- a/lib/sanbase_web/guardian/guardian.ex
+++ b/lib/sanbase_web/guardian/guardian.ex
@@ -57,9 +57,9 @@ defmodule SanbaseWeb.Guardian do
     |> Plug.Conn.put_session(:refresh_token, jwt_tokens_map.refresh_token)
   end
 
-  def get_jwt_tokens(%User{} = user, opts \\ []) do
-    platform = Keyword.get(opts, :platform, :unknown)
-    client = Keyword.get(opts, :client, :unknown)
+  def get_jwt_tokens(%User{} = user, args \\ %{}) do
+    platform = Map.get(args, :platform, :unknown)
+    client = Map.get(args, :client, :unknown)
 
     with {:ok, access_token, _claims} <-
            encode_and_sign(

--- a/priv/repo/migrations/20221215103058_add_registration_state_field.exs
+++ b/priv/repo/migrations/20221215103058_add_registration_state_field.exs
@@ -1,0 +1,9 @@
+defmodule Sanbase.Repo.Migrations.AddRegistrationStateField do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add(:registration_state, :jsonb, default: "{\"state\": \"init\"}")
+    end
+  end
+end

--- a/priv/repo/migrations/20221216095648_fill_registration_state_field.exs
+++ b/priv/repo/migrations/20221216095648_fill_registration_state_field.exs
@@ -1,0 +1,25 @@
+defmodule Sanbase.Repo.Migrations.FillRegistrationStateField do
+  use Ecto.Migration
+
+  import Ecto.Query
+
+  def up do
+    setup()
+    registration_state = %{"state" => "finished", "data" => %{}}
+
+    from(
+      user in Sanbase.Accounts.User,
+      where: user.is_registered == true,
+      update: [set: [registration_state: ^registration_state]]
+    )
+    |> Sanbase.Repo.update_all([])
+  end
+
+  def down do
+    :ok
+  end
+
+  defp setup do
+    Application.ensure_all_started(:tzdata)
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -3666,7 +3666,8 @@ CREATE TABLE public.users (
     is_registered boolean DEFAULT false,
     is_superuser boolean DEFAULT false,
     twitter_id character varying(255) DEFAULT NULL::character varying,
-    name character varying(255)
+    name character varying(255),
+    registration_state jsonb DEFAULT '{"state": "init"}'::jsonb
 );
 
 
@@ -8083,3 +8084,5 @@ INSERT INTO public."schema_migrations" (version) VALUES (20221118110940);
 INSERT INTO public."schema_migrations" (version) VALUES (20221129102156);
 INSERT INTO public."schema_migrations" (version) VALUES (20221212124926);
 INSERT INTO public."schema_migrations" (version) VALUES (20221213105305);
+INSERT INTO public."schema_migrations" (version) VALUES (20221215103058);
+INSERT INTO public."schema_migrations" (version) VALUES (20221216095648);

--- a/test/sanbase/auth/apikey/apikey_test.exs
+++ b/test/sanbase/auth/apikey/apikey_test.exs
@@ -9,9 +9,7 @@ defmodule Sanbase.Accounts.ApiKeyTest do
   setup do
     {:ok, user} = User.find_or_insert_by(:email, "as819asdnmaso1011@santiment.net")
 
-    %{
-      user: user
-    }
+    %{user: user}
   end
 
   test "masking apikey" do

--- a/test/sanbase/auth/user_test.exs
+++ b/test/sanbase/auth/user_test.exs
@@ -261,7 +261,7 @@ defmodule Sanbase.Accounts.UserTest do
           email: "test@example.com",
           username: "cersei",
           privacy_policy_accepted: true,
-          is_registered: true
+          registration_state: %{"state" => "finished"}
         )
 
       Sanbase.Mock.prepare_mock2(&UniswapStaking.fetch_uniswap_san_staked_user/1, 2001)

--- a/test/sanbase/email/emails_test.exs
+++ b/test/sanbase/email/emails_test.exs
@@ -24,7 +24,8 @@ defmodule Sanbase.EmailsTest do
      [fetch_default_card: fn _ -> {:ok, %{default_source: "123"}} end]},
     {Sanbase.TemplateMailer, [], [send: fn _, _, _ -> {:ok, :email_sent} end]}
   ]) do
-    not_registered_user = insert(:user, email: "example@santiment.net", is_registered: false)
+    not_registered_user = insert(:user_registration_not_finished, email: "example@santiment.net")
+
     user = insert(:user)
 
     conn = setup_jwt_auth(build_conn(), user)

--- a/test/sanbase_web/graphql/auth/email_login_api_test.exs
+++ b/test/sanbase_web/graphql/auth/email_login_api_test.exs
@@ -19,7 +19,7 @@ defmodule SanbaseWeb.Graphql.EmailLoginApiTest do
   describe "Email login verify" do
     test "with a valid email token, succeeds login", %{conn: conn} do
       {:ok, user} =
-        insert(:user, email: "example@santiment.net")
+        insert(:user_registration_not_finished, email: "example@santiment.net")
         |> User.Email.update_email_token()
 
       result =
@@ -208,7 +208,6 @@ defmodule SanbaseWeb.Graphql.EmailLoginApiTest do
 
       assert {:ok, %User{}} = User.by_email("john@example.com")
       assert result["success"]
-      assert result["firstLogin"]
     end
 
     test "emailLogin returns true if the login email was sent successfully", context do
@@ -220,7 +219,6 @@ defmodule SanbaseWeb.Graphql.EmailLoginApiTest do
 
       assert {:ok, %User{}} = User.by_email("john@example.com")
       assert result["success"]
-      assert result["firstLogin"]
     end
 
     test "succeeds if the user has attempted to login 5 times", context do

--- a/test/support/factory/factory.ex
+++ b/test/support/factory/factory.ex
@@ -39,6 +39,19 @@ defmodule Sanbase.Factory do
       email: (:crypto.strong_rand_bytes(16) |> Base.encode16()) <> "@santiment.net",
       salt: User.generate_salt(),
       privacy_policy_accepted: true,
+      registration_state: %{"state" => "finished"},
+      san_balance: Decimal.new(0),
+      san_balance_updated_at: Timex.now()
+    }
+  end
+
+  def user_registration_not_finished_factory() do
+    %User{
+      username: :crypto.strong_rand_bytes(16) |> Base.encode16(),
+      email: (:crypto.strong_rand_bytes(16) |> Base.encode16()) <> "@santiment.net",
+      salt: User.generate_salt(),
+      privacy_policy_accepted: true,
+      registration_state: %{"state" => "init"},
       san_balance: Decimal.new(0),
       san_balance_updated_at: Timex.now()
     }
@@ -57,7 +70,8 @@ defmodule Sanbase.Factory do
     %User{
       salt: User.generate_salt(),
       username: User.anonymous_user_username(),
-      email: User.anonymous_user_email()
+      email: User.anonymous_user_email(),
+      registration_state: %{"state" => "finished"}
     }
   end
 
@@ -66,7 +80,8 @@ defmodule Sanbase.Factory do
       salt: User.generate_salt(),
       san_balance: Decimal.new(20_000),
       san_balance_updated_at: Timex.now(),
-      privacy_policy_accepted: true
+      privacy_policy_accepted: true,
+      registration_state: %{"state" => "finished"}
     }
   end
 

--- a/test/support/graphql_test_helpers.ex
+++ b/test/support/graphql_test_helpers.ex
@@ -102,11 +102,7 @@ defmodule SanbaseWeb.Graphql.TestHelpers do
   def setup_jwt_auth(conn, user) do
     device_data = SanbaseWeb.Guardian.device_data(conn)
 
-    {:ok, tokens} =
-      SanbaseWeb.Guardian.get_jwt_tokens(user,
-        platform: device_data.platform,
-        client: device_data.client
-      )
+    {:ok, tokens} = SanbaseWeb.Guardian.get_jwt_tokens(user, device_data)
 
     # Call both plugs so the context can be properly set up every time
     conn


### PR DESCRIPTION
## Changes

Currently, the registration progress is tracked by a single `is_registered` boolean field in the `users` table. It is set to `true` when the registration is finished - email verified, google oauth successfully passed, etc.

There is a virtual field `first_login` which is set to `true` only when the user is inserted. This makes it very hard to propagate to the API result. For example, if we have code like:
```elixir
{:ok, user} = User.insert_or_find_by(...)
{:ok, user} = User.mark_as_registered(...)
```

The second call to the `User` module will set the `first_login` field to false, as we're getting the user not for the first time.
Furthermore, when authentication via `/auth/google`, this endpoint only sets the cookies but does not return the user. The first call to `currentUser` after that has `first_login: false` as this user is already seen as existing and registered, so it is not known if this is the first, second, or 100th login.

This PR reworks this process by introducing a `registration_state` JSON field that holds a `state` and additional `data` (like `origin_url`, `login_origin`, etc.). The state is evolved as a state machine - using the current state and an action (`send_login_email`, `google_oauth`, `login`, etc.) allows for multiple states to exist, also making it possible to forward the state from the `currentUser` process, too.

This state evolving is done by calling `Sanbase.Accounts.forward_registration(user, action, data)`, which is doing the state changing and events emitting. It is now responsible for emitting the `register_user` event. The additional data includes the details for the login/registration and is used for the events.

The code now will look like this:
```elixir
 with {:ok, user} <- twitter_login(email, twitter_id),
      {:ok, _, user} <- Accounts.forward_registration(user, "twitter_oauth", args),
      {:ok, %{} = jwt_tokens_map} <- SanbaseWeb.Guardian.get_jwt_tokens(user, device_data) do
  conn
  |> SanbaseWeb.Guardian.add_jwt_tokens_to_conn_session(jwt_tokens_map)
  |> redirect(external: redirect_urls.success)
else
  _ ->
    conn
    |> redirect(external: redirect_urls.fail)
end
```

`forward_registration` returns returns `{:error, error}` or a 3-element :ok tuple `{:ok, state_action, user}` where `state_action` is one of `:keep_state` or `:evolve_state`, with the following meaning:
- `:keep_state` - the state did not change or it was updated by some concurrent process on the same node or by other node.
- `:evolve_state` - the state changed. This can be used when emitting events, setting `firstLogin` or doing some other action that requires `only once` semantics. 
This is ensured by using an atomic `where ... update .. select` SQL query that will update only once, no matter the concurrency.

This can be illustrated by the following example:
```sql
{
  "data": {
    "first": {
      "email": "test@santiment.net",
      "firstLogin": true,
      "id": "16"
    },
    "second": {
      "email": "test@santiment.net",
      "firstLogin": false,
      "id": "16"
    },
    "third": {
      "email": "test@santiment.net",
      "firstLogin": false,
      "id": "16"
    }
  }
}
```

The `registration` state will also keep the `data` field even after finishing. Example:
<img width="388" alt="image" src="https://user-images.githubusercontent.com/6518376/208103801-cdea91a8-4e52-42fe-9189-0682d35c3ebe.png">

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
