### PR TITLE
Fix quote escaping in GraphiQL variables

### DIFF
--- a/lib/sanbase_web/graphql/plugs/graphiql/templates/graphiql.html.eex
+++ b/lib/sanbase_web/graphql/plugs/graphiql/templates/graphiql.html.eex
@@ -92,7 +92,7 @@ add "&raw" to the end of the URL within a browser.
         onEditVariables: onEditVariables,
         query: '<%= query_string %>',
         response: '<%= result_string %>',
-        variables: '<%= variables_string %>',
+        variables: '<%= variables_string |> String.replace(~s[\"], ~s[\\"]) %>',
       }),
       document.getElementById("root")
     );


### PR DESCRIPTION
## Changes
Now variables like  "{\"name\":\"selector\" ... " will be properly escaped. Previously the backward slash was omitted when a URL was opened, thus making the value unusable.

To reproduce use the following query:
```graphql
query($fn:json){
    allProjectsByFunction(function: $fn) {
      projects {
        slug name ticker
        volume_usd:aggregatedTimeseriesData(
            metric:"volume_usd"
            from:"utc_now-1d"
            to:"utc_now"
            aggregation:AVG
          )

      }
    }
  }
  ```
and put the following variable:
```json
{
  "fn": "{\"name\":\"selector\",\"args\":{\"filters\":[{\"args\":{\"metric\":\"marketcap_usd\",\"operator\":\"greater_than\",\"dynamicFrom\":\"1d\",\"dynamicTo\":\"now\",\"aggregation\":\"last\",\"threshold\":10000000},\"name\":\"metric\"}],\"orderBy\":{\"aggregation\":\"avg\",\"dynamicFrom\":\"1d\",\"direction\":\"desc\",\"dynamicTo\":\"now\",\"metric\":\"volume_usd\"},\"pagination\":{\"page\":1,\"pageSize\":10}}}"
}
```

<img width="1300" alt="image" src="https://github.com/santiment/sanbase2/assets/6518376/e674ded8-db78-4e24-b47c-17e62d28cb2b">

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
