### PR TITLE
Rework the SQL query of trending words

### DIFF
--- a/test/sanbase/social_data/trending_words/trending_words_test.exs
+++ b/test/sanbase/social_data/trending_words/trending_words_test.exs
@@ -36,7 +36,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
                          summaries: [
                            %{
                              datetime: dt1,
-                             source: "4chan,bitcointalk,reddit",
+                             source: "4chan,reddit",
                              summary: "summary2"
                            }
                          ],
@@ -53,7 +53,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
                          summaries: [
                            %{
                              datetime: dt1,
-                             source: "4chan,bitcointalk,reddit",
+                             source: "4chan,reddit",
                              summary: "summary1"
                            }
                          ],
@@ -72,7 +72,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
                          summaries: [
                            %{
                              datetime: dt2,
-                             source: "4chan,bitcointalk,reddit",
+                             source: "4chan,reddit",
                              summary: "summary4"
                            }
                          ],
@@ -89,7 +89,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
                          summaries: [
                            %{
                              datetime: dt2,
-                             source: "4chan,bitcointalk,reddit",
+                             source: "4chan,reddit",
                              summary: "summary3"
                            }
                          ],
@@ -108,7 +108,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
                          summaries: [
                            %{
                              datetime: dt3,
-                             source: "4chan,bitcointalk,reddit",
+                             source: "4chan,reddit",
                              summary: "summary6"
                            }
                          ],
@@ -125,7 +125,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
                          summaries: [
                            %{
                              datetime: dt3,
-                             source: "4chan,bitcointalk,reddit",
+                             source: "4chan,reddit",
                              summary: "summary5"
                            }
                          ],
@@ -173,7 +173,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
                        summaries: [
                          %{
                            datetime: ~U[2019-01-03 00:00:00Z],
-                           source: "4chan,bitcointalk,reddit",
+                           source: "4chan,reddit",
                            summary: "summary6"
                          }
                        ],
@@ -190,7 +190,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
                        summaries: [
                          %{
                            datetime: ~U[2019-01-03 00:00:00Z],
-                           source: "4chan,bitcointalk,reddit",
+                           source: "4chan,reddit",
                            summary: "summary5"
                          }
                        ],


### PR DESCRIPTION
## Changes

Before the fix, when the provided interval was bigger than 20 minutes, the result was returning words for different dts, instead of the words for the biggest dt in that group.

Also fix the ALL source on stage as bitcointalk was deprecated

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
