### PR TITLE
Change the dashboard_query_mappings id from int to string (UUID)

### DIFF
--- a/lib/sanbase/queries/dashboard/dashboard_query_mapping.ex
+++ b/lib/sanbase/queries/dashboard/dashboard_query_mapping.ex
@@ -17,12 +17,13 @@ defmodule Sanbase.Queries.DashboardQueryMapping do
           updated_at: DateTime.t()
         }
 
+  @type dashboard_query_mapping_id :: String.t()
   @type dashboard_id :: Dashboard.dashboard_id()
-  @type dashboard_query_mapping_id :: non_neg_integer()
   @type user_id :: non_neg_integer()
 
   @preload [:dashboard, :query, dashboard: :user, query: :user]
 
+  @primary_key {:id, :binary_id, autogenerate: true}
   schema "dashboard_query_mappings" do
     field(:settings, :map)
 

--- a/lib/sanbase/queries/dashboards.ex
+++ b/lib/sanbase/queries/dashboards.ex
@@ -168,7 +168,7 @@ defmodule Sanbase.Dashboards do
   %{
     "slug" => %{
       "value" => "bitcoin",
-      "overrides" => [%{"dashboard_query_mapping_id" => 101, "parameter" => "slug"}]
+      "overrides" => [%{"dashboard_query_mapping_id" => "05d2e783-ac22-40c5-9d51-f8df5a33f568", "parameter" => "slug"}]
     }
   }
 
@@ -179,7 +179,7 @@ defmodule Sanbase.Dashboards do
   - Extract the key-value pairs from the overrides;
   - Replace the parameters in `q` with the overrides.
   """
-  @spec apply_global_parameters(Query.t(), Dashboard.t(), non_neg_integer()) ::
+  @spec apply_global_parameters(Query.t(), Dashboard.t(), dashboard_query_mapping_id()) ::
           {:ok, Query.t()}
   def apply_global_parameters(
         %Query{} = query,
@@ -341,11 +341,11 @@ defmodule Sanbase.Dashboards do
     %{
       "slug" => %{
         "value" => "bitcoin",
-        "overrides" => [%{"dashboard_query_mapping_id" => 101, "parameter" => "slug"}]
+        "overrides" => [%{"dashboard_query_mapping_id" => "05d2e783-ac22-40c5-9d51-f8df5a33f568", "parameter" => "slug"}]
       },
       "another_key" => %{
         "value" => "another_value",
-        "overrides" => [%{"dashboard_query_mapping_id" => 101, "parameter" => "another_key"}]
+        "overrides" => [%{"dashboard_query_mapping_id" => "05d2e783-ac22-40c5-9d51-f8df5a33f568", "parameter" => "another_key"}]
       }
     }
 
@@ -414,15 +414,15 @@ defmodule Sanbase.Dashboards do
   %{
     "slug" => %{
       "value" => "bitcoin",
-      "overrides" => [%{"dashboard_query_mapping_id" => 101, "parameter" => "slug"}]
+      "overrides" => [%{"dashboard_query_mapping_id" => "05d2e783-ac22-40c5-9d51-f8df5a33f568", "parameter" => "slug"}]
     },
     "another_key" => %{
       "value" => "another_value",
-      "overrides" => [%{"dashboard_query_mapping_id" => 101, "parameter" => "another_key"}]
+      "overrides" => [%{"dashboard_query_mapping_id" => "05d2e783-ac22-40c5-9d51-f8df5a33f568", "parameter" => "another_key"}]
     }
   }
 
-  When deleting the override for the slug parameter and dashboard_query_mapping_id 101, the result will be:
+  When deleting the override for the slug parameter and dashboard_query_mapping_id "05d2e783-ac22-40c5-9d51-f8df5a33f568", the result will be:
   %{
     "slug" => %{
       "value" => "bitcoin",
@@ -430,7 +430,7 @@ defmodule Sanbase.Dashboards do
     },
     "another_key" => %{
       "value" => "another_value",
-      "overrides" => [%{"dashboard_query_mapping_id" => 101, "parameter" => "another_key"}]
+      "overrides" => [%{"dashboard_query_mapping_id" => "05d2e783-ac22-40c5-9d51-f8df5a33f568", "parameter" => "another_key"}]
     }
   }
   """

--- a/lib/sanbase/queries/query/query.ex
+++ b/lib/sanbase/queries/query/query.ex
@@ -83,7 +83,7 @@ defmodule Sanbase.Queries.Query do
     field(:is_hidden, :boolean)
 
     # TODO: Add comment
-    field(:dashboard_query_mapping_id, :integer, virtual: true)
+    field(:dashboard_query_mapping_id, :string, virtual: true)
 
     timestamps()
   end

--- a/lib/sanbase_web/graphql/schema/queries/queries_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/queries_queries.ex
@@ -184,7 +184,7 @@ defmodule SanbaseWeb.Graphql.Schema.QueriesQueries do
       meta(access: :free)
 
       arg(:dashboard_id, non_null(:integer))
-      arg(:dashboard_query_mapping_id, non_null(:integer))
+      arg(:dashboard_query_mapping_id, non_null(:string))
 
       middleware(UserAuth)
 
@@ -434,7 +434,7 @@ defmodule SanbaseWeb.Graphql.Schema.QueriesQueries do
     """
     field :update_dashboard_query, :dashboard_query_mapping do
       arg(:dashboard_id, non_null(:integer))
-      arg(:dashboard_query_mapping_id, non_null(:integer))
+      arg(:dashboard_query_mapping_id, non_null(:string))
       arg(:settings, :json)
 
       middleware(JWTAuth)
@@ -450,7 +450,7 @@ defmodule SanbaseWeb.Graphql.Schema.QueriesQueries do
     """
     field :delete_dashboard_query, :dashboard_query_mapping do
       arg(:dashboard_id, non_null(:integer))
