### PR TITLE
Add newsapi_crypto to the _total metrics. Add SD

### DIFF
--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -48,19 +48,20 @@ defmodule Sanbase.SocialData.MetricAdapter do
     "social_dominance_twitter_news",
     "social_dominance_twitter_nft",
     "social_dominance_youtube_videos",
+    "social_dominance_newsapi_crypto",
     "social_dominance_total",
     "social_dominance_ai_total"
   ]
 
+  # Exclude newsapi_crypto as sentiment metrics are not supported at the moment
+  sources = ["total"] ++ (SocialHelper.sources() -- [:newsapi_crypto])
+
   @sentiment_timeseries_metrics for name <- ["sentiment"],
+                                    source <- sources,
                                     type <- ["positive", "negative", "balance", "volume_consumed"],
-                                    source <-
-                                      ["total"] ++
-                                        Sanbase.SocialData.SocialHelper.sources(),
                                     do: "#{name}_#{type}_#{source}"
 
   @active_users_timeseries_metrics ["social_active_users"]
-
   @timeseries_metrics @social_dominance_timeseries_metrics ++
                         @social_volume_timeseries_metrics ++
                         @community_messages_count_timeseries_metrics ++

--- a/lib/sanbase/social_data/social_helper.ex
+++ b/lib/sanbase/social_data/social_helper.ex
@@ -11,7 +11,8 @@ defmodule Sanbase.SocialData.SocialHelper do
     :twitter_crypto,
     :twitter_news,
     :twitter_nft,
-    :youtube_videos
+    :youtube_videos,
+    :newsapi_crypto
   ]
 
   def sources(), do: @sources

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -750,6 +750,7 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "social_dominance_twitter_news",
         "social_dominance_twitter_nft",
         "social_dominance_youtube_videos",
+        "social_dominance_newsapi_crypto",
         "social_dominance_total",
         "social_dominance_ai_total",
         "social_dominance_total_1h_moving_average",

--- a/test/sanbase/social_data/social_volume_test.exs
+++ b/test/sanbase/social_data/social_volume_test.exs
@@ -138,7 +138,7 @@ defmodule Sanbase.SocialVolumeTest do
       # if we add it to the sources list, it will define the sentiment
       # metrics and they are not supported. Fix when all newsapi_crypto
       # metrics are introduced
-      expected_sources = ["newsapi_crypto"] ++ expected_sources
+      expected_sources = expected_sources
 
       assert expected_sources |> Enum.sort() == sources |> Enum.sort()
     end


### PR DESCRIPTION
## Changes

- Extend `Sanbase.SocialData.SocialHelper.sources()` to include `newsapi_crypto`;
- Manually exclude this source when building the list of sentiment metrics, as they are not supported at the moment;
- This way the `total`/`all` source for social volume and social dominance will now include the `newsapi_crypto` source;

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
