### PR TITLE
Add ecosystem and ecosystem_full_path fields to projects

### DIFF
--- a/lib/sanbase/project/jobs/project_job.ex
+++ b/lib/sanbase/project/jobs/project_job.ex
@@ -1,0 +1,25 @@
+defmodule Sanbase.Project.Job do
+  def compute_ecosystem_full_path() do
+    projects = Sanbase.Project.List.projects(include_hidden: true)
+    slug_to_project_map = Map.new(projects, &{&1.slug, &1})
+
+    Enum.map(projects, fn project ->
+      {project, get_ecosystem_full_path(project, slug_to_project_map)}
+    end)
+    |> Enum.map(fn
+      {project, []} -> {project, ""}
+      {project, path} -> {project, "/" <> Enum.join(path, "/") <> "/"}
+    end)
+  end
+
+  defp get_ecosystem_full_path(project, slug_to_project_map) do
+    case project.ecosystem == project.slug do
+      true ->
+        [project.slug]
+
+      false ->
+        parent_ecosystem_project = Map.get(slug_to_project_map, project.ecosystem)
+        get_ecosystem_full_path(parent_ecosystem_project, slug_to_project_map) ++ [project.slug]
+    end
+  end
+end

--- a/lib/sanbase/project/jobs/project_job.ex
+++ b/lib/sanbase/project/jobs/project_job.ex
@@ -1,4 +1,17 @@
 defmodule Sanbase.Project.Job do
+  @doc ~s"""
+  Projects have two fields for ecosystem: `ecosystem` and `ecosystem_full_path`.
+  `ecosystem` holds just the ecosystem name, while `ecosystem_full_path` is the
+  path enumeration, going to the root. For example if X is built on top of Arbitrum,
+  and Arbitrum is built on top of Ethereum, then we'll have the following:
+    ecosystem of Arbitrum: Ethereum
+    ecosystem_full_path of Arbitrum: /ethereum/
+    ecosystem of X: Arbitrum
+    ecosystem_full_path of X: /ethereum/arbitrum
+
+  This function uses the ecosystem to compute the ecosystem_full_path (recurisvelly,
+  where needed).
+  """
   def compute_ecosystem_full_path() do
     projects = Sanbase.Project.List.projects(include_hidden: true)
     slug_to_project_map = Map.new(projects, &{&1.slug, &1})

--- a/lib/sanbase/project/project.ex
+++ b/lib/sanbase/project/project.ex
@@ -48,6 +48,9 @@ defmodule Sanbase.Project do
     field(:website_link, :string)
     field(:whitepaper_link, :string)
 
+    field(:ecosystem, :string)
+    field(:ecosystem_full_path, :string)
+
     has_one(:social_volume_query, Project.SocialVolumeQuery)
 
     has_many(:chart_configurations, Sanbase.Chart.Configuration, on_delete: :delete_all)
@@ -88,6 +91,8 @@ defmodule Sanbase.Project do
       :coinmarketcap_id,
       :dark_logo_url,
       :description,
+      :ecosystem,
+      :ecosystem_full_path,
       :email,
       :facebook_link,
       :github_link,

--- a/lib/sanbase/repo_reader/jsonschema.json
+++ b/lib/sanbase/repo_reader/jsonschema.json
@@ -7,6 +7,7 @@
         "slug": { "type": "string" },
         "description": { "type": "string" },
         "ticker": { "type": "string" },
+        "ecosystem": { "type": "string" },
         "market_segments": { "type": "array", "items": { "type": "string" } }
       },
       "required": ["slug"]

--- a/lib/sanbase/repo_reader/repo_reader.ex
+++ b/lib/sanbase/repo_reader/repo_reader.ex
@@ -99,7 +99,8 @@ defmodule Sanbase.RepoReader do
     Enum.reduce_while(projects, :ok, fn project, _acc ->
       data = Map.get(projects_map, project.slug)
 
-      with :ok <- update_social_data(project, data),
+      with :ok <- update_general_data(project, data),
+           :ok <- update_social_data(project, data),
            :ok <- update_development_data(project, data),
            :ok <- update_contracts_data(project, data) do
         {:cont, :ok}
@@ -107,6 +108,28 @@ defmodule Sanbase.RepoReader do
         {:error, _} = error_tuple -> {:halt, error_tuple}
       end
     end)
