### PR TITLE
Add xrp DEX volume intraday metrics

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -2718,9 +2718,9 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Daily DEX volume in XRP",
-    "name": "daily_dex_volume_in_xrp",
-    "metric": "daily_dex_volume_in_xrp",
+    "human_readable_name": "DEX volume in XRP",
+    "name": "dex_volume_in_xrp_5m",
+    "metric": "dex_volume_in_xrp_5min",
     "version": "2019-01-01",
     "access": "restricted",
     "selectors": ["slug"],
@@ -2729,8 +2729,25 @@
       "SANBASE": "free"
     },
     "aggregation": "sum",
-    "min_interval": "1d",
-    "table": "daily_metrics_v2",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": true,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "DEX volume in USD",
+    "name": "dex_volume_in_usd_5m",
+    "metric": "dex_volume_in_usd_5min",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "sum",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
     "has_incomplete_data": true,
     "data_type": "timeseries"
   }

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -460,7 +460,8 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "total_assets_issued",
         "daily_trustlines_count_change",
         "total_trustlines_count",
-        "daily_dex_volume_in_xrp"
+        "dex_volume_in_xrp_5m",
+        "dex_volume_in_usd_5m"
       ]
       |> Enum.sort()
 
@@ -1524,7 +1525,8 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "total_assets_issued",
         "daily_trustlines_count_change",
         "total_trustlines_count",
-        "daily_dex_volume_in_xrp"
+        "dex_volume_in_xrp_5m",
+        "dex_volume_in_usd_5m"
       ]
       |> Enum.sort()
 


### PR DESCRIPTION
## Changes
Removing daily xrp volume and adding two intraday xrp dex volume metrics to API
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
