### PR TITLE
Rework getMetric's metric deprecation logic

### DIFF
--- a/lib/sanbase/clickhouse/metric/file_handler.ex
+++ b/lib/sanbase/clickhouse/metric/file_handler.ex
@@ -155,10 +155,10 @@ defmodule Sanbase.Clickhouse.MetricAdapter.FileHandler do
 
   @metrics_json_including_deprecated Helper.expand_patterns(@metrics_json_pre_expand_patterns)
 
-  @metrics_json Enum.reject(
-                  @metrics_json_including_deprecated,
-                  &(not is_nil(&1["deprecated_since"]))
-                )
+  # The deprecated metrics are filter at a later stage at runtime, not here at compile time
+  # This is because `deprecated_since` can hold a future value and until then
+  # it can still be used.
+  @metrics_json @metrics_json_including_deprecated
 
   @aggregations Sanbase.Metric.SqlQuery.Helper.aggregations()
   @metrics_data_type_map Helper.name_to_field_map(@metrics_json, "data_type",

--- a/lib/sanbase/clickhouse/metric/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/metric/metric_adapter.ex
@@ -39,6 +39,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
   @metric_to_names_map FileHandler.metric_to_names_map()
   @name_to_metric_map FileHandler.name_to_metric_map()
   @deprecated_metrics_map FileHandler.deprecated_metrics_map()
+  @soft_deprecated_metrics_map FileHandler.soft_deprecated_metrics_map()
   @timebound_flag_map FileHandler.timebound_flag_map()
   @default_complexity_weight 0.3
 
@@ -65,6 +66,9 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
 
   @impl Sanbase.Metric.Behaviour
   def deprecated_metrics_map(), do: @deprecated_metrics_map
+
+  @impl Sanbase.Metric.Behaviour
+  def soft_deprecated_metrics_map(), do: @soft_deprecated_metrics_map
 
   @impl Sanbase.Metric.Behaviour
   def access_map(), do: @access_map

--- a/lib/sanbase/clickhouse/metric/metric_files/social_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/social_metrics.json
@@ -8,10 +8,7 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -31,9 +28,7 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -50,10 +45,7 @@
     "metric": "social_dominance_v2",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -70,10 +62,7 @@
     "metric": "social_dominance_ai",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -90,9 +79,7 @@
     "metric": "sentiment_volume_consumed_1d",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -109,10 +96,7 @@
     "metric": "sentiment_positive",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -129,10 +113,7 @@
     "metric": "sentiment_negative",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -149,10 +130,7 @@
     "metric": "sentiment_balance",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -172,10 +150,7 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -192,10 +167,7 @@
     "metric": "social_dominance_4chan_v2",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -212,10 +184,7 @@
     "metric": "sentiment_volume_consumed_4chan",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -232,10 +201,7 @@
     "metric": "sentiment_positive_4chan",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -252,10 +218,7 @@
     "metric": "sentiment_negative_4chan",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -272,10 +235,7 @@
     "metric": "sentiment_balance_4chan",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -295,10 +255,7 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -315,10 +272,7 @@
     "metric": "social_dominance_telegram_v2",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -335,10 +289,7 @@
     "metric": "sentiment_volume_consumed_telegram",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -355,10 +306,7 @@
     "metric": "sentiment_positive_telegram",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -375,10 +323,7 @@
     "metric": "sentiment_negative_telegram",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -395,10 +340,7 @@
     "metric": "sentiment_balance_telegram",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -418,10 +360,7 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -438,10 +377,7 @@
     "metric": "social_dominance_reddit_v2",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -458,10 +394,7 @@
     "metric": "sentiment_volume_consumed_reddit",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -478,10 +411,7 @@
     "metric": "sentiment_positive_reddit",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -498,10 +428,7 @@
     "metric": "sentiment_negative_reddit",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -518,10 +445,7 @@
     "metric": "sentiment_balance_reddit",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -541,10 +465,7 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -562,10 +483,7 @@
     "metric": "social_dominance_discord",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -583,10 +501,7 @@
     "metric": "sentiment_volume_consumed_discord",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -604,10 +519,7 @@
     "metric": "sentiment_positive_discord",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -625,10 +537,7 @@
     "metric": "sentiment_negative_discord",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -646,10 +555,7 @@
     "metric": "sentiment_balance_discord",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -670,10 +576,7 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -691,10 +594,7 @@
     "metric": "social_dominance_professional_traders_chat",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -712,10 +612,7 @@
     "metric": "sentiment_volume_consumed_professional_traders_chat",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -733,10 +630,7 @@
     "metric": "sentiment_positive_professional_traders_chat",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -754,10 +648,7 @@
     "metric": "sentiment_negative_professional_traders_chat",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -775,10 +666,7 @@
     "metric": "sentiment_balance_professional_traders_chat",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -799,10 +687,7 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -822,10 +707,7 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -845,10 +727,7 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -868,10 +747,7 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -888,10 +764,7 @@
     "metric": "social_dominance_twitter_v2",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -908,10 +781,7 @@
     "metric": "social_dominance_twitter_crypto",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -928,10 +798,7 @@
     "metric": "social_dominance_twitter_news",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -948,10 +815,7 @@
     "metric": "social_dominance_twitter_nft",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -968,10 +832,7 @@
     "metric": "sentiment_volume_consumed_twitter",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -988,10 +849,7 @@
     "metric": "sentiment_volume_consumed_twitter_crypto",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1008,10 +866,7 @@
     "metric": "sentiment_volume_consumed_twitter_news",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1028,10 +883,7 @@
     "metric": "sentiment_volume_consumed_twitter_nft",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1048,10 +900,7 @@
     "metric": "sentiment_positive_twitter",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1068,10 +917,7 @@
     "metric": "sentiment_positive_twitter_crypto",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1088,10 +934,7 @@
     "metric": "sentiment_positive_twitter_news",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1108,10 +951,7 @@
     "metric": "sentiment_positive_twitter_nft",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1128,10 +968,7 @@
     "metric": "sentiment_negative_twitter",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1148,10 +985,7 @@
     "metric": "sentiment_negative_twitter_crypto",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1168,10 +1002,7 @@
     "metric": "sentiment_negative_twitter_news",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1188,10 +1019,7 @@
     "metric": "sentiment_negative_twitter_nft",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1208,10 +1036,7 @@
     "metric": "sentiment_balance_twitter",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1228,10 +1053,7 @@
     "metric": "sentiment_balance_twitter_crypto",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1248,10 +1070,7 @@
     "metric": "sentiment_balance_twitter_news",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1268,10 +1087,7 @@
     "metric": "sentiment_balance_twitter_nft",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1291,10 +1107,7 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1311,10 +1124,7 @@
     "metric": "social_dominance_youtube_videos",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1331,10 +1141,7 @@
     "metric": "sentiment_volume_consumed_youtube_videos",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1351,10 +1158,7 @@
     "metric": "sentiment_positive_youtube_videos",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1371,10 +1175,7 @@
     "metric": "sentiment_negative_youtube_videos",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1391,10 +1192,7 @@
     "metric": "sentiment_balance_youtube_videos",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1414,10 +1212,7 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1434,10 +1229,7 @@
     "metric": "social_dominance_bitcointalk_v2",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1454,10 +1246,7 @@
     "metric": "sentiment_volume_consumed_bitcointalk",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1474,10 +1263,7 @@
     "metric": "sentiment_positive_bitcointalk",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1494,10 +1280,7 @@
     "metric": "sentiment_negative_bitcointalk",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1514,10 +1297,7 @@
     "metric": "sentiment_balance_bitcointalk",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1534,10 +1314,7 @@
     "metric": "unique_social_volume_5m",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug",
-      "text"
-    ],
+    "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1554,9 +1331,7 @@
     "metric": "unique_social_volume_1h",
     "version": "2020-07-31",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1573,9 +1348,7 @@
     "metric": "social_dominance_1h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1592,9 +1365,7 @@
     "metric": "social_dominance_24h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1611,9 +1382,7 @@
     "metric": "social_dominance_ai_1h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1630,9 +1399,7 @@
     "metric": "social_dominance_ai_24h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1649,9 +1416,7 @@
     "metric": "social_dominance_telegram_1h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1668,9 +1433,7 @@
     "metric": "social_dominance_telegram_24h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1687,9 +1450,7 @@
     "metric": "social_dominance_4chan_1h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1706,9 +1467,7 @@
     "metric": "social_dominance_4chan_24h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1725,9 +1484,7 @@
     "metric": "social_dominance_reddit_1h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1744,9 +1501,7 @@
     "metric": "social_dominance_reddit_24h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1763,9 +1518,7 @@
     "metric": "social_dominance_twitter_1h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1782,9 +1535,7 @@
     "metric": "social_dominance_twitter_24h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1801,9 +1552,7 @@
     "metric": "social_dominance_twitter_crypto_1h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1820,9 +1569,7 @@
     "metric": "social_dominance_twitter_crypto_24h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1839,9 +1586,7 @@
     "metric": "social_dominance_twitter_news_1h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1858,9 +1603,7 @@
     "metric": "social_dominance_twitter_news_24h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1877,9 +1620,7 @@
     "metric": "social_dominance_twitter_nft_1h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1896,9 +1637,7 @@
     "metric": "social_dominance_twitter_nft_24h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1915,9 +1654,7 @@
     "metric": "social_dominance_youtube_videos_1h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1934,9 +1671,7 @@
     "metric": "social_dominance_youtube_videos_24h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1953,9 +1688,7 @@
     "metric": "social_dominance_bitcointalk_1h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1972,9 +1705,7 @@
     "metric": "social_dominance_bitcointalk_24h",
     "version": "2019-01-01",
     "access": "restricted",
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"
@@ -1994,9 +1725,7 @@
       "historical": "restricted",
       "realtime": "free"
     },