+  end
+
+  defp update_general_data(project, data) do
+    general = data["general"]
+
+    result =
+      Project.changeset(
+        project,
+        %{
+          name: general["name"],
+          ticker: general["ticker"],
+          description: general["description"],
+          ecosystem: general["ecosystem"],
+          website: general["website"]
+        }
+      )
+      |> Sanbase.Repo.update()
+
+    case result do
+      {:ok, _} -> :ok
+      error -> error
+    end
   end
 
   defp update_social_data(project, data) do

--- a/priv/repo/migrations/20221214090723_add_project_ecosystem_field.exs
+++ b/priv/repo/migrations/20221214090723_add_project_ecosystem_field.exs
@@ -1,0 +1,51 @@
+defmodule Sanbase.Repo.Migrations.AddProjectEcosystemField do
+  use Ecto.Migration
+
+  import Ecto.Query
+
+  def change do
+    alter table(:project) do
+      add(:ecosystem, :string)
+      add(:ecosystem_full_path, :string)
+    end
+  end
+
+  defp fill_ecosystem() do
+    projects = projects()
+
+    ticker_to_name_map = Map.new(projects, &{&1.ticker, &1.name})
+
+    projects
+    |> Enum.map(fn project ->
+      cond do
+        String.downcase(project.infrastructure.code) == "own" ->
+          {project.slug, project.name}
+
+        String.upcase(project.infrastructure.code) == project.infrastructure.code ->
+          {project.slug, Map.get(ticker_to_name_map, project.infrastructure.code)}
+
+        true ->
+          {project.slug, project.infrastructure.code}
+      end
+    end)
+  end
+
+  defp projects() do
+    Sanbase.Project.Job.compute_ecosystem_full_path()
+    |> Enum.reduce(
+      Ecto.Multi.new(),
+      fn {project, ecosystem_full_path}, multi ->
+        changeset =
+          project
+          |> Sanbase.Project.changeset(%{ecosystem_full_path: ecosystem_full_path})
+
+        Ecto.Multi.update(multi, project.slug, changeset, on_conflict: :nothing)
+      end
+    )
+    |> Sanbase.Repo.transaction()
+    |> case do
+      {:ok, _result} -> :ok
+      {:error, _name, error, _changes_so_far} -> {:error, error}
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2421,7 +2421,9 @@ CREATE TABLE public.project (
     is_hidden boolean DEFAULT false,
     dark_logo_url character varying(255),
     telegram_chat_id integer,
-    discord_link character varying(255)
+    discord_link character varying(255),
+    ecosystem character varying(255),
+    ecosystem_full_path character varying(255)
 );
 
 
@@ -8124,6 +8126,7 @@ INSERT INTO public."schema_migrations" (version) VALUES (20221129102156);
 INSERT INTO public."schema_migrations" (version) VALUES (20221205134151);
 INSERT INTO public."schema_migrations" (version) VALUES (20221212124926);
 INSERT INTO public."schema_migrations" (version) VALUES (20221213105305);
+INSERT INTO public."schema_migrations" (version) VALUES (20221214090723);
 INSERT INTO public."schema_migrations" (version) VALUES (20221215103058);
 INSERT INTO public."schema_migrations" (version) VALUES (20221216095648);
 INSERT INTO public."schema_migrations" (version) VALUES (20221221113902);

