### PR TITLE
Add newsapi_crypto social source

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/social_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/social_metrics.json
@@ -4,10 +4,7 @@
     "name": "social_volume_total",
     "metric": "social_volume",
     "version": "2020-07-31",
-    "access": {
-      "historical": "restricted",
-      "realtime": "free"
-    },
+    "access": "restricted",
     "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
@@ -24,10 +21,7 @@
     "name": "social_volume_ai_total",
     "metric": "social_metrics_volume_ai_total",
     "version": "2022-02-01",
-    "access": {
-      "historical": "restricted",
-      "realtime": "free"
-    },
+    "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",
@@ -146,10 +140,7 @@
     "name": "social_volume_4chan",
     "metric": "social_volume_4chan",
     "version": "2020-07-31",
-    "access": {
-      "historical": "restricted",
-      "realtime": "free"
-    },
+    "access": "restricted",
     "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
@@ -251,10 +242,7 @@
     "name": "social_volume_telegram",
     "metric": "social_volume_telegram",
     "version": "2020-07-31",
-    "access": {
-      "historical": "restricted",
-      "realtime": "free"
-    },
+    "access": "restricted",
     "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
@@ -356,10 +344,7 @@
     "name": "social_volume_reddit",
     "metric": "social_volume_reddit",
     "version": "2020-07-31",
-    "access": {
-      "historical": "restricted",
-      "realtime": "free"
-    },
+    "access": "restricted",
     "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
@@ -461,10 +446,7 @@
     "name": "social_volume_discord",
     "metric": "social_volume_discord",
     "version": "2020-07-31",
-    "access": {
-      "historical": "restricted",
-      "realtime": "free"
-    },
+    "access": "restricted",
     "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
@@ -572,10 +554,7 @@
     "name": "social_volume_professional_traders_chat",
     "metric": "social_volume_professional_traders_chat",
     "version": "2020-07-31",
-    "access": {
-      "historical": "restricted",
-      "realtime": "free"
-    },
+    "access": "restricted",
     "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
@@ -683,10 +662,7 @@
     "name": "social_volume_twitter",
     "metric": "social_volume_twitter",
     "version": "2020-07-31",
-    "access": {
-      "historical": "restricted",
-      "realtime": "free"
-    },
+    "access": "restricted",
     "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
@@ -703,10 +679,7 @@
     "name": "social_volume_twitter_crypto",
     "metric": "social_volume_twitter_crypto",
     "version": "2020-07-31",
-    "access": {
-      "historical": "restricted",
-      "realtime": "free"
-    },
+    "access": "restricted",
     "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
@@ -723,10 +696,7 @@
     "name": "social_volume_twitter_news",
     "metric": "social_volume_twitter_news",
     "version": "2020-07-31",
-    "access": {
-      "historical": "restricted",
-      "realtime": "free"
-    },
+    "access": "restricted",
     "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
@@ -743,10 +713,7 @@
     "name": "social_volume_twitter_nft",
     "metric": "social_volume_twitter_nft",
     "version": "2020-07-31",
-    "access": {
-      "historical": "restricted",
-      "realtime": "free"
-    },
+    "access": "restricted",
     "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
@@ -1103,10 +1070,7 @@
     "name": "social_volume_youtube_videos",
     "metric": "social_volume_youtube_videos",
     "version": "2020-07-31",
-    "access": {
-      "historical": "restricted",
-      "realtime": "free"
-    },
+    "access": "restricted",
     "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
@@ -1208,10 +1172,7 @@
     "name": "social_volume_bitcointalk",
     "metric": "social_volume_bitcointalk",
     "version": "2020-07-31",
