### PR TITLE
Add funding rate aggregated metrics to API

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -4093,5 +4093,56 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Funding Rates Aggregated by Exchange",
+    "name": "funding_rates_aggregated_by_exchange",
+    "metric": "funding_rates_aggregated_per_exchange",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug", "owner", "label"],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_label_based_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Funding Rates Aggregated by Settlement Currency",
+    "name": "funding_rates_aggregated_by_settlement_currency",
+    "metric": "funding_rates_aggregated_per_settlement_currency",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug", "owner", "label"],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_label_based_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
+  },
+  {
+    "human_readable_name": "Total Funding Rates Aggregated by Asset",
+    "name": "total_funding_rates_aggregated_per_asset",
+    "metric": "total_funding_rates_aggregated_per_asset",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": ["slug"],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries"
   }
 ]

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -728,6 +728,9 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "exchange_open_interest",
         "open_interest_per_settlement_currency",
         "total_open_interest",
+        "funding_rates_aggregated_by_exchange",
+        "funding_rates_aggregated_by_settlement_currency",
+        "total_funding_rates_aggregated_per_asset",
         # social metrics
         "community_messages_count_telegram",
         "community_messages_count_total",


### PR DESCRIPTION
## Changes
Adding 3 new metrics to API:
- funding_rates_aggregated_by_exchange
- funding_rates_aggregated_by_settlement_currency
- total_funding_rates_aggregated_per_asset
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
