### PR TITLE
Add sentiment ratios to getTrendingWords

### DIFF
--- a/lib/sanbase_web/graphql/schema/types/social_data_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/social_data_types.ex
@@ -100,6 +100,9 @@ defmodule SanbaseWeb.Graphql.SocialDataTypes do
     field(:context, list_of(:word_context))
     field(:score, non_null(:float))
     field(:word, non_null(:string))
+    field(:positive_sentiment_ratio, :float)
+    field(:negative_sentiment_ratio, :float)
+    field(:neutral_sentiment_ratio, :float)
 
     field :project, :project do
       cache_resolve(&SocialDataResolver.project_from_root_slug/3)

--- a/test/sanbase/email/emails_test.exs
+++ b/test/sanbase/email/emails_test.exs
@@ -11,7 +11,7 @@ defmodule Sanbase.EmailsTest do
 
   alias Sanbase.Accounts.User
   alias Sanbase.Billing.Subscription
-  alias Sanbase.Accounts.EmailJobs
+  # alias Sanbase.Accounts.EmailJobs
   alias Sanbase.StripeApi
   alias Sanbase.StripeApiTestResponse
 

--- a/test/sanbase/social_data/trending_words/trending_words_test.exs
+++ b/test/sanbase/social_data/trending_words/trending_words_test.exs
@@ -24,102 +24,120 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
       |> Sanbase.Mock.run_with_mocks(fn ->
         result = TrendingWords.get_trending_words(dt1, dt3, "1d", 2, :all)
 
-        context = [%{word: "usd", score: 1.0}, %{word: "money", score: 0.5}]
-
         assert result ==
-                 {:ok,
-                  %{
-                    dt1 => [
-                      %{
-                        score: 5,
-                        word: "ethereum",
-                        slug: "ethereum",
-                        context: context,
-                        summary: "summary2",
-                        summaries: [
-                          %{
-                            datetime: dt1,
-                            source: "reddit,telegram,twitter_crypto",
-                            summary: "summary2"
-                          }
-                        ]
-                      },
-                      %{
-                        score: 10,
-                        word: "bitcoin",
-                        slug: "bitcoin",
-                        context: context,
-                        summary: "summary1",
-                        summaries: [
-                          %{
-                            datetime: dt1,
-                            source: "reddit,telegram,twitter_crypto",
-                            summary: "summary1"
-                          }
-                        ]
-                      }
-                    ],
-                    dt2 => [
-                      %{
-                        score: 70,
-                        word: "boom",
-                        slug: nil,
-                        context: context,
-                        summary: "summary4",
-                        summaries: [
-                          %{
-                            datetime: dt2,
-                            source: "reddit,telegram,twitter_crypto",
-                            summary: "summary4"
-                          }
-                        ]
-                      },
-                      %{
-                        score: 2,
-                        word: "san",
-                        slug: "santiment",
-                        context: context,
-                        summary: "summary3",
-                        summaries: [
-                          %{
-                            datetime: dt2,
-                            source: "reddit,telegram,twitter_crypto",
-                            summary: "summary3"
-                          }
-                        ]
-                      }
-                    ],
-                    dt3 => [
-                      %{
-                        score: 2,
-                        word: "xrp",
-                        slug: "ripple",
-                        context: context,
-                        summary: "summary6",
-                        summaries: [
-                          %{
-                            datetime: dt3,
-                            source: "reddit,telegram,twitter_crypto",
-                            summary: "summary6"
-                          }
-                        ]
-                      },
-                      %{
-                        score: 1,
-                        word: "eth",
-                        slug: "ethereum",
-                        context: context,
-                        summary: "summary5",
-                        summaries: [
-                          %{
-                            datetime: dt3,
-                            source: "reddit,telegram,twitter_crypto",
-                            summary: "summary5"
-                          }
-                        ]
-                      }
-                    ]
-                  }}
+                 {
+                   :ok,
+                   %{
+                     dt1 => [
+                       %{
+                         context: [%{score: 1.0, word: "usd"}, %{score: 0.5, word: "money"}],
+                         score: 5,
+                         slug: "ethereum",
+                         summaries: [
+                           %{
+                             datetime: dt1,
+                             source: "4chan,bitcointalk,reddit",
+                             summary: "summary2"
+                           }
+                         ],
+                         summary: "summary2",
+                         word: "ethereum",
+                         negative_sentiment_ratio: 0.3,
+                         neutral_sentiment_ratio: 0.5,
+                         positive_sentiment_ratio: 0.2
+                       },
+                       %{
+                         context: [%{score: 1.0, word: "usd"}, %{score: 0.5, word: "money"}],
+                         score: 10,
+                         slug: "bitcoin",
+                         summaries: [
+                           %{
+                             datetime: dt1,
+                             source: "4chan,bitcointalk,reddit",
+                             summary: "summary1"
+                           }
+                         ],
+                         summary: "summary1",
+                         word: "bitcoin",
+                         negative_sentiment_ratio: 0.3,
+                         neutral_sentiment_ratio: 0.5,
+                         positive_sentiment_ratio: 0.2
+                       }
+                     ],
+                     dt2 => [
+                       %{
+                         context: [%{score: 1.0, word: "usd"}, %{score: 0.5, word: "money"}],
+                         score: 70,
+                         slug: nil,
+                         summaries: [
+                           %{
+                             datetime: dt2,
+                             source: "4chan,bitcointalk,reddit",
+                             summary: "summary4"
+                           }
+                         ],
+                         summary: "summary4",
+                         word: "boom",
+                         negative_sentiment_ratio: 0.1,
+                         neutral_sentiment_ratio: 0.7,
+                         positive_sentiment_ratio: 0.2
+                       },
+                       %{
+                         context: [%{score: 1.0, word: "usd"}, %{score: 0.5, word: "money"}],
+                         score: 2,
+                         slug: "santiment",
+                         summaries: [
+                           %{
+                             datetime: dt2,
+                             source: "4chan,bitcointalk,reddit",
+                             summary: "summary3"
+                           }
+                         ],
+                         summary: "summary3",
+                         word: "san",
+                         negative_sentiment_ratio: 0.1,
+                         neutral_sentiment_ratio: 0.5,
+                         positive_sentiment_ratio: 0.4
+                       }
+                     ],
+                     dt3 => [
+                       %{
+                         context: [%{score: 1.0, word: "usd"}, %{score: 0.5, word: "money"}],
+                         score: 2,
+                         slug: "ripple",
+                         summaries: [
+                           %{
+                             datetime: dt3,
+                             source: "4chan,bitcointalk,reddit",
+                             summary: "summary6"
+                           }
+                         ],
+                         summary: "summary6",
+                         word: "xrp",
+                         negative_sentiment_ratio: 0.3,
+                         neutral_sentiment_ratio: 0.5,
+                         positive_sentiment_ratio: 0.2
+                       },
+                       %{
+                         context: [%{score: 1.0, word: "usd"}, %{score: 0.5, word: "money"}],
+                         score: 1,
+                         slug: "ethereum",
+                         summaries: [
+                           %{
+                             datetime: dt3,
+                             source: "4chan,bitcointalk,reddit",
+                             summary: "summary5"
+                           }
+                         ],
+                         summary: "summary5",
+                         word: "eth",
+                         negative_sentiment_ratio: 0.3,
+                         neutral_sentiment_ratio: 0.5,
+                         positive_sentiment_ratio: 0.2
+                       }
+                     ]
+                   }
+                 }
       end)
     end
 
