### PR TITLE
Add user promo codes for submitted twitter handles

### DIFF
--- a/lib/sanbase/billing/user_promo_codes.ex
+++ b/lib/sanbase/billing/user_promo_codes.ex
@@ -1,0 +1,119 @@
+defmodule Sanbase.Billing.UserPromoCode do
+  use Ecto.Schema
+
+  alias Sanbase.Repo
+  alias Sanbase.Accounts.User
+  alias Sanbase.Billing.Plan
+
+  import Ecto.Query
+  import Ecto.Changeset
+
+  @timestamps_opts [type: :utc_datetime]
+  schema "user_promo_codes" do
+    field(:campaign, :string)
+    field(:coupon, :string)
+    field(:percent_off, :integer)
+    field(:redeem_by, :utc_datetime)
+    field(:max_redemptions, :integer, default: 1)
+    field(:times_redeemed, :integer, default: 0)
+    field(:metadata, :map, default: %{})
+    field(:extra_data, :map, default: %{})
+
+    field(:valid, :boolean, default: true)
+
+    belongs_to(:user, User)
+
+    timestamps()
+  end
+
+  def changeset(%__MODULE__{} = promo, attrs) do
+    promo
+    |> cast(attrs, [
+      :campaign,
+      :coupon,
+      :user_id,
+      :percent_off,
+      :redeem_by,
+      :metadata,
+      :extra_data,
+      :max_redemptions,
+      :times_redeemed
+    ])
+    |> validate_required([:campaign, :coupon, :user_id, :redeem_by, :percent_off])
+  end
+
+  def create(args) do
+    changeset(%__MODULE__{}, args)
+    |> Sanbase.Repo.insert()
+  end
+
+  @doc ~s"""
+  Mark that the coupon has been used one time by increasing
+  the times_redeemed field by one. This is done so we can stop
+  showing used codes in the list of the available user promo codes
+  """
+  def use_coupon(coupon) do
+    from(p in __MODULE__, where: p.coupon == ^coupon)
+    |> Repo.update_all(inc: [times_redeemed: +1])
+  end
+
+  @doc ~s"""
+  Get all currently valid promo codes for a user
+  """
+  def get_user_promo_codes(user_id) do
+    user_promo_codes_base_query(user_id)
+    |> Repo.all()
+  end
+
+  @doc ~s"""
+  Get all promo codes for a campgain, including no longer valid promo codes.
+  This is used when counting how many promo codes in total have been issued
+  """
+  def get_total_user_promo_codes_for_campaign(user_id, campaign) do
+    from(p in __MODULE__, where: p.user_id == ^user_id and p.campaign == ^campaign)
+    |> Repo.all()
+  end
+
+  def is_coupon_usable(nil, _), do: true
+
+  def is_coupon_usable(coupon, %Plan{} = plan) do
+    case Repo.get_by(__MODULE__, coupon: coupon) do
+      nil ->
+        # If there is no information in this table, this means that the coupon
+        # is issued in another way, e.g. by Stripe directly. In this case, we
+        # cannot check if the coupon is usable, so we assume it is. If it is not
+        # the step that submits it to the Stripe API will fail
+        true
+
+      %__MODULE__{} = promo ->
+        product = get_in(promo, [:metadata, "product"])
+
+        cond do
+          not is_nil(product) and product != plan.product.code ->
+            {:error, "The coupon is not valid for this product."}
+
+          # The rest of the checks are not really needed as Stripe API will
+          # check them anyway, but we do them here to avoid unnecessary API
+          # calls and to have more unified coupon validation failed messages
+          DateTime.compare(DateTime.utc_now(), coupon.redeem_by) == :gt ->
+            {:error, "The coupon has expired."}
+
+          promo.times_redeemed >= promo.max_redemptions ->
+            {:error, "The coupon has been used too many times."}
+
+          true ->
+            true
+        end
+    end
+  end
+
+  # Private functions
+  defp user_promo_codes_base_query(user_id) do
+    from(p in __MODULE__,
+      where:
+        p.user_id == ^user_id and
+          p.max_redemptions > p.times_redeemed and
+          p.redeem_by > fragment("now()") and p.valid == true
+    )
+  end
+end

--- a/lib/sanbase/monitored_twitter_handle/monitored_twitter_handle.ex
+++ b/lib/sanbase/monitored_twitter_handle/monitored_twitter_handle.ex
@@ -1,7 +1,9 @@
 defmodule Sanbase.MonitoredTwitterHandle do
   use Ecto.Schema
 
