### PR TITLE
Add signup=true to OAuth and Email login URLs

### DIFF
--- a/lib/sanbase/accounts/user/user_email.ex
+++ b/lib/sanbase/accounts/user/user_email.ex
@@ -119,13 +119,13 @@ defmodule Sanbase.Accounts.User.Email do
         @token_valid_window_minutes
   end
 
-  def send_login_email(user, origin_host_parts, args \\ %{})
+  def send_login_email(user, first_login, origin_host_parts, args \\ %{})
 
-  def send_login_email(user, ["santiment", "net"] = origin_host_parts, args),
-    do: do_send_login_email(user, origin_host_parts, args)
+  def send_login_email(user, first_login, ["santiment", "net"] = origin_host_parts, args),
+    do: do_send_login_email(user, first_login, origin_host_parts, args)
 
-  def send_login_email(user, [_, "santiment", "net"] = origin_host_parts, args),
-    do: do_send_login_email(user, origin_host_parts, args)
+  def send_login_email(user, first_login, [_, "santiment", "net"] = origin_host_parts, args),
+    do: do_send_login_email(user, first_login, origin_host_parts, args)
 
   def send_verify_email(user) do
     verify_link = SanbaseWeb.Endpoint.verify_url(user.email_candidate_token, user.email_candidate)
@@ -134,18 +134,30 @@ defmodule Sanbase.Accounts.User.Email do
     Sanbase.TemplateMailer.send(user.email_candidate, template, %{verify_link: verify_link})
   end
 
-  defp do_send_login_email(user, origin_host_parts, args) do
+  defp do_send_login_email(user, first_login, origin_host_parts, args) do
     origin_url = "https://" <> Enum.join(origin_host_parts, ".")
 
-    template =
-      Sanbase.Email.Template.choose_login_template(origin_url, first_login?: user.first_login)
+    template = Sanbase.Email.Template.choose_login_template(origin_url, first_login?: first_login)
 
     Sanbase.TemplateMailer.send(user.email, template, %{
-      login_link: generate_login_link(user, origin_url, args)
+      login_link: generate_login_link(user, first_login, origin_url, args)
     })
   end
 
   defp generate_login_link(user, origin_url, args) do
-    SanbaseWeb.Endpoint.login_url(user.email_token, user.email, origin_url, args)
+    # If this is the first login that also creates the user, then
+    # append signup=true to the query params
+    signup_map = if first_login, do: %{signup: true}, else: %{}
+
+    query_map =
+      signup_map
+      |> Map.merge(%{token: user.email_token, email: user.email})
+      |> Map.merge(Map.take(args, [:subscribe_to_weekly_newsletter]))
+
+    login_url = if origin_url, do: origin_url, else: frontend_url()
+
+    login_url
+    |> Path.join("/email_login")
+    |> URI.append_query(URI.encode_query(query_map))
   end
 end

--- a/lib/sanbase/accounts/user/user_email.ex
+++ b/lib/sanbase/accounts/user/user_email.ex
@@ -144,7 +144,7 @@ defmodule Sanbase.Accounts.User.Email do
     })
   end
 
-  defp generate_login_link(user, origin_url, args) do
+  defp generate_login_link(user, first_login, origin_url, args) do
     # If this is the first login that also creates the user, then
     # append signup=true to the query params
     signup_map = if first_login, do: %{signup: true}, else: %{}
@@ -154,10 +154,14 @@ defmodule Sanbase.Accounts.User.Email do
       |> Map.merge(%{token: user.email_token, email: user.email})
       |> Map.merge(Map.take(args, [:subscribe_to_weekly_newsletter]))
 
-    login_url = if origin_url, do: origin_url, else: frontend_url()
+    login_url = if is_binary(origin_url), do: origin_url, else: SanbaseWeb.Endpoint.frontend_url()
 
-    login_url
-    |> Path.join("/email_login")
+    login_url =
+      login_url
+      |> Path.join("/email_login")
+
+    URI.parse(login_url)
     |> URI.append_query(URI.encode_query(query_map))
+    |> URI.to_string()
   end
 end

--- a/lib/sanbase_web/controllers/auth_controller.ex
+++ b/lib/sanbase_web/controllers/auth_controller.ex
@@ -109,15 +109,11 @@ defmodule SanbaseWeb.AuthController do
     end
   end
 
-  defp extend_if_first_login(redirect_url, false), do: redirect_url
-
-  defp extend_if_first_login(redirect_url, true) do
-    uri = URI.parse(redirect_url)
-    query_map = URI.decode_query(uri.query || "")
-    query_map = Map.put(query_map, "signup", "true")
-    uri = %{uri | query: URI.encode_query(query_map)}
-
-    URI.to_string(uri)
+  defp extend_if_first_login(redirect_url, first_login) do
+    case first_login do
+      true -> URI.append_query(redirect_url, "signup=true")
+      false -> redirect_url
+    end
   end
 
   defp twitter_login(email, twitter_id)

--- a/lib/sanbase_web/controllers/auth_controller.ex
+++ b/lib/sanbase_web/controllers/auth_controller.ex
@@ -111,8 +111,14 @@ defmodule SanbaseWeb.AuthController do
 
   defp extend_if_first_login(redirect_url, first_login) do
     case first_login do
-      true -> URI.append_query(redirect_url, "signup=true")
-      false -> redirect_url
+      true ->
+        redirect_url
+        |> URI.parse()
+        |> URI.append_query("signup=true")
+        |> URI.to_string()
+
+      false ->
+        redirect_url
     end
   end
 

