### PR TITLE
Fix typo in obtaining an option in Sanbase.Cache

### DIFF
--- a/lib/sanbase/cache/cache.ex
+++ b/lib/sanbase/cache/cache.ex
@@ -13,7 +13,7 @@ defmodule Sanbase.Cache do
          name: Keyword.fetch!(opts, :name),
          ttl_check_interval: Keyword.get(opts, :ttl_check_interval, :timer.seconds(5)),
          global_ttl: Keyword.get(opts, :global_ttl, :timer.minutes(5)),
-         acquire_lock_timeout: Keyword.get(opts, :aquire_lock_timeout, 60_000)
+         acquire_lock_timeout: Keyword.get(opts, :acquire_lock_timeout, 60_000)
        ]},
       id: Keyword.fetch!(opts, :id)
     )


### PR DESCRIPTION
## Changes

Found in https://github.com/IvanIvanoff/absinthe_cache/pull/11

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
