### PR TITLE
Always use 6 decimals precision when computing mean

### DIFF
--- a/lib/sanbase/utils/math.ex
+++ b/lib/sanbase/utils/math.ex
@@ -374,7 +374,7 @@ defmodule Sanbase.Math do
   def simple_moving_average(values, period) do
     values
     |> Enum.chunk_every(period, 1, :discard)
-    |> Enum.map(&mean/1)
+    |> Enum.map(&mean(&1, precision: 6))
   end
 
   def simple_moving_average(list, period, opts) do


### PR DESCRIPTION
## Changes

With the previous change, the mean was rounding to 2 decimals for values >= 1 and to 6 decimals for smaller values. But this difference can be observed when applying `moving_average` on a chart that has values both above and below 1:
<img width="845" alt="image" src="https://user-images.githubusercontent.com/6518376/220362174-d5baa626-258f-438a-9bfa-52d02d990201.png">

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
