### PR TITLE
Add aave v2 apy metrics to API

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -2252,6 +2252,57 @@
     "data_type": "timeseries"
   },
   {
+    "human_readable_name": "Aave v2 supply APY",
+    "name": "aave_v2_supply_apy",
+    "metric": "aavev2_supply_apy",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Aave v2 stable borrow APY",
+    "name": "aave_v2_stable_borrow_apy",
+    "metric": "aavev2_stable_borrow_apy",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Aave v2 variable borrow APY",
+    "name": "aave_v2_variable_borrow_apy",
+    "metric": "aavev2_variable_borrow_apy",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
     "human_readable_name": "Compound deposits",
     "name": "compound_action_deposits",
     "metric": "compound_action_deposits",

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -1459,6 +1459,9 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "aave_v2_total_supplied_usd",
         "aave_v2_total_borrowed",
         "aave_v2_total_borrowed_usd",
+        "aave_v2_supply_apy",
+        "aave_v2_stable_borrow_apy",
+        "aave_v2_variable_borrow_apy",
         # Compound metrics
         "compound_action_deposits",
         "compound_action_liquidations",


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Add aave v2 apy metrics to API

## Ticket

<!--- Issue to which the pull request is related -->
https://www.notion.so/santiment/Implementing-Aave-v2-APY-Metrics-b0750d7b8c004886b3cc8a063439cf95

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
