### PR TITLE
Extend autocomplete functions

### DIFF
--- a/lib/sanbase/dashboard/autocomplete.ex
+++ b/lib/sanbase/dashboard/autocomplete.ex
@@ -1,12 +1,12 @@
 defmodule Sanbase.Dashboard.Autocomplete do
   alias Sanbase.ClickhouseRepo
 
-  def get_data() do
+  def get_data(opts \\ []) do
     Sanbase.ClickhouseRepo.put_dynamic_repo(Sanbase.ClickhouseRepo.ReadOnly)
 
     result = %{
       columns: get_columns(),
-      functions: get_functions(),
+      functions: get_functions(opts),
       tables: get_tables()
     }
 
@@ -79,14 +79,29 @@ defmodule Sanbase.Dashboard.Autocomplete do
     result
   end
 
-  defp get_functions() do
+  defp get_functions(opts) do
+    filter_functions =
+      case Keyword.get(opts, :functions_filter) do
+        :user_defined -> "origin = 'SQLUserDefined'"
+        :system -> "origin = 'System'"
+        _ -> nil
+      end
+
     sql = """
-    SELECT name
+    SELECT name, origin
     FROM system.functions
+    #{if filter_functions, do: "WHERE #{filter_functions}"}
     """
 
     query_struct = Sanbase.Clickhouse.Query.new(sql, %{})
-    {:ok, result} = ClickhouseRepo.query_transform(query_struct, fn [name] -> %{name: name} end)
+
+    {:ok, result} =
+      ClickhouseRepo.query_transform(query_struct, fn [name, origin] ->
+        %{name: name, origin: origin}
+      end)
+
     result
+    # TODO: Remove after cleanup
+    |> Enum.reject(&(&1.name =~ ~r"boris|tzanko"))
   end
 end

--- a/lib/sanbase_web/graphql/resolvers/dashboard_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/dashboard_resolver.ex
@@ -11,8 +11,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.DashboardResolver do
 
   require Logger
 
-  def get_clickhouse_database_metadata(_root, _args, _resolution) do
-    Dashboard.Autocomplete.get_data()
+  def get_clickhouse_database_metadata(_root, args, _resolution) do
+    opts = [functions_filter: args[:functions_filter]]
+    Dashboard.Autocomplete.get_data(opts)
   end
 
   def user_public_dashboards(%Sanbase.Accounts.User{} = user, _args, _resolution) do

--- a/lib/sanbase_web/graphql/schema/queries/dashboard_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/dashboard_queries.ex
@@ -20,6 +20,8 @@ defmodule SanbaseWeb.Graphql.Schema.DashboardQueries do
     field :get_clickhouse_database_metadata, :clickhouse_database_metadata do
       meta(access: :free)
 
+      arg(:functions_filter, :clickhouse_metadata_function_filter_enum)
+
       cache_resolve(&DashboardResolver.get_clickhouse_database_metadata/3)
     end
 

--- a/lib/sanbase_web/graphql/schema/types/dashboard_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/dashboard_types.ex
@@ -35,6 +35,12 @@ defmodule SanbaseWeb.Graphql.DashboardTypes do
   """
   object :clickhouse_database_function_metadata do
     field(:name, non_null(:string))
+    field(:origin, non_null(:string))
+  end
+
+  enum :clickhouse_metadata_function_filter_enum do
+    value(:system)
+    value(:user_defined)
   end
 
   @desc ~s"""

--- a/test/sanbase_web/graphql/dashboard/dashboard_api_test.exs
+++ b/test/sanbase_web/graphql/dashboard/dashboard_api_test.exs
@@ -858,7 +858,7 @@ defmodule SanbaseWeb.Graphql.DashboardApiTest do
         getClickhouseDatabaseMetadata{
           columns{ name isInSortingKey isInPartitionKey }
           tables{ name partitionKey sortingKey primaryKey }
-          functions{ name }
+          functions{ name origin }
         }
       }
       """
@@ -876,7 +876,7 @@ defmodule SanbaseWeb.Graphql.DashboardApiTest do
              }}
           end,
           # mock functions response
-          fn -> {:ok, %{rows: [["logTrace"], ["aes_decrypt_mysql"]]}} end,
+          fn -> {:ok, %{rows: [["logTrace", "System"], ["get_asset_id", "SQLUserDefined"]]}} end,
           # mock tables response
           fn ->
             {:ok,
@@ -912,7 +912,10 @@ defmodule SanbaseWeb.Graphql.DashboardApiTest do
                      "name" => "computed_at"
                    }
                  ],
-                 "functions" => [%{"name" => "logTrace"}, %{"name" => "aes_decrypt_mysql"}],
+                 "functions" => [
+                   %{"name" => "logTrace", "origin" => "System"},
+                   %{"name" => "get_asset_id", "origin" => "SQLUserDefined"}
+                 ],
                  "tables" => [
                    %{
                      "name" => "asset_metadata",


### PR DESCRIPTION
## Changes
```graphql
{
  getClickhouseDatabaseMetadata {
    functions {
      name
      origin
    }
  }
}
```

The `origin` field can be `SQLUserDefined` or `System`.

Also, allow filtering on the functions type: user-defined or system. If the argument is not provided, no filtering is done.
```graphql
{
  getClickhouseDatabaseMetadata(functionsFilter: USER_DEFINED) {
    functions {
      name
      origin
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
