### PR TITLE
Do not use alerts cache in the web pod

### DIFF
--- a/lib/sanbase/alerts/trigger/settings/behaviour.ex
+++ b/lib/sanbase/alerts/trigger/settings/behaviour.ex
@@ -3,6 +3,6 @@ defmodule Sanbase.Alert.Trigger.Settings.Behaviour do
   @type type :: String.t()
 
   @callback type() :: type()
-  @callback post_create_process(Trigger.t()) :: :nocache | Trigger.t(0)
-  @callback post_update_process(Trigger.t()) :: :nocache | Trigger.t(0)
+  @callback post_create_process(Trigger.t()) :: :nocache | Trigger.t()
+  @callback post_update_process(Trigger.t()) :: :nocache | Trigger.t()
 end

--- a/lib/sanbase/alerts/trigger/settings/result_builder/result_builder.ex
+++ b/lib/sanbase/alerts/trigger/settings/result_builder/result_builder.ex
@@ -101,7 +101,7 @@ defmodule Sanbase.Alert.ResultBuilder do
     added_items_key = Keyword.fetch!(opts, :added_items_key)
     removed_items_key = Keyword.fetch!(opts, :removed_items_key)
 
-    %{state: %{^state_list_key => previous_list}} = settings
+    previous_list = Map.get(settings.state, state_list_key, [])
 
     added_items = (current_list -- previous_list) |> Enum.reject(&is_nil/1)
     removed_items = (previous_list -- current_list) |> Enum.reject(&is_nil/1)
@@ -138,7 +138,8 @@ defmodule Sanbase.Alert.ResultBuilder do
     added_items_key = Keyword.fetch!(opts, :added_items_key)
     removed_items_key = Keyword.fetch!(opts, :removed_items_key)
 
-    %{state: %{^state_list_key => previous_map}} = settings
+    # TODO: Take a look at this. Sometimes it's a list, sometimes it's a map
+    previous_map = Map.get(settings.state, state_list_key, %{})
 
     template_kv =
       Enum.reduce(current_data, %{}, fn {identifier, current_list}, acc ->

--- a/lib/sanbase/alerts/trigger/settings/wallet/wallet_assets_held_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/wallet/wallet_assets_held_trigger_settings.ex
@@ -108,7 +108,7 @@ defmodule Sanbase.Alert.Trigger.WalletAssetsHeldTriggerSettings do
       {__MODULE__, :assets_held, selector, round_datetime(DateTime.utc_now())}
       |> Sanbase.Cache.hash()
 
-    Sanbase.Cache.get_or_store(:alerts_evaluator_cache, cache_key, fn ->
+    Sanbase.Cache.get_or_store(cache_key, fn ->
       {:ok, _} = HistoricalBalance.assets_held_by_address(selector)
     end)
   end

--- a/test/sanbase/alerts/wallet/trigger_wallet_assets_held_test.exs
+++ b/test/sanbase/alerts/wallet/trigger_wallet_assets_held_test.exs
@@ -13,6 +13,9 @@ defmodule Sanbase.Alert.WalletAssetsHeldTriggerSettingsTest do
   alias Sanbase.Clickhouse.HistoricalBalance
 
   setup do
+    # Some of the code needs to run in the web pod while creating the asset
+    # to do the initial setup. That's why we need to clear both caches
+    Sanbase.Cache.clear_all()
     Sanbase.Cache.clear_all(:alerts_evaluator_cache)
 
     user = insert(:user, user_settings: %{settings: %{alert_notify_telegram: true}})
@@ -63,11 +66,13 @@ defmodule Sanbase.Alert.WalletAssetsHeldTriggerSettingsTest do
       # Clear the cache after creating the triggers so the cached call to the HistoricalBalance
       # module that is used to initialize the states is cleared. In the next evaluation it should
       # call the second function in the mock_fun list
+      Sanbase.Cache.clear_all()
       Sanbase.Cache.clear_all(:alerts_evaluator_cache)
 
       log = capture_log(fn -> Scheduler.run_alert(WalletAssetsHeldTriggerSettings) end)
       assert log =~ "In total 2/2 wallet_assets_held alerts were sent successfully"
 
+      Sanbase.Cache.clear_all()
       Sanbase.Cache.clear_all(:alerts_evaluator_cache)
 
       assert capture_log(fn -> Scheduler.run_alert(WalletAssetsHeldTriggerSettings) end) =~
@@ -106,6 +111,7 @@ defmodule Sanbase.Alert.WalletAssetsHeldTriggerSettingsTest do
       # Clear the cache after creating the triggers so the cached call to the HistoricalBalance
       # module that is used to initialize the states is cleared. In the next evaluation it should
       # call the second function in the mock_fun list
+      Sanbase.Cache.clear_all()
       Sanbase.Cache.clear_all(:alerts_evaluator_cache)
 
       Scheduler.run_alert(WalletAssetsHeldTriggerSettings)


### PR DESCRIPTION
## Changes

Using the alerts cache in the web pod crashes because the process is not started.
Make other parts of the alerts more stable by not expecting that some key exists.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