--- a/test/sanbase/project/project_ecosystem_test.exs
+++ b/test/sanbase/project/project_ecosystem_test.exs
@@ -1,0 +1,31 @@
+defmodule Sanbase.Project.EcosystemTest do
+  use SanbaseWeb.ConnCase, async: true
+
+  import Sanbase.Factory
+
+  test "compute full path ecosystem" do
+    insert(:project, name: "Ethereum", slug: "ethereum", ecosystem: "ethereum")
+    insert(:project, name: "Bitcoin", slug: "bitcoin", ecosystem: "bitcoin")
+    insert(:project, name: "Santiment", slug: "santiment", ecosystem: "ethereum")
+    insert(:project, name: "Arbitrum", slug: "arbitrum", ecosystem: "ethereum")
+    insert(:project, name: "Xyz", slug: "xyz", ecosystem: "arbitrum")
+    insert(:project, name: "Abc", slug: "abc", ecosystem: "arbitrum")
+    insert(:project, name: "Ykc", slug: "ykc", ecosystem: "abc")
+
+    list =
+      Sanbase.Project.Job.compute_ecosystem_full_path()
+      |> Enum.map(fn {p, e} -> {p.slug, e} end)
+
+    expected_list = [
+      {"abc", "/ethereum/arbitrum/abc/"},
+      {"arbitrum", "/ethereum/arbitrum/"},
+      {"bitcoin", "/bitcoin/"},
+      {"ethereum", "/ethereum/"},
+      {"santiment", "/ethereum/santiment/"},
+      {"xyz", "/ethereum/arbitrum/xyz/"},
+      {"ykc", "/ethereum/arbitrum/abc/ykc/"}
+    ]
+
+    assert Enum.sort(list) == Enum.sort(expected_list)
+  end
+end


### PR DESCRIPTION
## Changes
Add support for `ecosystem` and `full_ecosystem_path` in the projects database table and Github repository.

It is important to note that the ecosystem is (in most cases?) transitive. `Arbitrum` is built on `Ethereum`, and project `XYZ` is built on `Arbitrum`, so `XYZ` should be included when computing reports for both `Arbitrum` and `Ethereum`.

Ideally, we should be able to get all projects that are on `Ethereum` (including all with infrastructure `Arbitrum`), or get all projects on `Arbitrum` only. Potentially, we might want to fetch all projects built on `Etheruem` directly (i.e. only the first level children)

This means that when we query all `Ethereum` building projects, we might want to match projects that don’t have `Ethereum` as their ecosystem.
This structure looks like comment trees - we have a root and replies to replies to replies, etc. In our case the `comment` is the `ecosystem` and we might want to get parts of the tree, based on some condition.

Comment trees can be implemented in multiple ways:

- [Nested sets](https://en.wikipedia.org/wiki/Nested_set_model) are too complicated for our task.
- [Closure tables](https://www.notion.so/Extend-the-projects-repo-with-ecosystem-and-market-segments-efb60efa2c074ee795f13d0f52b90d31) - again, too complicated for our task.
- Path Enumeration: Similar to the directories in your operating system. We’ll have an `ecosystem` and `ecosystem_full_path` fields. The `ecosystem_full_path` could look like `/Ethereum/Arbitrum/XYZ/ABC` where the full path is the full path of the `ecosystem` plus the ecosystem. This might work the best for our case as it does not require additional tables or complicated computations. The drawback is that it does not have [[referential integrity](https://en.wikipedia.org/wiki/Referential_integrity)](https://en.wikipedia.org/wiki/Referential_integrity), i.e. if some ecosystem in the path changes/disappears/renames, it will not be propagated to the full path. In our case we’ll have a limited number of projects, so we could try to rebuild the full path from time to time to apply these changes.

Path Enumeration Example: For the `XYZ` project mentioned above, the `Arbitrum` ecosystem would be `Ethereum`, so the `XYZ` full path ecosystem would be `/Ethereum/Arbitrum/`.

If we want to query all projects built on ethereum we do a regex `where ecosystem_full_path like '/Ethereum/%'`, for `Arbitrum` we can do `where ecosystem_full_path like '%/Arbitrum/%`. If `Arbitrum` starts building on more than one ecosystem, we could do choose only one of them by removing the wildcard in the beginning.

Here is an example how `ecosystem` and `ecosystem_full_path` will look for a list of projects:
<img width="672" alt="image" src="https://user-images.githubusercontent.com/6518376/208695323-64044ce9-6953-4a79-ab7c-54eca010fbc9.png">

<!--- Describe your changes -->

## Ticket
https://www.notion.so/santiment/Extend-the-projects-repo-with-ecosystem-and-market-segments-efb60efa2c074ee795f13d0f52b90d31

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
