### PR TITLE
Use /v2 instead of /v1 in CMC endpoint

### DIFF
--- a/lib/sanbase/external_services/coinmarketcap/cryptocurrency_info.ex
+++ b/lib/sanbase/external_services/coinmarketcap/cryptocurrency_info.ex
@@ -27,7 +27,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.CryptocurrencyInfo do
       Enum.map(projects, &Project.coinmarketcap_id/1)
       |> Enum.sort()
 
-    "v1/cryptocurrency/info?slug=#{Enum.join(coinmarketcap_ids, ",")}"
+    "v2/cryptocurrency/info?slug=#{Enum.join(coinmarketcap_ids, ",")}"
     |> get()
     |> case do
       {:ok, %Tesla.Env{status: 200, body: body}} ->

--- a/test/sanbase/external_services/coinmarketcap/cryptocurrency_info_test.exs
+++ b/test/sanbase/external_services/coinmarketcap/cryptocurrency_info_test.exs
@@ -43,11 +43,11 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.CryptocurrencyInfoTest do
 
     url_with_invalid_slugs =
       Config.module_get(Sanbase.ExternalServices.Coinmarketcap, :api_url) <>
-        "v1/cryptocurrency/info?slug=bitcoin,ethereum,invalid0,invalid1"
+        "v2/cryptocurrency/info?slug=bitcoin,ethereum,invalid0,invalid1"
 
     url_with_cleaned_slugs =
       Config.module_get(Sanbase.ExternalServices.Coinmarketcap, :api_url) <>
-        "v1/cryptocurrency/info?slug=bitcoin,ethereum"
+        "v2/cryptocurrency/info?slug=bitcoin,ethereum"
 
     mock(fn
       %{method: :get, url: ^url_with_invalid_slugs} ->

--- a/test/sanbase/external_services/coinmarketcap/logo_fetcher_test.exs
+++ b/test/sanbase/external_services/coinmarketcap/logo_fetcher_test.exs
@@ -19,7 +19,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.LogoFetcherTest do
 
       info_url =
         Config.module_get(Sanbase.ExternalServices.Coinmarketcap, :api_url) <>
-          "v1/cryptocurrency/info?slug=#{bitcoin.slug},#{ethereum.slug}"
+          "v2/cryptocurrency/info?slug=#{bitcoin.slug},#{ethereum.slug}"
 
       mock(fn
         %{method: :get, url: ^info_url} ->
@@ -82,7 +82,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.LogoFetcherTest do
 
       info_url =
         Config.module_get(Sanbase.ExternalServices.Coinmarketcap, :api_url) <>
-          "v1/cryptocurrency/info?slug=bitcoin"
+          "v2/cryptocurrency/info?slug=bitcoin"
 
       mock(fn
         %{


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