-    "selectors": [
-      "slug"
-    ],
+    "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"

--- a/lib/sanbase/clickhouse/metric/metric_files/social_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/social_metrics.json
@@ -475,7 +475,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "deprecated_since": "2021-09-27T00:00:00Z"
+    "hard_deprecate_after": "2021-09-27T00:00:00Z"
   },
   {
     "human_readable_name": "Social Dominance Discord",
@@ -493,7 +493,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "deprecated_since": "2021-09-27T00:00:00Z"
+    "hard_deprecate_after": "2021-09-27T00:00:00Z"
   },
   {
     "human_readable_name": "Sentiment Volume Consumed Discord",
@@ -511,7 +511,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "deprecated_since": "2021-09-27T00:00:00Z"
+    "hard_deprecate_after": "2021-09-27T00:00:00Z"
   },
   {
     "human_readable_name": "Sentiment Positive Discord",
@@ -529,7 +529,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "deprecated_since": "2021-09-27T00:00:00Z"
+    "hard_deprecate_after": "2021-09-27T00:00:00Z"
   },
   {
     "human_readable_name": "Sentiment Negative Discord",
@@ -547,7 +547,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "deprecated_since": "2021-09-27T00:00:00Z"
+    "hard_deprecate_after": "2021-09-27T00:00:00Z"
   },
   {
     "human_readable_name": "Sentiment Balance Discord",
@@ -565,7 +565,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "deprecated_since": "2021-09-27T00:00:00Z"
+    "hard_deprecate_after": "2021-09-27T00:00:00Z"
   },
   {
     "human_readable_name": "Social Volume Professional Traders Chat",
@@ -586,7 +586,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "deprecated_since": "2021-09-27T00:00:00Z"
+    "hard_deprecate_after": "2021-09-27T00:00:00Z"
   },
   {
     "human_readable_name": "Social Dominance Professional Traders Chat",
@@ -604,7 +604,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "deprecated_since": "2021-09-27T00:00:00Z"
+    "hard_deprecate_after": "2021-09-27T00:00:00Z"
   },
   {
     "human_readable_name": "Sentiment Volume Consumed Professional Traders Chat",
@@ -622,7 +622,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "deprecated_since": "2021-09-27T00:00:00Z"
+    "hard_deprecate_after": "2021-09-27T00:00:00Z"
   },
   {
     "human_readable_name": "Sentiment Positive Professional Traders Chat",
@@ -640,7 +640,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "deprecated_since": "2021-09-27T00:00:00Z"
+    "hard_deprecate_after": "2021-09-27T00:00:00Z"
   },
   {
     "human_readable_name": "Sentiment Negative Professional Traders Chat",
@@ -658,7 +658,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "deprecated_since": "2021-09-27T00:00:00Z"
+    "hard_deprecate_after": "2021-09-27T00:00:00Z"
   },
   {
     "human_readable_name": "Sentiment Balance Professional Traders Chat",
@@ -676,7 +676,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "deprecated_since": "2021-09-27T00:00:00Z"
+    "hard_deprecate_after": "2021-09-27T00:00:00Z"
   },
   {
     "human_readable_name": "Social Volume Twitter",

--- a/lib/sanbase/metric/behaviour.ex
+++ b/lib/sanbase/metric/behaviour.ex
@@ -35,7 +35,14 @@ defmodule Sanbase.Metric.Behaviour do
           data_type: available_data_types(),
           complexity_weight: number(),
           has_incomplete_data: boolean(),
-          is_timebound: boolean()
+          is_timebound: boolean(),
+          # A metric can be deprecated, which means that it is marked
+          # as deprecated, but it is still accsessible. If hard_deprecate_after
+          # is not set, the deprecation is considered soft.
+          is_deprecated: boolean(),
+          # A metric can be hard-deprecated, which means that it will no
+          # longer be accessible after this datetime.
+          hard_deprecate_after: DateTime.t() | nil
         }
 
   @type histogram_value :: String.t() | float() | integer()
