### PR TITLE
Report error when caching a query without all fields

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/queries_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/queries_resolver.ex
@@ -194,6 +194,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.QueriesResolver do
       ) do
     with {:ok, result_string} <- Result.decode_and_decompress(compressed_query_execution_result),
          {:ok, query_execution_result} <- Result.from_json_string(result_string),
+         true <- Result.all_fields_present?(query_execution_result),
          {:ok, dashboard_cache} <-
            Dashboards.store_dashboard_query_execution(
              dashboard_id,


### PR DESCRIPTION
## Changes
Provide a proper error when trying to store a dashboard query when not all of the fields are provided.
Before it resulted in Internal server error, now it returns a proper error:
```json
{
  "data": {
    "dashboard": null
  },
  "errors": [
    {
      "locations": [
        {
          "column": 5,
          "line": 2
        }
      ],
      "message": "The following result fields are not provided: columnTypes, columns, compressedRows, queryEndTime, queryStartTime, summary",
      "path": [
        "dashboard"
      ]
    }
  ]
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
