### PR TITLE
Add dashboard url first promoter

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/promoter_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/promoter_resolver.ex
@@ -19,6 +19,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.PromoterResolver do
 
   # Note: Adding new field to extract should be also reflected by adding it in promoter_types.ex
   defp extract_and_atomize_needed_fields({:ok, promoter}) do
+    auth_token = promoter["auth_token"]
+
     promoter =
       promoter
       |> Map.take([
@@ -46,6 +48,13 @@ defmodule SanbaseWeb.Graphql.Resolvers.PromoterResolver do
         end)
       end)
       |> Sanbase.MapUtils.atomize_keys()
+
+    promoter =
+      promoter
+      |> Map.put(
+        :dashboard_url,
+        "https://santiment.firstpromoter.com/view_dashboard_as?at=#{auth_token}"
+      )
 
     {:ok, promoter}
   end

--- a/lib/sanbase_web/graphql/schema/types/promoter_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/promoter_types.ex
@@ -7,6 +7,7 @@ defmodule SanbaseWeb.Graphql.Schema.PromoterTypes do
     field(:current_balance, :integer)
     field(:paid_balance, :integer)
     field(:promotions, list_of(:promotion))
+    field(:dashboard_url, :string)
   end
 
   object :promotion do

--- a/test/sanbase_web/graphql/promoter/promoter_api_test.exs
+++ b/test/sanbase_web/graphql/promoter/promoter_api_test.exs
@@ -58,6 +58,10 @@ defmodule SanbaseWeb.Graphql.PromoterApiTest do
         promotion = promoter["promotions"] |> hd
 
         assert promoter["email"] == resp["email"]
+
+        assert promoter["dashboardUrl"] ==
+                 "https://santiment.firstpromoter.com/view_dashboard_as?at=#{resp["auth_token"]}"
+
         assert promotion["visitorsCount"] == resp["promotions"] |> hd |> Map.get("visitors_count")
       end)
     end
@@ -86,6 +90,7 @@ defmodule SanbaseWeb.Graphql.PromoterApiTest do
         currentBalance
         earningsBalance
         paidBalance
+        dashboardUrl
         promotions {
           refId
           referralLink
@@ -112,6 +117,7 @@ defmodule SanbaseWeb.Graphql.PromoterApiTest do
         currentBalance
         earningsBalance
         paidBalance
+        dashboardUrl
         promotions {
           refId
           referralLink


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Added `dashboardUrl` to `createPromoter` and `showPromoter`.

```
     {
      showPromoter {
        email
        currentBalance
        earningsBalance
        paidBalance
        dashboardUrl
        promotions {
          refId
          referralLink
          promoCode
          visitorsCount
          leadsCount
          salesCount
          customersCount
          refundsCount
          cancellationsCount
          salesTotal
          refundsTotal
        }
      }
    }
```


## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
