### PR TITLE
Add current_user info about queries executions and limits

### DIFF
--- a/lib/sanbase/queries/authorization.ex
+++ b/lib/sanbase/queries/authorization.ex
@@ -17,6 +17,29 @@ defmodule Sanbase.Queries.Authorization do
     end
   end
 
+  def query_executions_limit(product_code, plan_name) do
+    case {product_code, plan_name} do
+      {_, "FREE"} -> %{minute: 1, hour: 5, day: 10}
+      {"SANBASE", "PRO"} -> %{minute: 10, hour: 100, day: 500}
+      {"SANAPI", "BASIC"} -> %{minute: 20, hour: 200, day: 1000}
+      {"SANAPI", "PRO"} -> %{minute: 50, hour: 600, day: 3000}
+      {"SANAPI", "CUSTOM"} -> %{minute: 200, hour: 1000, day: 5000}
+      {"SANAPI", "CUSTOM_" <> _} -> %{minute: 200, hour: 1000, day: 5000}
+    end
+  end
+
+  def credits_limit(product_code, plan_name) do
+    case {product_code, plan_name} do
+      {_, "FREE"} -> 5_000
+      {"SANBASE", "PRO"} -> 1_000_000
+      {"SANAPI", "BASIC"} -> 2_000_000
+      {"SANAPI", "PRO"} -> 5_000_000
+      {"SANAPI", "CUSTOM"} -> 20_000_000
+      # This needs to be updated so its taken from the plan definition
+      {"SANAPI", "CUSTOM_" <> _} -> 20_000_000
+    end
+  end
+
   # Private functions
 
   defp check_user_limits(user_id, product_code, plan_name) do
@@ -54,29 +77,6 @@ defmodule Sanbase.Queries.Authorization do
       false
     else
       true
-    end
-  end
-
-  defp query_executions_limit(product_code, plan_name) do
-    case {product_code, plan_name} do
-      {_, "FREE"} -> %{minute: 1, hour: 5, day: 10}
-      {"SANBASE", "PRO"} -> %{minute: 10, hour: 100, day: 500}
-      {"SANAPI", "BASIC"} -> %{minute: 20, hour: 200, day: 1000}
-      {"SANAPI", "PRO"} -> %{minute: 50, hour: 600, day: 3000}
-      {"SANAPI", "CUSTOM"} -> %{minute: 200, hour: 1000, day: 5000}
-      {"SANAPI", "CUSTOM_" <> _} -> %{minute: 200, hour: 1000, day: 5000}
-    end
-  end
-
-  defp credits_limit(product_code, plan_name) do
-    case {product_code, plan_name} do
-      {_, "FREE"} -> 5_000
-      {"SANBASE", "PRO"} -> 1_000_000
-      {"SANAPI", "BASIC"} -> 2_000_000
-      {"SANAPI", "PRO"} -> 5_000_000
-      {"SANAPI", "CUSTOM"} -> 20_000_000
-      # This needs to be updated so its taken from the plan definition
-      {"SANAPI", "CUSTOM_" <> _} -> 20_000_000
     end
   end
 end

--- a/lib/sanbase/queries/queries.ex
+++ b/lib/sanbase/queries/queries.ex
@@ -309,13 +309,13 @@ defmodule Sanbase.Queries do
         [
           store_execution_details:
             Application.get_env(
-              :__sanbase_queires__,
-              :store_execution_details,
+              :__sanbase_queries__,
+              :__store_execution_details__,
               Keyword.get(opts, :store_execution_details, true)
             ),
           wait_fetching_details_ms:
             Application.get_env(
-              :__sanbase_queires__,
+              :__sanbase_queries__,
               :__wait_fetching_details_ms_,
               Keyword.get(opts, :wait_fetching_details_ms, 7500)
             )

--- a/lib/sanbase/queries/query/query_execution.ex
+++ b/lib/sanbase/queries/query/query_execution.ex
@@ -114,7 +114,9 @@ defmodule Sanbase.Queries.QueryExecution do
         queries_executed_hour:
           fragment("COUNT(CASE WHEN inserted_at >= ? THEN 1 ELSE NULL END)", ^beginning_of_hour),
         queries_executed_day:
-          fragment("COUNT(CASE WHEN inserted_at >= ? THEN 1 ELSE NULL END)", ^beginning_of_day)
+          fragment("COUNT(CASE WHEN inserted_at >= ? THEN 1 ELSE NULL END)", ^beginning_of_day),
+        queries_executed_month:
+          fragment("COUNT(CASE WHEN inserted_at >= ? THEN 1 ELSE NULL END)", ^beginning_of_month)
       }
     )
   end

--- a/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
@@ -145,6 +145,33 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserResolver do
     {:ok, %{count: length(followers), users: followers}}
   end
 