-      arg(:dashboard_query_mapping_id, non_null(:integer))
+      arg(:dashboard_query_mapping_id, non_null(:string))
 
       middleware(JWTAuth)
 
@@ -540,7 +540,7 @@ defmodule SanbaseWeb.Graphql.Schema.QueriesQueries do
     """
     field :add_dashboard_global_parameter_override, :dashboard do
       arg(:dashboard_id, non_null(:integer))
-      arg(:dashboard_query_mapping_id, non_null(:integer))
+      arg(:dashboard_query_mapping_id, non_null(:string))
 
       arg(:dashboard_parameter_key, non_null(:string))
       arg(:query_parameter_key, non_null(:string))

--- a/lib/sanbase_web/graphql/schema/types/queries_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/queries_types.ex
@@ -224,7 +224,7 @@ defmodule SanbaseWeb.Graphql.QueriesTypes do
   end
 
   object :dashboard_query_mapping do
-    field(:id, non_null(:integer))
+    field(:id, non_null(:string))
     field(:query, non_null(:sql_query))
     field(:dashboard, non_null(:dashboard))
     field(:settings, :json)

--- a/priv/repo/migrations/20231012130814_rework_dashboard_query_mapping.exs
+++ b/priv/repo/migrations/20231012130814_rework_dashboard_query_mapping.exs
@@ -1,0 +1,54 @@
+defmodule Sanbase.Repo.Migrations.ReworkDashboardQueryMapping do
+  use Ecto.Migration
+
+  @table :dashboard_query_mappings
+  # def up do
+  #   alter table(@table) do
+  #     add(:uuid, :uuid, null: false)
+  #   end
+
+  #   create(unique_index(@table, [:uuid]))
+
+  #   rename(table(@table), :id, to: :old_primary_id)
+  #   rename(table(@table), :uuid, to: :id)
+
+  #   alter table(@table) do
+  #     remove(:old_primary_id)
+
+  #     modify(:id, :uuid, null: false, primary_key: true)
+  #   end
+  # end
+
+  def up do
+    drop(table(@table))
+
+    create table(@table, primary_key: false) do
+      add(:id, :uuid, primary_key: true)
+      add(:dashboard_id, references(:dashboards, on_delete: :delete_all))
+      add(:query_id, references(:queries, on_delete: :delete_all))
+
+      add(:settings, :map)
+
+      timestamps()
+    end
+
+    create(index(@table, [:dashboard_id]))
+    create(index(@table, [:query_id]))
+  end
+
+  def down do
+    drop(table(@table))
+
+    create table(@table) do
+      add(:dashboard_id, references(:dashboards, on_delete: :delete_all))
+      add(:query_id, references(:queries, on_delete: :delete_all))
+
+      add(:settings, :map)
+
+      timestamps()
+    end
+
+    create(index(@table, [:dashboard_id]))
+    create(index(@table, [:query_id]))
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -925,32 +925,13 @@ ALTER SEQUENCE public.dashboard_comments_mapping_id_seq OWNED BY public.dashboar
 --
 
 CREATE TABLE public.dashboard_query_mappings (
-    id bigint NOT NULL,
+    id uuid NOT NULL,
     dashboard_id bigint,
     query_id bigint,
     settings jsonb,
     inserted_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );
-
-
---
--- Name: dashboard_query_mappings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.dashboard_query_mappings_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: dashboard_query_mappings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.dashboard_query_mappings_id_seq OWNED BY public.dashboard_query_mappings.id;
 
 
 --
@@ -981,9 +962,10 @@ CREATE TABLE public.dashboards (
 CREATE TABLE public.dashboards_cache (
     id bigint NOT NULL,
     dashboard_id bigint,
-    panels jsonb NOT NULL,
+    panels jsonb DEFAULT '{}'::jsonb,
     inserted_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    queries jsonb DEFAULT '{}'::jsonb
 );
 
 
@@ -4546,13 +4528,6 @@ ALTER TABLE ONLY public.currencies ALTER COLUMN id SET DEFAULT nextval('public.c
 --
 
 ALTER TABLE ONLY public.dashboard_comments_mapping ALTER COLUMN id SET DEFAULT nextval('public.dashboard_comments_mapping_id_seq'::regclass);
-
-
---
--- Name: dashboard_query_mappings id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.dashboard_query_mappings ALTER COLUMN id SET DEFAULT nextval('public.dashboard_query_mappings_id_seq'::regclass);
 
 
 --
@@ -8809,3 +8784,5 @@ INSERT INTO public."schema_migrations" (version) VALUES (20230908085236);
 INSERT INTO public."schema_migrations" (version) VALUES (20230915121540);
 INSERT INTO public."schema_migrations" (version) VALUES (20230925041216);
 INSERT INTO public."schema_migrations" (version) VALUES (20231003070443);
+INSERT INTO public."schema_migrations" (version) VALUES (20231012122039);
+INSERT INTO public."schema_migrations" (version) VALUES (20231012130814);

--- a/test/sanbase_web/graphql/queries/queries_api_test.exs
+++ b/test/sanbase_web/graphql/queries/queries_api_test.exs
@@ -588,6 +588,7 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
             query_parameter_key: "slug"
           }
         )
+        |> IO.inspect(label: "591", limit: :infinity)
         |> get_in(["data", "addDashboardGlobalParameterOverride"])
 
       assert override == %{


### PR DESCRIPTION
## Changes

The idea is to have a unified ID format for all the entities that can be added to a dashboard (like text widgets), so the FE has an easier time integrating them

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
