### PR TITLE
Rework twitter dashboard buttons to not use dynamic class names

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -18,6 +18,7 @@ module.exports = {
       }
     },
   },
+  safelist: [ ],
   plugins: [
     require("@tailwindcss/forms"),
     // Allows prefixing tailwind classes with LiveView classes to add rules

--- a/lib/sanbase_web/live/monitored_twitter_handle/monitored_twitter_handle_live.ex
+++ b/lib/sanbase_web/live/monitored_twitter_handle/monitored_twitter_handle_live.ex
@@ -28,16 +28,16 @@ defmodule SanbaseWeb.MonitoredTwitterHandleLive do
             <.form for={@form} phx-submit="update_status">
               <.input type="text" class="" field={@form[:comment]} placeholder="Comment..." />
               <input type="hidden" name="record_id" value={row.id} />
-              <SanbaseWeb.MonitoredTwitterHandleLive.bbutton
+              <SanbaseWeb.MonitoredTwitterHandleLive.update_status_button
                 name="status"
                 value="approved"
-                color="green"
+                class="bg-green-600 hover:bg-green-800"
                 display_text="Approve"
               />
-              <SanbaseWeb.MonitoredTwitterHandleLive.bbutton
+              <SanbaseWeb.MonitoredTwitterHandleLive.update_status_button
                 name="status"
                 value="declined"
-                color="red"
+                class="bg-red-600 hover:bg-red-800"
                 display_text="Decline"
               />
             </.form>
@@ -48,17 +48,18 @@ defmodule SanbaseWeb.MonitoredTwitterHandleLive do
     """
   end
 
-  def bbutton(assigns) do
+  def update_status_button(assigns) do
     ~H"""
-    <.button
+    <button
       name={@name}
       value={@value}
-      class={"my-1 focus:outline-none text-white bg-#{@color}-700 hover:bg-#{@color}-800 focus:ring-4 focus:ring-#{@color}-300
-              font-medium rounded-lg text-sm px-5 py-2.5 mr-2 mb-2 dark:bg-#{@color}-600 dark:hover:bg-#{@color}-700
-              dark:focus:ring-#{@color}-800"}
+      class={[
+        "phx-submit-loading:opacity-75 rounded-lg my-1 py-2 px-3 text-sm font-semibold leading-6 text-white",
+        @class
+      ]}
     >
       <%= @display_text %>
-    </.button>
+    </button>
     """
   end
 


### PR DESCRIPTION
## Changes
Do not use classes like `bg-#{@color}-600` but instead provide the full class name as argument: `bg-red-600` and `bg-green-600`. Otherise Tailwind will purge these classes and they won't be included in the `app.css` file.

<img width="1299" alt="image" src="https://github.com/santiment/sanbase2/assets/6518376/48f2bbc6-9626-436f-b109-f9f8eb356132">

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
