### PR TITLE
Fix issue with remove_query_from_dashboard transaction

### DIFF
--- a/lib/sanbase/queries/dashboards.ex
+++ b/lib/sanbase/queries/dashboards.ex
@@ -717,7 +717,7 @@ defmodule Sanbase.Dashboards do
     |> Ecto.Multi.run(:remove_dashboard_query_mapping, fn _repo, %{get_mapping: struct} ->
       Repo.delete(struct)
     end)
-    |> Ecto.Multi.run(:add_preloads, fn _repo, %{add_query_to_dashboard: struct} ->
+    |> Ecto.Multi.run(:add_preloads, fn _repo, %{remove_dashboard_query_mapping: struct} ->
       # Do not preload the dashboard as it will be added in the next step
       {:ok, Repo.preload(struct, [:query])}
     end)

--- a/lib/sanbase/run_examples.ex
+++ b/lib/sanbase/run_examples.ex
@@ -713,6 +713,11 @@ defmodule Sanbase.RunExamples do
 
     {:ok, mapping} = Sanbase.Dashboards.add_query_to_dashboard(dashboard.id, query.id, user.id)
 
+    # Add and remove the mapping to test the removal
+    {:ok, mapping2} = Sanbase.Dashboards.add_query_to_dashboard(dashboard.id, query.id, user.id)
+
+    {:ok, _} = Sanbase.Dashboards.remove_query_from_dashboard(dashboard.id, mapping2.id, user.id)
+
     {:ok, q} = Sanbase.Queries.get_dashboard_query(dashboard.id, mapping.id, user.id)
 
     query_metadata = Sanbase.Queries.QueryMetadata.from_local_dev(user.id)


### PR DESCRIPTION
## Changes

- Fix the error on `deleteDashboardQuery` -- the issue is that the wrong key was looked up during the Ecto.Multi stages;
- Add tests for this fix;
- Reduce the test run speed for queries API from ~28 seconds to ~3 seconds.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
