### PR TITLE
Add a dashboard for approving twitter handles

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -9,5 +9,6 @@
     "mix.exs",
     ".formatter.exs"
   ],
-  plugins: [Phoenix.LiveView.HTMLFormatter]
+  # plugins: [Phoenix.LiveView.HTMLFormatter],
+  inputs: ["*.{heex,ex,exs}", "{config,lib,test}/**/*.{heex,ex,exs}", "priv/*/seeds.exs"]
 ]

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,6 +1,24 @@
-// js
-import "phoenix_html"
-import "./socket.js"
-
-// css
 import '../css/app.css';
+
+import "phoenix_html"
+// Establish Phoenix Socket and LiveView configuration.
+import {Socket} from "phoenix"
+import {LiveSocket} from "phoenix_live_view"
+import topbar from "../vendor/topbar"
+
+let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
+let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})
+
+// Show progress bar on live navigation and form submits
+topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
+window.addEventListener("phx:page-loading-start", _info => topbar.show(300))
+window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
+
+// connect if there are any LiveViews on the page
+liveSocket.connect()
+
+// expose liveSocket on window for web console debug logs and latency simulation:
+>> liveSocket.enableDebug()
+// >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session
+// >> liveSocket.disableLatencySim()
+window.liveSocket = liveSocket

--- a/lib/sanbase_web/components/layouts/app.html.heex
+++ b/lib/sanbase_web/components/layouts/app.html.heex
@@ -1,5 +1,4 @@
 <header class="px-4 sm:px-6 lg:px-8">
-
 </header>
 <main class="px-4 py-20 sm:px-6 lg:px-8">
   <div class="mx-auto max-w-2xl">

--- a/lib/sanbase_web/components/layouts/root.html.heex
+++ b/lib/sanbase_web/components/layouts/root.html.heex
@@ -4,15 +4,14 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content={get_csrf_token()} />
-    <.live_title>
-      <%= assigns[:page_title] || "Sanbase" %>
+    <.live_title suffix=" · Phoenix Framework">
+      <%= assigns[:page_title] || "Pento" %>
     </.live_title>
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
     </script>
   </head>
   <body class="bg-white antialiased">
-
     <%= @inner_content %>
   </body>
 </html>

--- a/lib/sanbase_web/controllers/custom_admin_controller.ex
+++ b/lib/sanbase_web/controllers/custom_admin_controller.ex
@@ -1,17 +1,16 @@
 defmodule SanbaseWeb.CustomAdminController do
   use SanbaseWeb, :controller
 
-  alias SanbaseWeb.Router.Helpers, as: Routes
-
   def index(conn, _params) do
     render(conn, "index.html",
       search_value: "",
       routes: [
-        {"Users", Routes.user_path(conn, :index)},
-        {"Webinars", Routes.webinar_path(conn, :index)},
-        {"Sheets templates", Routes.sheets_template_path(conn, :index)},
-        {"Reports", Routes.report_path(conn, :index)},
-        {"Custom plans", Routes.custom_plan_path(conn, :index)}
+        {"Users", ~p"/admin2/users"},
+        {"Webinars", ~p"/admin2/webinars"},
+        {"Sheets templates", ~p"/admin2/sheets_templates/"},
+        {"Reports", ~p"/admin2/reports"},
+        {"Custom plans", ~p"/admin2/custom_plans"},
+        {"Monitored Twitter Handles", ~p"/admin2/monitored_twitter_handle_live"}
       ]
     )
   end

--- a/lib/sanbase_web/graphql/schema/types/monitored_twitter_handle_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/monitored_twitter_handle_types.ex
@@ -6,6 +6,11 @@ defmodule SanbaseWeb.Graphql.MonitoredTwitterHandleTypes do
     field(:notes, :string)
     field(:status, :string)
 
+    @desc ~s"""
+    Comment submitted by a moderator when approving or declining a handle.
+    """
+    field(:comment, :string)
+
     field(:inserted_at, non_null(:datetime))
     field(:updated_at, non_null(:datetime))
   end

