### PR TITLE
Queries 2.0 caching

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,14 +1,6 @@
 [
-  inputs: [
-    "config/*.{ex,exs}",
-    "lib/*.{ex,exs}",
-    "lib/**/*.{ex,exs}",
-    "test/*.{ex,exs}",
-    "test/**/*.{ex,exs}",
-    "priv/**/*.{ex,exs}",
-    "mix.exs",
-    ".formatter.exs"
-  ],
+  import_deps: [:ecto, :ecto_sql, :phoenix],
   plugins: [Phoenix.LiveView.HTMLFormatter],
-  inputs: ["*.{heex,ex,exs}", "{config,lib,test}/**/*.{heex,ex,exs}", "priv/*/seeds.exs"]
+  inputs: ["*.{heex,ex,exs}", "{config,lib,test}/**/*.{heex,ex,exs}", "priv/*/seeds.exs"],
+  subdirectories: ["priv/*/migrations"]
 ]

--- a/.iex.exs
+++ b/.iex.exs
@@ -8,7 +8,6 @@ alias Sanbase.Model.{
   MarketSegment,
   LatestCoinmarketcapData,
   ModelUtils,
-
   Currency,
   Ico,
   IcoCurrency

--- a/lib/sanbase/dashboard/dashboard_cache.ex
+++ b/lib/sanbase/dashboard/dashboard_cache.ex
@@ -101,9 +101,9 @@ defmodule Sanbase.Dashboard.Cache do
   @doc ~s"""
   Update the dashboard's panel cache with the provided result.
   """
-  @spec update_panel_cache(non_neg_integer(), String.t(), Dashboad.Query.Result.t(), Keyword.t()) ::
+  @spec update_panel_cache(non_neg_integer(), String.t(), Dashboad.Query.Result.t()) ::
           {:ok, t()} | {:error, any()}
-  def update_panel_cache(dashboard_id, panel_id, query_result, opts \\ []) do
+  def update_panel_cache(dashboard_id, panel_id, query_result) do
     with true <- query_result_size_allowed?(query_result),
          {:ok, cache} <-
            by_dashboard_id(dashboard_id,
@@ -123,8 +123,6 @@ defmodule Sanbase.Dashboard.Cache do
       cache
       |> change(%{panels: panels})
       |> Repo.update()
-      |> maybe_apply_function(&transform_loaded_dashboard_cache(&1, opts))
-      |> IO.inspect(label: "127", limit: :infinity)
     end
   end
 
@@ -132,16 +130,15 @@ defmodule Sanbase.Dashboard.Cache do
   Remove the panel result from the cache. This is invoked when the panel is
   removed from the dashboard.
   """
-  @spec remove_panel_cache(non_neg_integer(), String.t(), Keyword.t()) ::
+  @spec remove_panel_cache(non_neg_integer(), String.t()) ::
           {:ok, t()} | {:error, any()}
-  def remove_panel_cache(dashboard_id, panel_id, opts \\ []) do
+  def remove_panel_cache(dashboard_id, panel_id) do
     {:ok, cache} = by_dashboard_id(dashboard_id, lock_for_update: true)
     panels = Enum.reject(cache.panels, &(&1.id == panel_id))
 
     cache
     |> change(%{panels: panels})
     |> Repo.update()
-    |> maybe_apply_function(&transform_loaded_dashboard_cache(&1, opts))
   end
 
   # Private functions

--- a/lib/sanbase/queries/dashboard/dashboard_cache.ex
+++ b/lib/sanbase/queries/dashboard/dashboard_cache.ex
@@ -1,0 +1,288 @@
+defmodule Sanbase.Queries.DashboardCache do
+  @moduledoc ~s"""
+  Holds the last computed result of dashboard's queries.
+
+  The cache is the dynamic part of the dashboard as the result of execution
+  of the SQL can change on every run. Dashboards can be slow to compute or
+  can be viewed by many users. Because of this, a cached version is kept in
+  the database and is shown to the users.
+  """
+  use Ecto.Schema
+
+  import Ecto.Query
+  import Ecto.Changeset
+  import Sanbase.Utils.Transform, only: [maybe_apply_function: 2]
+  import Sanbase.Utils.ErrorHandling, only: [changeset_errors_string: 1]
+
+  alias Sanbase.Repo
+  alias Sanbase.Queries.Dashboard
+  alias Sanbase.Queries.Executor.Result
+  alias Sanbase.Queries.QueryCache
+
+  @type user_id :: Sanbase.Accounts.User.user_id()
+  @type dashboard_id :: Dashboard.dashboard_id()
+  @type dashboard_query_mapping_id :: Dashboard.dashboard_query_mapping_id()
+
+  @type query_cache :: %{
+          dashboard_query_mapping_id => map()
+        }
+
+  @type t :: %__MODULE__{
+          id: non_neg_integer(),
+          dashboard_id: dashboard_id(),
+          queries: %{
+            # the key is dashboard_query_mapping_id
+            optional(String.t()) => query_cache()
+          }
+        }
+
+  schema "dashboards_cache" do
+    field(:dashboard_id, :integer)
+    field(:queries, :map, default: %{})
+
+    timestamps()
+  end
+
+  # defp get_for_read(dashboard_id, querying_user_id) do
+  # end
+
+  # def get_for_mutation(dashboard_id, querying_user_id) do
+  #   from(dc in __MODULE__,
+  #     where: dc.dashboard_id == ^dashboard_id,
+  #     join: d in Dashboard,
+  #     on: dc.dashboard_id == d.id
+  #   )
+  # end
+
+  @doc ~s"""
+  Fetch the latest cache values for the given dashboard.
+
+  The second `opts` argument can contain the following options:
+  - lock_for_update - Set to true, if the record is fetched for an update
+  - transform_loaded_queries - If set to true, the loaded query caches are
+  transformed from having `compressed_rows` to `rows`. Defaults to true.
+  """
+  @spec by_dashboard_id(dashboard_id(), user_id, Keyword.t()) :: {:ok, t()} | {:error, String.t()}
+  # def by_dashboard_id(dashboard_id, querying_user_id, opts) do
+  #   Ecto.Multi.new()
+  #   |> Ecto.Multi.run(:get_dashboard_cache, fn _ ->
+  #     get_for_read(dashboard_id, querying_user_id)
+  #   end)
+  # end
+
+  def by_dashboard_id(dashboard_id, querying_user_id, opts \\ []) do
+    query = from(d in __MODULE__, where: d.dashboard_id == ^dashboard_id)
+
+    query =
+      case Keyword.get(opts, :lock_for_update, false) do
+        false -> query
+        true -> query |> lock("FOR UPDATE")
+      end
+
+    case Repo.one(query) do
+      nil -> new(dashboard_id, querying_user_id)
+      %__MODULE__{} = cache -> {:ok, cache}
+    end
+    |> maybe_apply_function(&transform_loaded_dashboard_cache(&1, opts))
+  end
+
+  @doc ~s"""
+  Get the latest query cache for the given dashboard and dashboard_query_mapping_id.
+
+  The second `opts` argument can contain the following options:
+  - transform_loaded_queries - If set to true, the loaded query caches are
+  transformed from having `compressed_rows` to `rows`. Defaults to true.
+  """
+  @spec by_dashboard_and_dashboard_query_mapping_id(
+          dashboard_id(),
+          dashboard_query_mapping_id(),
+          Keyword.t()
+        ) :: {:ok, query_cache()} | {:error, String.t()}
+  def by_dashboard_and_dashboard_query_mapping_id(
+        dashboard_id,
+        dashboard_query_mapping_id,
+        opts \\ []
+      ) do
+    query = """
+    SELECT t.query
+    FROM dashboards_cache cache
+    CROSS JOIN LATERAL (
+      SELECT value AS query
+      FROM jsonb_each(cache.queries) AS x(key, value)
+      WHERE cache.dashboard_id = $1 AND key = $2
+    ) AS t
+    """
+
+    params = [dashboard_id, dashboard_query_mapping_id]
+
+    case Repo.query(query, params) do
+      {:ok, %{rows: [[%{} = query_cache]]}} -> {:ok, query_cache}
+      _ -> {:error, "Cannot load dashboard query cache"}
+    end
+    |> maybe_apply_function(&transform_loaded_dashboard_cache(&1, opts))
+  end
+
+  @doc ~s"""
+  Create a new empty record for the given dashboard_id.
+  """
+  @spec new(non_neg_integer(), user_id) :: {:ok, t()} | {:error, any()}
+  def new(dashboard_id, querying_user_id) do
+    case Sanbase.Dashboards.get_visibility_data(dashboard_id) do
+      {:ok, %{user_id: ^querying_user_id}} ->
+        %__MODULE__{}
+        |> change(%{dashboard_id: dashboard_id})
+        |> Repo.insert()
+        |> maybe_transform_error()
+
+      _ ->
+        {:error,
+         "Dashboard with id #{dashboard_id} does not exist or the user with id #{querying_user_id} is not the owner of it."}
+    end
+  end
+
+  @doc ~s"""
+  Update the dashboard's query cache with the provided result.
+  """
+  @spec update_query_cache(non_neg_integer(), String.t(), Result.t(), user_id()) ::
+          {:ok, t()} | {:error, any()}
+  def update_query_cache(dashboard_id, dashboard_query_mapping_id, query_result, querying_user_id) do
+    # Do not transform the loaded queries cache. Transforming it would
+    # convert `compressed_rows` to `rows`, which will be written back and break
+    with query_cache =
+           QueryCache.from_query_result(query_result, dashboard_query_mapping_id, dashboard_id),
+         true <- query_result_size_allowed?(query_cache),
+         {:ok, cache} <-
+           by_dashboard_id(dashboard_id, querying_user_id,
+             transform_loaded_queries: false,
+             lock_for_update: true
+           ) do
+      query_cache =
+        query_cache
+        |> Map.from_struct()
+        |> Map.delete(:rows)
+
+      queries =
+        Map.update(cache.queries, dashboard_query_mapping_id, query_cache, fn _ -> query_cache end)
+
+      cache
+      |> change(%{queries: queries})
+      |> Repo.update()
+      |> maybe_transform_error()
+    end
+  end
+
+  @doc ~s"""
+  Remove the query result from the cache. This is invoked when the panel is
+  removed from the dashboard.
+  """
+  @spec remove_query_cache(dashboard_id(), dashboard_query_mapping_id(), user_id) ::
+          {:ok, t()} | {:error, any()}
+  def remove_query_cache(dashboard_id, dashboard_query_mapping_id, querying_user_id) do
+    {:ok, cache} = by_dashboard_id(dashboard_id, querying_user_id, lock_for_update: true)
+    queries = Enum.reject(cache.queries, &(&1.id == dashboard_query_mapping_id))
+
+    cache
+    |> change(%{queries: queries})
+    |> Repo.update()
+    |> maybe_transform_error()
+  end
+
+  # Private functions
+
+  defp transform_loaded_dashboard_cache(%__MODULE__{} = cache, opts) do
+    flag = Keyword.get(opts, :transform_loaded_queries, true)
+
+    queries =
+      cache.queries
+      |> Map.new(fn {dashboard_query_mapping_id, query_cache} ->
+        query_cache =
+          case flag do
+            true -> transform_loaded_queries(query_cache)
+            false -> query_cache
+          end
+
+        {dashboard_query_mapping_id, query_cache}
+      end)
+
+    %{cache | queries: queries}
+  end
+
+  defp transform_loaded_queries(query_cache) do
+    IO.inspect(query_cache)
+
+    %{"compressed_rows" => compressed_rows, "updated_at" => updated_at} = query_cache
+    %{"query_start_time" => start_dt, "query_end_time" => query_end_dt} = query_cache
+
+    {:ok, rows} =
+      compressed_rows
+      |> Result.decompress_rows()
+      |> transform_rows()
+
+    {:ok, updated_at, _} = DateTime.from_iso8601(updated_at)
+
+    query_cache
+    |> Map.drop(["compressed_rows", "updated_at", "query_start_time", "query_end_time"])
+    |> Map.new(fn {k, v} ->
+      # Ignore old, no longer existing keys like san_query_id
+      try do
+        {String.to_existing_atom(k), v}
+      rescue
+        _ -> {nil, nil}
+      end
+    end)
+    |> Map.delete(nil)
+    |> Map.merge(%{
+      rows: rows,
+      updated_at: updated_at,
+      id: query_cache["id"],
+      query_start_time: Sanbase.DateTimeUtils.from_iso8601!(start_dt),
+      query_end_time: Sanbase.DateTimeUtils.from_iso8601!(query_end_dt)
+    })
+  end
+
+  defp transform_rows(rows) do
+    transformed_rows =
+      rows
+      |> Enum.map(fn row ->
+        row
+        |> Enum.map(fn
+          elem when is_binary(elem) ->
+            case DateTime.from_iso8601(elem) do
+              {:ok, datetime, _} -> datetime
+              _ -> elem
+            end
+
+          elem ->
+            elem
+        end)
+      end)
+
+    {:ok, transformed_rows}
+  end
+
+  # The byte size of the compressed rows should not exceed the allowed limit.
+  # Otherwise simple queries like `select * from intraday_metircs limit 9999999`
+  # can be executed and fill the database with lots of data.
+  @allowed_kb_size 500
+  defp query_result_size_allowed?(query_result) do
+    kb_size = byte_size(query_result.compressed_rows) / 1024
+    kb_size = Float.round(kb_size, 2)
+
+    case kb_size do
+      size when size <= @allowed_kb_size ->
+        true
+
+      size ->
+        {:error,
+         """
+         Cannot cache the panel because its compressed size is #{size}KB \
+         which is over the limit of #{@allowed_kb_size}KB
+         """}
+    end
+  end
+
+  defp maybe_transform_error({:ok, _} = result), do: result
+
+  defp maybe_transform_error({:error, changeset}),
+    do: {:error, changeset_errors_string(changeset)}
+end

--- a/lib/sanbase/queries/dashboards.ex
+++ b/lib/sanbase/queries/dashboards.ex
@@ -641,7 +641,7 @@ defmodule Sanbase.Dashboards do
   """
   @spec get_visibility_data(dashboard_id()) :: {:ok, visibility_data()} | {:error, String.t()}
   def get_visibility_data(dashboard_id) do
-    query = get_visibility_data(dashboard_id)
+    query = Dashboard.get_visibility_data(dashboard_id)
 
     case Repo.one(query) do
       %{} = data -> {:ok, data}
@@ -770,6 +770,47 @@ defmodule Sanbase.Dashboards do
     end)
     |> Repo.transaction()
     |> process_transaction_result(:fetch_dashboard_queries)
+  end
+
+  ## Cache-related
+
+  @doc ~s"""
+
+  """
+  @spec store_dashboard_query_execution(
+          dashboard_id(),
+          dashboard_query_mapping_id(),
+          map(),
+          user_id()
+        ) ::
+          {:ok, DashboardQueryMappingCache.t()} | {:error, String.t()}
+  def store_dashboard_query_execution(
+        dashboard_id,
+        dashboard_query_mapping_id,
+        query_result,
+        user_id
+      ) do
+    Sanbase.Queries.DashboardCache.update_query_cache(
+      dashboard_id,
+      dashboard_query_mapping_id,
+      query_result,
+      user_id
+    )
+  end
+
+  @doc ~s"""
+
+  """
+  @spec get_cached_dashboard_queries_executions(
+          dashboard_id(),
+          user_id()
+        ) ::
+          {:ok, DashboardQueryMappingCache.t()} | {:error, String.t()}
+  def get_cached_dashboard_queries_executions(
+        dashboard_id,
+        user_id
+      ) do
+    Sanbase.Queries.DashboardCache.by_dashboard_id(dashboard_id, user_id)
   end
 
   # Private functions

--- a/lib/sanbase/queries/executor/executor.ex
+++ b/lib/sanbase/queries/executor/executor.ex
@@ -62,7 +62,7 @@ defmodule Sanbase.Queries.Executor do
            clickhouse_query_id: map.query_id,
            summary: make_summary_values_numbers(map.summary),
            rows: map.rows,
-           compressed_rows: Result.compress_rows(map.rows),
+           compressed_rows: nil,
            columns: map.column_names,
            column_types: map.column_types,
            query_start_time: query_start_time,
@@ -92,6 +92,7 @@ defmodule Sanbase.Queries.Executor do
 
   defp create_clickhouse_query(query, query_metadata, environment) do
     query_metadata = QueryMetadata.sanitize(query_metadata)
+
     opts = [settings: "log_comment='#{Jason.encode!(query_metadata)}'", environment: environment]
 
     Sanbase.Clickhouse.Query.new(query.sql_query_text, query.sql_query_parameters, opts)

--- a/lib/sanbase/queries/executor/executor.ex
+++ b/lib/sanbase/queries/executor/executor.ex
@@ -43,7 +43,7 @@ defmodule Sanbase.Queries.Executor do
   @spec run(Query.t(), QueryMetadata.t(), Environment.t()) ::
           {:ok, Result.t()} | {:error, String.t()}
   def run(%Query{} = query, %{} = query_metadata, %{} = environment) do
-    query_start_time = DateTime.utc_now()
+    query_start_time = DateTime.utc_now() |> DateTime.truncate(:millisecond)
 
     _ = put_read_only_repo()
 
@@ -66,7 +66,7 @@ defmodule Sanbase.Queries.Executor do
            columns: map.column_names,
            column_types: map.column_types,
            query_start_time: query_start_time,
-           query_end_time: DateTime.utc_now()
+           query_end_time: DateTime.utc_now() |> DateTime.truncate(:millisecond)
          }}
 
       {:error, error} ->