@@ -239,6 +246,8 @@ defmodule Sanbase.Metric.Behaviour do
 
   @callback deprecated_metrics_map() :: %{required(String.t()) => String.t()}
 
+  @callback soft_deprecated_metrics_map() :: %{required(String.t()) => String.t()}
+
   @callback access_map() :: map()
 
   @callback min_plan_map() :: map()
@@ -247,6 +256,7 @@ defmodule Sanbase.Metric.Behaviour do
     histogram_data: 6,
     table_data: 5,
     deprecated_metrics_map: 0,
+    soft_deprecated_metrics_map: 0,
     # If the adapter is working with assets, the following 2 callbacks are implemented
     slugs_by_filter: 6,
     slugs_order: 5,

--- a/lib/sanbase/metric/helper.ex
+++ b/lib/sanbase/metric/helper.ex
@@ -45,6 +45,7 @@ defmodule Sanbase.Metric.Helper do
   Module.register_attribute(__MODULE__, :table_metric_module_mapping_acc, accumulate: true)
   Module.register_attribute(__MODULE__, :required_selectors_map_acc, accumulate: true)
   Module.register_attribute(__MODULE__, :deprecated_metrics_acc, accumulate: true)
+  Module.register_attribute(__MODULE__, :soft_deprecated_metrics_acc, accumulate: true)
 
   for module <- @metric_modules do
     @required_selectors_map_acc module.required_selectors
