### PR TITLE
Strip SETTINGS from the Clickhouse error

### DIFF
--- a/lib/sanbase/clickhouse_repo.ex
+++ b/lib/sanbase/clickhouse_repo.ex
@@ -245,6 +245,19 @@ defmodule Sanbase.ClickhouseRepo do
         [error_msg, error_code, _version_str] =
           Regex.split(~r|\([A-Z_]+\)|, error, include_captures: true, trim: true)
 
+        error_msg =
+          case String.split(error_msg, "SETTINGS log_comment", parts: 2) do
+            [_] ->
+              error_msg
+
+            [stripped_error_msg, _] ->
+              # Exclude the SETTINGS fragment from the error response
+              # so it is not shown in the result. The SETTINGS fragment
+              # are appended by the preprocessing done in the backend
+              # and not by the user, who will see the error
+              stripped_error_msg
+          end
+
         "#{error_code} #{error_msg}" |> String.trim()
     end
   end


### PR DESCRIPTION
## Changes

String everything after `SETTINGS log_comment` from the Clickhouse error reported back to the client.
We do it because this way the query in the error is closer to the original user query, as SETTINGS is appended by the backend


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