+  alias Sanbase.Repo
   alias Sanbase.Accounts.User
+  alias Sanbase.Billing.UserPromoCode
 
   import Ecto.Query
   import Ecto.Changeset
@@ -31,8 +33,8 @@ defmodule Sanbase.MonitoredTwitterHandle do
 
   def is_handle_monitored(handle) do
     query = from(m in __MODULE__, where: m.handle == ^handle)
-    boolean = Sanbase.Repo.exists?(query)
-    {:ok, boolean}
+
+    {:ok, Repo.exists?(query)}
   end
 
   @doc ~s"""
@@ -45,7 +47,7 @@ defmodule Sanbase.MonitoredTwitterHandle do
     |> change(%{handle: String.downcase(handle), user_id: user_id, origin: origin, notes: notes})
     |> validate_required([:handle, :user_id, :origin])
     |> unique_constraint(:handle)
-    |> Sanbase.Repo.insert()
+    |> Repo.insert()
     |> maybe_transform_error()
   end
 
@@ -56,7 +58,32 @@ defmodule Sanbase.MonitoredTwitterHandle do
   def get_user_submissions(user_id) do
     query = from(m in __MODULE__, where: m.user_id == ^user_id)
 
-    {:ok, Sanbase.Repo.all(query)}
+    {:ok, Repo.all(query)}
+  end
+
+  @doc false
+  def update_status(record_id, status)
+      when status in ["approved", "declined", "pending_approval"] do
+    # The status is updated from an admin panel
+    Repo.get!(__MODULE__, record_id)
+    |> change(%{status: status})
+    |> Repo.update()
+    |> case do
+      {:ok, %__MODULE__{user_id: user_id}} = result when status == "approved" ->
+        maybe_add_user_promo_code(user_id)
+        result
+
+      result ->
+        result
+    end
+  end
+
+  # Private functions
+
+  defp count_user_approved_submissions(user_id) do
+    query = from(m in __MODULE__, where: m.user_id == ^user_id and m.status == "approved")
+
+    {:ok, Repo.aggregate(query, :count, :id)}
   end
 
   defp maybe_transform_error({:ok, _} = result), do: result
@@ -70,5 +97,52 @@ defmodule Sanbase.MonitoredTwitterHandle do
         msg = Sanbase.Utils.ErrorHandling.changeset_errors_string(changeset)
         {:error, msg}
     end
+  end
+
+  # During Halloween 2023, if the user has enough approved submissions,
+  # they will be given a promo code for 27% or 54% off.
+  @campaign "trick_or_tweet_2023"
+  defp maybe_add_user_promo_code(user_id) do
+    with {:ok, records_count} <- count_user_approved_submissions(user_id),
+         {:ok, codes} <-
+           UserPromoCode.get_total_user_promo_codes_for_campaign(user_id, @campaign) do
+      # This includes all used and unused promo codes for that campaign.
+      codes_count = length(codes)
+
+      cond do
+        records_count >= 7 and codes_count <= 1 ->
+          create_user_promo_code(user_id, 27)
+
+        records_count >= 3 and codes_count == 0 ->
+          create_user_promo_code(user_id, 54)
+
+        true ->
+          :ok
+      end
+    end
+  end
+
+  defp create_user_promo_code(user_id, percent_off) do
+    redeem_by = DateTime.utc_now() |> DateTime.add(30, :day) |> DateTime.truncate(:second)
+
+    {:ok, coupon} =
+      Sanbase.StripeApi.create_promo_coupon(%{
+        duration: "once",
+        percent_off: percent_off,
+        redeem_by: redeem_by |> DateTime.to_unix(),
+        metadata: %{campaign: @campaign, product: "SANBASE"},
+        max_redemptions: 1
+      })
+
+    UserPromoCode.create(%{
+      campaign: @campaign,
+      coupon: coupon.id,
+      user_id: user_id,
+      max_redemptions: 1,
+      times_redeemed: 0,
+      percent_off: percent_off,
+      redeem_by: redeem_by,
+      metadata: %{campaign: @campaign, product: "SANBASE"}
+    })
   end
 end

--- a/lib/sanbase_web/graphql/resolvers/monitored_twitter_handle_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/monitored_twitter_handle_resolver.ex
@@ -1,26 +1,30 @@
 defmodule SanbaseWeb.Graphql.Resolvers.MonitoredTwitterHandleResolver do
+  alias Sanbase.MonitoredTwitterHandle
+  alias Sanbase.Billing.UserPromoCode
+
   def is_twitter_handle_monitored(_root, %{twitter_handle: handle}, _resolution) do
-    Sanbase.MonitoredTwitterHandle.is_handle_monitored(handle)
+    MonitoredTwitterHandle.is_handle_monitored(handle)
   end
 
-  def add_twitter_handle_to_monitor(_root, args, %{context: %{auth: %{current_user: user}}}) do
-    result =
-      Sanbase.MonitoredTwitterHandle.add_new(
-        args[:twitter_handle],
-        user.id,
-        "graphql_api",
-        args[:notes]
-      )
+  def add_twitter_handle_to_monitor(
+        _root,
+        %{twitter_handle: handle} = args,
+        %{context: %{auth: %{current_user: user}}}
+      ) do
+    result = MonitoredTwitterHandle.add_new(handle, user.id, "graphql_api", args[:notes])
 
     case result do
-      {:ok, _} -> {:ok, true}
-      {:error, error_msg} -> {:error, error_msg}
+      {:ok, _} ->
+        {:ok, true}
+
+      {:error, error_msg} ->
+        {:error, error_msg}
     end
   end
 
   def get_current_user_submitted_twitter_handles(_root, _args, %{
         context: %{auth: %{current_user: user}}
       }) do
-    Sanbase.MonitoredTwitterHandle.get_user_submissions(user.id)
+    MonitoredTwitterHandle.get_user_submissions(user.id)
   end
 end

--- a/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
@@ -251,6 +251,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserResolver do
     end
   end
 
+  def user_promo_codes(_root, _args, %{context: %{auth: %{current_user: user}}}) do
+    {:ok, Sanbase.Billing.UserPromoCode.get_user_promo_codes(user.id)}
+  end
+
   def user_no_preloads(%{user_id: user_id}, _args, %{context: %{loader: loader}}) do
     loader
     |> Dataloader.load(SanbaseDataloader, :users_by_id, user_id)

--- a/lib/sanbase_web/graphql/schema/types/user_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_types.ex
@@ -92,6 +92,16 @@ defmodule SanbaseWeb.Graphql.UserTypes do
     end
   end
 
+  object :user_promo_code do
+    field(:campaign, :string)
+    field(:coupon, :string)
+    field(:percent_off, :integer)
+    field(:redeem_by, :datetime)
+    field(:max_redemptions, :integer)
+    field(:times_redeemed, :integer)
+    field(:data, :json)
+  end
+
   object :user do
     field(:id, non_null(:id))
     field(:email, :string)
@@ -105,6 +115,10 @@ defmodule SanbaseWeb.Graphql.UserTypes do
     field(:stripe_customer_id, :string)
     field(:inserted_at, non_null(:datetime))
     field(:updated_at, non_null(:datetime))
+
+    field :promo_codes, list_of(:user_promo_code) do
+      resolve(&UserResolver.user_promo_codes/3)
+    end
 
     field :is_moderator, :boolean do
       resolve(&UserResolver.is_moderator/3)

--- a/priv/repo/migrations/20231026084628_add_user_promo_codes_table.exs
+++ b/priv/repo/migrations/20231026084628_add_user_promo_codes_table.exs
@@ -1,0 +1,26 @@
+defmodule Sanbase.Repo.Migrations.AddUserPromoCodeTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:user_promo_codes) do
+      add(:user_id, references(:users, on_delete: :delete_all), null: false)
+
+      add(:coupon, :string, null: false)
+      add(:campaign, :string, null: true)
+      add(:percent_off, :integer)
+      add(:max_redemptions, :integer, default: 1)
+      add(:times_redeemed, :integer, default: 0)
+      add(:redeem_by, :utc_datetime)
+      add(:metadata, :map, default_value: %{}, null: true)
+      add(:extra_data, :map, default_value: %{}, null: true)
+
+      # Will be set to false if max_redemptions is reached
+      # or if redeem_by date is reached
+      add(:valid, :boolean, null: false, default: true)
+
+      timestamps()
+    end
+
+    create(unique_index(:user_promo_codes, [:coupon]))
+  end
+end

--- a/priv/repo/seed_plans_and_products.exs
+++ b/priv/repo/seed_plans_and_products.exs
@@ -1,6 +1,4 @@
-alias Sanbase.Repo
-
-Repo.query!("""
+Sanbase.Repo.query!("""
 INSERT INTO products (id, name, code) VALUES
   (1, 'Neuro by Santiment', 'SANAPI'),
   (2, 'Sanbase by Santiment', 'SANBASE'),
@@ -9,7 +7,7 @@ INSERT INTO products (id, name, code) VALUES
   ON CONFLICT DO NOTHING
 """)
 
