### PR TITLE
Replace drop with drop_if_exists in Ecto migration

### DIFF
--- a/priv/repo/migrations/20240131160724_drop_unused_github_processing_table.exs
+++ b/priv/repo/migrations/20240131160724_drop_unused_github_processing_table.exs
@@ -2,7 +2,7 @@ defmodule Sanbase.Repo.Migrations.DropUnusedGithubProcessingTable do
   use Ecto.Migration
 
   def up do
-    drop(table(:processed_github_archives))
+    drop_if_exists(table(:processed_github_archives))
   end
 
   def down do


### PR DESCRIPTION
## Changes

In case an error with privilages occurs on prod, we can drop the table
manually. With drop_if_exists/1 this will not cause an error and the
migration will succeed.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
