### PR TITLE
Improve the precision while computing mean

### DIFF
--- a/lib/sanbase/utils/math.ex
+++ b/lib/sanbase/utils/math.ex
@@ -226,8 +226,16 @@ defmodule Sanbase.Math do
   def mean(list, opts \\ [])
   def mean([], _), do: 0.0
 
-  def mean(values, opts),
-    do: Float.round(Enum.sum(values) / length(values), Keyword.get(opts, :precision, 2))
+  def mean(values, opts) do
+    mean = Enum.sum(values) / length(values)
+
+    # In case the precision is not provided, round the according
+    # to some predfined rules (use more precision for smaller numbers)
+    case Keyword.get(opts, :precision) do
+      nil -> mean |> round_float()
+      precision -> Float.round(mean, precision)
+    end
+  end
 
   @doc ~s"""
   Compute the median of the numbers in the list

--- a/test/sanbase/utils/math_test.exs
+++ b/test/sanbase/utils/math_test.exs
@@ -9,7 +9,11 @@ defmodule Sanbase.MathTest do
   test "#average" do
     assert Math.mean([4, 6, 8, 2]) == 5.0
     assert Math.mean([]) == 0
-    assert Math.mean([0.126]) == 0.13
+    assert Math.mean([0.126], precision: 2) == 0.13
+    # default precision is 6 for values < 1
+    assert Math.mean([0.123456789]) == 0.123457
+    # default precision is 2 for values >= 1
+    assert Math.mean([1.123456789]) == 1.12
   end
 
   property "average is always between min and max when list of integers" do


### PR DESCRIPTION
## Changes

By default, if the value is between -1 and 1 use precision of 6 decimals. Use 2 decimals precision otherwise

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