--- a/lib/sanbase/queries/executor/result.ex
+++ b/lib/sanbase/queries/executor/result.ex
@@ -26,7 +26,7 @@ defmodule Sanbase.Queries.Executor.Result do
             query_end_time: nil
 
   def from_json_string(json) do
-    case Jason.decode(json) do
+    case map_from_json(json) do
       {:ok, map} ->
         result = %__MODULE__{
           query_id: map["query_id"],
@@ -44,6 +44,16 @@ defmodule Sanbase.Queries.Executor.Result do
 
       {:error, error} ->
         {:error, "Provided JSON is malformed: #{inspect(error)}"}
+    end
+  end
+
+  defp map_from_json(json) do
+    with {:ok, map} <- Jason.decode(json) do
+      # The JSON provided by the frontend to the API might include
+      # keys like queryStartTime, queryEndTime, etc.
+      map_with_underscore_keys = Map.new(map, fn {k, v} -> {Inflex.underscore(k), v} end)
+
+      {:ok, map_with_underscore_keys}
     end
   end
 

--- a/lib/sanbase/queries/executor/result.ex
+++ b/lib/sanbase/queries/executor/result.ex
@@ -8,7 +8,7 @@ defmodule Sanbase.Queries.Executor.Result do
           clickhouse_query_id: String.t(),
           summary: Map.t(),
           rows: list(String.t() | number() | boolean() | DateTime.t()),
-          compressed_rows: String.t(),
+          compressed_rows: String.t() | nil,
           columns: list(String.t()),
           column_types: list(String.t()),
           query_start_time: DateTime.t(),
@@ -24,6 +24,28 @@ defmodule Sanbase.Queries.Executor.Result do
             column_types: nil,
             query_start_time: nil,
             query_end_time: nil
+
+  def from_json_string(json) do
+    case Jason.decode(json) do
+      {:ok, map} ->
+        result = %__MODULE__{
+          query_id: map["query_id"],
+          clickhouse_query_id: map["clickhouse_query_id"],
+          summary: map["summary"],
+          rows: map["rows"],
+          compressed_rows: map["compressed_rows"],
+          columns: map["columns"],
+          column_types: map["column_types"],
+          query_start_time: map["query_start_time"],
+          query_end_time: map["query_end_time"]
+        }
+
+        {:ok, result}
+
+      {:error, error} ->
+        {:error, "Provided JSON is malformed: #{inspect(error)}"}
+    end
+  end
 
   def compress_rows(rows) do
     rows

--- a/lib/sanbase/queries/queries.ex
+++ b/lib/sanbase/queries/queries.ex
@@ -317,7 +317,7 @@ defmodule Sanbase.Queries do
             Application.get_env(
               :__sanbase_queires__,
               :__wait_fetching_details_ms_,
-              Keyword.get(opts, :store_execution_details, true)
+              Keyword.get(opts, :wait_fetching_details_ms, 7500)
             )
         ]
 

