### PR TITLE
Improve admin2 button and search placement

### DIFF
--- a/lib/sanbase_web/components/table.ex
+++ b/lib/sanbase_web/components/table.ex
@@ -214,7 +214,7 @@ defmodule SanbaseWeb.TableComponent do
   def has_many_table(assigns) do
     ~H"""
     <div class="table-responsive">
-      <div class="m-4">
+      <div class="m-4 flex flex-col gap-x-10">
         <h3 class="text-3xl font-medium text-gray-700 mb-2"><%= @resource_name %></h3>
         <%= if @create_link_kv != [] do %>
           <.new_resource_button resource={@resource} create_link_kv={@create_link_kv} />
@@ -241,11 +241,11 @@ defmodule SanbaseWeb.TableComponent do
   def table(assigns) do
     ~H"""
     <div class="table-responsive">
-      <div class="ml-4">
-        <.search fields={@search_fields} resource={@resource} search={@search} />
+      <div class="m-4 flex flex-col md:flex-row md:items-center gap-y-2 md:gap-x-10">
         <%= if :new in @actions do %>
           <.new_resource_button resource={@resource} create_link_kv={[]} />
         <% end %>
+        <.search fields={@search_fields} resource={@resource} search={@search} />
       </div>
       <div class="relative overflow-x-auto shadow-md sm:rounded-lg">
         <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-400">
@@ -376,7 +376,7 @@ defmodule SanbaseWeb.TableComponent do
     ~H"""
     <button
       type="button"
-      class="text-white bg-blue-500 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800"
+      class="text-white w-fit p-2 bg-blue-500 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800"
     >
       <.link href={
         if @create_link_kv,
@@ -463,16 +463,13 @@ defmodule SanbaseWeb.TableComponent do
   # The component was borrowed from: https://flowbite.com/docs/forms/search-input/#search-with-dropdown
   def search(assigns) do
     ~H"""
-    <div
-      class="mb-4"
-      x-data={Jason.encode!(%{open: false, selectedField: @search["field"] || "Fields"})}
-    >
+    <div x-data={Jason.encode!(%{open: false, selectedField: @search["field"] || "Fields"})}>
       <.form
         for={%{}}
         as={:search}
         method="get"
         action={Routes.generic_path(SanbaseWeb.Endpoint, :search, resource: @resource)}
-        class="max-w-lg mx-auto mt-2"
+        class="max-w-lg md:w-96"
       >
         <input type="hidden" name="search[field]" x-bind:value="selectedField" />
         <input type="hidden" name="resource" value={@resource} />


### PR DESCRIPTION
## Changes

Improve the alignment of the new resource button and search bar. Small improvements in the responsiveness of them, too.
Old: 
<img width="1917" alt="image" src="https://github.com/santiment/sanbase2/assets/6518376/5bc77a61-3598-40e2-bc65-9c6c65219dae">
<img width="698" alt="image" src="https://github.com/santiment/sanbase2/assets/6518376/b7f2575e-1e9a-4a28-b282-3a59cbd99564">
<img width="947" alt="image" src="https://github.com/santiment/sanbase2/assets/6518376/3433c18e-d0a8-440b-a00e-3455ac331030">

New:
<img width="1537" alt="image" src="https://github.com/santiment/sanbase2/assets/6518376/733ac36a-ebd5-418a-8966-949cb9478cc5">
<img width="591" alt="image" src="https://github.com/santiment/sanbase2/assets/6518376/f959ff06-478b-4d38-aa60-b40b6ecf6652">

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
