### PR TITLE
Fix the unique index for dashboard_id in the votes table

### DIFF
--- a/priv/repo/migrations/20240126133441_fix_dashboard_votes_unique_index.exs
+++ b/priv/repo/migrations/20240126133441_fix_dashboard_votes_unique_index.exs
@@ -1,0 +1,8 @@
+defmodule Sanbase.Repo.Migrations.FixDashboardVotesUniqueIndex do
+  use Ecto.Migration
+
+  def change do
+    drop(unique_index(:votes, [:dashboard_id]))
+    create(unique_index(:votes, [:dashboard_id, :user_id]))
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -7486,10 +7486,10 @@ CREATE UNIQUE INDEX votes_chart_configuration_id_user_id_index ON public.votes U
 
 
 --
--- Name: votes_dashboard_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: votes_dashboard_id_user_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX votes_dashboard_id_index ON public.votes USING btree (dashboard_id);
+CREATE UNIQUE INDEX votes_dashboard_id_user_id_index ON public.votes USING btree (dashboard_id, user_id);
 
 
 --
@@ -9284,3 +9284,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20240115140319);
 INSERT INTO public."schema_migrations" (version) VALUES (20240123102455);
 INSERT INTO public."schema_migrations" (version) VALUES (20240123102628);
 INSERT INTO public."schema_migrations" (version) VALUES (20240125141406);
+INSERT INTO public."schema_migrations" (version) VALUES (20240126133441);


### PR DESCRIPTION
## Changes

The unique index must be on [:dashboard_id, :user_id] and not on
:dashboard_id only. Each user can have a single record for an entity.
Multiple votes are recored by bumping the count column.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
