### PR TITLE
Improve the custom plan creation form UI

### DIFF
--- a/lib/sanbase_web/templates/custom_plan_html/form.html.eex
+++ b/lib/sanbase_web/templates/custom_plan_html/form.html.eex
@@ -6,77 +6,69 @@
     </div>
   <% end %>
 
-  <div class="mb-4 relative"> <h2> General Plan fields </h2> </div>
+  <div class="mb-4 relative"> <h1 class="text-lg font-bold"> General Plan fields </h1> </div>
 
   <div class="mb-4 relative">
-    <%= text_input f, :name, id: "name", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600" %>
-    <label for="name" class="label absolute mb-0 -mt-2 pt-4 pl-3 leading-tighter text-gray-400 text-base mt-2 cursor-text">Name (Custom plans must start with `CUSTOM_`)</label>
+    <%= text_input f, :name, id: "name", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600", placeholder: "Name (Custom plans must start with CUSTOM_)" %>
     <%= error_tag f, :name %>
   </div>
 
   <div class="mb-4 relative">
-    <%= textarea f, :amount, id: "amount", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600" %>
-    <label for="amount" class="label absolute mb-0 -mt-2 pt-4 pl-3 leading-tighter text-gray-400 text-base mt-2 cursor-text">Amount (in cents; $49 is 4900) </label>
+    <%= textarea f, :amount, id: "amount", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600", placeholder: "Amount (in cents; $49 is 4900)" %>
     <%= error_tag f, :amount %>
   </div>
 
   <div class="mb-4 relative">
-    <%= textarea f, :currency, id: "currency", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600" %>
-    <label for="currency" class="label absolute mb-0 -mt-2 pt-4 pl-3 leading-tighter text-gray-400 text-base mt-2 cursor-text">Currency (Most of the times this is just USD)</label>
-    <%= error_tag f,:currency %>
+    <%= textarea f, :currency, id: "currency", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600", placeholder: "Currency (Most of the times this is just USD)" %>
     <%= error_tag f, :currency %>
   </div>
 
   <div class="mb-4 relative">
-    <%= textarea f, :interval, id: "interval", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600" %>
-    <label for="interval" class="label absolute mb-0 -mt-2 pt-4 pl-3 leading-tighter text-gray-400 text-base mt-2 cursor-text">Interval (`month` or `year`)</label>
+    <%= textarea f, :interval, id: "interval", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600", placeholder: "Interval (`month` or `year`)" %>
     <%= error_tag f,:interval %>
   </div>
 
-  <div class="mb-4 relative"> <h2> Custom Plan restrictions' fields </h2> </div>
+  <div class="mb-4 relative"> <h1 class="text-lg font-bold">Custom Plan restrictions fields</h1> </div>
  <%= inputs_for f, :restrictions, fn ff -> %>
 
     <div class="mb-4 relative">