--- a/lib/sanbase_web/controllers/auth_controller.ex
+++ b/lib/sanbase_web/controllers/auth_controller.ex
@@ -23,10 +23,12 @@ defmodule SanbaseWeb.AuthController do
     # state sharing between the request and the callback phases, which gives us the
     # option to dynamically configure via parameters the redirect URLs and the real
     # origin URL
+
     referer_url = Plug.Conn.get_req_header(conn, "referer") |> List.first()
     referer_url = referer_url || SanbaseWeb.Endpoint.website_url()
 
     success_redirect_url = get_redirect_url(params, "success_redirect_url", referer_url)
+
     fail_redirect_url = get_redirect_url(params, "fail_redirect_url", referer_url)
 
     origin_url =
@@ -61,16 +63,20 @@ defmodule SanbaseWeb.AuthController do
     args = %{login_origin: :google, origin_url: origin_url}
 
     with true <- is_binary(email) and byte_size(email) > 0,
-         {:ok, user} <- User.find_or_insert_by(:email, email, args),
+         {:ok, %{first_login: first_login} = user} <- User.find_or_insert_by(:email, email, args),
          {:ok, _, user} <-
            Accounts.forward_registration(user, "google_oauth", args),
          {:ok, %{} = jwt_tokens_map} <-
            SanbaseWeb.Guardian.get_jwt_tokens(user, device_data) do
       emit_event({:ok, user}, :login_user, args)
 
+      redirect_url = get_session(conn, :__san_success_redirect_url)
+
+      redirect_url = extend_if_first_login(redirect_url, first_login)
+
       conn
       |> SanbaseWeb.Guardian.add_jwt_tokens_to_conn_session(jwt_tokens_map)
-      |> redirect(external: get_session(conn, :__san_success_redirect_url))
+      |> redirect(external: redirect_url)
     else
       _ ->
         conn
@@ -101,6 +107,17 @@ defmodule SanbaseWeb.AuthController do
         conn
         |> redirect(external: get_session(conn, :__san_fail_redirect_url))
     end
+  end
+
+  defp extend_if_first_login(redirect_url, false), do: redirect_url
+
+  defp extend_if_first_login(redirect_url, true) do
+    uri = URI.parse(redirect_url)
+    query_map = URI.decode_query(uri.query || "")
+    query_map = Map.put(query_map, "signup", "true")
+    uri = %{uri | query: URI.encode_query(query_map)}
+
+    URI.to_string(uri)
   end
 
   defp twitter_login(email, twitter_id)

--- a/lib/sanbase_web/endpoint.ex
+++ b/lib/sanbase_web/endpoint.ex
@@ -158,19 +158,6 @@ defmodule SanbaseWeb.Endpoint do
     backend_url() <> "/graphql"
   end
 
-  def login_url(token, email, origin_url, args \\ %{}) do
-    query_string =
-      Map.merge(%{token: token, email: email}, Map.take(args, [:subscribe_to_weekly_newsletter]))
-      |> URI.encode_query()
-
-    login_path = "/email_login?#{query_string}"
-
-    case origin_url do
-      nil -> frontend_url() <> login_path
-      origin_url -> origin_url <> login_path
-    end
-  end
-
   def verify_url(email_candidate_token, email_candidate) do
     frontend_url() <>
       "/verify_email?" <>

--- a/lib/sanbase_web/graphql/resolvers/user/auth_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/auth_resolver.ex
@@ -91,7 +91,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.AuthResolver do
            User.find_or_insert_by(:email, email, %{username: args[:username]}),
          :ok <- EmailLoginAttempt.has_allowed_login_attempts(user, remote_ip),
          {:ok, user} <- User.Email.update_email_token(user, args[:consent]),
-         {:ok, user} <- User.Email.send_login_email(user, first_login, origin_host_parts, args),
+         {:ok, _res} <- User.Email.send_login_email(user, first_login, origin_host_parts, args),
          {:ok, %EmailLoginAttempt{}} <- EmailLoginAttempt.create(user, remote_ip),
          {:ok, _, user} <-
            Accounts.forward_registration(user, "send_login_email", %{"origin_url" => origin_url}) do

--- a/lib/sanbase_web/graphql/resolvers/user/auth_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/auth_resolver.ex
@@ -87,10 +87,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.AuthResolver do
 
     with true <- allowed_email_domain?(email),
          true <- allowed_origin?(origin_host_parts, origin_url),
-         {:ok, user} <- User.find_or_insert_by(:email, email, %{username: args[:username]}),
+         {:ok, %{first_login: first_login} = user} <-
+           User.find_or_insert_by(:email, email, %{username: args[:username]}),
          :ok <- EmailLoginAttempt.has_allowed_login_attempts(user, remote_ip),
          {:ok, user} <- User.Email.update_email_token(user, args[:consent]),
-         {:ok, _user} <- User.Email.send_login_email(user, origin_host_parts, args),
+         {:ok, user} <- User.Email.send_login_email(user, first_login, origin_host_parts, args),
          {:ok, %EmailLoginAttempt{}} <- EmailLoginAttempt.create(user, remote_ip),
          {:ok, _, user} <-
            Accounts.forward_registration(user, "send_login_email", %{"origin_url" => origin_url}) do


### PR DESCRIPTION
## Changes

When this is the first login with Google or Twitter OAuth, append `signup=key`
to the query part of the URL (?signup=true or &signup=true if there are other params)

Also append `signup=true` to the email login link if this is the first login.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
