### PR TITLE
Increase the Sanbase.Cache timeout from 30s to 60s

### DIFF
--- a/lib/sanbase/application/application.ex
+++ b/lib/sanbase/application/application.ex
@@ -300,7 +300,7 @@ defmodule Sanbase.Application do
          name: Sanbase.Cache.name(),
          ttl_check_interval: :timer.seconds(30),
          global_ttl: :timer.minutes(5),
-         acquire_lock_timeout: 30_000
+         acquire_lock_timeout: 60_000
        ]},
 
       # Service for fast checking if a slug is valid


### PR DESCRIPTION
This cache is used also in alerts and it often timeouts on heavier queries when computing alerts.

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