@@ -79,6 +80,9 @@ defmodule Sanbase.Metric.Helper do
 
     if function_exported?(module, :deprecated_metrics_map, 0),
       do: @deprecated_metrics_acc(module.deprecated_metrics_map)
+
+    if function_exported?(module, :soft_deprecated_metrics_map, 0),
+      do: @soft_deprecated_metrics_acc(module.soft_deprecated_metrics_map)
   end
 
   flat_unique = fn list -> list |> List.flatten() |> Enum.uniq() end
@@ -137,9 +141,16 @@ defmodule Sanbase.Metric.Helper do
                           |> Enum.reject(&match?({_, nil}, &1))
                           |> Map.new()
 
+  @soft_deprecated_metrics_map Enum.reduce(@soft_deprecated_metrics_acc, %{}, &Map.merge(&1, &2))
+                               |> Enum.reject(&match?({_, nil}, &1))
+                               |> Map.new()
+
   # Do not remove deprecated metrics from the deprecated_metrics_map, as it
   # will just become empty and unusable
-  def deprecated_metrics_map(), do: @deprecated_metrics_map |> transform(remove_deprecated: false)
+  def deprecated_metrics_map(),
+    do: @deprecated_metrics_map |> transform(remove_hard_deprecated: false)
+
+  def soft_deprecated_metrics_map(), do: @soft_deprecated_metrics_map |> transform()
   def access_map(), do: @access_map |> transform()
   def aggregations_per_metric(), do: @aggregations_per_metric |> transform()
   def aggregations(), do: @aggregations |> transform()