-      <%= textarea ff, :metric_access, id: "metric_access", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600" %>
-      <label for="metric_access" class="label absolute mb-0 -mt-2 pt-4 pl-3 leading-tighter text-gray-400 text-base mt-2 cursor-text">Metric Access (JSON field like  {"accessible": "all", "not_accessible": ["daily_active_addresses"], "not_accessible_patterns": ["mvrv_usd"]} )</label>
+      <span> Example: {"accessible": "all", "not_accessible": [], "not_accessible_patterns": []]}
+      <%= textarea ff, :metric_access, id: "metric_access", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600", placeholder: "Metric Access (JSON field like  {\"accessible\": \"all\", \"not_accessible\": [\"daily_active_addresses\"], \"not_accessible_patterns\": [\"mvrv_usd\"]})" %>
       <%= error_tag ff, :metric_access %>
     </div>
 
 
-    <div class="mb-4 relative">
-      <%= textarea ff, :query_access, id: "query_access", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600" %>
-      <label for="query_access" class="label absolute mb-0 -mt-2 pt-4 pl-3 leading-tighter text-gray-400 text-base mt-2 cursor-text">Query Access (JSON field like  {"accessible": "all", "not_accessible": ["history_price"], "not_accessible_patterns": ["mvrv"]} )</label>
+    <div class="flex flex-col">
+      <span> Example: {"accessible": "all", "not_accessible": [], "not_accessible_patterns": []]}
+      <%= textarea ff, :query_access, id: "query_access", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600", placeholder: "Metric Access (JSON field like  {\"accessible\": \"all\", \"not_accessible\": [\"daily_active_addresses\"], \"not_accessible_patterns\": [\"mvrv_usd\"]})" %>
       <%= error_tag ff, :query_access %>
     </div>
 
     <div class="mb-4 relative">
-      <%= textarea ff, :signal_access, class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600" %>
-      <label for="signal_access" class="label absolute mb-0 -mt-2 pt-4 pl-3 leading-tighter text-gray-400 text-base mt-2 cursor-text">Signal Access (JSON field like  {"accessible": "all", "not_accessible": [], "not_accessible_patterns": []} )</label>
+      <span> Example: {"accessible": "all", "not_accessible": [], "not_accessible_patterns": []}
+      <%= textarea ff, :signal_access, class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600", placeholder: "Metric Access (JSON field like  {\"accessible\": \"all\", \"not_accessible\": [\"daily_active_addresses\"], \"not_accessible_patterns\": [\"mvrv_usd\"]})"   %>
       <%= error_tag ff, :signal_access %>
     </div>
 
     <div class="mb-4 relative">
-      <%= textarea ff, :api_call_limits, id: "api_call_limits", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600" %>
-      <label for="api_call_limits" class="label absolute mb-0 -mt-2 pt-4 pl-3 leading-tighter text-gray-400 text-base mt-2 cursor-text">Api Call Limits (JSON field like  {"month": 3000000, "hour": 100000, "minute": 3000} )</label>
+      <span>Example: {"month": 300000, "hour": 20000, "minute": 300}</span>
+      <%= textarea ff, :api_call_limits, id: "api_call_limits", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600", placeholder: "Api Call Limits (JSON field like  {\"month\": 3000000, \"hour\": 100000, \"minute\": 3000}" %>
       <%= error_tag ff, :api_call_limits %>
     </div>
 
 
     <div class="mb-4 relative">
-      <%= textarea ff, :historical_data_in_days, id: "historical_data_in_days", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600" %>
-      <label for="historical_data_in_days" class="label absolute mb-0 -mt-2 pt-4 pl-3 leading-tighter text-gray-400 text-base mt-2 cursor-text">Historical Data In Days (An non-negative integer or empty if no restrictions are applied)</label>
+      <%= textarea ff, :historical_data_in_days, id: "historical_data_in_days", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600", placeholder: "Historical Data In Days (An non-negative integer or empty if no restrictions are applied)" %>
       <%= error_tag ff, :historical_data_in_days %>
     </div>
 
     <div class="mb-4 relative">
-      <%= textarea ff, :realtime_data_cut_off_in_days, id: "realtime_data_cut_off_in_days", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600" %>
-      <label for="realtime_data_cut_off_in_days" class="label absolute mb-0 -mt-2 pt-4 pl-3 leading-tighter text-gray-400 text-base mt-2 cursor-text">Realtime Data Cut Off In Days (An non-negative integer or empty if no restrictions are applied)</label>
+      <%= textarea ff, :realtime_data_cut_off_in_days, id: "realtime_data_cut_off_in_days", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600", placeholder: "Realtime Data Cut Off In Days (An non-negative integer or empty if no restrictions are applied)" %>
       <%= error_tag ff, :realtime_data_cut_off_in_days %>
     </div>
 
     <div class="mb-4 relative">
-      <%= textarea ff, :restricted_access_as_plan, id: "restricted_access_as_plan", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600" %>
-      <label for="restricted_access_as_plan" class="label absolute mb-0 -mt-2 pt-4 pl-3 leading-tighter text-gray-400 text-base mt-2 cursor-text">Restricted Access As Plan (One of: FREE, BASIC, PRO, PREMIUM)</label>
+      <%= textarea ff, :restricted_access_as_plan, id: "restricted_access_as_plan", class: "input border border-gray-400 appearance-none rounded w-full px-3 py-3 pt-5 pb-2 focus focus:border-indigo-600 focus:outline-none active:outline-none active:border-indigo-600", placeholder: "Restricted Access As Plan (One of: FREE, BASIC, PRO, PREMIUM). This controls how the min_plan field is applied." %>
       <%= error_tag ff, :restricted_access_as_plan %>
     </div>
 

--- a/priv/repo/seed_plans_and_products.exs
+++ b/priv/repo/seed_plans_and_products.exs
@@ -42,3 +42,9 @@ INSERT INTO plans (id, name, product_id, amount, currency, interval, "order") VA
   (52,'EXTENSION',5,216000,'USD','year',0)
   ON CONFLICT DO NOTHING
 """)
+
+# Otherwise when we try to create a custom plan it will fail
+# as plans_id_seq will produce `1` as the next value
+Sanbase.Repo.query!("""
+ALTER SEQUENCE plans_id_seq RESTART WITH 1000;
+""")


### PR DESCRIPTION
## Changes

After the migration to the in-house admin panel, the UI for custom plan creation is not displayed properly.

This PR also fixes the seed used locally to populate plans: `mix run priv/repo/seed_plans_and_products.exs` to also alter the `plans_id_seq`, otherwise the custom plan will be assigned the id of `1`, which is already taken.

Old: 
<img width="1346" alt="image" src="https://github.com/santiment/sanbase2/assets/6518376/91b2ed82-ce34-44ce-bf1d-a59aa48aeb48">
New: 
<img width="1066" alt="image" src="https://github.com/santiment/sanbase2/assets/6518376/0ed2481c-1848-4825-ab81-f17b3715ab36">

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