@@ -144,40 +162,46 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
       |> Sanbase.Mock.run_with_mocks(fn ->
         result = TrendingWords.get_currently_trending_words(10, :all)
 
-        context = [%{word: "usd", score: 1.0}, %{word: "money", score: 0.5}]
-
         assert result ==
-                 {:ok,
-                  [
-                    %{
-                      score: 2,
-                      word: "xrp",
-                      slug: "ripple",
-                      context: context,
-                      summary: "summary6",
-                      summaries: [
-                        %{
-                          datetime: dt3,
-                          source: "reddit,telegram,twitter_crypto",
-                          summary: "summary6"
-                        }
-                      ]
-                    },
-                    %{
-                      score: 1,
-                      word: "eth",
-                      slug: "ethereum",
-                      context: context,
-                      summary: "summary5",
-                      summaries: [
-                        %{
-                          datetime: dt3,
-                          source: "reddit,telegram,twitter_crypto",
-                          summary: "summary5"
-                        }
-                      ]
-                    }
-                  ]}
+                 {
+                   :ok,
+                   [
+                     %{
+                       context: [%{score: 1.0, word: "usd"}, %{score: 0.5, word: "money"}],
+                       score: 2,
+                       slug: "ripple",
+                       summaries: [
+                         %{
+                           datetime: ~U[2019-01-03 00:00:00Z],
+                           source: "4chan,bitcointalk,reddit",
+                           summary: "summary6"
+                         }
+                       ],
+                       summary: "summary6",
+                       word: "xrp",
+                       negative_sentiment_ratio: 0.3,
+                       neutral_sentiment_ratio: 0.5,
+                       positive_sentiment_ratio: 0.2
+                     },
+                     %{
+                       context: [%{score: 1.0, word: "usd"}, %{score: 0.5, word: "money"}],
+                       score: 1,
+                       slug: "ethereum",
+                       summaries: [
+                         %{
+                           datetime: ~U[2019-01-03 00:00:00Z],
+                           source: "4chan,bitcointalk,reddit",
+                           summary: "summary5"
+                         }
+                       ],
+                       summary: "summary5",
+                       word: "eth",
+                       negative_sentiment_ratio: 0.3,
+                       neutral_sentiment_ratio: 0.5,
+                       positive_sentiment_ratio: 0.2
+                     }
+                   ]
+                 }
       end)
     end
 
