### PR TITLE
Add internalName and filter to getAccessRestrictions

### DIFF
--- a/lib/sanbase/billing/plan/restrictions.ex
+++ b/lib/sanbase/billing/plan/restrictions.ex
@@ -9,6 +9,7 @@ defmodule Sanbase.Billing.Plan.Restrictions do
   @type restriction :: %{
           type: String.t(),
           name: String.t(),
+          internal_name: String.t(),
           min_interval: String.t(),
           is_accessible: boolean(),
           is_restricted: boolean(),
@@ -48,14 +49,11 @@ defmodule Sanbase.Billing.Plan.Restrictions do
   Return a list in which every element describes either a metric or a query.
   The elements are maps describing the time restrictions of the given metric/query.
   """
-  @spec get_all(String.t(), String.t()) :: list(restriction)
-  def get_all(plan_name, product_code) do
+  @spec get_all(String.t(), String.t(), :query | :metric | :signal | nil) :: list(restriction)
+  def get_all(plan_name, product_code, filter \\ nil) do
     metrics = Sanbase.Metric.available_metrics() |> Enum.map(&{:metric, &1})
     signals = Sanbase.Signal.available_signals() |> Enum.map(&{:signal, &1})
-
-    queries =
-      Sanbase.Project.AvailableQueries.all_atom_names()
-      |> Enum.map(&{:query, &1})
+    queries = Sanbase.Project.AvailableQueries.all_atom_names() |> Enum.map(&{:query, &1})
 
     # elements are {:metric, <string>} or {:query, <atom>} or {:signal, <string>}
     result =
@@ -65,30 +63,42 @@ defmodule Sanbase.Billing.Plan.Restrictions do
     (get_extra_queries(plan_name, product_code) ++ result)
     |> Enum.uniq_by(& &1.name)
     |> Enum.sort_by(& &1.name)
+    |> maybe_filter_by_type(filter)
   end
 
   # Private functions
 
+  defp maybe_filter_by_type(list, nil), do: list
+
+  defp maybe_filter_by_type(list, filter) do
+    filter = to_string(filter)
+    Enum.filter(list, &(&1.type == filter))
+  end
+
   defp no_access_map(type_str, name_str) do
+    additional_data = additional_data(type_str, name_str)
+
     %{
       type: type_str,
       name: name_str,
-      min_interval: min_interval(type_str, name_str),
       is_accessible: false,
       is_restricted: true,
       restricted_from: nil,
       restricted_to: nil
     }
+    |> Map.merge(additional_data)
   end
 
   defp not_restricted_access_map(type_str, name_str) do
+    additional_data = additional_data(type_str, name_str)
+
     %{
       type: type_str,
       name: name_str,
-      min_interval: min_interval(type_str, name_str),
       is_accessible: true,
       is_restricted: false
     }
+    |> Map.merge(additional_data)
   end
 
   defp maybe_restricted_access_map(type_str, name_str, plan_name, product_code, query_or_metric) do
@@ -107,42 +117,58 @@ defmodule Sanbase.Billing.Plan.Restrictions do
         days -> Timex.shift(now, days: -days)
       end
 
+    additional_data = additional_data(type_str, name_str)
+
     %{
       type: type_str,
       name: name_str,
-      min_interval: min_interval(type_str, name_str),
       is_accessible: true,
       is_restricted: not is_nil(restricted_from) or not is_nil(restricted_to),
       restricted_from: restricted_from,
       restricted_to: restricted_to
     }
+    |> Map.merge(additional_data)
   end
 
   defp construct_name(:metric, name), do: name |> to_string()
   defp construct_name(:signal, name), do: name |> to_string()
   defp construct_name(:query, name), do: name |> Inflex.camelize(:lower)
 
-  defp min_interval("metric", metric) do
-    {:ok, metadata} = Sanbase.Metric.metadata(metric)
-    metadata.min_interval
-  end
+  defp additional_data("metric", metric) do
+    case Sanbase.Metric.metadata(metric) do
+      {:ok, metadata} ->
+        %{
+          min_interval: metadata.min_interval,
+          internal_name: metadata.internal_metric
+        }
 
-  defp min_interval("signal", signal) do
-    case Sanbase.Signal.metadata(signal) do
-      {:ok, metadata} -> metadata.min_interval
-      {:error, error} -> raise(error)
+      {:error, error} ->
+        raise(error)
     end
   end
 
-  defp min_interval("query", query)
+  defp additional_data("signal", signal) do
+    case Sanbase.Signal.metadata(signal) do
+      {:ok, metadata} ->
+        %{
+          min_interval: metadata.min_interval,
+          internal_name: metadata.internal_signal
+        }
+
+      {:error, error} ->
+        raise(error)
+    end
+  end
+
+  defp additional_data("query", query)
        when query in [
               "dailyActiveDeposits",
               "historyTwitterData",
               "percentOfTokenSupplyOnExchanges"
             ],
-       do: "1d"
+       do: %{min_interval: "1d", internal_name: query}
 
-  defp min_interval("query", query)
+  defp additional_data("query", query)
        when query in [
               "gasUsed",
               "devActivity",
@@ -156,9 +182,9 @@ defmodule Sanbase.Billing.Plan.Restrictions do
               "getProjectTrendingHistory",
               "ethSpentOverTime"
             ],
-       do: "5m"
+       do: %{min_interval: "5m", internal_name: query}
 
-  defp min_interval("query", _query), do: nil
+  defp additional_data("query", query), do: %{min_interval: nil, internal_name: query}
 
   defp get_extra_queries(_plan_name, _product_code) do
     [not_restricted_access_map("query", "ethSpentOverTime")]

--- a/lib/sanbase/signal/signal_adapter.ex
+++ b/lib/sanbase/signal/signal_adapter.ex
@@ -18,6 +18,7 @@ defmodule Sanbase.Signal.SignalAdapter do
   @selectors_map FileHandler.selectors_map()
   @human_readable_name_map FileHandler.human_readable_name_map()
   @signal_to_name_map FileHandler.signal_to_name_map()
+  @name_to_signal_map FileHandler.name_to_signal_map()
   @access_map FileHandler.access_map()
   @min_plan_map FileHandler.min_plan_map()
   @free_signals FileHandler.signals_with_access(:free)
@@ -83,6 +84,7 @@ defmodule Sanbase.Signal.SignalAdapter do
     {:ok,
      %{
        signal: signal,
+       internal_signal: Map.get(@name_to_signal_map, signal),
        min_interval: Map.get(@min_interval_map, signal),
        default_aggregation: Map.get(@aggregation_map, signal),
        available_aggregations: @aggregations,

--- a/lib/sanbase/signal/sql_query/signal_sql_query.ex
+++ b/lib/sanbase/signal/sql_query/signal_sql_query.ex
@@ -16,6 +16,8 @@ defmodule Sanbase.Signal.SqlQuery do
 
   alias Sanbase.Signal.FileHandler
 
+  @name_to_signal_map FileHandler.name_to_signal_map()
+
   schema @table do
     field(:datetime, :utc_datetime, source: :dt)
     field(:value, :float)
@@ -54,7 +56,7 @@ defmodule Sanbase.Signal.SqlQuery do
     """
 
     params = %{
-      signal: Map.get(FileHandler.name_to_signal_map(), signal)
+      signal: Map.get(@name_to_signal_map, signal)
     }
 
     Sanbase.Clickhouse.Query.new(sql, params)
@@ -70,7 +72,7 @@ defmodule Sanbase.Signal.SqlQuery do
     """
 
     params = %{
-      signal: Map.get(FileHandler.name_to_signal_map(), signal),
+      signal: Map.get(@name_to_signal_map, signal),
       slug: slug
     }
 
@@ -129,7 +131,7 @@ defmodule Sanbase.Signal.SqlQuery do
     params = %{
       from: from |> DateTime.to_unix(),
       to: to |> DateTime.to_unix(),
-      signal: Map.get(FileHandler.name_to_signal_map(), signal),
+      signal: Map.get(@name_to_signal_map, signal),
       slug: slug_or_slugs
     }
 
@@ -164,7 +166,7 @@ defmodule Sanbase.Signal.SqlQuery do
       interval: str_to_sec(interval),
       from: from |> DateTime.to_unix(),
       to: to |> DateTime.to_unix(),
-      signal: Map.get(FileHandler.name_to_signal_map(), signal),
+      signal: Map.get(@name_to_signal_map, signal),
       slug: slug_or_slugs
     }
 
@@ -197,7 +199,7 @@ defmodule Sanbase.Signal.SqlQuery do
     """
 
     params = %{
-      signal: Map.get(FileHandler.name_to_signal_map(), signal),
+      signal: Map.get(@name_to_signal_map, signal),
       from: from |> DateTime.to_unix(),
       to: to |> DateTime.to_unix(),
       slugs: slug_or_slugs |> List.wrap()

--- a/lib/sanbase_web/graphql/resolvers/access_control_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/access_control_resolver.ex
@@ -11,12 +11,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.AccessControlResolver do
 
     product_code = Product.code_by_id(product_id)
 
+    filter = Map.get(args, :filter)
+
     Cache.wrap(
       fn ->
-        restrictions = Sanbase.Billing.Plan.Restrictions.get_all(plan_name, product_code)
+        restrictions = Sanbase.Billing.Plan.Restrictions.get_all(plan_name, product_code, filter)
         {:ok, restrictions}
       end,
-      {:get_access_restrictions, plan_name, product_code}
+      {:get_access_restrictions, plan_name, product_code, filter}
     ).()
   end
 

--- a/lib/sanbase_web/graphql/schema/queries/user_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/user_queries.ex
@@ -58,6 +58,7 @@ defmodule SanbaseWeb.Graphql.Schema.UserQueries do
 
       arg(:product, :products_enum)
       arg(:plan, :plans_enum)
+      arg(:filter, :access_restriction_filter_enum)
 
       resolve(&AccessControlResolver.get_access_restrictions/3)
     end

--- a/lib/sanbase_web/graphql/schema/types/user_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_types.ex
@@ -265,9 +265,16 @@ defmodule SanbaseWeb.Graphql.UserTypes do
     field(:pulse_count, :integer)
   end
 
+  enum :access_restriction_filter_enum do
+    value(:metric)
+    value(:query)
+    value(:signal)
+  end
+
   object :access_restriction do
     field(:type, non_null(:string))
     field(:name, non_null(:string))
+    field(:internal_name, non_null(:string))
     field(:min_interval, :string)
     field(:is_restricted, non_null(:boolean))
     field(:is_accessible, non_null(:boolean))

--- a/test/sanbase_web/graphql/access_restrictions_test.exs
+++ b/test/sanbase_web/graphql/access_restrictions_test.exs
@@ -65,6 +65,7 @@ defmodule SanbaseWeb.Graphql.AccessRestrictionsTest do
       getAccessRestrictions{
         type
         name
+        internalName
         isRestricted
         restrictedFrom
         restrictedTo


### PR DESCRIPTION
## Changes

- Add optional `filter` parameter with values `METRIC`, `QUERY`, or `SIGNAL`.
- Add `internalName` field that will return the internal name of the metric or signal used in clickhouse. For queries it is the same as the query name.

```graphql
{
  getAccessRestrictions(filter: METRIC){
    type
    name
    internalName
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
