### PR TITLE
Rework Alert internals

### DIFF
--- a/lib/sanbase/alerts/alert.ex
+++ b/lib/sanbase/alerts/alert.ex
@@ -132,23 +132,23 @@ defimpl Sanbase.Alert, for: Any do
                }
              }
            }
-         } = trigger,
+         } = user_trigger,
          %{"telegram" => max_alerts_to_send}
        )
        when is_integer(telegram_chat_id) and telegram_chat_id > 0 do
     fun = fn _identifier, payload ->
-      payload = transform_payload(payload, trigger.id, :telegram)
+      payload = transform_payload(payload, user_trigger.id, :telegram)
 
-      response = Sanbase.Telegram.send_message(trigger.user, payload)
+      response = Sanbase.Telegram.send_message(user_trigger.user, payload)
 
       # Deactivate the alert if the message is sent to telegram, telegram
       # is the only channel and the telegram bot is blocked by the user.
       # The function returns :ok or {:error, reason} which is used in the
       # caller.
-      deactivate_alert_if_bot_blocked(response, trigger)
+      deactivate_alert_if_bot_blocked(response, user_trigger)
     end
 
-    send_or_limit("telegram", trigger, max_alerts_to_send, fun)
+    send_or_limit("telegram", user_trigger, max_alerts_to_send, fun)
   end
 
   defp send_telegram(
@@ -161,7 +161,7 @@ defimpl Sanbase.Alert, for: Any do
                }
              }
            }
-         } = trigger,
+         } = user_trigger,
          _max_alerts_to_send
        )
        when is_integer(telegram_chat_id) and telegram_chat_id > 0 do
@@ -171,7 +171,7 @@ defimpl Sanbase.Alert, for: Any do
       trigger: %{
         settings: %{payload: payload_map}
       }
