### PR TITLE
Add API to fetch current user submitted twitter handles

### DIFF
--- a/lib/sanbase/monitored_twitter_handle/monitored_twitter_handle.ex
+++ b/lib/sanbase/monitored_twitter_handle/monitored_twitter_handle.ex
@@ -46,6 +46,16 @@ defmodule Sanbase.MonitoredTwitterHandle do
     |> maybe_transform_error()
   end
 
+  @doc ~s"""
+  Get a list of all twitter handles that a user has submitted
+  """
+  @spec get_user_submissions(User.user_id()) :: {:ok, [t()]}
+  def get_user_submissions(user_id) do
+    query = from(m in __MODULE__, where: m.user_id == ^user_id)
+
+    {:ok, Sanbase.Repo.all(query)}
+  end
+
   defp maybe_transform_error({:ok, _} = result), do: result
 
   defp maybe_transform_error({:error, changeset}) do

--- a/lib/sanbase/monitored_twitter_handle/monitored_twitter_handle.ex
+++ b/lib/sanbase/monitored_twitter_handle/monitored_twitter_handle.ex
@@ -12,6 +12,8 @@ defmodule Sanbase.MonitoredTwitterHandle do
           user_id: User.user_id(),
           user: User.t(),
           origin: String.t(),
+          # One of approved/declined/pending_approval
+          status: String.t(),
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
         }
@@ -20,6 +22,7 @@ defmodule Sanbase.MonitoredTwitterHandle do
     field(:handle, :string)
     field(:notes, :string)
     field(:origin, :string)
+    field(:status, :string)
 
     belongs_to(:user, User)
 

--- a/lib/sanbase_web/graphql/resolvers/monitored_twitter_handle_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/monitored_twitter_handle_resolver.ex
@@ -17,4 +17,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.MonitoredTwitterHandleResolver do
       {:error, error_msg} -> {:error, error_msg}
     end
   end
+
+  def get_current_user_submitted_twitter_handles(_root, _args, %{
+        context: %{auth: %{current_user: user}}
+      }) do
+    Sanbase.MonitoredTwitterHandle.get_user_submissions(user.id)
+  end
 end

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -55,6 +55,7 @@ defmodule SanbaseWeb.Graphql.Schema do
   import_types(Graphql.MarketSegmentTypes)
   import_types(Graphql.MarketTypes)
   import_types(Graphql.MetricTypes)
+  import_types(Graphql.MonitoredTwitterHandleTypes)
   import_types(Graphql.NftTypes)
   import_types(Graphql.PaginationTypes)
   import_types(Graphql.PriceTypes)

--- a/lib/sanbase_web/graphql/schema/queries/monitored_twitter_handle_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/monitored_twitter_handle_queries.ex
@@ -8,6 +8,14 @@ defmodule SanbaseWeb.Graphql.Schema.MonitoredTwitterHandleQueries do
   alias SanbaseWeb.Graphql.Resolvers.MonitoredTwitterHandleResolver
 
   object :monitored_twitter_handle_queries do
+    field :get_current_user_submitted_twitter_handles, list_of(:monitored_twitter_handle) do
+      meta(access: :free)
+
+      middleware(UserAuth)
+
+      resolve(&MonitoredTwitterHandleResolver.get_current_user_submitted_twitter_handles/3)
+    end
+
     field :is_twitter_handle_monitored, :boolean do
       meta(access: :free)
 

--- a/lib/sanbase_web/graphql/schema/types/monitored_twitter_handle_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/monitored_twitter_handle_types.ex
@@ -4,6 +4,7 @@ defmodule SanbaseWeb.Graphql.MonitoredTwitterHandleTypes do
   object :monitored_twitter_handle do
     field(:handle, non_null(:string))
     field(:notes, :string)
+    field(:status, :string)
 
     field(:inserted_at, non_null(:datetime))
     field(:updated_at, non_null(:datetime))

