### PR TITLE
Fix preload issue in get_dashboard API

### DIFF
--- a/lib/sanbase/dashboards/dashboard/dashboard.ex
+++ b/lib/sanbase/dashboards/dashboard/dashboard.ex
@@ -115,7 +115,7 @@ defmodule Sanbase.Dashboards.Dashboard do
   @create_fields [:name, :description, :is_public, :parameters, :settings, :user_id]
   @update_fields @create_fields -- [:user_id]
 
-  @preload [:queries, :user, :featured_item, queries: :user]
+  @preload [:queries, :user, :featured_item, [queries: :user]]
   def default_preload(), do: @preload
 
   def create_changeset(%__MODULE__{} = dashboard, attrs) do
@@ -304,7 +304,7 @@ defmodule Sanbase.Dashboards.Dashboard do
         query
 
       true ->
-        preload = Keyword.get(opts, :preload, @preload)
+        preload = opts |> Keyword.get(:preload, @preload)
         query |> preload(^preload)
     end
   end

--- a/lib/sanbase/dashboards/dashboards.ex
+++ b/lib/sanbase/dashboards/dashboards.ex
@@ -45,9 +45,12 @@ defmodule Sanbase.Dashboards do
   @spec get_dashboard(dashboard_id(), user_id() | nil, Keyword.t()) ::
           {:ok, Dashboard.t()} | {:error, String.t()}
   def get_dashboard(dashboard_id, querying_user_id, opts \\ []) do
-    # If empty, set the default options so the rest of the logic that depends on the defaults
-    # can still work
-    opts = if [] == opts, do: [preload?: true, preload: Dashboard.default_preload()], else: opts
+    # We put the preloads here, if they are missing, as the preload value
+    # is checked in this function, too.
+    opts =
+      opts
+      |> Keyword.put_new(:preload?, true)
+      |> Keyword.put_new(:preload, Dashboard.default_preload())
 
     Ecto.Multi.new()
     |> Ecto.Multi.run(:get_dashboard, fn _repo, _changes ->


### PR DESCRIPTION
## Changes

The user struct was not preloaded for any of the queries on a dashboard.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
