### PR TITLE
Add Undo button to the ecosystem change suggestions

### DIFF
--- a/lib/sanbase/project/ecosystem/ecosystem_project_mapping.ex
+++ b/lib/sanbase/project/ecosystem/ecosystem_project_mapping.ex
@@ -60,8 +60,8 @@ defmodule Sanbase.ProjectEcosystemMapping do
         where: m.project_id == ^project_id and m.ecosystem_id == ^ecosystem_id
       )
 
-    {_, nil} = Sanbase.Repo.delete_all(query)
-    :ok
+    {count, nil} = Sanbase.Repo.delete_all(query)
+    {:ok, "Removed #{count} records"}
   end
 
   def remove(project_id, ecosystem) when is_binary(ecosystem) do

--- a/lib/sanbase_web/components/admin/user_submission_admin_components.ex
+++ b/lib/sanbase_web/components/admin/user_submission_admin_components.ex
@@ -19,6 +19,12 @@ defmodule SanbaseWeb.Admin.UserSubmissionAdminComponents do
     """
   end
 
+  attr(:name, :string, required: true)
+  attr(:value, :string, required: true)
+  attr(:display_text, :string, required: true)
+  attr(:class, :string, required: true)
+  attr(:disabled, :boolean, default: false)
+
   def update_status_button(assigns) do
     ~H"""
     <button
@@ -28,6 +34,7 @@ defmodule SanbaseWeb.Admin.UserSubmissionAdminComponents do
         "phx-submit-loading:opacity-75 rounded-lg my-1 py-2 px-3 text-sm font-semibold leading-6 text-white",
         @class
       ]}
+      disabled={@disabled}
     >
       <%= @display_text %>
     </button>


### PR DESCRIPTION
## Changes
Add an `Undo` button that is inactive when the status is `PENDING APPROVAL`
<img width="1873" alt="image" src="https://github.com/santiment/sanbase2/assets/6518376/eb423cb4-4837-4f00-8903-0a2cf61d4cfd">

The `Undo` button becomes active when the suggestion is either approved, or declined. When the `Undo` button is active, the `Approve` and `Decline` buttons become inactive.

If the suggestion is approved, the `Undo` button reverses the applied changes and sets the status to `pending_approval`.

If the suggestion is declined, the `Undo` button only sets the status to `pending_approval`.
<img width="1916" alt="image" src="https://github.com/santiment/sanbase2/assets/6518376/0f05413a-4116-4368-a7be-12d10a2c4c89">

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
