### PR TITLE
Drop unused processed_github_archives table

### DIFF
--- a/priv/repo/migrations/20240131160724_drop_unused_github_processing_table.exs
+++ b/priv/repo/migrations/20240131160724_drop_unused_github_processing_table.exs
@@ -1,0 +1,20 @@
+defmodule Sanbase.Repo.Migrations.DropUnusedGithubProcessingTable do
+  use Ecto.Migration
+
+  def up do
+    drop(table(:processed_github_archives))
+  end
+
+  def down do
+    # This table is unused for a long time. Its purpose and work has been moved
+    # to the github-exporter project
+    create table(:processed_github_archives) do
+      add(:project_id, references(:project, on_delete: :delete_all))
+      add(:archive, :string, null: false)
+
+      timestamps()
+    end
+
+    create(unique_index(:processed_github_archives, [:project_id, :archive]))
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2759,38 +2759,6 @@ ALTER SEQUENCE public.price_scraping_progress_id_seq OWNED BY public.price_scrap
 
 
 --
--- Name: processed_github_archives; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.processed_github_archives (
-    id bigint NOT NULL,
-    project_id bigint,
-    archive character varying(255) NOT NULL,
-    inserted_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: processed_github_archives_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.processed_github_archives_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: processed_github_archives_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.processed_github_archives_id_seq OWNED BY public.processed_github_archives.id;
-
-
---
 -- Name: products; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5123,13 +5091,6 @@ ALTER TABLE ONLY public.price_scraping_progress ALTER COLUMN id SET DEFAULT next
 
 
 --
--- Name: processed_github_archives id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.processed_github_archives ALTER COLUMN id SET DEFAULT nextval('public.processed_github_archives_id_seq'::regclass);
-
-
---
 -- Name: products id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -6027,14 +5988,6 @@ ALTER TABLE ONLY public.price_migration_tmp
 
 ALTER TABLE ONLY public.price_scraping_progress
     ADD CONSTRAINT price_scraping_progress_pkey PRIMARY KEY (id);
-
-
---
--- Name: processed_github_archives processed_github_archives_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.processed_github_archives
-    ADD CONSTRAINT processed_github_archives_pkey PRIMARY KEY (id);
 
 
 --
@@ -7083,13 +7036,6 @@ CREATE UNIQUE INDEX presigned_s3_urls_user_id_bucket_object_index ON public.pres
 --
 
 CREATE UNIQUE INDEX price_scraping_progress_identifier_source_index ON public.price_scraping_progress USING btree (identifier, source);
-
-
---
--- Name: processed_github_archives_project_id_archive_index; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX processed_github_archives_project_id_archive_index ON public.processed_github_archives USING btree (project_id, archive);
 
 
 --
@@ -8296,14 +8242,6 @@ ALTER TABLE ONLY public.presigned_s3_urls
 
 
 --
--- Name: processed_github_archives processed_github_archives_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.processed_github_archives
-    ADD CONSTRAINT processed_github_archives_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.project(id) ON DELETE CASCADE;
-
-
---
 -- Name: project_ecosystem_mappings project_ecosystem_mappings_ecosystem_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9349,3 +9287,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20240123102628);
 INSERT INTO public."schema_migrations" (version) VALUES (20240125095156);
 INSERT INTO public."schema_migrations" (version) VALUES (20240125141406);
 INSERT INTO public."schema_migrations" (version) VALUES (20240126133441);
+INSERT INTO public."schema_migrations" (version) VALUES (20240131160724);


### PR DESCRIPTION
## Changes

The work is now done by github-exporter in a different postgres
database. This table has no new data since 2019-01-09, but it takes up
8GB of space (53 million records), which is around 13% of the total space used by RDS.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
