### PR TITLE
Focus on admin searchbar when / is pressed

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -5,13 +5,15 @@ import { LiveSocket } from "phoenix_live_view"
 import topbar from "../vendor/topbar"
 import Alpine from 'alpinejs'
 import "flowbite/dist/flowbite.phoenix.js";
+import { FocusInput } from "./focus_input"
 
 window.Alpine = Alpine
 Alpine.start()
-
+const Hooks = { FocusInput: FocusInput }
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 let liveSocket = new LiveSocket("/live", Socket, {
   params: { _csrf_token: csrfToken },
+  hooks: Hooks,
   dom: {
     onBeforeElUpdated(from, to) {
       if (from._x_dataStack) {

--- a/assets/js/focus_input.js
+++ b/assets/js/focus_input.js
@@ -1,0 +1,17 @@
+const FocusInput = {
+  mounted() {
+
+    document.addEventListener('keyup', (e) => {
+      const input = document.getElementById('search-input');
+      const search_result = document.getElementById('search-result-suggestions')
+      if (document.activeElement != input) {
+        if (e.key === '/') {
+          input.focus();
+          search_result.classList.remove('hidden')
+        }
+      }
+    })
+  }
+}
+
+export { FocusInput }

--- a/lib/sanbase_web/components/admin_components.ex
+++ b/lib/sanbase_web/components/admin_components.ex
@@ -887,11 +887,7 @@ defmodule SanbaseWeb.LiveSearch do
   @impl true
   def render(assigns) do
     ~H"""
-    <div
-      x-data="{results_open: true}"
-      @click="results_open = true"
-      @click.outside="results_open = false"
-    >
+    <div>
       <div class="relative m-3">
         <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
           <.icon name="hero-magnifying-glass" />
@@ -901,23 +897,24 @@ defmodule SanbaseWeb.LiveSearch do
           phx-keyup="do-search"
           phx-debounce="200"
           type="text"
-          id="simple-search"
-          class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full ps-10 p-2.5  dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-          placeholder="Search resources..."
+          id="search-input"
+          class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg block w-full ps-10 p-2.5 "
+          placeholder="Type / to search"
+          phx-hook="FocusInput"
+          phx-click={JS.remove_class("hidden", to: "#search-result-suggestions")}
+          phx-click-away={JS.add_class("hidden", to: "#search-result-suggestions")}
           required
         />
       </div>
       <ul
-        x-show="results_open"
+        :if={@routes != []}
+        id="search-result-suggestions"
         x-transition
-        class="absolute ml-2 py-2 text-gray-700 dark:text-gray-200 border shadow-xl bg-blue-50 rounded-xl"
+        class="absolute z-20 ml-2 py-2 min-w-96 text-gray-700 border shadow-xl bg-gray-50 rounded-lg"
         aria-labelledby="dropdownDefaultButton"
       >
         <li :for={{name, path} <- @routes}>
-          <a
-            href={path}
-            class="block p-4 hover:bg-blue-100 dark:hover:bg-gray-600 dark:hover:text-white text-md font-semibold"
-          >
+          <a href={path} class="block p-4 hover:bg-gray-100 text-sm font-semibold">
             <%= name %>
           </a>
         </li>


### PR DESCRIPTION
## Changes
- Make the admin search input focus when `/` is pressed
- Rework how the logic for showing the result is handled, so it properly works when there are no clicks, but the the search input is navigated to by the key shortcut
- Improve the styles of the search result to match the style of the search input
- Make the search result appear on top of the table when searching from within a resource (increase z index)
- Now it's possible to search without the mouse, using `/`, tab and enter.

<img width="258" alt="image" src="https://github.com/santiment/sanbase2/assets/6518376/e91095a2-8183-4ffc-9455-5d5cc21ed610">
<br/>
<img width="481" alt="image" src="https://github.com/santiment/sanbase2/assets/6518376/bab29397-129a-4d0c-9ec0-803239ca2955">

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
