### PR TITLE
Support COUNT aggregations for price metrics

### DIFF
--- a/lib/sanbase/metric/sql_query_helper.ex
+++ b/lib/sanbase/metric/sql_query_helper.ex
@@ -74,7 +74,7 @@ defmodule Sanbase.Metric.SqlQuery.Helper do
     do: "argMin(#{value_column}, #{dt_column})"
 
   def aggregation(:count, value_column, _dt_column),
-    do: "coalesce(count(#{value_column}), 0)"
+    do: "coalesce(toFloat64(count(#{value_column})), 0.0)"
 
   def aggregation(:sum, value_column, _dt_column),
     do: "sumKahan(#{value_column})"

--- a/lib/sanbase/prices/metric_adapter.ex
+++ b/lib/sanbase/prices/metric_adapter.ex
@@ -2,7 +2,7 @@ defmodule Sanbase.Price.MetricAdapter do
   @behaviour Sanbase.Metric.Behaviour
   alias Sanbase.Price
 
-  @aggregations [:any, :sum, :avg, :min, :max, :last, :first, :median, :ohlc]
+  @aggregations [:any, :sum, :avg, :min, :max, :last, :first, :median, :ohlc, :count]
   @default_aggregation :last
 
   @timeseries_metrics ["price_usd", "price_btc", "volume_usd", "marketcap_usd"]

--- a/lib/sanbase/prices/price_pair/metric_adapter.ex
+++ b/lib/sanbase/prices/price_pair/metric_adapter.ex
@@ -2,7 +2,7 @@ defmodule Sanbase.PricePair.MetricAdapter do
   @behaviour Sanbase.Metric.Behaviour
   alias Sanbase.PricePair
 
-  @aggregations [:any, :sum, :avg, :min, :max, :last, :first, :median, :ohlc]
+  @aggregations [:any, :sum, :avg, :min, :max, :last, :first, :median, :ohlc, :count]
   @default_aggregation :last
 
   @timeseries_metrics ["price_usd", "price_eth", "price_usdt", "price_btc"]


### PR DESCRIPTION
## Changes

Support running queries with `COUNT` aggregation.
```graphql
{
  allProjects{
    slug
    countOfPrices: aggregatedTimeseriesData(
      selector: {source:"cryptocompare"}
      metric: "price_usd"
      from: "utc_now-2d"
      to: "utc_now"
      aggregation: COUNT)
  }
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