-    "access": {
-      "historical": "restricted",
-      "realtime": "free"
-    },
+    "access": "restricted",
     "selectors": ["slug", "text"],
     "min_plan": {
       "SANAPI": "free",
@@ -1721,10 +1682,7 @@
     "name": "trending_words_rank",
     "metric": "trending_rank",
     "version": "2019-01-01",
-    "access": {
-      "historical": "restricted",
-      "realtime": "free"
-    },
+    "access": "restricted",
     "selectors": ["slug"],
     "min_plan": {
       "SANAPI": "free",

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -684,7 +684,7 @@ defmodule Sanbase.Metric do
   """
   @spec is_historical_data_freely_available?(metric) :: boolean
   def is_historical_data_freely_available?(metric) do
-    get_in(@access_map, [metric, "historical"]) == "FREE"
+    get_in(@access_map, [metric, "historical"]) == :free
   end
 
   @doc ~s"""
@@ -692,7 +692,7 @@ defmodule Sanbase.Metric do
   """
   @spec is_realtime_data_freely_available?(metric) :: boolean
   def is_realtime_data_freely_available?(metric) do
-    get_in(@access_map, [metric, "realtime"]) == "FREE"
+    get_in(@access_map, [metric, "realtime"]) == :free
   end
 
   @doc ~s"""

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -75,18 +75,10 @@ defmodule Sanbase.SocialData.MetricAdapter do
   # plan related - the plan is upcase string
   @min_plan_map Enum.reduce(@metrics, %{}, fn metric, acc -> Map.put(acc, metric, "FREE") end)
 
-  # restriction related - the restriction is atom :free or :restricted
-  @social_volume_metric_access_map @social_volume_timeseries_metrics
-                                   |> Enum.into(
-                                     %{},
-                                     &{&1, %{"historical" => :restricted, "realtime" => :free}}
-                                   )
-
-  @access_map (@metrics -- @social_volume_timeseries_metrics)
+  @access_map @metrics
               |> Enum.reduce(%{}, fn metric, acc ->
                 Map.put(acc, metric, :restricted)
               end)
-              |> Map.merge(@social_volume_metric_access_map)
 
   @required_selectors Enum.into(@metrics, %{}, &{&1, []})
                       |> Map.put("social_active_users", [[:source]])

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -28,6 +28,7 @@ defmodule Sanbase.SocialData.MetricAdapter do
     "social_volume_twitter_news",
     "social_volume_twitter_nft",
     "social_volume_youtube_videos",
+    "social_volume_newsapi_crypto",
     "social_volume_total",
     "nft_social_volume"
   ]
@@ -346,8 +347,12 @@ defmodule Sanbase.SocialData.MetricAdapter do
        default_aggregation: :sum,
        available_aggregations: @aggregations,
        available_selectors: selectors,
+       required_selectors: [],
        data_type: :timeseries,
-       complexity_weight: @default_complexity_weight
+       complexity_weight: @default_complexity_weight,
+       hard_deprecate_after: nil,
+       is_deprecated: false,
+       is_timebound: false
      }}
   end
 
@@ -365,6 +370,12 @@ defmodule Sanbase.SocialData.MetricAdapter do
   defp source_first_datetime("total"), do: source_first_datetime("bitcointalk")
   defp source_first_datetime("telegram"), do: {:ok, ~U[2016-03-29 00:00:00Z]}
   defp source_first_datetime("twitter"), do: {:ok, ~U[2018-02-13 00:00:00Z]}
+  defp source_first_datetime("twitter_crypto"), do: {:ok, ~U[2018-02-13 00:00:00Z]}
+  defp source_first_datetime("twitter_news"), do: {:ok, ~U[2018-02-13 00:00:00Z]}
+  defp source_first_datetime("twitter_nft"), do: {:ok, ~U[2018-02-13 00:00:00Z]}
   defp source_first_datetime("reddit"), do: {:ok, ~U[2016-01-01 00:00:00Z]}
   defp source_first_datetime("bitcointalk"), do: {:ok, ~U[2011-06-01 00:00:00Z]}
+  defp source_first_datetime("newsapi_crypto"), do: {:ok, ~U[2024-01-01 00:00:00Z]}
+  defp source_first_datetime("youtube_videos"), do: {:ok, ~U[2018-02-13 00:00:00Z]}
+  defp source_first_datetime("4chan"), do: {:ok, ~U[2018-02-13 00:00:00Z]}
 end

--- a/lib/sanbase/social_data/social_volume.ex
+++ b/lib/sanbase/social_data/social_volume.ex
@@ -153,18 +153,22 @@ defmodule Sanbase.SocialData.SocialVolume do
 
   defp social_volume_request(selector, from, to, interval, source, opts) do
     with {:ok, search_text} <- SocialHelper.social_metrics_selector_handler(selector) do
-      url = Path.join([metrics_hub_url(), opts_to_metric(opts)])
+      url =
+        Path.join([metrics_hub_url(), opts_to_metric(opts)])
+        |> IO.inspect(label: "URL")
 