--- a/lib/sanbase/queries/queries.ex
+++ b/lib/sanbase/queries/queries.ex
@@ -300,18 +300,46 @@ defmodule Sanbase.Queries do
 
   # Private functions
 
+  defp get_store_execution_opts(opts) do
+    # In test env allow the configuration to be provided as application env
+    # so that we can disable the storing of details even when the function is called through
+    # the API where  we cannot provide the opts arg.
+    case @compile_env do
+      :test ->
+        [
+          store_execution_details:
+            Application.get_env(
+              :__sanbase_queires__,
+              :store_execution_details,
+              Keyword.get(opts, :store_execution_details, true)
+            ),
+          wait_fetching_details_ms:
+            Application.get_env(
+              :__sanbase_queires__,
+              :__wait_fetching_details_ms_,
+              Keyword.get(opts, :store_execution_details, true)
+            )
+        ]
+
+      _ ->
+        [
+          store_execution_details: Keyword.get(opts, :store_execution_details, true),
+          wait_fetching_details_ms: Keyword.get(opts, :wait_fetching_details_ms, 7500)
+        ]
+    end
+  end
+
   defp maybe_store_execution_data_async(result, user_id, opts) do
     # When a Clickhouse query is executed, the query details are buffered in
     # memory for up to 7500ms before they flush to the database table.
     # Because of this, storing the execution data is done in a separate process
     # to avoid blocking the main process and to return the result to the user
     # faster.
+    opts = get_store_execution_opts(opts)
 