@@ -284,12 +308,12 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
     ]
 
     [
-      [dt1_unix, "bitcoin", "BTC_bitcoin", 10, context, "summary1"],
-      [dt1_unix, "ethereum", "ETH_ethereum", 5, context, "summary2"],
-      [dt2_unix, "san", "SAN_santiment", 2, context, "summary3"],
-      [dt2_unix, "boom", nil, 70, context, "summary4"],
-      [dt3_unix, "eth", "ETH_ethereum", 1, context, "summary5"],
-      [dt3_unix, "xrp", "XRP_ripple", 2, context, "summary6"]
+      [dt1_unix, "bitcoin", "BTC_bitcoin", 10, context, "summary1", [0.2, 0.3, 0.5]],
+      [dt1_unix, "ethereum", "ETH_ethereum", 5, context, "summary2", [0.2, 0.3, 0.5]],
+      [dt2_unix, "san", "SAN_santiment", 2, context, "summary3", [0.4, 0.1, 0.5]],
+      [dt2_unix, "boom", nil, 70, context, "summary4", [0.2, 0.1, 0.7]],
+      [dt3_unix, "eth", "ETH_ethereum", 1, context, "summary5", [0.2, 0.3, 0.5]],
+      [dt3_unix, "xrp", "XRP_ripple", 2, context, "summary6", [0.2, 0.3, 0.5]]
     ]
   end
 end

--- a/test/sanbase_web/graphql/billing/subscribe_api_test.exs
+++ b/test/sanbase_web/graphql/billing/subscribe_api_test.exs
@@ -796,17 +796,17 @@ defmodule SanbaseWeb.Graphql.Billing.SubscribeApiTest do
     """
   end
 
-  defp check_annual_discount_eligibility() do
-    """
-    {
-      checkAnnualDiscountEligibility {
-        isEligible
-        discount {
-          percentOff
-          expireAt
-        }
-      }
-    }
-    """
-  end
+  # defp check_annual_discount_eligibility() do
+  #   """
+  #   {
+  #     checkAnnualDiscountEligibility {
+  #       isEligible
+  #       discount {
+  #         percentOff
+  #         expireAt
+  #       }
+  #     }
+  #   }
+  #   """
+  # end
 end

--- a/test/sanbase_web/graphql/social_data/trending_words_api_test.exs
+++ b/test/sanbase_web/graphql/social_data/trending_words_api_test.exs
@@ -36,7 +36,8 @@ defmodule SanbaseWeb.Graphql.TrendingWordsApiTest do
             "{'word': 'btc', 'score': 0.85}",
             "{'word': 'halving', 'score': 1.0}"
           ],
