### PR TITLE
Fetch only the latest summary

### DIFF
--- a/lib/sanbase/social_data/trending_words.ex
+++ b/lib/sanbase/social_data/trending_words.ex
@@ -77,10 +77,18 @@ defmodule Sanbase.SocialData.TrendingWords do
       [dt, word, _project, score, context, summary], acc ->
         datetime = DateTime.from_unix!(dt)
 
-        summaries = [%{source: source, summary: summary}]
+        summaries = [%{source: source, datetime: datetime, summary: summary}]
         context = transform_context(context)
 
-        elem = %{word: word, score: score, context: context, summaries: summaries}
+        elem = %{
+          word: word,
+          score: score,
+          context: context,
+          # Keep both summaries and summary for backwards compatibility. Remove summaries later
+          summary: summary,
+          summaries: summaries
+        }
+
         Map.update(acc, datetime, [elem], fn words -> [elem | words] end)
     end)
   end

--- a/lib/sanbase_web/graphql/schema/types/social_data_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/social_data_types.ex
@@ -94,6 +94,7 @@ defmodule SanbaseWeb.Graphql.SocialDataTypes do
     field(:context, list_of(:word_context))
     field(:score, non_null(:float))
     field(:word, non_null(:string))
+    field(:summary, non_null(:string))
     field(:summaries, list_of(:trending_word_summary))
   end
 

--- a/test/sanbase/social_data/trending_words/trending_words_test.exs
+++ b/test/sanbase/social_data/trending_words/trending_words_test.exs
@@ -34,13 +34,27 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
                         score: 5,
                         word: "ethereum",
                         context: context,
-                        summaries: [%{datetime: dt1, source: "telegram", summary: "summary2"}]
+                        summary: "summary2",
+                        summaries: [
+                          %{
+                            datetime: dt1,
+                            source: "reddit,telegram,twitter_crypto",
+                            summary: "summary2"
+                          }
+                        ]
                       },
                       %{
                         score: 10,
                         word: "bitcoin",
                         context: context,
-                        summaries: [%{datetime: dt1, source: "telegram", summary: "summary1"}]
+                        summary: "summary1",
+                        summaries: [
+                          %{
+                            datetime: dt1,
+                            source: "reddit,telegram,twitter_crypto",
+                            summary: "summary1"
+                          }
+                        ]
                       }
                     ],
                     dt2 => [
@@ -48,13 +62,27 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
                         score: 70,
                         word: "boom",
                         context: context,
-                        summaries: [%{datetime: dt2, source: "telegram", summary: "summary4"}]
+                        summary: "summary4",
+                        summaries: [
+                          %{
+                            datetime: dt2,
+                            source: "reddit,telegram,twitter_crypto",
+                            summary: "summary4"
+                          }
+                        ]
                       },
                       %{
                         score: 2,
                         word: "san",
                         context: context,
-                        summaries: [%{datetime: dt2, source: "telegram", summary: "summary3"}]
+                        summary: "summary3",
+                        summaries: [
+                          %{
+                            datetime: dt2,
+                            source: "reddit,telegram,twitter_crypto",
+                            summary: "summary3"
+                          }
+                        ]
                       }
                     ],
                     dt3 => [
@@ -62,13 +90,27 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
                         score: 2,
                         word: "xrp",
                         context: context,
-                        summaries: [%{datetime: dt3, source: "telegram", summary: "summary6"}]
+                        summary: "summary6",
+                        summaries: [
+                          %{
+                            datetime: dt3,
+                            source: "reddit,telegram,twitter_crypto",
+                            summary: "summary6"
+                          }
+                        ]
                       },
                       %{
                         score: 1,
                         word: "eth",
                         context: context,
-                        summaries: [%{datetime: dt3, source: "reddit", summary: "summary5"}]
+                        summary: "summary5",
+                        summaries: [
+                          %{
+                            datetime: dt3,
+                            source: "reddit,telegram,twitter_crypto",
+                            summary: "summary5"
+                          }
+                        ]
                       }
                     ]
                   }}
@@ -105,13 +147,27 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
                       score: 2,
                       word: "xrp",
                       context: context,
-                      summaries: [%{datetime: dt3, source: "telegram", summary: "summary6"}]
+                      summary: "summary6",
+                      summaries: [
+                        %{
+                          datetime: dt3,
+                          source: "reddit,telegram,twitter_crypto",
+                          summary: "summary6"
+                        }
+                      ]
                     },
                     %{
                       score: 1,
                       word: "eth",
                       context: context,
-                      summaries: [%{datetime: dt3, source: "reddit", summary: "summary5"}]
+                      summary: "summary5",
+                      summaries: [
+                        %{
+                          datetime: dt3,
+                          source: "reddit,telegram,twitter_crypto",
+                          summary: "summary5"
+                        }
+                      ]
                     }
                   ]}
       end)
@@ -220,12 +276,12 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
     ]
 
     [
-      [dt1_unix, "bitcoin", nil, 10, context, [["telegram", dt1_unix, "summary1"]]],
-      [dt1_unix, "ethereum", nil, 5, context, [["telegram", dt1_unix, "summary2"]]],
-      [dt2_unix, "san", nil, 2, context, [["telegram", dt2_unix, "summary3"]]],
-      [dt2_unix, "boom", nil, 70, context, [["telegram", dt2_unix, "summary4"]]],
-      [dt3_unix, "eth", nil, 1, context, [["reddit", dt3_unix, "summary5"]]],
-      [dt3_unix, "xrp", nil, 2, context, [["telegram", dt3_unix, "summary6"]]]
+      [dt1_unix, "bitcoin", nil, 10, context, "summary1"],
+      [dt1_unix, "ethereum", nil, 5, context, "summary2"],
+      [dt2_unix, "san", nil, 2, context, "summary3"],
+      [dt2_unix, "boom", nil, 70, context, "summary4"],
+      [dt3_unix, "eth", nil, 1, context, "summary5"],
+      [dt3_unix, "xrp", nil, 2, context, "summary6"]
     ]
   end
 end


### PR DESCRIPTION
## Changes

Fetch only the latest summary for the trending word. Also introduce a string `summary` as a list is no longer needed. Keep `summaries` until the FE migrates.

```graphql
{
  getTrendingWords(size: 10, from: "utc_now-3h" to: "utc_now" interval: "1h"){
    datetime
    topWords{
      word
      score
     	summary
      summaries{
        summary
      }
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
