### PR TITLE
Add deleteDashboardGlobalParameterOverride mutation

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/queries_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/queries_resolver.ex
@@ -294,15 +294,15 @@ defmodule SanbaseWeb.Graphql.Resolvers.QueriesResolver do
         %{
           dashboard_id: dashboard_id,
           dashboard_query_mapping_id: mapping_id,
-          key: key
+          dashboard_parameter_key: dashboard_parameter_key
         },
         %{context: %{auth: %{current_user: user}}}
       ) do
-    Dashboards.add_global_parameter_override(
+    Dashboards.delete_global_parameter_override(
       dashboard_id,
       mapping_id,
       user.id,
-      key
+      dashboard_parameter_key: dashboard_parameter_key
     )
   end
 

--- a/lib/sanbase_web/graphql/schema/queries/queries_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/queries_queries.ex
@@ -650,6 +650,17 @@ defmodule SanbaseWeb.Graphql.Schema.QueriesQueries do
       resolve(&QueriesResolver.add_dashboard_global_parameter_override/3)
     end
 
+    field :delete_dashboard_global_parameter_override, :dashboard do
+      arg(:dashboard_id, non_null(:integer))
+      arg(:dashboard_query_mapping_id, non_null(:string))
+
+      arg(:dashboard_parameter_key, non_null(:string))
+
+      middleware(JWTAuth)
+
+      resolve(&QueriesResolver.delete_dashboard_global_parameter_override/3)
+    end
+
     field :add_dashboard_text_widget, :dashboard_text_widget_tuple do
       arg(:dashboard_id, non_null(:integer))
 

--- a/test/sanbase_web/graphql/queries/queries_api_test.exs
+++ b/test/sanbase_web/graphql/queries/queries_api_test.exs
@@ -642,16 +642,18 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
              }
 
       # Add global parameter override for a query local parameter
+      param_override_args = %{
+        dashboard_id: dashboard.id,
+        dashboard_query_mapping_id: mapping["id"],
+        dashboard_parameter_key: "slug",
+        query_parameter_key: "slug"
+      }
+
       override =
         execute_global_parameter_mutation(
           context.conn,
           :add_dashboard_global_parameter_override,
-          %{
-            dashboard_id: dashboard.id,
-            dashboard_query_mapping_id: mapping["id"],
-            dashboard_parameter_key: "slug",
-            query_parameter_key: "slug"
-          }
+          param_override_args
         )
         |> get_in(["data", "addDashboardGlobalParameterOverride"])
 
@@ -665,6 +667,28 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
                  }
                }
              }
+
+      # Delete global parameter override for a query local parameter
+      override =
+        execute_global_parameter_mutation(
+          context.conn,
+          :delete_dashboard_global_parameter_override,
+          param_override_args |> Map.delete(:query_parameter_key)
+        )
+        |> get_in(["data", "deleteDashboardGlobalParameterOverride"])
+
+      assert override == %{
+               "parameters" => %{
+                 "slug" => %{"overrides" => [], "value" => "santiment"}
+               }
+             }
+
+      # Add back the deleted param override
+      execute_global_parameter_mutation(
+        context.conn,
+        :add_dashboard_global_parameter_override,
+        param_override_args
+      )
 
       mock_fun =
         Sanbase.Mock.wrap_consecutives(


### PR DESCRIPTION
## Changes

We have `add` mutation for the global parameter override (use global instead of query local parameter), but we were missing the mutation for deleting such an override.

```graphql
mutation{ 
  deleteDashboardGlobalParameterOverride(
      dashboardId: 5,
      dashboardQueryMappingId: "the-string-id"
      dashboardParameterKey: "slug"){
         id
         parameters
      }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