-    if Keyword.get(opts, :store_execution_details, true) do
-      wait_fetching_details_ms = Keyword.get(opts, :wait_fetching_details_ms, 7500)
-
+    if opts[:store_execution_details] do
       store = fn ->
-        QueryExecution.store_execution(result, user_id, wait_fetching_details_ms)
+        QueryExecution.store_execution(result, user_id, opts[:wait_fetching_details_ms])
       end
 
       # In test do not do it in an async way as this can lead to mocking issues.

--- a/lib/sanbase/queries/query/query_cache.ex
+++ b/lib/sanbase/queries/query/query_cache.ex
@@ -1,0 +1,58 @@
+defmodule Sanbase.Queries.QueryCache do
+  @type t :: %__MODULE__{
+          query_id: String.t(),
+          dashboard_query_mapping_id: non_neg_integer(),
+          clickhouse_query_id: String.t(),
+          dashboard_id: non_neg_integer(),
+          columns: list(String.t()),
+          column_types: list(String.t()),
+          rows: List.t(),
+          compressed_rows: String.t(),
+          updated_at: DateTime.t(),
+          query_start_time: DateTime.t(),
+          query_end_time: DateTime.t(),
+          summary: String.t()
+        }
+
+  defstruct query_id: nil,
+            dashboard_query_mapping_id: nil,
+            clickhouse_query_id: nil,
+            dashboard_id: nil,
+            columns: nil,
+            column_types: nil,
+            rows: nil,
+            compressed_rows: nil,
+            updated_at: nil,
+            query_start_time: nil,
+            query_end_time: nil,
+            summary: nil
+
+  alias Sanbase.Queries.Executor.Result
+
+  @spec from_query_result(Result.t(), String.t(), non_neg_integer()) :: t()
+  def from_query_result(%Result{} = result, dashboard_query_mapping_id, dashboard_id) do
+    compressed_rows =
+      if is_nil(result.compressed_rows) do
+        Result.compress_rows(result.rows)
+      else
+        result.compressed_rows
+      end
+
+      IO.inspect(result)
+
+    %__MODULE__{
+      query_id: result.query_id,
+      dashboard_query_mapping_id: dashboard_query_mapping_id,
+      dashboard_id: dashboard_id,
+      columns: result.columns,
+      column_types: result.column_types,
+      rows: result.rows,
+      compressed_rows: compressed_rows,
+      updated_at: DateTime.utc_now(),
+      query_start_time: result.query_start_time,
+      query_end_time: result.query_end_time,
+      clickhouse_query_id: result.clickhouse_query_id,
+      summary: result.summary
+    }
+  end
+end

--- a/lib/sanbase/queries/query/query_cache.ex
+++ b/lib/sanbase/queries/query/query_cache.ex
@@ -38,8 +38,6 @@ defmodule Sanbase.Queries.QueryCache do
         result.compressed_rows
       end
 
-      IO.inspect(result)
-
     %__MODULE__{
       query_id: result.query_id,
       dashboard_query_mapping_id: dashboard_query_mapping_id,

--- a/lib/sanbase/queries/query/query_metadata.ex
+++ b/lib/sanbase/queries/query/query_metadata.ex
@@ -21,7 +21,7 @@ defmodule Sanbase.Queries.QueryMetadata do
   end
 
   @doc false
-  def from_local_dev(user_id) do
+  def from_local_dev(user_id) when is_integer(user_id) do
     # To be used only in test and dev environment
     %{
       sanbase_user_id: user_id,

--- a/lib/sanbase/run_examples.ex
+++ b/lib/sanbase/run_examples.ex
@@ -718,8 +718,8 @@ defmodule Sanbase.RunExamples do
     {:ok, dashboard_cache} =
       Sanbase.Dashboards.get_cached_dashboard_queries_executions(dashboard.id, user.id)
 
-    # for r <- [dashboard_cache, mapping, dashboard, query],
-    #     do: Sanbase.Repo.delete(r)
+    for r <- [dashboard_cache, mapping, dashboard, query],
+        do: Sanbase.Repo.delete(r)
 
     {:ok, :success}
   end

--- a/lib/sanbase_web/components/layouts/app.html.heex
+++ b/lib/sanbase_web/components/layouts/app.html.heex
@@ -1,5 +1,4 @@
-<header class="px-4 sm:px-6 lg:px-8">
-</header>
+<header class="px-4 sm:px-6 lg:px-8"></header>
 <main class="px-4 py-20 sm:px-6 lg:px-8">
   <div class="mx-auto">
     <.flash_group flash={@flash} />

--- a/lib/sanbase_web/graphql/resolvers/queries_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/queries_resolver.ex
@@ -200,7 +200,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.QueriesResolver do
              query_execution_result,
              user.id
            ) do
-      queries = Map.values(dashboard_cache.queries)
+      queries =
+        Map.values(dashboard_cache.queries)
+        |> IO.inspect(label: "205", limit: :infinity)
+
       {:ok, %{queries: queries}}
     end
   end

--- a/lib/sanbase_web/graphql/resolvers/queries_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/queries_resolver.ex
@@ -188,11 +188,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.QueriesResolver do
         %{
           dashboard_id: dashboard_id,
           dashboard_query_mapping_id: mapping_id,
-          query_execution_result: query_execution_result
+          compressed_query_execution_result: compressed_query_execution_result
         },
         %{context: %{auth: %{current_user: user}}}
       ) do
-    with {:ok, query_execution_result} <- Result.from_json_string(query_execution_result),
+    with {:ok, result_string} <- Result.decode_and_decompress(compressed_query_execution_result),
+         {:ok, query_execution_result} <- Result.from_json_string(result_string),
          {:ok, dashboard_cache} <-
            Dashboards.store_dashboard_query_execution(
              dashboard_id,

--- a/lib/sanbase_web/graphql/resolvers/queries_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/queries_resolver.ex
@@ -200,9 +200,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.QueriesResolver do
              query_execution_result,
              user.id
            ) do
-      queries =
-        Map.values(dashboard_cache.queries)
-        |> IO.inspect(label: "205", limit: :infinity)
+      queries = Map.values(dashboard_cache.queries)
 
       {:ok, %{queries: queries}}
     end

--- a/lib/sanbase_web/graphql/schema/queries/queries_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/queries_queries.ex
@@ -344,7 +344,13 @@ defmodule SanbaseWeb.Graphql.Schema.QueriesQueries do
       arg(:dashboard_id, non_null(:integer))
       arg(:dashboard_query_mapping_id, non_null(:string))
 
-      arg(:query_execution_result, non_null(:string))
+      @desc ~s"""
+      This is the result of the query execution. The JSON obtained from
+      runSqlQuery/runRawSqlQuery/runDashboardSqlQuery is first stringified,
+      then gzipped and the encoded in base64. This is done to reduce the
+      size of the data sent from the frontend to the backend.
+      """
+      arg(:compressed_query_execution_result, non_null(:string))
 
       middleware(JWTAuth)
 

--- a/lib/sanbase_web/graphql/schema/queries/queries_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/queries_queries.ex
@@ -297,6 +297,59 @@ defmodule SanbaseWeb.Graphql.Schema.QueriesQueries do
 
       resolve(&QueriesResolver.delete_query/3)
     end
