### PR TITLE
Add is_deprecated and hard_deprecate_after to get_access_restrictions

### DIFF
--- a/lib/sanbase_web/graphql/schema/types/user_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_types.ex
@@ -296,6 +296,8 @@ defmodule SanbaseWeb.Graphql.UserTypes do
     field(:is_accessible, non_null(:boolean))
     field(:restricted_from, :datetime)
     field(:restricted_to, :datetime)
+    field(:is_deprecated, non_null(:boolean))
+    field(:hard_deprecate_after, :datetime)
   end
 
   object :api_call_data do

--- a/test/sanbase_web/graphql/access_restrictions_test.exs
+++ b/test/sanbase_web/graphql/access_restrictions_test.exs
@@ -11,6 +11,19 @@ defmodule SanbaseWeb.Graphql.AccessRestrictionsTest do
     [user: user, conn: conn]
   end
 
+  test "deprecated metrics", %{conn: conn} do
+    get_access_restrictions(conn)
+    |> Enum.each(fn restriction ->
+      assert is_boolean(restriction["isDeprecated"]) == true
+
+      if not is_nil(restriction["hardDeprecateAfter"]) do
+        assert restriction["isDeprecated"] == true
+
+        assert {:ok, %DateTime{}, _} = DateTime.from_iso8601(restriction["hardDeprecateAfter"])
+      end
+    end)
+  end
+
   test "free sanbase user", %{conn: conn} do
     days_ago = Timex.shift(Timex.now(), days: -29)
     over_two_years_ago = Timex.shift(Timex.now(), days: -(2 * 365 + 1))
@@ -65,10 +78,13 @@ defmodule SanbaseWeb.Graphql.AccessRestrictionsTest do
       getAccessRestrictions{
         type
         name
+        minInterval
         internalName
         isRestricted
         restrictedFrom
         restrictedTo
+        isDeprecated
+        hardDeprecateAfter
       }
     }
     """


### PR DESCRIPTION
## Changes

Add `isDeprecated` and `hardDeprecateAfter` to the `getAccessRestrictions` API.

```graphql
{
  getAccessRestrictions{
    name
    type
    isDeprecated
    hardDeprecateAfter
  }
}
```
```json
// ...
{
  "hardDeprecateAfter": "2024-01-10T00:00:00Z",
  "isDeprecated": true,
  "name": "whales_to_exchanges_flow",
  "type": "metric"
}
// ...
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
