### PR TITLE
Rework OAuth login - fix origin url and support redirects

### DIFF
--- a/lib/sanbase_web/controllers/auth_controller.ex
+++ b/lib/sanbase_web/controllers/auth_controller.ex
@@ -1,4 +1,4 @@
-defmodule SanbaseWeb.AccountsController do
+defmodule SanbaseWeb.AuthController do
   @moduledoc """
   Auth controller responsible for handling Ueberauth responses
   """
@@ -7,10 +7,38 @@ defmodule SanbaseWeb.AccountsController do
 
   import Sanbase.Accounts.EventEmitter, only: [emit_event: 3]
 
-  plug(Ueberauth)
-
   alias Sanbase.Accounts
   alias Sanbase.Accounts.User
+
+  @providers %{
+    "google" => Application.compile_env(:ueberauth, [Ueberauth, :providers, :google]),
+    "twitter" => Application.compile_env(:ueberauth, [Ueberauth, :providers, :twitter])
+  }
+
+  def request(conn, %{"provider" => provider} = params) do
+    # Do not `use Ueberauth` but create a custom `request/2` action that adds a few
+    # parameters to the session before invoking the `callback/2` action. This allows
+    # state sharing between the request and the callback phases, which gives us the
+    # option to dynamically configure via parameters the redirect URLs and the real
+    # origin URL
+    referer_url = Plug.Conn.get_req_header(conn, "referer") |> List.first()
+    referer_url = referer_url || SanbaseWeb.Endpoint.website_url()
+
+    success_redirect_url =
+      params["success_redirect_url"] || referer_url || SanbaseWeb.Endpoint.website_url()
+
+    fail_redirect_url =
+      params["fail_redirect_url"] || referer_url || SanbaseWeb.Endpoint.website_url()
+
+    origin_url =
+      referer_url |> URI.parse() |> Map.merge(%{fragment: nil, path: nil}) |> URI.to_string()
+
+    conn
+    |> put_session(:__san_success_redirect_url, success_redirect_url)
+    |> put_session(:__san_fail_redirect_url, fail_redirect_url)
+    |> put_session(:__san_origin_url, origin_url)
+    |> Ueberauth.run_request(provider, @providers[provider])
+  end
 
   def delete(conn, _params) do
     conn
@@ -18,57 +46,68 @@ defmodule SanbaseWeb.AccountsController do
     |> redirect(to: "/")
   end
 
+  def callback(conn, %{"provider" => "google"}) do
+    %{assigns: %{ueberauth_auth: auth}} =
+      conn
+      |> Ueberauth.run_callback("google", @providers["google"])
+
+    email = auth.info.email
+    device_data = SanbaseWeb.Guardian.device_data(conn)
+    origin_url = get_session(conn, :__san_origin_url)
+    args = %{login_origin: :google, origin_url: origin_url}
+
+    with true <- is_binary(email) and byte_size(email) > 0,
+         {:ok, user} <- User.find_or_insert_by(:email, email, args),
+         {:ok, _, user} <-
+           Accounts.forward_registration(user, "google_oauth", args),
+         {:ok, %{} = jwt_tokens_map} <-
+           SanbaseWeb.Guardian.get_jwt_tokens(user, device_data) do
+      emit_event({:ok, user}, :login_user, args)
+
+      conn
+      |> SanbaseWeb.Guardian.add_jwt_tokens_to_conn_session(jwt_tokens_map)
+      |> redirect(external: get_session(conn, :__san_success_redirect_url))
+    else
+      _ ->
+        conn
+        |> redirect(external: get_session(conn, :__san_fail_redirect_url))
+    end
+  end
+
+  def callback(conn, %{"provider" => "twitter"}) do
+    %{assigns: %{ueberauth_auth: auth}} =
+      conn
+      |> Ueberauth.run_callback("twitter", @providers["twitter"])
+
+    %{uid: twitter_id, info: %{email: email}} = auth
+    device_data = SanbaseWeb.Guardian.device_data(conn)
+    origin_url = get_session(conn, :__san_origin_url)
+    args = %{login_origin: :twitter, origin_url: origin_url}
+
+    with {:ok, user} <- twitter_login(email, twitter_id),
+         {:ok, _, user} <-
+           Accounts.forward_registration(user, "twitter_oauth", args),
+         {:ok, %{} = jwt_tokens_map} <-
+           SanbaseWeb.Guardian.get_jwt_tokens(user, device_data) do
+      emit_event({:ok, user}, :login_user, args)
+
+      conn
+      |> SanbaseWeb.Guardian.add_jwt_tokens_to_conn_session(jwt_tokens_map)
+      |> redirect(external: get_session(conn, :__san_success_redirect_url))
+    else
+      _ ->
+        conn
+        |> redirect(external: get_session(conn, :__san_fail_redirect_url))
+    end
+  end
+
   def callback(%{assigns: %{ueberauth_failure: _fails}} = conn, _params) do
     conn
     |> redirect(to: "/")
   end
 