+
+    @desc ~s"""
+    Update the dashboard cache with the provided data.
+
+    This mutation, along with computeDashboardPanel, provides
+    the capabilities to compute and store dashboard panel results
+    separately. In contrast to computeAndStoreDashboardPanel, having
+    the methods separated allows users to compute many different panel
+    configurations and only store the result of the one that satisfies
+    the requirements.
+
+    All the panel fields are required.
+
+    The `rows` and `summary` fields must be JSON encoded.
+
+    Example:
+
+    mutation {
+      storeDashboardPanel(
+        dashboardId: 134
+        panelId: "c5a3b5dd-0e31-42ae-954a-83b741818a28"
+        panel: {
+            clickhouseQueryId: "177a5a3d-072b-48ac-8cf5-d8375c8314ef"
+            columns: ["asset_id", "metric_id", "dt", "value", "computed_at"]
+            columnTypes: ["UInt64", "UInt64", "DateTime", "Float64", "DateTime"]
+            queryEndTime: "2022-06-14T12:08:10Z"
+            queryStartTime: "2022-06-14T12:08:10Z"
+            rows: "[[2503,250,\"2008-12-10T00:00:00Z\",0.0,\"2020-02-28T15:18:42Z\"],[2503,250,\"2008-12-10T00:05:00Z\",0.0,\"2020-02-28T15:18:42Z\"]]"
+            summary: "{\"read_bytes\":\"0\",\"read_rows\":\"0\",\"total_rows_to_read\":\"0\",\"written_bytes\":\"0\",\"written_rows\":\"0\"}"
+        }
+      ){
+        id
+        clickhouseQueryId
+        dashboardId
+        columns
+        rows
+        summary
+        updatedAt
+        queryStartTime
+        queryEndTime
+      }
+    }
+    """
+    field :store_dashboard_query_execution, :dashboard_cached_executions do
+      arg(:dashboard_id, non_null(:integer))
+      arg(:dashboard_query_mapping_id, non_null(:string))
+
+      arg(:query_execution_result, non_null(:string))
+
+      middleware(JWTAuth)
+
+      resolve(&QueriesResolver.store_dashboard_query_execution/3)
+    end
   end
 
   object :dashboard_queries do
@@ -308,6 +361,29 @@ defmodule SanbaseWeb.Graphql.Schema.QueriesQueries do
       arg(:id, non_null(:integer))
 
       resolve(&QueriesResolver.get_dashboard/3)
+    end
+
+    @desc ~s"""
+    Get the last computed version of the queries on a dashboard.
+
+    The query returns a list of the last execution of every
+    query. The query execution (cache) is described by its
+    id and a JSON-formatted string of the result. The result
+    contains the column names, the column types, the rows and
+    the time they were computed. The SQL query text and parameters that
+    were used to compute the result can be found in the dashhboard
+    schema, fetched by the getDashboard query.
+
+    This is called a cache because only the latest result is
+    stored and all previous states are discarded. Storing data
+    for long time after other computations and changes are done
+    is done via snapshots (to be implemented).
+    """
+    field :get_cached_dashboard_queries_executions, :dashboard_cached_executions do
+      meta(access: :free)
+      arg(:dashboard_id, non_null(:integer))
+
+      resolve(&QueriesResolver.get_cached_dashboard_queries_executions/3)
     end
 
     @desc ~s"""

--- a/lib/sanbase_web/graphql/schema/types/queries_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/queries_types.ex
@@ -17,6 +17,8 @@ defmodule SanbaseWeb.Graphql.QueriesTypes do
   object :sql_query do
     # Identification data
     field(:id, non_null(:integer))
+    field(:dashboard_query_mapping_id, :string)
+
     field(:uuid, non_null(:string))
     field(:origin_id, :integer)
 
@@ -51,6 +53,9 @@ defmodule SanbaseWeb.Graphql.QueriesTypes do
     field(:updated_at, non_null(:datetime))
   end
 
+  @desc ~s"""
+  TODO: Document this type
+  """
   object :text_widget do
     field(:id, non_null(:string))
     field(:name, :string)
@@ -76,6 +81,7 @@ defmodule SanbaseWeb.Graphql.QueriesTypes do
   the query's own parameters. The interaction with the global parameter happens through the
   putDashboardGlobalParameter and putDashboardGlobalParameterOverride mutations.
   """
+
   object :dashboard do
     field(:id, non_null(:integer))
     field(:name, non_null(:string))