@@ -169,41 +180,42 @@ defmodule Sanbase.Metric.Helper do
   # Private functions
 
   defp transform(metrics, opts \\ []) do
-    # The `remove_deprecated_metrics/1` function is used to remove deprecated
-    # metrics. The `deprecated_metrics_map` contains the metric as a key and a
-    # datetime as a value
+    # The `remove_hard_deprecated/1` function is used to completely remove
+    # hard deprecated metrics. The `deprecated_metrics_map` contains the metric
+    # as a key and a datetime as a value. If the current time is after that value,
+    # the metric is excluded
     metrics
     |> then(fn metrics ->
-      if Keyword.get(opts, :remove_deprecated, true),
-        do: remove_deprecated_metrics(metrics),
+      if Keyword.get(opts, :remove_hard_deprecated, true),
+        do: remove_hard_deprecated(metrics),
         else: metrics
     end)
   end
 
-  defp remove_deprecated_metrics(metrics) when is_list(metrics) do
+  defp remove_hard_deprecated(metrics) when is_list(metrics) do
     now = DateTime.utc_now()
 
     Enum.reject(metrics, fn metric ->
-      deprecated_since = Map.get(@deprecated_metrics_map, metric)
-      not is_nil(deprecated_since) and DateTime.compare(deprecated_since, now) == :lt
+      hard_deprecate_after = Map.get(@deprecated_metrics_map, metric)
+      not is_nil(hard_deprecate_after) and DateTime.compare(hard_deprecate_after, now) == :lt
     end)
   end
 
-  defp remove_deprecated_metrics(%MapSet{} = metrics) do
+  defp remove_hard_deprecated(%MapSet{} = metrics) do
     now = DateTime.utc_now()
 
     MapSet.reject(metrics, fn metric ->
-      deprecated_since = Map.get(@deprecated_metrics_map, metric)
-      not is_nil(deprecated_since) and DateTime.compare(deprecated_since, now) == :lt
+      hard_deprecate_after = Map.get(@deprecated_metrics_map, metric)
+      not is_nil(hard_deprecate_after) and DateTime.compare(hard_deprecate_after, now) == :lt
     end)
   end
 
-  defp remove_deprecated_metrics(metrics) when is_map(metrics) do
+  defp remove_hard_deprecated(metrics) when is_map(metrics) do
     now = DateTime.utc_now()
 
     Map.reject(metrics, fn {metric, _} ->
-      deprecated_since = Map.get(@deprecated_metrics_map, metric)
-      not is_nil(deprecated_since) and DateTime.compare(deprecated_since, now) == :lt
+      hard_deprecate_after = Map.get(@deprecated_metrics_map, metric)
+      not is_nil(hard_deprecate_after) and DateTime.compare(hard_deprecate_after, now) == :lt
     end)
   end
 end

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -90,12 +90,14 @@ defmodule Sanbase.Metric do
   end
 
   def is_not_deprecated?(metric) do