--- a/lib/sanbase_web/live/monitored_twitter_handle/monitored_twitter_handle_live.ex
+++ b/lib/sanbase_web/live/monitored_twitter_handle/monitored_twitter_handle_live.ex
@@ -1,0 +1,96 @@
+defmodule SanbaseWeb.MonitoredTwitterHandleLive do
+  use SanbaseWeb, :live_view
+
+  alias Sanbase.MonitoredTwitterHandle
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <div class="flex-1 p:2 sm:p-6 justify-between flex flex-col-reverse scrolling-auto">
+        <.table id="monitored_twitter_handles" rows={@handles}>
+          <:col :let={row} label="Twitter Handle"><%= row.handle %></:col>
+          <:col :let={row} label="Status"><%= row.status %></:col>
+          <:col :let={row} label="Notes"><%= row.notes %></:col>
+          <:col :let={row} label="Moderator comment"><%= row.comment %></:col>
+          <:action :let={row}>
+            <.form :let={f} for={@form} phx-submit="update_status">
+              <.input type="text" field={@form[:comment]} placeholder="Comment..." />
+              <input type="hidden" name="record_id" value={row.id} />
+              <.button name="status" value="approved">Approve</.button>
+              <.button name="status" value="declined">Decline</.button>
+            </.form>
+          </:action>
+        </.table>
+      </div>
+    </div>
+    """
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:handles, list_handles())
+     |> assign(:form, to_form(%{}))}
+  end
+
+  def handle_event(
+        "update_status",
+        %{"status" => status, "record_id" => record_id} = params,
+        socket
+      )
+      when status in ["approved", "declined"] do
+    record_id = String.to_integer(record_id)
+    comment = if params["comment"] == "", do: nil, else: params["comment"]
+    MonitoredTwitterHandle.update_status(record_id, status, comment)
+    handles = update_assigns_handle(socket.assigns.handles, record_id, status, comment)
+
+    {:noreply, assign(socket, :handles, handles)}
+  end
+
+  defp update_assigns_handle(handles, record_id, status, comment \\ nil) do
+    handles
+    |> Enum.map(fn
+      %{id: ^record_id} = record ->
+        comment = comment || record.comment
+
+        record
+        |> Map.put(:status, status)
+        |> Map.put(:comment, comment)
+
+      record ->
+        record
+    end)
+    |> order_records()
+  end
+
+  defp list_handles() do
+    Sanbase.MonitoredTwitterHandle.list_all_submissions()
+    |> Enum.map(fn struct ->
+      %{
+        id: struct.id,
+        status: struct.status,
+        handle: struct.handle,
+        notes: struct.notes,
+        comment: struct.comment,
+        inserted_at: struct.inserted_at
+      }
+    end)
+    |> order_records()
+  end
+
+  defp order_records(handles) do
+    handles
+    |> Enum.sort_by(
+      fn record ->
+        case record.status do
+          "pending_approval" -> 1
+          "approved" -> 2
+          "declined" -> 3
+        end
+      end,
+      :asc
+    )
+  end
+end

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -10,6 +10,7 @@ defmodule SanbaseWeb.Router do
     plug(:accepts, ["html"])
     plug(:fetch_session)
     plug(:fetch_live_flash)
+    plug(:put_root_layout, {SanbaseWeb.Layouts, :root})
     plug(:protect_from_forgery)
     plug(:put_secure_browser_headers)
   end
@@ -57,6 +58,7 @@ defmodule SanbaseWeb.Router do
     import Phoenix.LiveDashboard.Router
 
     live_dashboard("/dashboard", metrics: SanbaseWeb.Telemetry, ecto_repos: [Sanbase.Repo])
+    live("/monitored_twitter_handle_live", MonitoredTwitterHandleLive)
 
     post("/users", UserController, :search)
 

--- a/lib/sanbase_web/sanbase_web.ex
+++ b/lib/sanbase_web/sanbase_web.ex
@@ -55,7 +55,7 @@ defmodule SanbaseWeb do
   def live_view do
     quote do
       use Phoenix.LiveView,
-        layout: {PentoWeb.Layouts, :app}
+        layout: {SanbaseWeb.Layouts, :app}
 
       unquote(html_helpers())
     end

--- a/priv/repo/migrations/20231101104145_extend_monitored_twitter_handles_table.exs
+++ b/priv/repo/migrations/20231101104145_extend_monitored_twitter_handles_table.exs
@@ -1,0 +1,9 @@
+defmodule Sanbase.Repo.Migrations.ExtendMonitoredTwitterHandlesTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:monitored_twitter_handles) do
+      add(:comment, :text)
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2048,7 +2048,8 @@ CREATE TABLE public.monitored_twitter_handles (
     user_id bigint,
     inserted_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    status character varying(255) DEFAULT 'pending_approval'::character varying
+    status character varying(255) DEFAULT 'pending_approval'::character varying,
+    comment text
 );
 
 
@@ -8924,3 +8925,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20231012130814);
 INSERT INTO public."schema_migrations" (version) VALUES (20231019111320);
 INSERT INTO public."schema_migrations" (version) VALUES (20231023123140);
 INSERT INTO public."schema_migrations" (version) VALUES (20231026084628);
+INSERT INTO public."schema_migrations" (version) VALUES (20231101104145);


### PR DESCRIPTION
## Changes

Add a dashboard (behind VPN on `/admin2/monitored_twitter_handle_live`) that will allow you to approve/decline twitter handles.

The twitter handles are sorted by first showing the ones with `pending_approval` status, then `approved` and then `declined`
<img width="671" alt="image" src="https://github.com/santiment/sanbase2/assets/6518376/97704ef7-5545-4a20-87dc-b22543745225">
https://www.loom.com/share/74310e914f974bc68106c388616e710e
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
