### PR TITLE
Add insetedAt and updatedAt fields to user GQL

### DIFF
--- a/lib/sanbase/accounts/accounts.ex
+++ b/lib/sanbase/accounts/accounts.ex
@@ -48,7 +48,7 @@ defmodule Sanbase.Accounts do
         {:ok, :keep_state, user}
 
       {:next_state, state, data} ->
-        registration_state = %{"state" => state, "data" => data}
+        registration_state = %{"state" => state, "data" => data, "datetime" => DateTime.utc_now()}
 
         case atomic_update(user.id, current_state, registration_state) do
           {1, [user]} -> {:ok, :evolve_state, user}

--- a/lib/sanbase/accounts/user.ex
+++ b/lib/sanbase/accounts/user.ex
@@ -64,7 +64,7 @@ defmodule Sanbase.Accounts.User do
     field(:first_login, :boolean, default: false, virtual: true)
     field(:avatar_url, :string)
     field(:is_registered, :boolean, default: false)
-    field(:registration_state, :map, default: %{"state" => "init"})
+    field(:registration_state, :map)
     field(:is_superuser, :boolean, default: false)
     field(:twitter_id, :string)
 
@@ -143,7 +143,8 @@ defmodule Sanbase.Accounts.User do
       :test_san_balance,
       :twitter_id,
       :username,
-      :name
+      :name,
+      :registration_state
     ])
     |> normalize_user_identificator(:username, attrs[:username])
     |> normalize_user_identificator(:email, attrs[:email])
@@ -163,7 +164,11 @@ defmodule Sanbase.Accounts.User do
 
   def create(attrs) do
     attrs = if attrs[:salt], do: attrs, else: Map.put(attrs, :salt, generate_salt())
-    attrs = Map.put(attrs, :first_login, true)
+
+    attrs =
+      attrs
+      |> Map.put(:first_login, true)
+      |> Map.put_new(:registration_state, %{"state" => "init", "datetime" => DateTime.utc_now()})
 
     %__MODULE__{}
     |> changeset(attrs)

--- a/lib/sanbase_web/graphql/schema/types/user_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_types.ex
@@ -103,6 +103,8 @@ defmodule SanbaseWeb.Graphql.UserTypes do
     field(:first_login, :boolean, default_value: false)
     field(:avatar_url, :string)
     field(:stripe_customer_id, :string)
+    field(:inserted_at, non_null(:datetime))
+    field(:updated_at, non_null(:datetime))
 
     field :is_moderator, :boolean do
       resolve(&UserResolver.is_moderator/3)

--- a/test/sanbase/auth/user_test.exs
+++ b/test/sanbase/auth/user_test.exs
@@ -265,7 +265,7 @@ defmodule Sanbase.Accounts.UserTest do
           email: "test@example.com",
           username: "cersei",
           privacy_policy_accepted: true,
-          registration_state: %{"state" => "finished"}
+          registration_state: %{"state" => "finished", "datetime" => DateTime.utc_now()}
         )
 
       Sanbase.Mock.prepare_mock2(&UniswapStaking.fetch_uniswap_san_staked_user/1, 2001)

--- a/test/sanbase_web/graphql/context_plug_test.exs
+++ b/test/sanbase_web/graphql/context_plug_test.exs
@@ -6,18 +6,16 @@ defmodule SanbaseWeb.Graphql.ContextPlugTest do
   @moduletag capture_log: true
 
   alias Sanbase.Accounts.User
-  alias Sanbase.Repo
   alias SanbaseWeb.Graphql.{AuthPlug, ContextPlug}
   alias Sanbase.Accounts.Apikey
   alias Sanbase.Billing.{Subscription, Product}
 
   test "loading the user from the current token", %{conn: conn} do
-    user =
-      %User{
-        salt: User.generate_salt(),
-        privacy_policy_accepted: true
-      }
-      |> Repo.insert!()
+    {:ok, user} = User.create(%{privacy_policy_accepted: true})
+    # Do it like this, as the `user` from User.create/1 has `first_login: true`
+    # which won't correspond to the one from the AuthPlug as it will again
+    # fetch the user and it will no longer be the first login.
+    {:ok, user} = Sanbase.Accounts.get_user(user.id)
 
     conn =
       conn


### PR DESCRIPTION
## Changes
```graphql
{
  currentUser {
    insertedAt
    updatedAt
  }
}
```
```json
{
  "data": {
    "currentUser": {
      "insertedAt": "2023-08-01T08:47:12Z",
      "updatedAt": "2023-08-01T08:47:45Z"
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
