### PR TITLE
Create setup intent API

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
@@ -216,6 +216,22 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
     end
   end
 
+  def create_stripe_setup_intent(_root, _args, %{
+        context: %{auth: %{current_user: current_user}}
+      }) do
+    case StripeApi.create_setup_intent(current_user) do
+      {:ok, setup_intent} ->
+        {:ok, %{client_secret: setup_intent.client_secret}}
+
+      {:error, %Stripe.Error{message: message} = reason} ->
+        log_error("Create setup intent: user=#{inspect(current_user)}", reason)
+        {:error, message}
+
+      _ ->
+        {:error, "Can't create setup intent"}
+    end
+  end
+
   def subscriptions(%User{} = user, _args, _resolution) do
     {:ok, Subscription.user_subscriptions_plus_incomplete(user)}
   end

--- a/lib/sanbase_web/graphql/schema/queries/billing_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/billing_queries.ex
@@ -147,5 +147,16 @@ defmodule SanbaseWeb.Graphql.Schema.BillingQueries do
 
       resolve(&BillingResolver.delete_default_payment_instrument/3)
     end
+
+    @desc ~s"""
+    Create setup intent
+    """
+    field :create_stripe_setup_intent, :setup_intent do
+      meta(access: :free)
+
+      middleware(JWTAuth)
+
+      resolve(&BillingResolver.create_stripe_setup_intent/3)
+    end
   end
 end

--- a/lib/sanbase_web/graphql/schema/types/billing_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/billing_types.ex
@@ -99,4 +99,8 @@ defmodule SanbaseWeb.Graphql.BillingTypes do
     field(:percent_off, non_null(:integer))
     field(:expire_at, non_null(:datetime))
   end
+
+  object :setup_intent do
+    field(:client_secret, non_null(:string))
+  end
 end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->



Adds mutation `createStripeSetupIntent`.
Needed as a first step of integrating 3dsv2 payments to save card that has 2nd step verification for off_session payments.

Example: 

```graphql
mutation {
  createStripeSetupIntent {
    clientSecret
  }
}
```

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
