### PR TITLE
Make the schedule_next_job: true always schedule the next job

### DIFF
--- a/lib/sanbase/cryptocompare/open_interest/open_interest_historical_worker.ex
+++ b/lib/sanbase/cryptocompare/open_interest/open_interest_historical_worker.ex
@@ -48,7 +48,12 @@ defmodule Sanbase.Cryptocompare.OpenInterest.HistoricalWorker do
     limit = Map.get(args, "limit", @limit)
 
     case get_data(market, instrument, limit, timestamp) do
-      {:ok, _, []} ->
+      {:ok, min_timestamp, []} when is_integer(min_timestamp) ->
+        :ok = maybe_schedule_next_job(min_timestamp, args)
+
+        :ok
+
+      {:ok, _min_timestamp, []} ->
         :ok
 
       {:ok, min_timestamp, data} ->


### PR DESCRIPTION
## Changes

Make it so if we enable a historical scraping while there is data already exported, the scheduling of the next job is properly added.

This happens if we enable a historical scrape after one or two days of data has been exported. Without this fix the `maybe_schedule_next_job` is never executed because the exporter progress checks that the data exported is already exported and stops the process. The process must stop only when we hit `first_timestamp_reached`

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