-    case Map.get(@deprecated_metrics_map, metric) do
-      nil ->
-        true
+    now = DateTime.utc_now()
+    deprecated_since = Map.get(@deprecated_metrics_map, metric)
 
-      %DateTime{} = deprecated_since ->
-        {:error, "The metric #{metric} is deprecated since #{deprecated_since}"}
+    # The metric is not deprecated if `deprecated_since` is nil or if the the
+    # date is in the future
+    case is_nil(deprecated_since) or DateTime.compare(now, deprecated_since) == :lt do
+      true -> true
+      false -> {:error, "The metric #{metric} is deprecated since #{deprecated_since}"}
     end
   end
 

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -372,6 +372,24 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:available_selectors, list_of(:selector_name))
 
     @desc ~s"""
+    A metric can be marked as deprecated. If this is the case, the metric
+    should not be used anymore as it is going to be removed in the future.
+    A deprecation can be soft or hard. A soft deprecation means that the
+    metric is marked as deprecated, but is still accessible. A hard deprecation
+    means that the metric is marked as deprecated and it is no longer accessible.
+    All accessible metrics are soft-deprecated. A metric that is marked as deprecated
+    will become hard-deprecated at `hardDeprecateDatetime` datetime (which might not be
+    yet set.)
+    """
+    field(:is_deprecated, non_null(:boolean))
+
+    @desc ~s"""
+    After `hardDeprecateDatetime` the metric is hard-deprecated and will no longer
+    be accsessible.
+    """
+    field(:hard_deprecate_after, :datetime)
+
+    @desc ~s"""
     The data type of the metric can be either timeseries or histogram.
       - Timeseries data is a sequence taken at successive equally spaced points
         in time (every 5 minutes, every day, every year, etc.).
@@ -382,14 +400,37 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     """
     field(:data_type, :metric_data_type)
 
+    @desc ~s"""
+    A metric is considered timebound, if it is computed on the set of coins/tokens
+    that have been moved in a specified time period.
+    For more information visit https://academy.santiment.net/metrics/details/timebound
+    """
     field(:is_timebound, :boolean)
 
+    @desc ~s"""
+    A boolean flag that indicates whether the metric is accessible or not by the
+    current querying user. Some of the metrics are accsessible only to users with
+    a PRO plan or higher, for example.
+    """
     field(:is_accessible, :boolean)
 
+    @desc ~s"""
+    A boolean flag that indicates whether the metric has partially restricted accsess by the
+    current querying user. Some of the metrics have their historical or realtime data
+    available only to users with a PRO  plan or higher, for example.
+    """
     field(:is_restricted, :boolean)
 
+    @desc ~s"""
+    If the current querying user has restricted accsess to the metric, this field contains the
+    first datetime that the user has access to.
+    """
     field(:restricted_from, :datetime)
 
+    @desc ~s"""
+    If the current querying user has restricted accsess to the metric, this field contains the
+    last datetime that the user has access to.
+    """
     field(:restricted_to, :datetime)
   end
 


### PR DESCRIPTION
## Changes

The `deprecate_since` JSON field can now contain future dates and is renamed to `hard_deprecate_after`.
After the specified datetime has passed, the metric becomes inaccessible. Until then the metric has the `isDeprecated` field set to true and `hardDeprecateAfter` set to the specified datetime in the getMetric's metadata.

If the metric needs to be marked as deprecated, but without specifying a hard-deprecation datetime, the JSON field `"is_deprecated": true|false` can be used instead.

In the API this is exposed as 2 fields: `isDeprecated` and `hardDeprecateAfter`. `isDeprecated` is `true` if the `is_deprecated` JSON field is provided, or if the `hard_deprecate_after` is set.
`hardDeprecateAfter` shows the value of the `hard_deprecate_after` JSON field.

```graphql
{
  getMetric(metric: "active_deposits_per_exchange") {
    metadata {
      isDeprecated
      hardDeprecateAfter
    }
  }
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
