### PR TITLE
Add dashboardQueryMappingId to the dashboard queries

### DIFF
--- a/lib/sanbase/queries/dashboard/dashboard.ex
+++ b/lib/sanbase/queries/dashboard/dashboard.ex
@@ -109,8 +109,8 @@ defmodule Sanbase.Queries.Dashboard do
 
   @create_fields [:name, :description, :is_public, :parameters, :settings, :user_id]
   @update_fields @create_fields -- [:user_id]
-  @preload [:queries, :user, :featured_item]
 
+  @preload [:queries, :user, :featured_item]
   def default_preload(), do: @preload
 
   def create_changeset(%__MODULE__{} = dashboard, attrs) do

--- a/lib/sanbase/queries/dashboard/dashboard.ex
+++ b/lib/sanbase/queries/dashboard/dashboard.ex
@@ -111,6 +111,8 @@ defmodule Sanbase.Queries.Dashboard do
   @update_fields @create_fields -- [:user_id]
   @preload [:queries, :user, :featured_item]
 
+  def default_preload(), do: @preload
+
   def create_changeset(%__MODULE__{} = dashboard, attrs) do
     dashboard
     |> cast(attrs, @create_fields)

--- a/lib/sanbase/queries/dashboard/dashboard_query_mapping.ex
+++ b/lib/sanbase/queries/dashboard/dashboard_query_mapping.ex
@@ -47,6 +47,13 @@ defmodule Sanbase.Queries.DashboardQueryMapping do
     |> maybe_preload(opts)
   end
 
+  def dashboard_id_rows(dashboard_id) do
+    from(d in __MODULE__,
+      where: d.dashboard_id == ^dashboard_id,
+      preload: [:query]
+    )
+  end
+
   # Private functions
 
   defp maybe_preload(query, opts) do

--- a/lib/sanbase/queries/query/query.ex
+++ b/lib/sanbase/queries/query/query.ex
@@ -82,6 +82,9 @@ defmodule Sanbase.Queries.Query do
     field(:is_deleted, :boolean)
     field(:is_hidden, :boolean)
 
+    # TODO: Add comment
+    field(:dashboard_query_mapping_id, :integer, virtual: true)
+
     timestamps()
   end
 

--- a/lib/sanbase_web/graphql/resolvers/queries_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/queries_resolver.ex
@@ -43,7 +43,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.QueriesResolver do
       )
     else
       {:error,
-       "Error getting user queries: no userId provided, nor the query is executed by a logged in user."}
+       "Error getting user queries: neither userId is provided, nor the query is executed by a logged in user."}
     end
   end
 
@@ -103,6 +103,27 @@ defmodule SanbaseWeb.Graphql.Resolvers.QueriesResolver do
         %{context: %{auth: %{current_user: user}}}
       ) do
     Dashboards.get_dashboard(id, user.id)
+  end
+
+  def get_user_dashboards(
+        _root,
+        %{page: page, page_size: page_size} = args,
+        resolution
+      ) do
+    querying_user_id = get_in(resolution.context.auth, [:current_user, Access.key(:id)])
+    queried_user_id = Map.get(args, :user_id, querying_user_id)
+
+    if not is_nil(queried_user_id) do
+      Dashboards.user_dashboards(
+        queried_user_id,
+        querying_user_id,
+        page: page,
+        page_size: page_size
+      )
+    else
+      {:error,
+       "Error getting user dashboards: neither userId is provided, nor the query is executed by a logged in user."}
+    end
   end
 
   def create_dashboard(

--- a/lib/sanbase_web/graphql/schema/queries/queries_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/queries_queries.ex
@@ -309,6 +309,28 @@ defmodule SanbaseWeb.Graphql.Schema.QueriesQueries do
 
       resolve(&QueriesResolver.get_dashboard/3)
     end
+
+    @desc ~s"""
+    Fetch a list of the dashboards that belong to a user.
+
+    If the querying user is the same as the queried user, both public and private
+    dashboards are returned. If the querying user is different from the queried user,
+    only the public queries are shown.
+    """
+    field :get_user_dashboards, list_of(:dashboard_for_lists) do
+      meta(access: :free)
+
+      @desc ~s"""
+      The id of the user whose queries are being fetched.
+      If the argument is not provided, fetch the current user queries.
+      """
+      arg(:user_id, :integer)
+
+      arg(:page, non_null(:integer))
+      arg(:page_size, non_null(:integer))
+
+      resolve(&QueriesResolver.get_user_dashboards/3)
+    end
   end
 
   object :dashboard_mutations do

--- a/lib/sanbase_web/graphql/schema/types/queries_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/queries_types.ex
@@ -109,6 +109,40 @@ defmodule SanbaseWeb.Graphql.QueriesTypes do
     field(:updated_at, :datetime)
   end
 
+  object :dashboard_for_lists do
+    # Do not allow fetching queries/panels when a list
+    # of dashboards is used.
+
+    field(:id, non_null(:integer))
+    field(:name, non_null(:string))
+    field(:is_public, non_null(:boolean))
+    field(:description, :string)
+    field(:parameters, :json)
+    field(:settings, :json)
+
+    # Virtual view field
+    field(:views, :integer)
+
+    field :user, non_null(:public_user) do
+      resolve(&UserResolver.user_no_preloads/3)
+    end
+
+    field :comments_count, :integer do
+      resolve(&DashboardResolver.comments_count/3)
+    end
+
+    field :voted_at, :datetime do
+      resolve(&VoteResolver.voted_at/3)
+    end
+
+    field :votes, :vote do
+      resolve(&VoteResolver.votes/3)
+    end
+
+    field(:inserted_at, :datetime)
+    field(:updated_at, :datetime)
+  end
+
   input_object :dashboard_global_parameter_value do
     field(:boolean, :boolean)
     field(:integer, :integer)

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -111,6 +111,7 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           :get_telegram_deep_link,
           :get_trigger_by_id,
           :get_user,
+          :get_user_dashboards,
           :get_webinars,
           :github_activity,
           :github_availables_repos,


### PR DESCRIPTION
## Changes

- Add `getUserDashboards` API that works similar to `getUserQueries`. If the `userId` is not provided, the current user data is fetched.
- Add `dashboardQueryMappingId` to the Query GraphQL type.
It is filled only when the query is fetched via the `dashboard` GraphQL type.

There is no easy way to preload the queries AND the join-through table autogenerated id.
Because of this, the process of getting a dashboard is done in a transaction, rather than with simple preloads. When the dashboard is fetched, if the `:queries` is in the list of required preloads, the queries are fetched separately (with the addition of the mapping id) and added to the already fetched dashboard. 

Example:
```graphql
{
  getDashboard(id: 1){
    queries { id dashboardQueryMappingId }
  }
}
```
In this example, the same query can be added 10 times to the dashboard -- in all cases `id` will be the same, but `dashboardQueryMappingId` will differ.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