@@ -214,6 +220,25 @@ defmodule SanbaseWeb.Graphql.QueriesTypes do
   - queryEndTime: The time when the query finished executing.
   """
   object :sql_query_execution_result do
+    @desc "Non-null when executing a stored query"
+    field(:query_id, :integer)
+    @desc "Non-null when executing a dashboard query"
+    field(:dashboard_query_mapping_id, :string)
+
+    field(:clickhouse_query_id, non_null(:string))
+    field(:summary, non_null(:json))
+    field(:rows, non_null(:json))
+    field(:columns, non_null(list_of(:string)))
+    field(:column_types, non_null(list_of(:string)))
+    field(:query_start_time, non_null(:datetime))
+    field(:query_end_time, non_null(:datetime))
+  end
+
+  object :dashboard_cached_executions do
+    field(:queries, list_of(:sql_query_execution_result))
+  end
+
+  input_object :sql_query_execution_result_input_object do
     field(:clickhouse_query_id, non_null(:string))
     field(:summary, non_null(:json))
     field(:rows, non_null(:json))

--- a/lib/sanbase_web/templates/custom_admin_html/index.html.heex
+++ b/lib/sanbase_web/templates/custom_admin_html/index.html.heex
@@ -7,7 +7,13 @@
       </div>
       <%= for {name, path} <- @routes do %>
         <nav class="mt-10">
-          <span><%= link name, to: path, class: "flex items-center px-6 py-2 mt-4 duration-200 border-l-4 border-gray-900 text-gray-500 hover:bg-gray-600 hover:bg-opacity-25 hover:text-gray-100" %></span>
+          <span>
+            <%= link(name,
+              to: path,
+              class:
+                "flex items-center px-6 py-2 mt-4 duration-200 border-l-4 border-gray-900 text-gray-500 hover:bg-gray-600 hover:bg-opacity-25 hover:text-gray-100"
+            ) %>
+          </span>
         </nav>
       <% end %>
     </div>
@@ -15,10 +21,25 @@
   <div class="flex-1 flex flex-col overflow-hidden">
     <header class="flex items-center justify-between px-6 py-4 bg-white border-b-4 border-indigo-600">
       <div class="relative mx-4 lg:mx-0">
-        <span class="absolute inset-y-0 left-0 flex items-center pl-3"><svg class="w-5 h-5 text-gray-500" viewBox="0 0 24 24" fill="none"><path d="M21 21L15 15M17 10C17 13.866 13.866 17 10 17C6.13401 17 3 13.866 3 10C3 6.13401 6.13401 3 10 3C13.866 3 17 6.13401 17 10Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg></span>
+        <span class="absolute inset-y-0 left-0 flex items-center pl-3">
+          <svg class="w-5 h-5 text-gray-500" viewBox="0 0 24 24" fill="none">
+            <path
+              d="M21 21L15 15M17 10C17 13.866 13.866 17 10 17C6.13401 17 3 13.866 3 10C3 6.13401 6.13401 3 10 3C13.866 3 17 6.13401 17 10Z"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+            </path>
+          </svg>
+        </span>
         <%= form_for @conn, Routes.user_path(@conn, :search), [as: :user_search], fn f -> %>
-          <%= text_input f, :user_search, value: @search_value, class: "w-32 pl-10 pr-4 text-indigo-600 border-gray-200 rounded-md sm:w-64 focus:border-indigo-600 focus:ring focus:ring-opacity-40 focus:ring-indigo-500"%>
-          <%= submit "Search Users" %>
+          <%= text_input(f, :user_search,
+            value: @search_value,
+            class:
+              "w-32 pl-10 pr-4 text-indigo-600 border-gray-200 rounded-md sm:w-64 focus:border-indigo-600 focus:ring focus:ring-opacity-40 focus:ring-indigo-500"
+          ) %>
+          <%= submit("Search Users") %>
         <% end %>
       </div>
     </header>

--- a/lib/sanbase_web/templates/user_html/index.html.heex
+++ b/lib/sanbase_web/templates/user_html/index.html.heex
@@ -2,12 +2,25 @@
 
 <table class="table-auto border-collapse w-full mb-4">
   <thead>
-    <tr class="rounded-lg text-sm font-medium text-gray-700 text-left" style="font-size: 0.9674rem">
-      <th class="px-5 py-3 text-xs font-semibold tracking-wider text-left text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">ID</th>
-      <th class="px-5 py-3 text-xs font-semibold tracking-wider text-left text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">Name</th>
-      <th class="px-5 py-3 text-xs font-semibold tracking-wider text-left text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">Email</th>
-      <th class="px-5 py-3 text-xs font-semibold tracking-wider text-left text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">Username</th>
-      <th class="px-5 py-3 text-xs font-semibold tracking-wider text-left text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">Actions</th>
+    <tr
+      class="rounded-lg text-sm font-medium text-gray-700 text-left"
+      style="font-size: 0.9674rem"
+    >
+      <th class="px-5 py-3 text-xs font-semibold tracking-wider text-left text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">
+        ID
+      </th>
+      <th class="px-5 py-3 text-xs font-semibold tracking-wider text-left text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">
+        Name
+      </th>
+      <th class="px-5 py-3 text-xs font-semibold tracking-wider text-left text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">
+        Email
+      </th>
+      <th class="px-5 py-3 text-xs font-semibold tracking-wider text-left text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">
+        Username
+      </th>
+      <th class="px-5 py-3 text-xs font-semibold tracking-wider text-left text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">
+        Actions
+      </th>
     </tr>
   </thead>
   <tbody class="text-sm font-normal text-gray-700">
@@ -18,8 +31,9 @@
         <td class="px-5 py-5 text-sm bg-white border-b border-gray-200"><%= user.email %></td>
         <td class="px-5 py-5 text-sm bg-white border-b border-gray-200"><%= user.username %></td>
         <td class="px-5 py-5 text-sm bg-white border-b border-gray-200">
-          <span><%= link "Show", to: Routes.user_path(@conn, :show, user) %></span> |
-          <span><%= link "Edit", to: Routes.user_path(@conn, :edit, user) %></span> |
+          <span><%= link("Show", to: Routes.user_path(@conn, :show, user)) %></span>
+          | <span><%= link("Edit", to: Routes.user_path(@conn, :edit, user)) %></span>
+          |
         </td>
       </tr>
     <% end %>

--- a/lib/sanbase_web/templates/user_html/show.html.heex
+++ b/lib/sanbase_web/templates/user_html/show.html.heex
@@ -6,18 +6,30 @@
       <table class="w-full text-left border-collapse">
         <tbody>
           <%= for f <- @string_fields do %>
-          <tr class="hover:bg-gray-200">
-            <td class="px-6 py-4 text-lg text-gray-700 border-b"><%= to_string(f) %></td>
-            <td class="px-6 py-4 text-gray-500 border-b"><%= Map.get(@user, f) |> to_string() %></td>
-          </tr>
+            <tr class="hover:bg-gray-200">
+              <td class="px-6 py-4 text-lg text-gray-700 border-b"><%= to_string(f) %></td>
+              <td class="px-6 py-4 text-gray-500 border-b">
+                <%= Map.get(@user, f) |> to_string() %>
+              </td>
+            </tr>
           <% end %>
         </tbody>
       </table>
     </div>
   </div>
 
-  <span><%= link "Edit", to: Routes.user_path(@conn, :edit, @user), class: "flex-shrink-0 border-4 text-teal-500 hover:text-teal-800 py-1 px-2 rounded"%></span>
-  <span><%= link "Back", to: Routes.user_path(@conn, :index), class: "flex-shrink-0 border-4 text-teal-500 hover:text-teal-800 py-1 px-2 rounded" %></span>
+  <span>
+    <%= link("Edit",
+      to: Routes.user_path(@conn, :edit, @user),
+      class: "flex-shrink-0 border-4 text-teal-500 hover:text-teal-800 py-1 px-2 rounded"
+    ) %>
+  </span>
+  <span>
+    <%= link("Back",
+      to: Routes.user_path(@conn, :index),
+      class: "flex-shrink-0 border-4 text-teal-500 hover:text-teal-800 py-1 px-2 rounded"
+    ) %>
+  </span>
 
   <%= for bt <- @belongs_to do %>
     <div class="mt-4">
@@ -25,20 +37,32 @@
       <table class="table-auto border-collapse w-full mb-4">
         <tbody>
           <%= for field <- bt.fields do %>
-            <tr><td class="px-6 py-4 text-lg text-gray-700 border-b"><%= field.field_name %></td> <td class="show"><pre><%= field.data %></pre></td></tr>
+            <tr>
+              <td class="px-6 py-4 text-lg text-gray-700 border-b"><%= field.field_name %></td>
+
+              <td class="show"><pre><%= field.data %></pre></td>
+            </tr>
           <% end %>
         </tbody>
       </table>
 
       <%= for action <- bt.actions do %>
-        <span><%= link to_string(action), to: Routes.user_path(@conn, action, id: @user.id), class: "flex-shrink-0 border-4 text-teal-500 hover:text-teal-800 py-1 px-2 rounded"%></span>
+        <span>
+          <%= link(to_string(action),
+            to: Routes.user_path(@conn, action, id: @user.id),
+            class: "flex-shrink-0 border-4 text-teal-500 hover:text-teal-800 py-1 px-2 rounded"
+          ) %>
+        </span>
       <% end %>
     </div>
   <% end %>
 
-
-
   <%= for table <- @has_many do %>
-    <SanbaseWeb.CoreComponents.old_table model={table.model} rows={table.rows} fields={table.fields} funcs={table.funcs} />
+    <SanbaseWeb.CoreComponents.old_table
+      model={table.model}
+      rows={table.rows}
+      fields={table.fields}
+      funcs={table.funcs}
+    />
   <% end %>
 </div>

--- a/priv/repo/migrations/20231012122039_add-queries-to-cache.exs
+++ b/priv/repo/migrations/20231012122039_add-queries-to-cache.exs
@@ -1,0 +1,12 @@
+defmodule :"Elixir.Sanbase.Repo.Migrations.Add-queries-to-cache" do
+  use Ecto.Migration
+
+  def change do
+    alter table(:dashboards_cache) do
+      # Add capabilities to store queries
+      add(:queries, :map, default: %{}, null: true)
+      # Allow the panels to be null now that we'll store queries
+      modify(:panels, :map, default: %{}, null: true)
+    end
+  end
+end

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -77,6 +77,7 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           :get_available_metrics,
           :get_available_signals,
           :get_blockchain_address_labels,
+          :get_cached_dashboard_queries,
           :get_chart_configuration_shared_access_token,
           :get_clickhouse_database_metadata,
           :get_clickhouse_query_execution_stats,

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -77,7 +77,7 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           :get_available_metrics,
           :get_available_signals,
           :get_blockchain_address_labels,
-          :get_cached_dashboard_queries,
+          :get_cached_dashboard_queries_executions,
           :get_chart_configuration_shared_access_token,
           :get_clickhouse_database_metadata,
           :get_clickhouse_query_execution_stats,

--- a/test/sanbase/queries/queries_test.exs
+++ b/test/sanbase/queries/queries_test.exs
@@ -622,7 +622,7 @@ defmodule Sanbase.QueriesTest do
 
       # Test outside of the mock to make sure no database queries are made
       {:ok, dashboard_cache} =
-        Sanbase.Dashboards.get_cached_dashboard_queries(dashboard.id, user.id)
+        Sanbase.Dashboards.get_cached_dashboard_queries_executions(dashboard.id, user.id)
 
       assert %Sanbase.Queries.DashboardCache{
                queries: %{},

--- a/test/sanbase/queries/queries_test.exs
+++ b/test/sanbase/queries/queries_test.exs
@@ -590,6 +590,85 @@ defmodule Sanbase.QueriesTest do
     end
   end
 
+  describe "Caching" do
+    test "cache dashboard queries", context do
+      %{
+        query: %{id: query_id} = query,
+        dashboard_query_mapping: %{id: dashboard_query_mapping_id} = dashboard_query_mapping,
+        dashboard: %{id: dashboard_id} = dashboard,
+        user: user,
+        query_metadata: query_metadata
+      } = context
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:ok, result_mock()})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        {:ok, result} =
+          Sanbase.Queries.run_query(query, user, query_metadata, store_execution_details: false)
+
+        {:ok, dashboard_cache} =
+          Sanbase.Dashboards.store_dashboard_query_execution(
+            dashboard.id,
+            dashboard_query_mapping.id,
+            result,
+            user.id
+          )
+
+        assert %Sanbase.Queries.DashboardCache{
+                 queries: %{},
+                 inserted_at: _,
+                 updated_at: _
+               } = dashboard_cache
+      end)
+
+      # Test outside of the mock to make sure no database queries are made
+      {:ok, dashboard_cache} =
+        Sanbase.Dashboards.get_cached_dashboard_queries(dashboard.id, user.id)
+
+      assert %Sanbase.Queries.DashboardCache{
+               queries: %{},
+               inserted_at: _,
+               updated_at: _
+             } = dashboard_cache
+
+      assert %{
+               query_id: ^query_id,
+               dashboard_query_mapping_id: ^dashboard_query_mapping_id,
+               clickhouse_query_id: "1774C4BC91E05698",
+               column_types: ["UInt64", "UInt64", "DateTime", "Float64", "DateTime"],
+               columns: ["asset_id", "metric_id", "dt", "value", "computed_at"],
+               dashboard_id: ^dashboard_id,
+               query_end_time: _,
+               query_start_time: _,
+               rows: [
+                 [
+                   1482,
+                   1645,
+                   ~U[1970-01-01 00:00:00Z],
+                   0.045183932486757644,
+                   ~U[2023-07-26 13:10:51Z]
+                 ],
+                 [
+                   1482,
+                   1647,
+                   ~U[1970-01-01 00:00:00Z],
+                   -0.13018891098082416,
+                   ~U[2023-07-25 20:27:06Z]
+                 ]
+               ],
+               summary: %{
+                 "read_bytes" => 408_534.0,
+                 "read_rows" => 12667.0,
+                 "result_bytes" => 0.0,
+                 "result_rows" => 0.0,
+                 "total_rows_to_read" => 4475.0,
+                 "written_bytes" => 0.0,
+                 "written_rows" => 0.0
+               },
+               updated_at: _
+             } = dashboard_cache.queries[dashboard_query_mapping.id]
+    end
+  end
+
   # MOCKS
 
   defp result_mock() do

--- a/test/sanbase_web/graphql/queries/queries_api_test.exs
+++ b/test/sanbase_web/graphql/queries/queries_api_test.exs
@@ -682,11 +682,13 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
           })
           |> get_in(["data", "runDashboardSqlQuery"])
 
+        compressed_result = Jason.encode!(result) |> :zlib.gzip() |> Base.encode64()
+
         stored =
           store_dashboard_query_execution(context.conn, %{
             dashboard_id: dashboard.id,
             dashboard_query_mapping_id: dashboard_query_mapping.id,
-            query_execution_result: Jason.encode!(result)
+            compressed_query_execution_result: compressed_result
           })
           |> get_in(["data", "storeDashboardQueryExecution"])
 

--- a/test/sanbase_web/graphql/queries/queries_api_test.exs
+++ b/test/sanbase_web/graphql/queries/queries_api_test.exs
@@ -328,7 +328,7 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
     end
   end
 
-  describe "dashboard text widget" do
+  describe "Dashboards Text Widget" do
     test "create", context do
       {:ok, %{id: dashboard_id}} =
         Sanbase.Dashboards.create_dashboard(%{name: "My Dashboard"}, context.user.id)
@@ -455,7 +455,7 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
     end
   end
 
-  describe "run queries" do
+  describe "Run Queries" do
     test "run raw sql query", context do
       mock_fun =
         Sanbase.Mock.wrap_consecutives(
@@ -478,7 +478,7 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
           run_sql_query(context.conn, :run_raw_sql_query, args)
           |> get_in(["data", "runRawSqlQuery"])
 
-        assert result == %{
+        assert %{
                  "clickhouseQueryId" => "177a5a3d-072b-48ac-8cf5-d8375c8314ef",
                  "columns" => ["asset_id", "metric_id", "dt", "value", "computed_at"],
                  "columnTypes" => ["UInt64", "UInt64", "DateTime", "Float64", "DateTime"],
@@ -493,7 +493,7 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
                    "written_bytes" => 0.0,
                    "written_rows" => 0.0
                  }
-               }
+               } = result
       end)
     end
 
@@ -515,7 +515,8 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
           run_sql_query(context.conn, :run_sql_query, %{id: query.id})
           |> get_in(["data", "runSqlQuery"])
 
-        assert result == %{
+        # Use match `=` operator to avoid checking the queryStartTime and queryEndTime
+        assert %{
                  "clickhouseQueryId" => "177a5a3d-072b-48ac-8cf5-d8375c8314ef",
                  "columns" => ["asset_id", "metric_id", "dt", "value", "computed_at"],
                  "columnTypes" => ["UInt64", "UInt64", "DateTime", "Float64", "DateTime"],
@@ -530,7 +531,7 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
                    "written_bytes" => 0.0,
                    "written_rows" => 0.0
                  }
-               }
+               } = result
       end)
     end
 
@@ -621,7 +622,7 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
           })
           |> get_in(["data", "runDashboardSqlQuery"])
 
-        assert result == %{
+        assert %{
                  "clickhouseQueryId" => "177a5a3d-072b-48ac-8cf5-d8375c8314ef",
                  "columns" => ["asset_id", "metric_id", "dt", "value", "computed_at"],
                  "columnTypes" => ["UInt64", "UInt64", "DateTime", "Float64", "DateTime"],
@@ -636,7 +637,56 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
                    "written_bytes" => 0.0,
                    "written_rows" => 0.0
                  }
-               }
+               } = result
+      end)
+    end
+  end
+
+  describe "Caching" do
+    test "cache queries on a dashboard", context do
+      {:ok, query} = Sanbase.Queries.create_query(%{name: "Query"}, context.user.id)
+
+      {:ok, dashboard} =
+        Sanbase.Dashboards.create_dashboard(%{name: "Dashboard"}, context.user.id)
+
+      {:ok, dashboard_query_mapping} =
+        Sanbase.Dashboards.add_query_to_dashboard(
+          dashboard.id,
+          query.id,
+          context.user.id
+        )
+
+      mock_fun =
+        Sanbase.Mock.wrap_consecutives(
+          [
+            fn -> {:ok, mocked_clickhouse_result()} end,
+            fn -> {:ok, mocked_execution_details_result()} end
+          ],
+          arity: 2
+        )
+
+      # Run a dashboard query. Expect the dashboard parameter to override
+      # the query local parameter
+      Sanbase.Mock.prepare_mock(Sanbase.ClickhouseRepo, :query, mock_fun)
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result =
+          run_sql_query(context.conn, :run_dashboard_sql_query, %{
+            dashboard_id: dashboard.id,
+            dashboard_query_mapping_id: dashboard_query_mapping.id
+          })
+          |> get_in(["data", "runDashboardSqlQuery"])
+
+        stored =
+          store_dashboard_query_execution(context.conn, %{
+            dashboard_id: dashboard.id,
+            dashboard_query_mapping_id: dashboard_query_mapping.id,
+            query_execution_result: Jason.encode!(result)
+          })
+          |> IO.inspect(label: "685", limit: :infinity)
+
+        cache =
+          get_cached_dashboard_queries_executions(context.conn, %{dashboard_id: dashboard.id})
+          |> IO.inspect(label: "688", limit: :infinity)
       end)
     end
   end
@@ -930,17 +980,52 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
     mutation = """
     {
       #{query_name}(#{map_to_args(args)}){
-          columns
-          columnTypes
-          rows
-          clickhouseQueryId
-          summary
+        columns
+        columnTypes
+        rows
+        clickhouseQueryId
+        summary
+        queryStartTime
+        queryEndTime
       }
     }
     """
 
     conn
     |> post("/graphql", mutation_skeleton(mutation))
+    |> json_response(200)
+  end
+
+  defp store_dashboard_query_execution(conn, args) do
+    mutation = """
+    mutation{
+      storeDashboardQueryExecution(#{map_to_args(args)}){
+        queries{
+          queryId
+          dashboardQueryMappingId
+        }
+      }
+    }
+    """
+
+    conn
+    |> post("/graphql", mutation_skeleton(mutation))
+    |> json_response(200)
+  end
+
+  defp get_cached_dashboard_queries_executions(conn, args) do
+    query = """
+    {
+      getCachedDashboardQueriesExecutions(#{map_to_args(args)}){
+        queries{
+          dashboardQueryMappingId
+        }
+      }
+    }
+    """
+
+    conn
+    |> post("/graphql", query_skeleton(query))
     |> json_response(200)
   end
 


### PR DESCRIPTION
## Changes

Add APIs for caching Queries 2.0 dashboard queries. This PR introduces functionality where query executions can be saved on a dashboard and later retrieved.

There is an nginx limit of the body size of HTTP requests. At the moment it is 1mb, but we will increase it. Link: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#custom-max-body-size


### Storing 
The storing of the executed dashboard query is done by the `storeDashboardQueryExecution` mutation.
It accepts the following parameters:
- `dashboardId` - identify the dashboard;
- `dashboardQueryMappingId` - identify the exact query for which we'll be storing data;
- `compressedQueryExecutionResult` - the result of `runDashboardSqlQuery`. The result is not directly passed as an input object, but it is instead stringified, gzipped and base64 encoded. In some cases this can reduce the size of the result by a factor of 5.

> Note: All of the fields served by the `storeDashboardQueryExecution` must be provided to the `storeDashboardQueryExecution` mutation, otherwise it will return an error.

Running a query:
```graphql
{
  runDashboardSqlQuery(dashboardId: 4, dashboardQueryMappingId: "af9c43bd-189d-49c3-9a9e-6cb0c5b14355") {
    queryId
    dashboardQueryMappingId
    columnTypes
    columns
    rows
    queryStartTime
    queryEndTime
  }
}
```
<details>
<summary>Result:</summary>

```json
{
  "data": {
    "runDashboardSqlQuery": {
      "columnTypes": [
        "UInt64",
        "UInt64",
        "DateTime",
        "Float64",
        "DateTime",
        "UInt64"
      ],
      "columns": [
        "asset_id",
        "metric_id",
        "dt",
        "value",
        "computed_at",
        "batch_id"
      ],
      "dashboardQueryMappingId": null,
      "queryEndTime": "2023-11-09T10:39:35Z",
      "queryId": 1,
      "queryStartTime": "2023-11-09T10:39:34Z",
      "rows": [
        [
          1482,
          1645,
          "1970-01-01T00:00:00Z",
          -0.25806922893410084,
          "2023-11-06T16:09:25Z",
          0
        ]
      ]
    }
  }
}
```

</details>

#### Data manipulation

The JSON value of the `runDashboardSqlQuery` looks like: `{"columnTypes": [ ... ], "columns": [ ... ], "rows": [ ... ], ... }`
This JSON is assigned to the var `result` and then stringified, gzipped and encoded in base64.
Example JS code that can do this:
```js
var stream = new Blob([JSON.stringify(result)], {
    type: 'application/json',
}).stream()

const compressedReadableStream = stream.pipeThrough(
    new CompressionStream("gzip")
);

const compressedResponse = 
  await new Response(compressedReadableStream);

// Get response Blob
const blob = await compressedResponse.blob();
// Get the ArrayBuffer
const buffer = await blob.arrayBuffer();

// convert ArrayBuffer to base64 encoded string
const compressedBase64 = btoa(
  String.fromCharCode(
    ...new Uint8Array(buffer)
  )
);

console.log(compressedBase64)
```

In elixir this can be done by:
```elixir
elixir_map |> Jason.encode!() |> :zlib.gzip() |> Base.encode64!()
```

The result string of the example above is: `H4sIAAAAAAAAE3WOQWvEIBSE/4tnszyNsdFzW9jDHkrtpUtY3CjdgImp0Zal9L9X08AeSkFkmPfNMF+o9y6Nk7rOdkHyiF72U+QM4Zu419GqYbRZPjqv/5gb2OGtaq3Ry2LjaTD5PtoYhv5Xm5i/D+1SCfZ+nFO05qSLe9axvxQqFxm9XM5eB/OUbLge9DwP09veIDkl5zB6L+7DZNYBElGgdUVIBUIRkLWQdfOKNqqEyKafow7x3wwrmeA/y/wjYS3FhLMGIyLuoIJMEgUg15fJCna0aYELSltRMwLQMnxr5YpwCULSsgS67vsHMa3TkGgBAAA=`

This value is passed to `compressedQueryExecutionResult`.
<!--- Describe your changes -->

### Fetching the cached values

Each query on a dashboard (as identified by the `dashboardQueryMappingId`) has only has only one cached value -- the last one.
The cached query executions can be obtained by the following API:
```graphql
{
  getCachedDashboardQueriesExecutions(dashboardId: 4){
    queries{
      queryId
      dashboardQueryMappingId
      columnTypes
      columns
      rows
      queryStartTime
      queryEndTime
    }
  }
}
```
## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
