### PR TITLE
Add a computeRawClickhouseQuery query, deprecate mutation

### DIFF
--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -42,6 +42,7 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           :check_annual_discount_eligibility,
           :comments_feed,
           :comments,
+          :compute_raw_clickhouse_query,
           :currencies_market_segments,
           :current_user,
           :daily_active_addresses,


### PR DESCRIPTION
## Changes
Currently, the `computeRawClickhouseQuery` is a mutation, not a query.
This is not correct because the API does not mutate anything and is instead used as a query to obtain data.
Being a mutation, it also does not add to the API calls count.

Add it also as a query and add a deprecation message to the mutation. After the frontend is migrated, remove the mutation.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
