### PR TITLE
Remove unnecessary and duplicated :auth_token in session

### DIFF
--- a/lib/sanbase_web/graphql/middlewares/create_or_delete_session.ex
+++ b/lib/sanbase_web/graphql/middlewares/create_or_delete_session.ex
@@ -12,7 +12,6 @@ defmodule SanbaseWeb.Graphql.Middlewares.CreateOrDeleteSession do
     Map.update!(resolution, :context, fn context ->
       context
       |> Map.put(:create_session, true)
-      |> Map.put(:auth_token, access_token)
       |> Map.put(:access_token, access_token)
       |> Map.put(:refresh_token, refresh_token)
     end)

--- a/lib/sanbase_web/graphql/plugs/auth_plug.ex
+++ b/lib/sanbase_web/graphql/plugs/auth_plug.ex
@@ -120,7 +120,6 @@ defmodule SanbaseWeb.Graphql.AuthPlug do
 
       access_token ->
         conn
-        |> put_session(:auth_token, access_token)
         |> put_session(:access_token, access_token)
     end
   end
@@ -176,11 +175,8 @@ defmodule SanbaseWeb.Graphql.AuthPlug do
     end
   end
 
-  # TODO: After these changes, the session will now also contain `access_token`
-  # insted of only `auth_token`, which is better named and should be used. This
-  # is a process of authentication, not authentication
   def jwt_access_token_authentication(%Plug.Conn{} = conn) do
-    access_token = get_session(conn, :access_token) || get_session(conn, :auth_token)
+    access_token = get_session(conn, :access_token)
 
     case access_token && bearer_authenticate(conn, access_token) do
       {:ok, %{current_user: current_user} = map} ->

--- a/lib/sanbase_web/graphql/plugs/context_plug.ex
+++ b/lib/sanbase_web/graphql/plugs/context_plug.ex
@@ -60,7 +60,7 @@ defmodule SanbaseWeb.Graphql.ContextPlug do
 
   defp conn_to_jwt_tokens(conn) do
     %{
-      access_token: get_session(conn, :access_token) || get_session(conn, :auth_token),
+      access_token: get_session(conn, :access_token),
       refresh_token: get_session(conn, :refresh_token)
     }
   end

--- a/lib/sanbase_web/guardian/guardian.ex
+++ b/lib/sanbase_web/guardian/guardian.ex
@@ -52,7 +52,6 @@ defmodule SanbaseWeb.Guardian do
 
   def add_jwt_tokens_to_conn_session(conn, jwt_tokens_map) do
     conn
-    |> Plug.Conn.put_session(:auth_token, jwt_tokens_map.access_token)
     |> Plug.Conn.put_session(:access_token, jwt_tokens_map.access_token)
     |> Plug.Conn.put_session(:refresh_token, jwt_tokens_map.refresh_token)
   end

--- a/test/sanbase_web/graphql/auth/email_login_api_test.exs
+++ b/test/sanbase_web/graphql/auth/email_login_api_test.exs
@@ -33,7 +33,8 @@ defmodule SanbaseWeb.Graphql.EmailLoginApiTest do
       assert login_data["user"]["firstLogin"] == true
       assert login_data["user"]["email"] == user.email
 
-      assert login_data["token"] == result.private.plug_session["auth_token"]
+      assert login_data["token"] == result.private.plug_session["access_token"]
+
       # Assert that now() and validated_at do not differ by more than 2 seconds
       assert Sanbase.TestUtils.datetime_close_to(
                Timex.now(),


### PR DESCRIPTION
## Changes

For some time both `:auth_token` and `:access_token` were put in the session. A sufficient amount of time has passed and there are no current active sessions that have only the `:auth_token` in them. Now only the `:access_token` can be used.


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