+  def queries_executions_info(_root, _args, %{context: %{auth: %{current_user: user}} = context}) do
+    product_code = context.product_code
+    plan_name = context.auth.plan
+
+    with {:ok, details} <- Sanbase.Queries.user_executions_summary(user.id) do
+      credits_limit = Sanbase.Queries.Authorization.credits_limit(product_code, plan_name)
+
+      executions_limit =
+        Sanbase.Queries.Authorization.query_executions_limit(product_code, plan_name)
+
+      result = %{
+        credits_availalbe_month: credits_limit,
+        credits_spent_month: details.monthly_credits_spent,
+        credits_remaining_month: credits_limit - details.monthly_credits_spent,
+        queries_executed_month: details.queries_executed_month,
+        queries_executed_day: details.queries_executed_day,
+        queries_executed_hour: details.queries_executed_hour,
+        queries_executed_minute: details.queries_executed_minute,
+        queries_executed_day_limit: executions_limit.day,
+        queries_executed_hour_limit: executions_limit.hour,
+        queries_executed_minute_limit: executions_limit.minute
+      }
+
+      {:ok, result}
+    end
+  end
+
   def change_name(_root, %{name: new_name}, %{context: %{auth: %{current_user: user}}}) do
     case User.change_name(user, new_name) do
       {:ok, user} ->

--- a/lib/sanbase_web/graphql/schema/types/user_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_types.ex
@@ -102,6 +102,19 @@ defmodule SanbaseWeb.Graphql.UserTypes do
     field(:data, :json)
   end
 
+  object :queries_executions_info do
+    field(:credits_availalbe_month, non_null(:integer))
+    field(:credits_spent_month, non_null(:integer))
+    field(:credits_remaining_month, non_null(:integer))
+    field(:queries_executed_month, non_null(:integer))
+    field(:queries_executed_day, non_null(:integer))
+    field(:queries_executed_hour, non_null(:integer))
+    field(:queries_executed_minute, non_null(:integer))
+    field(:queries_executed_day_limit, non_null(:integer))
+    field(:queries_executed_hour_limit, non_null(:integer))
+    field(:queries_executed_minute_limit, non_null(:integer))
+  end
+
   object :user do
     field(:id, non_null(:id))
     field(:email, :string)
@@ -115,6 +128,10 @@ defmodule SanbaseWeb.Graphql.UserTypes do
     field(:stripe_customer_id, :string)
     field(:inserted_at, non_null(:datetime))
     field(:updated_at, non_null(:datetime))
+
+    field :queries_executions_info, :queries_executions_info do
+      resolve(&UserResolver.queries_executions_info/3)
+    end
 
     field :promo_codes, list_of(:user_promo_code) do
       resolve(&UserResolver.user_promo_codes/3)

--- a/test/sanbase/queries/queries_test.exs
+++ b/test/sanbase/queries/queries_test.exs
@@ -1,5 +1,5 @@
 defmodule Sanbase.QueriesTest do
-  use SanbaseWeb.ConnCase, async: true
+  use SanbaseWeb.ConnCase, async: false
 
   import Sanbase.Factory
   import Mock, only: [assert_called: 1]

--- a/test/sanbase_web/graphql/queries/queries_api_test.exs
+++ b/test/sanbase_web/graphql/queries/queries_api_test.exs
@@ -458,8 +458,9 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
   describe "Run Queries" do
     test "run raw sql query", context do
       # In test env the storing runs not async and there's a 7500ms sleep
-      Application.put_env(:__sanbase_queires__, :store_execution_details, false)
-      on_exit(fn -> Application.delete_env(:__sanbase_queires__, :store_execution_details) end)
+      Application.put_env(:__sanbase_queries__, :__store_execution_details__, false)
+
+      on_exit(fn -> Application.delete_env(:__sanbase_queries__, :__store_execution_details__) end)
 
       mock_fun =
         Sanbase.Mock.wrap_consecutives(
@@ -503,8 +504,9 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
 
     test "run sql query by id", context do
       # In test env the storing runs not async and there's a 7500ms sleep
-      Application.put_env(:__sanbase_queires__, :store_execution_details, false)
-      on_exit(fn -> Application.delete_env(:__sanbase_queires__, :store_execution_details) end)
+      Application.put_env(:__sanbase_queries__, :__store_execution_details__, false)
+
+      on_exit(fn -> Application.delete_env(:__sanbase_queries__, :__store_execution_details__) end)
 
       {:ok, query} = create_query(context.user.id)
 
@@ -594,8 +596,9 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
 
     test "run dashboard query (resolve global params)", context do
       # In test env the storing runs not async and there's a 7500ms sleep
-      Application.put_env(:__sanbase_queires__, :store_execution_details, false)
-      on_exit(fn -> Application.delete_env(:__sanbase_queires__, :store_execution_details) end)
+      Application.put_env(:__sanbase_queries__, :__store_execution_details__, false)
+
+      on_exit(fn -> Application.delete_env(:__sanbase_queries__, :__store_execution_details__) end)
 
       {:ok, query} = create_query(context.user.id)
 
@@ -701,13 +704,87 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
                } = result
       end)
     end