-          "The summary"
+          "The summary",
+          [0.2, 0.3, 0.5]
         ],
         [
           DateTime.to_unix(dt1),
@@ -47,7 +48,8 @@ defmodule SanbaseWeb.Graphql.TrendingWordsApiTest do
             "{'word': 'eth', 'score': 0.63}",
             "{'word': 'bitcoin', 'score': 1.0}"
           ],
-          "Another summary"
+          "Another summary",
+          [0.8, 0.1, 0.1]
         ],
         [
           DateTime.to_unix(dt1),
@@ -58,7 +60,8 @@ defmodule SanbaseWeb.Graphql.TrendingWordsApiTest do
             "{'word': 'short', 'score': 0.82}",
             "{'word': 'tight', 'score': 1.0}"
           ],
-          "Third summary"
+          "Third summary",
+          [0.5, 0.15, 0.35]
         ]
       ]
 
@@ -76,34 +79,43 @@ defmodule SanbaseWeb.Graphql.TrendingWordsApiTest do
                        "datetime" => DateTime.to_iso8601(dt1),
                        "topWords" => [
                          %{
-                           "project" => nil,
-                           "score" => 82.0,
-                           "word" => "word",
                            "context" => [
                              %{"score" => 1.0, "word" => "tight"},
                              %{"score" => 0.82, "word" => "short"}
                            ],
-                           "summary" => "Third summary"
+                           "project" => nil,
+                           "score" => 82.0,
+                           "summary" => "Third summary",
+                           "word" => "word",
+                           "negativeSentimentRatio" => 0.15,
+                           "neutralSentimentRatio" => 0.35,
+                           "positiveSentimentRatio" => 0.5
                          },
                          %{
-                           "project" => %{"slug" => "bitcoin"},
-                           "score" => 74.5,
-                           "word" => "btc",
                            "context" => [
                              %{"score" => 1.0, "word" => "bitcoin"},
                              %{"score" => 0.63, "word" => "eth"}
                            ],
-                           "summary" => "Another summary"
+                           "project" => %{"slug" => "bitcoin"},
+                           "score" => 74.5,
+                           "summary" => "Another summary",
+                           "word" => "btc",
+                           "negativeSentimentRatio" => 0.1,
+                           "neutralSentimentRatio" => 0.1,
+                           "positiveSentimentRatio" => 0.8
                          },
                          %{
-                           "project" => %{"slug" => "ethereum"},
-                           "score" => 72.4,
-                           "word" => "eth",
                            "context" => [
                              %{"score" => 1.0, "word" => "halving"},
                              %{"score" => 0.85, "word" => "btc"}
                            ],
-                           "summary" => "The summary"
+                           "project" => %{"slug" => "ethereum"},
+                           "score" => 72.4,
+                           "summary" => "The summary",
+                           "word" => "eth",
+                           "negativeSentimentRatio" => 0.3,
+                           "neutralSentimentRatio" => 0.5,
+                           "positiveSentimentRatio" => 0.2
                          }
                        ]
                      }
@@ -250,6 +262,9 @@ defmodule SanbaseWeb.Graphql.TrendingWordsApiTest do
             project{ slug }
             score
             summary
+            positiveSentimentRatio
+            negativeSentimentRatio
+            neutralSentimentRatio
             context{
               word
               score


### PR DESCRIPTION
## Changes

- Add `positiveSentimentRatio`, `negativeSentimentRatio`, and `neutralPositiveRatio` fields to the `getTrendingWords` API. These values show the % of documents that mention the given word that have positive/negative/neutral sentiment. The values are in the range [0,1] and add up to 1.
  - As of now, the ratios are available **only** for words that refer to projects.
- Conditionally choose the source that constitutes `ALL` so the API does not break on stage.

```graphql
{
  getTrendingWords(size: 10, from: "utc_now-1d", to: "utc_now", interval: "12h", wordTypeFilter: PROJECT) {
    datetime
    topWords {
      word
      project {
        slug
      }
      score
      positiveSentimentRatio
      negativeSentimentRatio
      neutralSentimentRatio
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