-  def callback(%{assigns: %{ueberauth_auth: %{provider: :google} = auth}} = conn, params) do
-    redirect_urls = get_redirect_urls(params)
-    device_data = SanbaseWeb.Guardian.device_data(conn)
-    email = auth.info.email
-    origin_url = Plug.Conn.get_req_header(conn, "host") |> List.first()
-    args = %{login_origin: :google, origin_url: origin_url}
-
-    with true <- is_binary(email) and byte_size(email) > 0,
-         {:ok, user} <- User.find_or_insert_by(:email, email, args),
-         {:ok, _, user} <- Accounts.forward_registration(user, "google_oauth", args),
-         {:ok, %{} = jwt_tokens_map} <- SanbaseWeb.Guardian.get_jwt_tokens(user, device_data) do
-      emit_event({:ok, user}, :login_user, args)
-
-      conn
-      |> SanbaseWeb.Guardian.add_jwt_tokens_to_conn_session(jwt_tokens_map)
-      |> redirect(external: redirect_urls.success)
-    else
-      _ ->
-        conn
-        |> redirect(external: redirect_urls.fail)
-    end
-  end
-
-  def callback(%{assigns: %{ueberauth_auth: %{provider: :twitter} = auth}} = conn, params) do
-    redirect_urls = get_redirect_urls(params)
-    device_data = SanbaseWeb.Guardian.device_data(conn)
-    %{uid: twitter_id, info: %{email: email}} = auth
-    origin_url = Plug.Conn.get_req_header(conn, "host") |> List.first()
-    args = %{login_origin: :twitter, origin_url: origin_url}
-
-    with {:ok, user} <- twitter_login(email, twitter_id),
-         {:ok, _, user} <- Accounts.forward_registration(user, "twitter_oauth", args),
-         {:ok, %{} = jwt_tokens_map} <- SanbaseWeb.Guardian.get_jwt_tokens(user, device_data) do
-      emit_event({:ok, user}, :login_user, args)
-
-      conn
-      |> SanbaseWeb.Guardian.add_jwt_tokens_to_conn_session(jwt_tokens_map)
-      |> redirect(external: redirect_urls.success)
-    else
-      _ ->
-        conn
-        |> redirect(external: redirect_urls.fail)
-    end
-  end
-
-  defp twitter_login(email, twitter_id) when is_binary(email) and byte_size(email) > 0 do
+  defp twitter_login(email, twitter_id)
+       when is_binary(email) and byte_size(email) > 0 do
     # There are 2 cases: The user has their email address visible AFTER
     # their first sanbase login. In this case this operation might fail - the find_or_insert_by/3
     # will return a new user but the update_field/3 will fail as another user will have the same
@@ -97,37 +136,5 @@ defmodule SanbaseWeb.AccountsController do
 
   defp twitter_login(_email, twitter_id) do
     User.find_or_insert_by(:twitter_id, twitter_id, %{login_origin: :twitter})
-  end
-
-  defp get_redirect_urls(%{"san_redirects_state" => state}) do
-    website_url = SanbaseWeb.Endpoint.website_url()
-
-    map =
-      state
-      |> Base.decode64!()
-      |> Jason.decode!()
-
-    %{
-      success: Map.get(map, "success_redirect_url", website_url),
-      fails: Map.get(map, "fail_redirect_url", website_url)
-    }
-    |> Enum.into(%{}, fn {key, url} ->
-      # Use the state provided redirects only if they're form the santiment host
-      with %URI{host: host} <- URI.parse(url),
-           ["santiment", "net"] <- host |> String.split(".") |> Enum.take(-2) do
-        {key, url}
-      else
-        _ -> {key, website_url}
-      end
-    end)
-  end
-
-  defp get_redirect_urls(_params) do
-    website_url = SanbaseWeb.Endpoint.website_url()
-
-    %{
-      success: website_url,
-      fail: website_url
-    }
   end
 end

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -42,9 +42,9 @@ defmodule SanbaseWeb.Router do
   scope "/auth", SanbaseWeb do
     pipe_through(:browser)
 
-    get("/delete", AccountsController, :delete)
-    get("/:provider", AccountsController, :request)
-    get("/:provider/callback", AccountsController, :callback)
+    get("/delete", AuthController, :delete)
+    get("/:provider", AuthController, :request)
+    get("/:provider/callback", AuthController, :callback)
   end
 
   scope "/admin", ExAdmin do


### PR DESCRIPTION
## Changes

Issues fixed: Allow configuring where to redirect to after oauth login. Fix the origin_url in the events emitted by the oauth logins.

Do not `use Ueberauth` in the AuthController directly, so we can write a custom `request` function which can be used to pass parameters from the request phase to the callback phase. Use it to pass the redirect URLs and the original origin URL.

Example:
```
http://localhost:4000/auth/google?success_redirect_url=https://app.santiment.net&fail_redirect_url=https://app.santiment.net
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