-Repo.query!("""
+Sanbase.Repo.query!("""
 INSERT INTO plans (id, name, product_id, amount, currency, interval, "order") VALUES
   (1,'FREE',1,0,'USD','month',13),
   (101,'ESSENTIAL',1,16000,'USD','month',12),
@@ -25,7 +23,7 @@ INSERT INTO plans (id, name, product_id, amount, currency, interval, "order") VA
   (7,'PRO',1,387720,'USD','year',2),
   (8,'PREMIUM',1,776520,'USD','year',1),
   (11,'FREE',2,0,'USD','month',9),
-  (205,'BASIC',2,2500,'USD','month',9)
+  (205,'BASIC',2,2500,'USD','month',9),
   (201,'PRO',2,4900,'USD','month',8),
   (203,'PRO_PLUS',2,24900,'USD','month',7),
   (202,'PRO',2,52900,'USD','year',6),

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -3949,6 +3949,46 @@ ALTER SEQUENCE public.user_lists_id_seq OWNED BY public.user_lists.id;
 
 
 --
+-- Name: user_promo_codes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_promo_codes (
+    id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    coupon character varying(255) NOT NULL,
+    campaign character varying(255),
+    percent_off integer,
+    max_redemptions integer DEFAULT 1,
+    times_redeemed integer DEFAULT 0,
+    redeem_by timestamp(0) without time zone,
+    metadata jsonb,
+    extra_data jsonb,
+    valid boolean DEFAULT true NOT NULL,
+    inserted_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: user_promo_codes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.user_promo_codes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: user_promo_codes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.user_promo_codes_id_seq OWNED BY public.user_promo_codes.id;
+
+
+--
 -- Name: user_roles; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5091,6 +5131,13 @@ ALTER TABLE ONLY public.user_lists ALTER COLUMN id SET DEFAULT nextval('public.u
 
 
 --
+-- Name: user_promo_codes id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_promo_codes ALTER COLUMN id SET DEFAULT nextval('public.user_promo_codes_id_seq'::regclass);
+
+
+--
 -- Name: user_settings id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -6034,6 +6081,14 @@ ALTER TABLE ONLY public.user_intercom_attributes
 
 ALTER TABLE ONLY public.user_lists
     ADD CONSTRAINT user_lists_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_promo_codes user_promo_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_promo_codes
+    ADD CONSTRAINT user_promo_codes_pkey PRIMARY KEY (id);
 
 
 --
@@ -7058,6 +7113,13 @@ CREATE INDEX user_intercom_attributes_user_id_index ON public.user_intercom_attr
 --
 
 CREATE UNIQUE INDEX user_lists_slug_index ON public.user_lists USING btree (slug);
+
+
+--
+-- Name: user_promo_codes_coupon_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX user_promo_codes_coupon_index ON public.user_promo_codes USING btree (coupon);
 
 
 --
@@ -8213,6 +8275,14 @@ ALTER TABLE ONLY public.user_lists
 
 
 --
+-- Name: user_promo_codes user_promo_codes_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_promo_codes
+    ADD CONSTRAINT user_promo_codes_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
 -- Name: user_roles user_roles_role_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8853,3 +8923,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20231012122039);
 INSERT INTO public."schema_migrations" (version) VALUES (20231012130814);
 INSERT INTO public."schema_migrations" (version) VALUES (20231019111320);
 INSERT INTO public."schema_migrations" (version) VALUES (20231023123140);
+INSERT INTO public."schema_migrations" (version) VALUES (20231026084628);


### PR DESCRIPTION
## Changes

Add `user_promo_codes` table that will store the availalbe promo codes for each user.
When a submitted Twitter handle is approved (at a later stage by an admin/moderator), if the total number of submitted handles:
- exceeds 3 - Add a promo code for 27% discount;
- exceeds 6 - Add a promo code for 54% discount.

The user promo codes can be obtained by the `currentUser` API.
```graphql
{
  currentUser {
    id
    promoCodes{
      campaign
      coupon
      percentOff
      timesRedeemed
      maxRedemptions
      
    }
  }
}
```
```json
{
  "data": {
    "currentUser": {
      "id": "3",
      "promoCodes": [
        {
          "campaign": "local_test",
          "coupon": "wo4V68Vu",
          "maxRedemptions": 1,
          "percentOff": 3,
          "timesRedeemed": 0
        }
      ]
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