-    } = trigger
+    } = user_trigger
 
     Enum.map(payload_map, fn {identifier, _payload} ->
       {identifier,
@@ -184,12 +184,12 @@ defimpl Sanbase.Alert, for: Any do
     end)
   end
 
-  defp send_telegram(trigger, _max_alerts_to_send) do
+  defp send_telegram(user_trigger, _max_alerts_to_send) do
     %{
       id: trigger_id,
       user: %User{id: user_id},
       trigger: %{settings: %{payload: payload_map}}
-    } = trigger
+    } = user_trigger
 
     Enum.map(payload_map, fn {identifier, _payload} ->
       {identifier, {:error, %{reason: :no_telegram, user_id: user_id, trigger_id: trigger_id}}}
@@ -197,26 +197,26 @@ defimpl Sanbase.Alert, for: Any do
   end
 
   defp send_telegram_channel(
-         trigger,
+         user_trigger,
          channel,
          %{"telegram_channel" => max_alerts_to_send}
        ) do
     fun = fn _identifier, payload ->
-      payload = transform_payload(payload, trigger.id, :telegram_channel)
-      {payload, opts} = maybe_extend_payload_telegram_channel(payload, trigger, channel)
+      payload = transform_payload(payload, user_trigger.id, :telegram_channel)
+      {payload, opts} = maybe_extend_payload_telegram_channel(payload, user_trigger, channel)
 
       response = Sanbase.Telegram.send_message_to_chat_id(channel, payload)
       # Send a reply to the original message, if it was delived successfuly
       # It contains the chat preview image.
-      maybe_send_preview_image_as_reply(response, trigger, channel, opts)
+      maybe_send_preview_image_as_reply(response, user_trigger, channel, opts)
       # Deactivate the alert if the message is sent to telegram, telegram
       # is the only channel and the telegram bot is blocked by the user.
       # The function returns :ok or {:error, reason} which is used in the
       # caller.
-      deactivate_alert_if_bot_blocked(response, trigger)
+      deactivate_alert_if_bot_blocked(response, user_trigger)
     end
 
-    send_or_limit("telegram_channel", trigger, max_alerts_to_send, fun)
+    send_or_limit("telegram_channel", user_trigger, max_alerts_to_send, fun)
   end
 
   # For daily and intraday metric signals add preview image of the chart for metric + asset
@@ -237,15 +237,15 @@ defimpl Sanbase.Alert, for: Any do
 
   defp maybe_send_preview_image_as_reply(_, _, _, _), do: :ok
 
-  defp deactivate_alert_if_bot_blocked({:error, error}, trigger) do
+  defp deactivate_alert_if_bot_blocked({:error, error}, user_trigger) do
     case String.contains?(error, "blocked the telegram bot") do
       true ->
-        # In case the trigger does not have other channels but only telegram
+        # In case the user_trigger does not have other channels but only telegram
         # and the user has blocked our telegram bot, the alert is disabled
         # so it does not spend resources running
-        deactivate_if_telegram_channel_only(trigger)
+        deactivate_if_telegram_channel_only(user_trigger)
 
-        %{user: %User{id: user_id}, trigger: %{id: trigger_id}} = trigger
+        %{user: %User{id: user_id}, trigger: %{id: trigger_id}} = user_trigger
         {:error, %{reason: :telegram_bot_blocked, user_id: user_id, trigger_id: trigger_id}}
 
       false ->
@@ -278,12 +278,12 @@ defimpl Sanbase.Alert, for: Any do
     end
   end
 
-  defp deactivate_if_telegram_channel_only(trigger) do
-    case trigger do
+  defp deactivate_if_telegram_channel_only(user_trigger) do
+    case user_trigger do
       %{trigger: %{settings: %{channel: channel}}} when channel in ["telegram", ["telegram"]] ->
-        Logger.info("Deactivating user trigger with id #{trigger.id} because the user \
-        with id #{trigger.user.id} has blocked the telegram bot.")
-        Sanbase.Alert.UserTrigger.update_is_active(trigger.id, trigger.user, false)
+        Logger.info("Deactivating user trigger with id #{user_trigger.id} because the user \
+        with id #{user_trigger.user.id} has blocked the telegram bot.")
+        Sanbase.Alert.UserTrigger.update_is_active(user_trigger.id, user_trigger.user_id, false)
 
       _ ->
         :ok

--- a/lib/sanbase/alerts/alert_event_emitter.ex
+++ b/lib/sanbase/alerts/alert_event_emitter.ex
@@ -4,7 +4,7 @@ defmodule Sanbase.Alert.EventEmitter do
   @topic :alert_events
   def topic(), do: @topic
 
-  def handle_event({:error, _}, _), do: :ok
+  def handle_event({:error, _}, _even_type, _args), do: :ok
 
   def handle_event({:ok, alert}, event_type, _args)
       when event_type in [:create_alert, :delete_alert] do

--- a/lib/sanbase/alerts/evaluator/evaluator.ex
+++ b/lib/sanbase/alerts/evaluator/evaluator.ex
@@ -54,7 +54,7 @@ defmodule Sanbase.Alert.Evaluator do
         |> emit_event(Trigger.triggered?(evaluated_trigger), :alert_triggered)
 
       {:error, {:disable_alert, reason}} ->
-        Logger.info("Disable alert with id #{user_trigger.id}. Reason: #{inspect(reason)}")
+        Logger.info("Auto disable alert with id #{user_trigger.id}. Reason: #{inspect(reason)}")
 
         _ = UserTrigger.update_is_active(user_trigger.id, user_trigger.user_id, false)
 

--- a/lib/sanbase/alerts/evaluator/scheduler.ex
+++ b/lib/sanbase/alerts/evaluator/scheduler.ex
@@ -268,7 +268,7 @@ defmodule Sanbase.Alert.Scheduler do
   defp deactivate_non_repeating(triggers) do
     for %UserTrigger{id: ut_id, user: user, trigger: %{is_repeating: false}} <-
           triggers do
-      UserTrigger.update_is_active(ut_id, user, false)
+      UserTrigger.update_is_active(ut_id, user.id, false)
     end
   end
 

--- a/lib/sanbase/alerts/evaluator/scheduler.ex
+++ b/lib/sanbase/alerts/evaluator/scheduler.ex
@@ -134,6 +134,8 @@ defmodule Sanbase.Alert.Scheduler do
     [#{info_map.run_uuid}] There are no active alerts of type #{info_map.type} \
     to be run.
     """)
+
+    []
   end
 
   defp run_batches(trigger_batches, info_map) do
@@ -215,10 +217,12 @@ defmodule Sanbase.Alert.Scheduler do
     total_count = length(user_triggers)
     frozen_count = total_count - length(filtered)
 
-    Logger.info("""
-    [#{run_uuid}] In total #{frozen_count}/#{total_count} active receivable alerts of type \
-    #{type} are frozen and won't be processed.
-    """)
+    if frozen_count > 0 do
+      Logger.info("""
+      [#{run_uuid}] In total #{frozen_count}/#{total_count} active receivable alerts of type \
+      #{type} are frozen and won't be processed.
+      """)
+    end
 
     filtered
   end
@@ -255,12 +259,14 @@ defmodule Sanbase.Alert.Scheduler do
     total_count = length(user_triggers)
     disabled_count = total_count - length(filtered)
 
-    Logger.info("""
-    [#{run_uuid}] In total #{disabled_count}/#{total_count} active alerts of type \
-    #{type} are not being computed because they cannot be sent. The owners of \
-    these alerts have disabled the notification channels or has no telegram/email \
-    linked to their account.
-    """)
+    if disabled_count > 0 do
+      Logger.info("""
+      [#{run_uuid}] In total #{disabled_count}/#{total_count} active alerts of type \
+      #{type} are not being computed because they cannot be sent. The owners of \
+      these alerts have disabled the notification channels or has no telegram/email \
+      linked to their account.
+      """)
+    end
 
     filtered
   end

--- a/lib/sanbase/alerts/trigger/settings/behaviour.ex
+++ b/lib/sanbase/alerts/trigger/settings/behaviour.ex
@@ -3,6 +3,6 @@ defmodule Sanbase.Alert.Trigger.Settings.Behaviour do
   @type type :: String.t()
 
   @callback type() :: type()
-  @callback post_create_process(Trigger.t()) :: :nochange | Trigger.t()
-  @callback post_update_process(Trigger.t()) :: :nochange | Trigger.t()
+  @callback post_create_process(Trigger.t()) :: :nochange | {:ok, Trigger.t()} | {:error, any()}
+  @callback post_update_process(Trigger.t()) :: :nochange | {:ok, Trigger.t()} | {:error, any()}
 end

--- a/lib/sanbase/alerts/trigger/settings/metric/metric_trigger_helper.ex
+++ b/lib/sanbase/alerts/trigger/settings/metric/metric_trigger_helper.ex
@@ -117,7 +117,7 @@ defmodule Sanbase.Alert.Trigger.MetricTriggerHelper do
   end
 
   defp handle_fetch_metric_error(error_msg, metric, selector) when is_binary(error_msg) do
-    if error_msg =~ "not supported or is mistyped" do
+    if error_msg =~ "not supported, is deprecated or is mistyped" do
       {:error, {:disable_alert, error_msg}}
     else
       {:error, "Cannot fetch #{metric} for #{inspect(selector)}. Reason: #{error_msg}"}

--- a/lib/sanbase/alerts/trigger/settings/metric/metric_trigger_helper.ex
+++ b/lib/sanbase/alerts/trigger/settings/metric/metric_trigger_helper.ex
@@ -33,26 +33,32 @@ defmodule Sanbase.Alert.Trigger.MetricTriggerHelper do
 
   def evaluate(%{} = settings, _trigger) do
     case get_data(settings) do
-      data when is_list(data) and data != [] ->
+      {:ok, data} when is_list(data) and data != [] ->
         build_result(data, settings)
 
       _ ->
-        %{settings | triggered?: false}
+        # TODO: Handle the error case
+        {:ok, %{settings | triggered?: false}}
     end
   end
 
   def get_data(%{} = settings) do
     %{filtered_target: %{list: target_list, type: type}} = settings
 
-    target_list
-    |> Enum.map(fn identifier ->
-      {identifier, fetch_metric(%{type => identifier}, settings)}
-    end)
-    |> Enum.reject(fn
-      {_, {:error, _}} -> true
-      {_, nil} -> true
-      _ -> false
-    end)
+    data =
+      target_list
+      |> Enum.map(fn identifier ->
+        {identifier, fetch_metric(%{type => identifier}, settings)}
+      end)
+      |> Enum.reject(fn
+        {_, {:error, _}} -> true
+        {_, nil} -> true
+        _ -> false
+      end)
+
+    # TODO: Return error on mistyped/no longer supported metric
+    # in order to disable the alert
+    {:ok, data}
   end
 
   # Private functions

--- a/lib/sanbase/alerts/trigger/settings/screener_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/screener_trigger_settings.ex
@@ -60,26 +60,36 @@ defmodule Sanbase.Alert.Trigger.ScreenerTriggerSettings do
   @doc ~s"""
   Return a list of the `settings.metric` values for the necessary time range
   """
-  @spec get_data(ScreenerTriggerSettings.t()) :: list(String.t())
+  @spec get_data(ScreenerTriggerSettings.t()) :: {:ok, list(String.t())} | {:error, any()}
   def get_data(%__MODULE__{operation: %{selector: %{watchlist_id: watchlist_id}}}) do
-    {:ok, slugs} =
-      case Sanbase.UserList.by_id(watchlist_id, []) do
-        {:error, _} -> {:ok, []}
-        {:ok, watchlist} -> watchlist |> Sanbase.UserList.get_slugs()
-      end
+    case Sanbase.UserList.by_id(watchlist_id, []) do
+      {:error, _} ->
+        {:ok, []}
 
-    slugs
+      {:ok, watchlist} ->
+        case Sanbase.UserList.get_slugs(watchlist) do
+          {:ok, slugs} ->
+            {:ok, slugs}
+
+          {:error, error} ->
+            if error =~ "is not supported or is mistyped" do
+              # Return {:error, :disable_alert, details}
+            end
+
+            {:ok, []}
+        end
+    end
   end
 
   def get_data(%__MODULE__{operation: %{selector: _} = selector}) do
     {:ok, %{slugs: slugs}} = Project.ListSelector.slugs(selector)
 
-    slugs
+    {:ok, slugs}
   end
 
   defp fill_current_state(trigger) do
     %{settings: settings} = trigger
-    slugs = get_data(settings)
+    {:ok, slugs} = get_data(settings)
     settings = %{settings | state: %{slugs_in_screener: slugs}}
 
     %{trigger | settings: settings}
@@ -91,14 +101,15 @@ defmodule Sanbase.Alert.Trigger.ScreenerTriggerSettings do
 
     def triggered?(%ScreenerTriggerSettings{triggered?: triggered}), do: triggered
 
-    @spec evaluate(ScreenerTriggerSettings.t(), any) :: ScreenerTriggerSettings.t()
     def evaluate(%ScreenerTriggerSettings{} = settings, trigger) do
       case ScreenerTriggerSettings.get_data(settings) do
-        data when is_list(data) and data != [] ->
+        {:ok, data} when is_list(data) and data != [] ->
           build_result(data, settings, trigger)
 
         _ ->
-          %ScreenerTriggerSettings{settings | triggered?: false}
+          # TODO: Handle error case
+          settings = %ScreenerTriggerSettings{settings | triggered?: false}
+          {:ok, settings}
       end
     end
 

--- a/lib/sanbase/alerts/trigger/settings/screener_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/screener_trigger_settings.ex
@@ -57,7 +57,7 @@ defmodule Sanbase.Alert.Trigger.ScreenerTriggerSettings do
   def post_create_process(trigger), do: fill_current_state(trigger)
   def post_update_process(trigger), do: fill_current_state(trigger)
 
-  @missing_metric_error "The metric used is not supported, deprecated or is mistyped"
+  @missing_metric_error "The metric used is not supported, is deprecated or is mistyped"
   @doc ~s"""
   Return a list of the `settings.metric` values for the necessary time range
   """
@@ -68,7 +68,7 @@ defmodule Sanbase.Alert.Trigger.ScreenerTriggerSettings do
       {:ok, slugs}
     else
       {:error, error_msg} when is_binary(error_msg) ->
-        if error_msg =~ "is not supported or is mistyped",
+        if error_msg =~ "is not supported, is deprecated or is mistyped",
           do: {:error, {:disable_alert, @missing_metric_error}},
           else: {:ok, []}
 
@@ -82,7 +82,7 @@ defmodule Sanbase.Alert.Trigger.ScreenerTriggerSettings do
       {:ok, slugs}
     else
       {:error, error_msg} when is_binary(error_msg) ->
-        if error_msg =~ "is not supported or is mistyped",
+        if error_msg =~ "is not supported, is deprecated or is mistyped",
           do: {:error, {:disable_alert, @missing_metric_error}},
           else: {:ok, []}
 

--- a/lib/sanbase/alerts/trigger/settings/trending_words_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/trending_words_trigger_settings.ex
@@ -79,7 +79,8 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
     def triggered?(%TrendingWordsTriggerSettings{triggered?: triggered}), do: triggered
 
     def evaluate(%TrendingWordsTriggerSettings{filtered_target: %{list: []}} = settings, _trigger) do
-      %TrendingWordsTriggerSettings{settings | triggered?: false}
+      settings = %TrendingWordsTriggerSettings{settings | triggered?: false}
+      {:ok, settings}
     end
 
     def evaluate(%TrendingWordsTriggerSettings{} = settings, _trigger) do
@@ -88,7 +89,8 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
           build_result(top_words, settings)
 
         _ ->
-          %TrendingWordsTriggerSettings{settings | triggered?: false}
+          settings = %TrendingWordsTriggerSettings{settings | triggered?: false}
+          {:ok, settings}
       end
     end
 
@@ -104,14 +106,17 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
       now = Time.utc_now()
       after_15_mins = Time.add(now, 15 * 60, :second)
 
-      case Sanbase.DateTimeUtils.time_in_range?(trigger_time, now, after_15_mins) do
-        true ->
-          template_kv = %{settings.target => template_kv(settings, top_words)}
-          %TrendingWordsTriggerSettings{settings | triggered?: true, template_kv: template_kv}
+      settings =
+        case Sanbase.DateTimeUtils.time_in_range?(trigger_time, now, after_15_mins) do
+          true ->
+            template_kv = %{settings.target => template_kv(settings, top_words)}
+            %TrendingWordsTriggerSettings{settings | triggered?: true, template_kv: template_kv}
 
-        false ->
-          %TrendingWordsTriggerSettings{settings | triggered?: false}
-      end
+          false ->
+            %TrendingWordsTriggerSettings{settings | triggered?: false}
+        end
+
+      {:ok, settings}
     end
 
     defp build_result(
@@ -124,14 +129,17 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
         MapSet.intersection(MapSet.new(top_words), MapSet.new(words))
         |> Enum.to_list()
 
-      case trending_words do
-        [] ->
-          %TrendingWordsTriggerSettings{settings | triggered?: false}
+      settings =
+        case trending_words do
+          [] ->
+            %TrendingWordsTriggerSettings{settings | triggered?: false}
 
-        [_ | _] = words ->
-          template_kv = %{words => template_kv(settings, words)}
-          %TrendingWordsTriggerSettings{settings | triggered?: true, template_kv: template_kv}
-      end
+          [_ | _] = words ->
+            template_kv = %{words => template_kv(settings, words)}
+            %TrendingWordsTriggerSettings{settings | triggered?: true, template_kv: template_kv}
+        end
+
+      {:ok, settings}
     end
 
     defp build_result(
@@ -152,27 +160,30 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
       trending_words_mapset =
         MapSet.intersection(MapSet.new(top_words), MapSet.new(project_words))
 
-      case Enum.empty?(trending_words_mapset) do
-        true ->
-          # If there are no trending words in the intersection there is no
-          # point of checking the projects separately
-          %TrendingWordsTriggerSettings{settings | triggered?: false}
+      settings =
+        case Enum.empty?(trending_words_mapset) do
+          true ->
+            # If there are no trending words in the intersection there is no
+            # point of checking the projects separately
+            %TrendingWordsTriggerSettings{settings | triggered?: false}
 
-        false ->
-          template_kv =
-            Enum.reduce(projects, %{}, fn project, acc ->
-              case Project.is_trending?(project, trending_words_mapset) do
-                true -> Map.put(acc, project.slug, template_kv(settings, project))
-                false -> acc
-              end
-            end)
+          false ->
+            template_kv =
+              Enum.reduce(projects, %{}, fn project, acc ->
+                case Project.is_trending?(project, trending_words_mapset) do
+                  true -> Map.put(acc, project.slug, template_kv(settings, project))
+                  false -> acc
+                end
+              end)
 
-          %TrendingWordsTriggerSettings{
-            settings
-            | triggered?: template_kv != %{},
-              template_kv: template_kv
-          }
-      end
+            %TrendingWordsTriggerSettings{
+              settings
+              | triggered?: template_kv != %{},
+                template_kv: template_kv
+            }
+        end
+
+      {:ok, settings}
     end
 
     defp template_kv(

--- a/lib/sanbase/alerts/trigger/settings/wallet/wallet_assets_held_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/wallet/wallet_assets_held_trigger_settings.ex
@@ -67,7 +67,8 @@ defmodule Sanbase.Alert.Trigger.WalletAssetsHeldTriggerSettings do
     temp_settings =
       Map.put(settings, :filtered_target, Sanbase.Alert.Trigger.get_filtered_target(trigger))
 
-    address_key_to_slugs_map = get_data(temp_settings) |> Map.new()
+    {:ok, data} = get_data(temp_settings)
+    address_key_to_slugs_map = Map.new(data)
 
     settings = %{settings | state: %{slugs_held_by_address: address_key_to_slugs_map}}
 
@@ -81,26 +82,29 @@ defmodule Sanbase.Alert.Trigger.WalletAssetsHeldTriggerSettings do
         filtered_target: %{list: target_list},
         selector: selector
       }) do
-    target_list
-    |> Enum.map(fn address ->
-      address = Sanbase.BlockchainAddress.to_internal_format(address)
+    data =
+      target_list
+      |> Enum.map(fn address ->
+        address = Sanbase.BlockchainAddress.to_internal_format(address)
 
-      selector = %{address: address, infrastructure: selector.infrastructure}
+        selector = %{address: address, infrastructure: selector.infrastructure}
 
-      with {:ok, result} when is_list(result) <- assets_held(selector) do
-        slugs_list = Enum.map(result, & &1.slug)
+        with {:ok, result} when is_list(result) <- assets_held(selector) do
+          slugs_list = Enum.map(result, & &1.slug)
 
-        {address, slugs_list}
-      else
-        result ->
-          raise("""
-          The result returned from assets_held in WalletAssetsHeldTriggerSettings has \
-          different format than the expected one.
-          Got: #{inspect(result)}
-          """)
-      end
-    end)
-    |> Enum.reject(&(match?({:error, _}, &1) or match?({:ok, []}, &1)))
+          {address, slugs_list}
+        else
+          result ->
+            raise("""
+            The result returned from assets_held in WalletAssetsHeldTriggerSettings has \
+            different format than the expected one.
+            Got: #{inspect(result)}
+            """)
+        end
+      end)
+      |> Enum.reject(&(match?({:error, _}, &1) or match?({:ok, []}, &1)))
+
+    {:ok, data}
   end
 
   defp assets_held(selector) do
@@ -123,11 +127,13 @@ defmodule Sanbase.Alert.Trigger.WalletAssetsHeldTriggerSettings do
 
     def evaluate(%WalletAssetsHeldTriggerSettings{} = settings, _trigger) do
       case WalletAssetsHeldTriggerSettings.get_data(settings) do
-        data when is_list(data) and data != [] ->
+        {:ok, data} when is_list(data) and data != [] ->
           build_result(data, settings)
 
         _ ->
-          %WalletAssetsHeldTriggerSettings{settings | triggered?: false}
+          # TODO: Handle errror case
+          settings = %WalletAssetsHeldTriggerSettings{settings | triggered?: false}
+          {:ok, settings}
       end
     end
 

--- a/lib/sanbase/alerts/trigger/settings/wallet/wallet_assets_held_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/wallet/wallet_assets_held_trigger_settings.ex
@@ -67,12 +67,14 @@ defmodule Sanbase.Alert.Trigger.WalletAssetsHeldTriggerSettings do
     temp_settings =
       Map.put(settings, :filtered_target, Sanbase.Alert.Trigger.get_filtered_target(trigger))
 
-    {:ok, data} = get_data(temp_settings)
-    address_key_to_slugs_map = Map.new(data)
+    with {:ok, data} <- get_data(temp_settings) do
+      address_key_to_slugs_map = Map.new(data)
 
-    settings = %{settings | state: %{slugs_held_by_address: address_key_to_slugs_map}}
+      settings = %{settings | state: %{slugs_held_by_address: address_key_to_slugs_map}}
 
-    %{trigger | settings: settings}
+      trigger = %{trigger | settings: settings}
+      {:ok, trigger}
+    end
   end
 
   @doc ~s"""

--- a/lib/sanbase/alerts/trigger/settings/wallet/wallet_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/wallet/wallet_trigger_settings.ex
@@ -169,7 +169,8 @@ defmodule Sanbase.Alert.Trigger.WalletTriggerSettings do
           build_result(data, settings)
 
         _ ->
-          %WalletTriggerSettings{settings | triggered?: false}
+          settings = %WalletTriggerSettings{settings | triggered?: false}
+          {:ok, settings}
       end
     end
 

--- a/lib/sanbase/alerts/trigger/settings/wallet/wallet_usd_valuation_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/wallet/wallet_usd_valuation_trigger_settings.ex
@@ -143,7 +143,8 @@ defmodule Sanbase.Alert.Trigger.WalletUsdValuationTriggerSettings do
           build_result(data, settings)
 
         _ ->
-          %WalletUsdValuationTriggerSettings{settings | triggered?: false}
+          settings = %WalletUsdValuationTriggerSettings{settings | triggered?: false}
+          {:ok, settings}
       end
     end
 

--- a/lib/sanbase/alerts/trigger/trigger.ex
+++ b/lib/sanbase/alerts/trigger/trigger.ex
@@ -9,6 +9,7 @@ defprotocol Sanbase.Alert.Settings do
   - Add a map between the StructMapTransformation
   """
 
+  @spec evaluate(map(), map()) :: {:ok, map} | {:error, any()}
   def evaluate(trigger_settings, trigger)
 
   @spec triggered?(struct()) :: boolean()
@@ -115,12 +116,16 @@ defmodule Sanbase.Alert.Trigger do
 
   def evaluate(%Trigger{settings: %{target: target} = trigger_settings} = trigger) do
     filtered_target = remove_targets_on_cooldown(target, trigger)
+    trigger_settings = %{trigger_settings | filtered_target: filtered_target}
 
-    trigger_settings =
-      %{trigger_settings | filtered_target: filtered_target}
-      |> Sanbase.Alert.Settings.evaluate(trigger)
+    case Sanbase.Alert.Settings.evaluate(trigger_settings, trigger) do
+      {:ok, trigger_settings} ->
+        trigger = %Trigger{trigger | settings: trigger_settings}
+        {:ok, trigger}
 
-    %Trigger{trigger | settings: trigger_settings}
+      {:error, error} ->
+        {:error, error}
+    end
   end
 
   @spec historical_trigger_points(Sanbase.Alert.Trigger.t()) :: {:error, any} | {:ok, [any]}

--- a/lib/sanbase/alerts/user_trigger.ex
+++ b/lib/sanbase/alerts/user_trigger.ex
@@ -388,10 +388,14 @@ defmodule Sanbase.Alert.UserTrigger do
         :nochange ->
           {:ok, user_trigger}
 
-        trigger ->
+        {:ok, trigger} ->
           user_trigger
           |> update_changeset(%{trigger: trigger |> Map.from_struct() |> clean_params()})
           |> Repo.update()
+
+        {:error, reason} ->
+          {:error,
+           "Cannot create an alert because the post create processing failed. Reason: #{inspect(reason)}"}
       end
     end
   end
@@ -404,10 +408,14 @@ defmodule Sanbase.Alert.UserTrigger do
         :nochange ->
           {:ok, user_trigger}
 
-        trigger ->
+        {:ok, trigger} ->
           user_trigger
           |> update_changeset(%{trigger: trigger |> Map.from_struct() |> clean_params()})
           |> Repo.update()
+
+        {:error, reason} ->
+          {:error,
+           "Cannot update an alert because the post update processing failed. Reason: #{inspect(reason)}"}
       end
     end
   end

--- a/lib/sanbase/alerts/user_trigger.ex
+++ b/lib/sanbase/alerts/user_trigger.ex
@@ -81,8 +81,8 @@ defmodule Sanbase.Alert.UserTrigger do
     |> validate_required([:user_id, :trigger])
   end
 
-  def update_is_active(user_trigger_id, user, is_active) do
-    update_user_trigger(user.id, %{
+  def update_is_active(user_trigger_id, user_id, is_active) do
+    update_user_trigger(user_id, %{
       id: user_trigger_id,
       is_active: is_active
     })

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -720,7 +720,7 @@ defmodule Sanbase.Metric do
   defp metric_not_available_error_details(metric, type) do
     %{
       close: maybe_get_close_metric(metric, type),
-      error_msg: "The metric '#{metric}' is not supported or is mistyped."
+      error_msg: "The metric '#{metric}' is not supported, is deprecated or is mistyped."
     }
   end
 

--- a/lib/sanbase/signal/signal_adapter.ex
+++ b/lib/sanbase/signal/signal_adapter.ex
@@ -196,7 +196,7 @@ defmodule Sanbase.Signal.SignalAdapter do
   defp signal_not_available_error_details(signal) do
     %{
       close: Enum.find(@signals_mapset, &(String.jaro_distance(signal, &1) > 0.8)),
-      error_msg: "The signal '#{signal}' is not supported or is mistyped."
+      error_msg: "The signal '#{signal}' is not supported, is deprecated or is mistyped."
     }
   end
 

--- a/lib/sanbase/stripe/stripe_api.ex
+++ b/lib/sanbase/stripe/stripe_api.ex
@@ -68,7 +68,7 @@ defmodule Sanbase.StripeApi do
     })
   end
 
-  @spec update_customer(%User{}, String.t()) ::
+  @spec update_customer(%User{stripe_customer_id: binary()}, String.t()) ::
           {:ok, Stripe.Customer.t()} | {:error, Stripe.Error.t()}
   def update_customer(%User{stripe_customer_id: stripe_customer_id}, card_token)
       when is_binary(stripe_customer_id) do

--- a/lib/sanbase/utils/map_utils.ex
+++ b/lib/sanbase/utils/map_utils.ex
@@ -107,8 +107,15 @@ defmodule Sanbase.MapUtils do
   # Private functions
 
   @compile {:inline, atomize: 1}
-  defp atomize(value) when is_atom(value) or is_binary(value),
-    do: value |> Inflex.underscore() |> String.to_existing_atom()
+  case Mix.env() == :test do
+    true ->
+      defp atomize(value) when is_atom(value) or is_binary(value),
+        do: value |> Inflex.underscore() |> String.to_atom()
+
+    false ->
+      defp atomize(value) when is_atom(value) or is_binary(value),
+        do: value |> Inflex.underscore() |> String.to_existing_atom()
+  end
 
   defp do_find_pair_path(map, key, value, path) when is_map(map) do
     keys = Map.keys(map)

--- a/lib/sanbase/utils/validation.ex
+++ b/lib/sanbase/utils/validation.ex
@@ -81,7 +81,7 @@ defmodule Sanbase.Validation do
     else
       _ ->
         {:error,
-         "The metric #{inspect(metric)} is not supported or is mistyped or does not have min interval equal or less than to 5 minutes."}
+         "The metric #{inspect(metric)} is not supported, is deprecated or is mistyped or does not have min interval equal or less than to 5 minutes."}
     end
   end
 
@@ -93,7 +93,7 @@ defmodule Sanbase.Validation do
     else
       _ ->
         {:error,
-         "The metric #{inspect(metric)} is not supported or is mistyped or does not have min interval equal or bigger than to 1 day."}
+         "The metric #{inspect(metric)} is not supported, is deprecated or is mistyped or does not have min interval equal or bigger than to 1 day."}
     end
   end
 

--- a/lib/sanbase_web/graphql/resolvers/metric/metric_transform.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_transform.ex
@@ -23,7 +23,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricTransform do
         {:ok, transform}
 
       false ->
-        {:error, "Transform type '#{transform.type}' is not supported or is mistyped.\
+        {:error,
+         "Transform type '#{transform.type}' is not supported, is deprecated or is mistyped.\
         Supported types are: #{Enum.join(@transform_types, ", ")}"}
     end
   end
@@ -57,7 +58,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricTransform do
   end
 
   def calibrate_transform_params(%{type: type}, _from, _to, _interval) do
-    {:error, "The transform type '#{type}' is not supported or is mistyped."}
+    {:error, "The transform type '#{type}' is not supported, is deprecated or is mistyped."}
   end
 
   def apply_transform(%{type: "none"}, data), do: {:ok, data}

--- a/lib/sanbase_web/graphql/resolvers/metric/metric_transform.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_transform.ex
@@ -23,7 +23,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricTransform do
         {:ok, transform}
 
       false ->
-        {:error, "Transform type '#{transform.type}' is not supported or mistyped.\
+        {:error, "Transform type '#{transform.type}' is not supported or is mistyped.\
         Supported types are: #{Enum.join(@transform_types, ", ")}"}
     end
   end
@@ -57,7 +57,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricTransform do
   end
 
   def calibrate_transform_params(%{type: type}, _from, _to, _interval) do
-    {:error, "The transform type '#{type}' is not supported or mistyped."}
+    {:error, "The transform type '#{type}' is not supported or is mistyped."}
   end
 
   def apply_transform(%{type: "none"}, data), do: {:ok, data}

--- a/test/sanbase/alerts/metric/daily_metric_trigger_settings_test.exs
+++ b/test/sanbase/alerts/metric/daily_metric_trigger_settings_test.exs
@@ -171,7 +171,7 @@ defmodule Sanbase.Alert.DailyMetricTriggerSettingsTest do
                    settings: trigger_settings
                  })
 
-               assert error_msg =~ "not supported or is mistyped"
+               assert error_msg =~ "not supported, is deprecated or is mistyped"
              end)
     end)
   end

--- a/test/sanbase/alerts/metric/intraday_metric_trigger_settings_test.exs
+++ b/test/sanbase/alerts/metric/intraday_metric_trigger_settings_test.exs
@@ -87,7 +87,7 @@ defmodule Sanbase.Alert.MetricTriggerSettingsTest do
 
       Sanbase.Cache.clear_all(:alerts_evaluator_cache)
 
-      user = insert(:user)
+      user = insert(:user, user_settings: %{settings: %{alert_notify_telegram: true}})
       Sanbase.Accounts.UserSettings.set_telegram_chat_id(user.id, 123_123_123_123)
 
       project = Sanbase.Factory.insert(:random_project)
@@ -341,6 +341,55 @@ defmodule Sanbase.Alert.MetricTriggerSettingsTest do
 
                  assert error_msg =~ "not supported or is mistyped"
                end)
+      end)
+    end
+
+    test "wrong metric name disables the alert", context do
+      trigger_settings = %{
+        type: "metric_signal",
+        metric: "active_addresses_24h",
+        target: %{slug: context.project.slug},
+        channel: "telegram",
+        operation: %{percent_up: 100}
+      }
+
+      # aggregated_timeseries_data should be called 2 times, but after the first call that returns
+      # error we go to the error handling phase, not calling anything else
+      mock_fun =
+        [
+          fn ->
+            {:error, "The metric 'active_addresses_24h' is not supported or is mistyped."}
+          end
+        ]
+        |> Sanbase.Mock.wrap_consecutives(arity: 4)
+
+      Sanbase.Mock.prepare_mock(Sanbase.Metric, :aggregated_timeseries_data, mock_fun)
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        {:ok, ut} =
+          UserTrigger.create_user_trigger(context.user, %{
+            title: "title",
+            is_public: true,
+            cooldown: "1h",
+            settings: trigger_settings
+          })
+
+        # Clear the result of the filter
+        Sanbase.Cache.clear_all()
+        Sanbase.Cache.clear_all(:alerts_evaluator_cache)
+
+        log =
+          capture_log(fn ->
+            assert [_] = Sanbase.Alert.Scheduler.run_alert(MetricTriggerSettings)
+          end)
+
+        IO.puts(log)
+
+        assert log =~ "Auto disable alert"
+        assert log =~ "active_addresses_24h"
+        assert log =~ "metric used is not supported, deprecated or is mistyped"
+        {:ok, user_trigger} = Sanbase.Alert.UserTrigger.by_user_and_id(ut.user_id, ut.id)
+
+        assert user_trigger.trigger.is_active == false
       end)
     end
   end

--- a/test/sanbase/alerts/metric/intraday_metric_trigger_settings_test.exs
+++ b/test/sanbase/alerts/metric/intraday_metric_trigger_settings_test.exs
@@ -339,7 +339,7 @@ defmodule Sanbase.Alert.MetricTriggerSettingsTest do
                      settings: trigger_settings
                    })
 
-                 assert error_msg =~ "not supported or is mistyped"
+                 assert error_msg =~ "not supported, is deprecated or is mistyped"
                end)
       end)
     end
@@ -358,7 +358,8 @@ defmodule Sanbase.Alert.MetricTriggerSettingsTest do
       mock_fun =
         [
           fn ->
-            {:error, "The metric 'active_addresses_24h' is not supported or is mistyped."}
+            {:error,
+             "The metric 'active_addresses_24h' is not supported, is deprecated or is mistyped."}
           end
         ]
         |> Sanbase.Mock.wrap_consecutives(arity: 4)
@@ -382,11 +383,9 @@ defmodule Sanbase.Alert.MetricTriggerSettingsTest do
             assert [_] = Sanbase.Alert.Scheduler.run_alert(MetricTriggerSettings)
           end)
 
-        IO.puts(log)
-
         assert log =~ "Auto disable alert"
         assert log =~ "active_addresses_24h"
-        assert log =~ "metric used is not supported, deprecated or is mistyped"
+        assert log =~ "not supported, is deprecated or is mistyped"
         {:ok, user_trigger} = Sanbase.Alert.UserTrigger.by_user_and_id(ut.user_id, ut.id)
 
         assert user_trigger.trigger.is_active == false

--- a/test/sanbase/alerts/screener/screener_trigger_settings_test.exs
+++ b/test/sanbase/alerts/screener/screener_trigger_settings_test.exs
@@ -103,7 +103,7 @@ defmodule Sanbase.Alert.ScreenerTriggerSettingsTest do
           assert [_] = Sanbase.Alert.Scheduler.run_alert(ScreenerTriggerSettings)
         end)
 
-      assert log =~ "Disable alert"
+      assert log =~ "Auto disable alert"
       assert log =~ "active_addresses_24h"
       assert log =~ "metric used is not supported, deprecated or is mistyped"
       {:ok, user_trigger} = Sanbase.Alert.UserTrigger.by_user_and_id(ut.user_id, ut.id)

--- a/test/sanbase/alerts/screener/screener_trigger_settings_test.exs
+++ b/test/sanbase/alerts/screener/screener_trigger_settings_test.exs
@@ -80,7 +80,10 @@ defmodule Sanbase.Alert.ScreenerTriggerSettingsTest do
         # Called in post_create_process when creating the alert
         fn -> {:ok, []} end,
         # Called when evaluating the alert fn ->
-        fn -> {:error, "The metric 'active_addresses_24h' is not supported or is mistyped."} end
+        fn ->
+          {:error,
+           "The metric 'active_addresses_24h' is not supported, is deprecated or is mistyped."}
+        end
       ]
       |> Sanbase.Mock.wrap_consecutives(arity: 6)
 
@@ -105,7 +108,7 @@ defmodule Sanbase.Alert.ScreenerTriggerSettingsTest do
 
       assert log =~ "Auto disable alert"
       assert log =~ "active_addresses_24h"
-      assert log =~ "metric used is not supported, deprecated or is mistyped"
+      assert log =~ "metric used is not supported, is deprecated or is mistyped"
       {:ok, user_trigger} = Sanbase.Alert.UserTrigger.by_user_and_id(ut.user_id, ut.id)
 
       assert user_trigger.trigger.is_active == false

--- a/test/sanbase/alerts/signal/signal_trigger_settings_test.exs
+++ b/test/sanbase/alerts/signal/signal_trigger_settings_test.exs
@@ -139,7 +139,7 @@ defmodule Sanbase.Alert.SignalTriggerSettingsTest do
                    settings: trigger_settings
                  })
 
-               assert error_msg =~ "not supported or is mistyped"
+               assert error_msg =~ "not supported, is deprecated or is mistyped"
              end)
     end
   end

--- a/test/sanbase/project/project_list_selector_test.exs
+++ b/test/sanbase/project/project_list_selector_test.exs
@@ -66,7 +66,7 @@ defmodule Sanbase.ProjectListSelectorTest do
       {:error, error_msg} = ListSelector.valid_selector?(%{selector: selector})
 
       assert error_msg =~
-               "The metric 'nvtt' is not supported or is mistyped. Did you mean the metric 'nvt'?"
+               "The metric 'nvtt' is not supported, is deprecated or is mistyped. Did you mean the metric 'nvt'?"
     end
   end
 

--- a/test/sanbase_web/graphql/metric/api_metric_aggregated_timeseries_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_aggregated_timeseries_data_test.exs
@@ -152,7 +152,8 @@ defmodule SanbaseWeb.Graphql.ApiMetricAggregatedTimeseriesDataTest do
       %{"errors" => [%{"message" => error_message}]} =
         get_aggregated_timeseries_metric(conn, metric, %{slug: slug}, from, to, aggregation)
 
-      assert error_message == "The metric '#{metric}' is not supported or is mistyped."
+      assert error_message ==
+               "The metric '#{metric}' is not supported, is deprecated or is mistyped."
     end
   end
 

--- a/test/sanbase_web/graphql/metric/api_metric_computed_at_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_computed_at_test.exs
@@ -51,7 +51,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricComputedAtTest do
       } = get_last_datetime_computed_at(conn, metric, %{slug: project.slug})
 
       assert error_message ==
-               "The metric '#{metric}' is not supported or is mistyped."
+               "The metric '#{metric}' is not supported, is deprecated or is mistyped."
     end
   end
 

--- a/test/sanbase_web/graphql/metric/api_metric_histogram_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_histogram_data_test.exs
@@ -93,7 +93,8 @@ defmodule SanbaseWeb.Graphql.ApiMetricHistogramDataTest do
         ]
       } = get_histogram_metric(conn, metric, slug, from, to, "1d", 100)
 
-      assert error_message == "The metric '#{metric}' is not supported or is mistyped."
+      assert error_message ==
+               "The metric '#{metric}' is not supported, is deprecated or is mistyped."
     end
   end
 

--- a/test/sanbase_web/graphql/metric/api_metric_metadata_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_metadata_test.exs
@@ -105,7 +105,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricMetadataTest do
       } = get_metric_metadata(conn, metric)
 
       assert error_message ==
-               "The metric '#{metric}' is not supported or is mistyped."
+               "The metric '#{metric}' is not supported, is deprecated or is mistyped."
     end
   end
 

--- a/test/sanbase_web/graphql/metric/api_metric_table_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_table_data_test.exs
@@ -171,7 +171,8 @@ defmodule SanbaseWeb.Graphql.ApiMetricTableDataTest do
         ]
       } = get_table_metric(conn, metric, slugs, from, to)
 
-      assert error_message == "The metric '#{metric}' is not supported or is mistyped."
+      assert error_message ==
+               "The metric '#{metric}' is not supported, is deprecated or is mistyped."
     end
   end
 

--- a/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
@@ -353,7 +353,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesDataTest do
         )
 
       assert error_message ==
-               "The metric '#{metric}' is not supported or is mistyped."
+               "The metric '#{metric}' is not supported, is deprecated or is mistyped."
     end
   end
 

--- a/test/sanbase_web/graphql/projects/projects_by_function_api_test.exs
+++ b/test/sanbase_web/graphql/projects/projects_by_function_api_test.exs
@@ -112,7 +112,9 @@ defmodule SanbaseWeb.Graphql.ProjectsByFunctionApiTest do
         execute_query(conn, query(function))
         |> get_in(["errors", Access.at(0), "message"])
 
-      assert error_msg =~ "The metric 'aily_active_addresses' is not supported or is mistyped"
+      assert error_msg =~
+               "The metric 'aily_active_addresses' is not supported, is deprecated or is mistyped"
+
       assert error_msg =~ "Did you mean the timeseries metric 'daily_active_addresses'?"
     end)
   end
@@ -143,7 +145,7 @@ defmodule SanbaseWeb.Graphql.ProjectsByFunctionApiTest do
         execute_query(conn, query(function))
         |> get_in(["errors", Access.at(0), "message"])
 
-      assert error_msg =~ "The metric 'rice_usd' is not supported or is mistyped"
+      assert error_msg =~ "The metric 'rice_usd' is not supported, is deprecated or is mistyped"
       assert error_msg =~ "Did you mean the timeseries metric 'price_usd'?"
     end)
   end

--- a/test/sanbase_web/graphql/signal/api_signal_metadata_test.exs
+++ b/test/sanbase_web/graphql/signal/api_signal_metadata_test.exs
@@ -42,7 +42,8 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ApiSignalMetadataTest do
         ]
       } = get_signal_metadata(conn, signal)
 
-      assert error_message == "The signal '#{signal}' is not supported or is mistyped."
+      assert error_message ==
+               "The signal '#{signal}' is not supported, is deprecated or is mistyped."
     end
   end
 

--- a/test/sanbase_web/graphql/signal/api_signal_timeseries_data_test.exs
+++ b/test/sanbase_web/graphql/signal/api_signal_timeseries_data_test.exs
@@ -163,7 +163,8 @@ defmodule SanbaseWeb.Graphql.Clickhouse.ApiSignalTimeseriesDataTest do
       %{"errors" => [%{"message" => error_message}]} =
         get_timeseries_signal(conn, signal, slug, from, to, interval, aggregation)
 
-      assert error_message == "The signal '#{signal}' is not supported or is mistyped."
+      assert error_message ==
+               "The signal '#{signal}' is not supported, is deprecated or is mistyped."
     end
   end
 


### PR DESCRIPTION
## Changes

- Make each alert `evaluate/2` function return ok or error tuple.
- Handle a special `evaluate/2` error type that has the form `{:error, {:disable_alert, reason}}` that is used when an alert is using an already deprecated metric, or somehow else ended up with a metric that is not valid (mistyped, unsupported, deprecated). Currently these alerts are evaluated every 5 minutes, non-stop.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
