### PR TITLE
Restart ratelimiter on timeout

### DIFF
--- a/lib/sanbase/discord/discord_consumer.ex
+++ b/lib/sanbase/discord/discord_consumer.ex
@@ -307,13 +307,35 @@ defmodule Sanbase.DiscordConsumer do
   end
 
   defp warm_up(msg) do
+    t1 = System.monotonic_time(:millisecond)
+
     Nostrum.Api.get_current_user()
     |> case do
       {:ok, _} ->
         log(msg, "WARM UP SUCCESS")
 
+      {:error, :timeout} ->
+        log(msg, "WARM UP TIMEOUT. Restart Ratelimiter", type: :error)
+        {:ok, pid} = restart_ratelimiter()
+        log(msg, "WARM UP TIMEOUT. Ratelimiter pid: #{pid}", type: :error)
+
       error ->
         log(msg, "WARM UP ERROR #{inspect(error)}", type: :error)
     end
+
+    t2 = System.monotonic_time(:millisecond)
+    log(msg, "Time spent warming up #{t2 - t1}ms.")
+  end
+
+  def restart_ratelimiter() do
+    supervisor_pid =
+      Process.whereis(Ratelimiter)
+      |> Process.info()
+      |> Keyword.get(:dictionary)
+      |> Keyword.get(:"$ancestors")
+      |> List.first()
+
+    :ok = Supervisor.terminate_child(supervisor_pid, Nostrum.Api.Ratelimiter)
+    Supervisor.restart_child(supervisor_pid, Nostrum.Api.Ratelimiter)
   end
 end


### PR DESCRIPTION
## Changes

That will fix the case where `{:error, :timeout}` comes for some reason from the RateLimiter gen server due to some congestion. Or will rule it out.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
