### PR TITLE
Rework how the validator part of the repo reader works.

### DIFF
--- a/lib/sanbase_web/controllers/repo_reader_controller.ex
+++ b/lib/sanbase_web/controllers/repo_reader_controller.ex
@@ -4,34 +4,34 @@ defmodule SanbaseWeb.RepoReaderController do
   require Sanbase.Utils.Config, as: Config
   require Logger
 
-  def validator_webhook(conn, %{"secret" => secret} = params) do
-    case endpoint_secret() == secret do
-      true ->
-        changed_files = Map.get(params, "changed_files", [])
-        branch = Map.get(params, "branch", "main")
+  def validator_webhook(conn, params) do
+    Logger.info(
+      "[RepoReaderController] Received validator webhook with params: #{inspect(Map.delete(params, "secret"))}"
+    )
 
-        case Sanbase.RepoReader.validate_changes(branch, changed_files) do
-          :ok ->
-            conn
-            |> put_resp_header("content-type", "application/json; charset=utf-8")
-            |> put_status(200)
-            |> json(%{result: "OK"})
+    changed_files = Map.get(params, "changed_files", [])
+    branch = Map.get(params, "branch", "main")
 
-          {:error, error} ->
-            conn
-            |> put_resp_header("content-type", "application/json; charset=utf-8")
-            |> put_status(400)
-            |> json(%{error: error})
-        end
-
-      false ->
+    case Sanbase.RepoReader.validate_changes(branch, changed_files) do
+      :ok ->
         conn
-        |> send_resp(403, "Unauthorized")
-        |> halt()
+        |> put_resp_header("content-type", "application/json; charset=utf-8")
+        |> put_status(200)
+        |> json(%{result: "OK"})
+
+      {:error, error} ->
+        conn
+        |> put_resp_header("content-type", "application/json; charset=utf-8")
+        |> put_status(400)
+        |> json(%{error: error})
     end
   end
 
   def reader_webhook(conn, %{"secret" => secret} = params) do
+    Logger.info(
+      "[RepoReaderController] Received reader webhook with params: #{inspect(Map.delete(params, "secret"))}"
+    )
+
     case endpoint_secret() == secret do
       true ->
         changed_files = Map.get(params, "changed_files", [])

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -158,7 +158,7 @@ defmodule SanbaseWeb.Router do
     get("/cryptocompare_asset_mapping", CryptocompareAssetMappingController, :data)
     post("/stripe_webhook", StripeController, :webhook)
 
-    post("/projects_data_validator_webhook/:secret", RepoReaderController, :validator_webhook)
+    post("/projects_data_validator_webhook", RepoReaderController, :validator_webhook)
     post("/projects_data_reader_webhook/:secret", RepoReaderController, :reader_webhook)
   end
 

--- a/test/sanbase_web/controller/repo_reader_controller_test.exs
+++ b/test/sanbase_web/controller/repo_reader_controller_test.exs
@@ -18,7 +18,7 @@ defmodule SanbaseWeb.RepoReaderControllerTest do
       |> Sanbase.Mock.run_with_mocks(fn ->
         assert %{"error" => error} =
                  context.conn
-                 |> post("/projects_data_validator_webhook/#{context.secret}", %{
+                 |> post("/projects_data_validator_webhook", %{
                    "branch" => "some_branch",
                    "changed_files" => "projects/santiment/data.json"
                  })
@@ -35,7 +35,7 @@ defmodule SanbaseWeb.RepoReaderControllerTest do
       |> Sanbase.Mock.run_with_mocks(fn ->
         assert %{"error" => error} =
                  context.conn
-                 |> post("/projects_data_validator_webhook/#{context.secret}", %{
+                 |> post("/projects_data_validator_webhook", %{
                    "branch" => "some_branch",
                    "changed_files" => "projects/santiment/data.json"
                  })
@@ -51,7 +51,7 @@ defmodule SanbaseWeb.RepoReaderControllerTest do
       end)
       |> Sanbase.Mock.run_with_mocks(fn ->
         context.conn
-        |> post("/projects_data_validator_webhook/#{context.secret}", %{
+        |> post("/projects_data_validator_webhook", %{
           "branch" => "some_branch",
           "changed_files" => "projects/santiment/data.json"
         })
@@ -67,7 +67,7 @@ defmodule SanbaseWeb.RepoReaderControllerTest do
       |> Sanbase.Mock.run_with_mocks(fn ->
         assert %{"error" => error} =
                  context.conn
-                 |> post("/projects_data_validator_webhook/#{context.secret}", %{
+                 |> post("/projects_data_validator_webhook", %{
                    "branch" => "some_branch",
                    "changed_files" => "projects/santiment/data.json"
                  })
@@ -85,7 +85,7 @@ defmodule SanbaseWeb.RepoReaderControllerTest do
       |> Sanbase.Mock.run_with_mocks(fn ->
         assert %{"error" => error} =
                  context.conn
-                 |> post("/projects_data_validator_webhook/#{context.secret}", %{
+                 |> post("/projects_data_validator_webhook", %{
                    "branch" => "some_branch",
                    "changed_files" => "projects/santiment/data.json"
                  })
@@ -103,7 +103,7 @@ defmodule SanbaseWeb.RepoReaderControllerTest do
       |> Sanbase.Mock.run_with_mocks(fn ->
         assert %{"error" => error} =
                  context.conn
-                 |> post("/projects_data_validator_webhook/#{context.secret}", %{
+                 |> post("/projects_data_validator_webhook", %{
                    "branch" => "some_branch",
                    "changed_files" => "projects/santiment/data.json"
                  })


### PR DESCRIPTION
## Changes

Do not require authentication for the validation part. When people use the santiment/projects repo they fork it, so the validation part can run outside of our repo. The forks do not inherit the secrets, so requring authentication makes for worse UX.

Applying the changes still requires authentication for security purposes.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
