### PR TITLE
Add user_id_data_only to getMostRecent API

### DIFF
--- a/lib/sanbase/entity/entity.ex
+++ b/lib/sanbase/entity/entity.ex
@@ -692,6 +692,7 @@ defmodule Sanbase.Entity do
         [preload?: false, distinct?: true, ordered?: false]
 
     current_user_id = Keyword.get(opts, :current_user_id)
+
     include_current_user_entities = Keyword.fetch!(opts, :include_current_user_entities)
     include_public_entities = Keyword.fetch!(opts, :include_public_entities)
 
@@ -837,6 +838,14 @@ defmodule Sanbase.Entity do
   end
 
   defp update_opts(opts) do
+    # TODO: Make it so it errors or combines the values
+    # when user_role_data_only is provided
+    opts =
+      case Keyword.get(opts, :user_id_data_only) do
+        user_id when is_integer(user_id) -> Keyword.put(opts, :user_ids, [user_id])
+        _ -> opts
+      end
+
     opts =
       case Keyword.get(opts, :filter) do
         %{slugs: slugs} = filter ->

--- a/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
@@ -185,6 +185,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EntityResolver do
     |> maybe_add_user_option(:current_user_data_only, args, resolution)
     |> maybe_add_user_option(:current_user_voted_for_only, args, resolution)
     |> maybe_add_value_option(:user_role_data_only, args)
+    |> maybe_add_value_option(:user_id_data_only, args)
     |> maybe_add_value_option(:is_featured_data_only, args)
     |> maybe_add_value_option(:min_title_length, args)
     |> maybe_add_value_option(:min_description_length, args)

--- a/lib/sanbase_web/graphql/schema/queries/entity_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/entity_queries.ex
@@ -43,7 +43,19 @@ defmodule SanbaseWeb.Graphql.Schema.EntityQueries do
       arg(:page_size, :integer)
       arg(:is_featured_data_only, :boolean, default_value: false)
       arg(:user_role_data_only, :user_role)
+
+      @desc ~s"""
+      If true, return only entities created by the current user that
+      executes this query
+      """
       arg(:current_user_data_only, :boolean, default_value: false)
+
+      @desc ~s"""
+      If provide, return the public entities of the specified user.
+      If the specified user is the current user, only the public entities will be shown.
+      To see the private entities of the current user, use the `currentUserDataOnly` flag
+      """
+      arg(:user_id_data_only, :integer, default_value: nil)
       arg(:cursor, :cursor_input_no_order, default_value: nil)
       arg(:filter, :entity_filter)
 


### PR DESCRIPTION
## Changes
```graphql
{
  getMostRecent(userIdDataOnly: 32, types: [DASHBOARD, ADDRESS_WATCHLIST, INSIGHT, PROJECT_WATCHLIST]) {
    data {
      addressWatchlist {
        user {
          id
        }
      }
      projectWatchlist {
        user {
          id
        }
      }
      insight {
        user {
          id
        }
      }
      dashboard {
        user {
          id
        }
      }
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