--- a/lib/sanbase_web/graphql/schema/types/monitored_twitter_handle_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/monitored_twitter_handle_types.ex
@@ -1,0 +1,11 @@
+defmodule SanbaseWeb.Graphql.MonitoredTwitterHandleTypes do
+  use Absinthe.Schema.Notation
+
+  object :monitored_twitter_handle do
+    field(:handle, non_null(:string))
+    field(:notes, :string)
+
+    field(:inserted_at, non_null(:datetime))
+    field(:updated_at, non_null(:datetime))
+  end
+end

--- a/priv/repo/migrations/20231023123140_add_monitored_twitter_handles_approval_status.exs
+++ b/priv/repo/migrations/20231023123140_add_monitored_twitter_handles_approval_status.exs
@@ -1,0 +1,9 @@
+defmodule Sanbase.Repo.Migrations.AddMonitoredTwitterHandlesApprovalStatus do
+  use Ecto.Migration
+
+  def change do
+    alter table(:monitored_twitter_handles) do
+      add(:status, :string, default: "pending_approval")
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2047,7 +2047,8 @@ CREATE TABLE public.monitored_twitter_handles (
     notes text,
     user_id bigint,
     inserted_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    status character varying(255) DEFAULT 'pending_approval'::character varying
 );
 
 
@@ -8851,3 +8852,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20231003070443);
 INSERT INTO public."schema_migrations" (version) VALUES (20231012122039);
 INSERT INTO public."schema_migrations" (version) VALUES (20231012130814);
 INSERT INTO public."schema_migrations" (version) VALUES (20231019111320);
+INSERT INTO public."schema_migrations" (version) VALUES (20231023123140);

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -80,6 +80,7 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           :get_chart_configuration_shared_access_token,
           :get_clickhouse_database_metadata,
           :get_clickhouse_query_execution_stats,
+          :get_current_user_submitted_twitter_handles,
           :get_coupon,
           :get_dashboard_cache,
           :get_dashboard_panel_cache,

--- a/test/sanbase_web/graphql/monitored_twitter_handle/monitored_twitter_handle_api_test.exs
+++ b/test/sanbase_web/graphql/monitored_twitter_handle/monitored_twitter_handle_api_test.exs
@@ -39,6 +39,13 @@ defmodule SanbaseWeb.Graphql.MonitoredTwitterHandleApiTest do
       |> get_in(["errors", Access.at(0), "message"])
 
     assert error_msg =~ "already being monitored"
+
+    # Get current user added handles
+    handles =
+      get_current_user_handles(conn)
+      |> get_in(["data", "getCurrentUserSubmittedTwitterHandles"])
+
+    assert handles == [%{"handle" => "santimentfeed", "notes" => "note"}]
   end
 
   defp add_twitter_handle_to_monitor(conn, args) do
@@ -51,6 +58,21 @@ defmodule SanbaseWeb.Graphql.MonitoredTwitterHandleApiTest do
 
   defp is_twitter_handle_monitored(conn, args) do
     query = "{ isTwitterHandleMonitored(#{map_to_args(args)}) }"
+
+    conn
+    |> post("/graphql", query_skeleton(query))
+    |> json_response(200)
+  end
+
+  defp get_current_user_handles(conn) do
+    query = """
+    {
+      getCurrentUserSubmittedTwitterHandles {
+        notes
+        handle
+      }
+    }
+    """
 
     conn
     |> post("/graphql", query_skeleton(query))


### PR DESCRIPTION
## Changes
The value of `status` will be one of:
- `approved`
- `declined`
- `pending_approval` (default)
In a later PR, an admin dashboard will be added where admins/moderators can set the status of the handles.
```graphql
{
  getCurrentUserSubmittedTwitterHandles {
    notes
    handle
    status
  }
}
```
```json
{
  "data": {
    "getCurrentUserSubmittedTwitterHandles": [
      {
        "handle": "santimentfeed",
        "notes": "optional notes to add",
        "status": "pending_approval"
      },
      {
        "handle": "santimentfeed2",
        "notes": "optional notes to add",
        "status": "pending_approval"
      }
    ]
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
