### PR TITLE
Revert the trending words query to the old one + FINAL

### DIFF
--- a/lib/sanbase/social_data/trending_words.ex
+++ b/lib/sanbase/social_data/trending_words.ex
@@ -268,32 +268,28 @@ defmodule Sanbase.SocialData.TrendingWords do
       bb_sentiment_ratios
     FROM
     (
-        SELECT
-            #{to_unix_timestamp(interval, "dt", argument_name: "interval")} AS t,
-            dt,
-            max(dt) OVER (PARTITION BY t) AS last_dt_in_group,
-            argMax(word, computed_at) AS word,
-            argMax(project, computed_at) AS project,
-            argMax(score, computed_at) / {{score_equalizer}} AS score,
-            argMax(words_context, computed_at) AS context,
-            argMax(summary, computed_at) AS summary,
-            argMax(bullish_summary, computed_at) AS bullish_summary,
-            argMax(bearish_summary, computed_at) AS bearish_summary,
-            (argMax(positive_ratio, computed_at), argMax(neutral_ratio, computed_at), argMax(negative_ratio, computed_at)) AS sentiment_ratios,
-            (argMax(positive_bb_ratio, computed_at), argMax(neutral_bb_ratio, computed_at), argMax(negative_bb_ratio, computed_at)) AS bb_sentiment_ratios
-        FROM #{@table}
-        WHERE (dt >= toDateTime({{from}})) AND (dt < toDateTime({{to}})) AND (source = {{source}})
-        GROUP BY
-            t,
-            dt,
-            source,
-            docs_id
+      SELECT
+        #{to_unix_timestamp(interval, "dt", argument_name: "interval")} AS t,
+        dt,
+        max(dt) OVER (PARTITION BY t) AS last_dt_in_group,
+        word,
+        project,
+        score / {{score_equalizer}} AS score,
+        words_context AS context,
+        summary,
+        bullish_summary,
+        bearish_summary,
+        tuple(positive_ratio, neutral_ratio, negative_ratio) AS sentiment_ratios,
+        tuple(positive_bb_ratio, neutral_bb_ratio, negative_bb_ratio) AS bb_sentiment_ratios
+      FROM #{@table} FINAL
+      WHERE
+        dt >= toDateTime({{from}}) AND
+        dt < toDateTime({{to}}) AND
+        source = {{source}}
         #{word_type_filter_str(word_type_filter)}
     )
-    WHERE (dt = last_dt_in_group) AND (dt = t)
-    ORDER BY
-        t ASC,
-        score DESC
+    WHERE dt = last_dt_in_group
+    ORDER BY t, score DESC
     LIMIT {{limit}} BY t
     """
 
@@ -314,8 +310,8 @@ defmodule Sanbase.SocialData.TrendingWords do
   defp word_type_filter_str(word_type_filter) do
     case word_type_filter do
       :all -> ""
-      :project -> "HAVING project IS NOT NULL"
-      :non_project -> "HAVING project IS NULL"
+      :project -> "AND project IS NOT NULL"
+      :non_project -> "AND project IS NULL"
     end
   end
 


### PR DESCRIPTION
In the now reverted query there is a check like t = dt and t = last_dt_in_group. This is an issue because t is being computed as the beginning of the interval, so a check where t=last_dt_in_group would never yield the required result -- the data with last dt

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