+
+    test "get credits stats after run", context do
+      # In test env the storing runs not async and there's a 7500ms sleep, put it to 0
+      # we need to store it here so we can later retrieve the executions info
+      Application.put_env(:__sanbase_queries__, :__wait_fetching_details_ms_, 0)
+
+      on_exit(fn -> Application.delete_env(:__sanbase_queries__, :__wait_fetching_details_ms_) end)
+
+      mock_fun =
+        Sanbase.Mock.wrap_consecutives(
+          [
+            fn -> {:ok, mocked_clickhouse_result()} end,
+            fn -> {:ok, mocked_execution_details_result()} end
+          ],
+          arity: 2
+        )
+
+      Sanbase.Mock.prepare_mock(Sanbase.ClickhouseRepo, :query, mock_fun)
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        args = %{
+          sql_query_text: "SELECT * FROM intraday_metrics LIMIT {{limit}}",
+          sql_query_parameters: %{limit: 2}
+        }
+
+        run_sql_query(context.conn, :run_raw_sql_query, args)
+
+        stats =
+          get_current_user_credits_stats(context.conn)
+          |> get_in(["data", "currentUser", "queriesExecutionsInfo"])
+
+        assert stats == %{
+                 "creditsAvailalbeMonth" => 5000,
+                 "creditsRemainingMonth" => 4999,
+                 "creditsSpentMonth" => 1,
+                 "queriesExecutedDay" => 1,
+                 "queriesExecutedDayLimit" => 10,
+                 "queriesExecutedHour" => 1,
+                 "queriesExecutedHourLimit" => 5,
+                 "queriesExecutedMinute" => 1,
+                 "queriesExecutedMinuteLimit" => 1,
+                 "queriesExecutedMonth" => 1
+               }
+      end)
+    end
+
+    defp get_current_user_credits_stats(conn) do
+      conn
+      |> post(
+        "/graphql",
+        query_skeleton("""
+        {
+          currentUser {
+            queriesExecutionsInfo {
+              # credits info
+              creditsAvailalbeMonth
+              creditsSpentMonth
+              creditsRemainingMonth
+              # queries executed
+              queriesExecutedMonth
+              queriesExecutedDay
+              queriesExecutedHour
+              queriesExecutedMinute
+              # queries executions limits
+              queriesExecutedDayLimit
+              queriesExecutedHourLimit
+              queriesExecutedMinuteLimit
+            }
+          }
+        }
+        """)
+      )
+      |> json_response(200)
+    end
   end
 
   describe "Caching" do
     test "cache queries on a dashboard", context do
       # In test env the storing runs not async and there's a 7500ms sleep
-      Application.put_env(:__sanbase_queires__, :store_execution_details, false)
-      on_exit(fn -> Application.delete_env(:__sanbase_queires__, :store_execution_details) end)
+      Application.put_env(:__sanbase_queries__, :__store_execution_details__, false)
+
+      on_exit(fn -> Application.delete_env(:__sanbase_queries__, :__store_execution_details__) end)
 
       {:ok, query} = Sanbase.Queries.create_query(%{name: "Query"}, context.user.id)
 


### PR DESCRIPTION
## Changes
```graphql
{
  currentUser {
    id
    queriesExecutionsInfo {
      # credits info
      creditsAvailalbeMonth
      creditsSpentMonth
      creditsRemainingMonth
      # queries executed
      queriesExecutedMonth
      queriesExecutedDay
      queriesExecutedHour
      queriesExecutedMinute
      # queries executions limits
      queriesExecutedDayLimit
      queriesExecutedHourLimit
      queriesExecutedMinuteLimit
    }
  }
}
```
```json
{
  "data": {
    "currentUser": {
      "id": "32",
      "queriesExecutionsInfo": {
        "creditsAvailalbeMonth": 5000,
        "creditsRemainingMonth": 4999,
        "creditsSpentMonth": 1,
        "queriesExecutedDay": 0,
        "queriesExecutedDayLimit": 10,
        "queriesExecutedHour": 0,
        "queriesExecutedHourLimit": 5,
        "queriesExecutedMinute": 0,
        "queriesExecutedMinuteLimit": 1,
        "queriesExecutedMonth": 1
      }
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