-      options = [
-        recv_timeout: @recv_timeout,
-        params: [
-          {"search_text", search_text},
-          {"from_timestamp", from |> DateTime.truncate(:second) |> DateTime.to_iso8601()},
-          {"to_timestamp", to |> DateTime.truncate(:second) |> DateTime.to_iso8601()},
-          {"interval", interval},
-          {"source", source}
+      options =
+        [
+          recv_timeout: @recv_timeout,
+          params: [
+            {"search_text", search_text},
+            {"from_timestamp", from |> DateTime.truncate(:second) |> DateTime.to_iso8601()},
+            {"to_timestamp", to |> DateTime.truncate(:second) |> DateTime.to_iso8601()},
+            {"interval", interval},
+            {"source", source}
+          ]
         ]
-      ]
+        |> IO.inspect(label: "OPTIONS")
 
       http_client().get(url, [], options)
     end

--- a/lib/sanbase/social_data/social_volume.ex
+++ b/lib/sanbase/social_data/social_volume.ex
@@ -153,9 +153,7 @@ defmodule Sanbase.SocialData.SocialVolume do
 
   defp social_volume_request(selector, from, to, interval, source, opts) do
     with {:ok, search_text} <- SocialHelper.social_metrics_selector_handler(selector) do
-      url =
-        Path.join([metrics_hub_url(), opts_to_metric(opts)])
-        |> IO.inspect(label: "URL")
+      url = Path.join([metrics_hub_url(), opts_to_metric(opts)])
 
       options =
         [
@@ -168,7 +166,6 @@ defmodule Sanbase.SocialData.SocialVolume do
             {"source", source}
           ]
         ]
-        |> IO.inspect(label: "OPTIONS")
 
       http_client().get(url, [], options)
     end

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -775,6 +775,7 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "social_dominance_bitcointalk_1h_moving_average",
         "social_dominance_bitcointalk_24h_moving_average",
         "social_volume_4chan",
+        "social_volume_newsapi_crypto",
         "social_volume_reddit",
         "social_volume_twitter",
         "social_volume_twitter_crypto",
@@ -1480,23 +1481,7 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
       |> Enum.map(&elem(&1, 0))
       |> Enum.sort()
 
-    expected =
-      [
-        "nft_social_volume",
-        "social_volume_bitcointalk",
-        "social_volume_reddit",
-        "social_volume_4chan",
-        "social_volume_telegram",
-        "social_volume_total",
-        "social_volume_twitter",
-        "social_volume_twitter_crypto",
-        "social_volume_twitter_news",
-        "social_volume_twitter_nft",
-        "social_volume_youtube_videos",
-        "social_volume_ai_total",
-        "trending_words_rank"
-      ]
-      |> Enum.sort()
+    expected = []
 
     assert result == expected
   end

--- a/test/sanbase/social_data/social_volume_test.exs
+++ b/test/sanbase/social_data/social_volume_test.exs
@@ -134,6 +134,12 @@ defmodule Sanbase.SocialVolumeTest do
           source -> Atom.to_string(source)
         end)
 
+      # newsapi_crypto is added as a social volume metric for now.
+      # if we add it to the sources list, it will define the sentiment
+      # metrics and they are not supported. Fix when all newsapi_crypto
+      # metrics are introduced
+      expected_sources = ["newsapi_crypto"] ++ expected_sources
+
       assert expected_sources |> Enum.sort() == sources |> Enum.sort()
     end
   end

--- a/test/sanbase_web/graphql/metric/api_metric_social_metrics_timeframe_restriction_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_social_metrics_timeframe_restriction_test.exs
@@ -33,16 +33,19 @@ defmodule Sanbase.Graphql.ApiMetricSocialMetricsTimeframeRestrictionTest do
   end
 
   describe "SANBase product, No subscription" do
-    test "can access realtime data for social metrics", context do
+    test "cannot access realtime data for social metrics", context do
       {from, to} = from_to(2, 0)
       slug = context.project.slug
       metric = Enum.random(context.metrics)
       interval = "5m"
       query = metric_query(metric, slug, from, to, interval)
-      result = execute_query(context.conn, query, "getMetric")
 
-      assert_called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
-      assert result != nil
+      result = execute_query_with_error(context.conn, query, "getMetric")
+
+      refute called(Metric.timeseries_data(metric, :_, from, to, :_, :_))
+
+      assert result =~
+               "Both `from` and `to` parameters are outside the allowed interval you can query"
     end
 
     test "cannot access historical data for social metrics", context do


### PR DESCRIPTION
## Changes
- Add `social_volume_newsapi_crypto` metric
- Fix issue with partly restricted metrics (metrics that are restricted and explicitly allow either realtime or historical data for free). Previously they were handled as if they are fully restricted.
- Make all social volume metrics fully restricted. They were defined as having free realtime data, but this has never worked. 
- Fix a test that misses the `_test` part in its name. Rework the test to handle the new social volume restrictions.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
