### PR TITLE
Add jsonData to watchlist's settings

### DIFF
--- a/lib/sanbase/user_lists/settings.ex
+++ b/lib/sanbase/user_lists/settings.ex
@@ -21,22 +21,25 @@ defmodule Sanbase.UserList.Settings do
     @type t :: %{
             page_size: non_neg_integer(),
             table_columns: map(),
-            time_window: String.t()
+            time_window: String.t(),
+            json_data: map()
           }
 
     @default_page_size 20
     @default_time_window "180d"
     @default_table_columns %{}
+    @default_json_data %{}
 
     embedded_schema do
       field(:page_size, :integer, default: @default_page_size)
       field(:time_window, :string, default: @default_time_window)
       field(:table_columns, :map, default: @default_table_columns)
+      field(:json_data, :map, default: @default_json_data)
     end
 
     def changeset(%__MODULE__{} = settings, attrs \\ %{}) do
       settings
-      |> cast(attrs, [:page_size, :time_window, :table_columns])
+      |> cast(attrs, [:page_size, :time_window, :table_columns, :json_data])
       |> validate_number(:page_size, greater_than: 0)
       |> validate_change(:time_window, &valid_time_window?/2)
     end
@@ -45,7 +48,8 @@ defmodule Sanbase.UserList.Settings do
       %{
         page_size: @default_page_size,
         time_window: @default_time_window,
-        table_columns: @default_table_columns
+        table_columns: @default_table_columns,
+        json_data: @default_json_data
       }
     end
 

--- a/lib/sanbase_web/graphql/schema/types/user_list_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_list_types.ex
@@ -53,12 +53,14 @@ defmodule SanbaseWeb.Graphql.UserListTypes do
     field(:time_window, :string)
     field(:page_size, :integer)
     field(:table_columns, :json)
+    field(:json_data, :json)
   end
 
   input_object :watchlist_settings_input_object do
     field(:time_window, :string)
     field(:page_size, :integer)
     field(:table_columns, :json)
+    field(:json_data, :json)
   end
 
   object :user_list do

--- a/lib/sanbase_web/live/ecosystem_labeling/add_ecosystems_labels_live.ex
+++ b/lib/sanbase_web/live/ecosystem_labeling/add_ecosystems_labels_live.ex
@@ -118,8 +118,6 @@ defmodule SanbaseWeb.AddEcosystemLabelsLive do
     {new, removed} =
       case params do
         %{"value" => "on", "ecosystem" => e} ->
-          IO.inspect(e, label: "ADDED")
-
           new =
             case e in stored do
               # Append to the back so it looks better in the UI

--- a/test/sanbase_web/graphql/watchlist/project/watchlist_settings_api_test.exs
+++ b/test/sanbase_web/graphql/watchlist/project/watchlist_settings_api_test.exs
@@ -19,7 +19,13 @@ defmodule SanbaseWeb.Graphql.WatchlistSettingsApiTest do
     %{"id" => watchlist_id} = create_watchlist(conn, title: rand_str())
 
     settings = get_watchlist_settings(conn, watchlist_id)
-    assert settings == %{"pageSize" => 20, "timeWindow" => "180d", "tableColumns" => %{}}
+
+    assert settings == %{
+             "pageSize" => 20,
+             "timeWindow" => "180d",
+             "tableColumns" => %{},
+             "jsonData" => %{}
+           }
   end
 
   test "cannot fetch settings of not own private watchlist", %{conn: conn, conn2: conn2} do
@@ -101,7 +107,8 @@ defmodule SanbaseWeb.Graphql.WatchlistSettingsApiTest do
     update_watchlist_settings(conn, watchlist_id,
       page_size: 50,
       time_window: "60d",
-      table_columns: %{shown_columns: [1, 2, 3]}
+      table_columns: %{shown_columns: [1, 2, 3]},
+      json_data: %{x: 12}
     )
 
     settings = get_watchlist_settings(conn2, watchlist_id)
@@ -109,7 +116,8 @@ defmodule SanbaseWeb.Graphql.WatchlistSettingsApiTest do
     assert settings == %{
              "pageSize" => 50,
              "tableColumns" => %{"shown_columns" => [1, 2, 3]},
-             "timeWindow" => "60d"
+             "timeWindow" => "60d",
+             "jsonData" => %{"x" => 12}
            }
   end
 
@@ -122,13 +130,15 @@ defmodule SanbaseWeb.Graphql.WatchlistSettingsApiTest do
     update_watchlist_settings(conn2, watchlist_id,
       page_size: 10,
       time_window: "30d",
-      table_columns: %{shown_columns: [2, 3]}
+      table_columns: %{shown_columns: [2, 3]},
+      json_data: %{some_key: "foo"}
     )
 
     update_watchlist_settings(conn, watchlist_id,
       page_size: 50,
       time_window: "60d",
-      table_columns: %{shown_columns: [1, 2, 3]}
+      table_columns: %{shown_columns: [1, 2, 3]},
+      json_data: %{some_key: "bar"}
     )
 
     settings = get_watchlist_settings(conn2, watchlist_id)
@@ -136,7 +146,8 @@ defmodule SanbaseWeb.Graphql.WatchlistSettingsApiTest do
     assert settings == %{
              "pageSize" => 10,
              "tableColumns" => %{"shown_columns" => [2, 3]},
-             "timeWindow" => "30d"
+             "timeWindow" => "30d",
+             "jsonData" => %{"some_key" => "foo"}
            }
   end
 
@@ -147,14 +158,21 @@ defmodule SanbaseWeb.Graphql.WatchlistSettingsApiTest do
       update_watchlist_settings(conn, watchlist_id,
         page_size: 20,
         time_window: "180d",
-        table_columns: %{}
+        table_columns: %{},
+        json_data: %{}
       )
 
     updated_settings = result["data"]["updateWatchlistSettings"]
 
     watchlist_settings = get_watchlist_settings(conn, watchlist_id)
     # default settings
-    assert updated_settings == %{"pageSize" => 20, "timeWindow" => "180d", "tableColumns" => %{}}
+    assert updated_settings == %{
+             "pageSize" => 20,
+             "timeWindow" => "180d",
+             "tableColumns" => %{},
+             "jsonData" => %{}
+           }
+
     assert updated_settings == watchlist_settings
   end
 
@@ -164,18 +182,26 @@ defmodule SanbaseWeb.Graphql.WatchlistSettingsApiTest do
     update_watchlist_settings(conn, watchlist_id,
       page_size: 50,
       time_window: "280d",
-      table_columns: %{shown: [1, 2, 3]}
+      table_columns: %{shown: [1, 2, 3]},
+      json_data: %{a: 1}
     )
 
     result =
       update_watchlist_settings(conn, watchlist_id,
         page_size: 20,
         time_window: "180d",
-        table_columns: %{}
+        table_columns: %{},
+        json_data: %{b: 2}
       )
 
     updated_settings = result["data"]["updateWatchlistSettings"]
-    assert updated_settings == %{"pageSize" => 20, "timeWindow" => "180d", "tableColumns" => %{}}
+
+    assert updated_settings == %{
+             "pageSize" => 20,
+             "timeWindow" => "180d",
+             "tableColumns" => %{},
+             "jsonData" => %{"b" => 2}
+           }
   end
 
   test "update page_size watchlist settings twice", %{conn: conn} do
@@ -184,7 +210,8 @@ defmodule SanbaseWeb.Graphql.WatchlistSettingsApiTest do
     update_watchlist_settings(conn, watchlist_id,
       page_size: 50,
       time_window: "280d",
-      table_columns: %{shown: [1, 2, 3]}
+      table_columns: %{shown: [1, 2, 3]},
+      json_data: %{x: 2}
     )
 
     result = update_watchlist_settings(conn, watchlist_id, page_size: 20)
@@ -194,7 +221,8 @@ defmodule SanbaseWeb.Graphql.WatchlistSettingsApiTest do
     assert updated_settings == %{
              "pageSize" => 20,
              "tableColumns" => %{"shown" => [1, 2, 3]},
-             "timeWindow" => "280d"
+             "timeWindow" => "280d",
+             "jsonData" => %{"x" => 2}
            }
   end
 
@@ -204,7 +232,8 @@ defmodule SanbaseWeb.Graphql.WatchlistSettingsApiTest do
     update_watchlist_settings(conn, watchlist_id,
       page_size: 50,
       time_window: "280d",
-      table_columns: %{shown: [1, 2, 3]}
+      table_columns: %{shown: [1, 2, 3]},
+      json_data: %{a: 1}
     )
 
     result = update_watchlist_settings(conn, watchlist_id, time_window: "20d")
@@ -214,7 +243,8 @@ defmodule SanbaseWeb.Graphql.WatchlistSettingsApiTest do
     assert updated_settings == %{
              "pageSize" => 50,
              "tableColumns" => %{"shown" => [1, 2, 3]},
-             "timeWindow" => "20d"
+             "timeWindow" => "20d",
+             "jsonData" => %{"a" => 1}
            }
   end
 
@@ -243,6 +273,7 @@ defmodule SanbaseWeb.Graphql.WatchlistSettingsApiTest do
            pageSize
            tableColumns
            timeWindow
+           jsonData
          }
       }
     }
@@ -257,30 +288,19 @@ defmodule SanbaseWeb.Graphql.WatchlistSettingsApiTest do
   end
 
   defp update_watchlist_settings(conn, watchlist_id, opts) do
-    page_size = if val = Keyword.get(opts, :page_size), do: "pageSize: #{val}"
-    time_window = if val = Keyword.get(opts, :time_window), do: "timeWindow: '#{val}'"
-
-    table_columns =
-      if val = Keyword.get(opts, :table_columns), do: "tableColumns: '#{val |> Jason.encode!()}'"
+    map = opts |> Map.new()
 
     mutation =
-      ~s|
+      ~s"""
       mutation {
-        updateWatchlistSettings(
-          id: #{watchlist_id},
-          settings: {
-            #{page_size}
-            #{time_window}
-            #{table_columns}
-          }) {
-            pageSize
-            tableColumns
-            timeWindow
-          }
+        updateWatchlistSettings(id: #{watchlist_id}, settings: #{map_to_input_object_str(map)}){
+          pageSize
+          tableColumns
+          timeWindow
+          jsonData
+        }
       }
-      |
-      |> String.replace(~r|\"|, ~S|\\"|)
-      |> String.replace(~r|'|, ~S|"|)
+      """
 
     conn
     |> post("/graphql", mutation_skeleton(mutation))

--- a/test/support/graphql_test_helpers.ex
+++ b/test/support/graphql_test_helpers.ex
@@ -169,10 +169,9 @@ defmodule SanbaseWeb.Graphql.TestHelpers do
   def map_to_args(%{} = map, opts \\ []) do
     map_as_input_object? = Keyword.get(opts, :map_as_input_object, false)
 
-    map = Map.delete(map, :map_as_input_object)
-    map = Map.new(map, fn {k, v} -> {Inflex.camelize(k, :lower), v} end)
-
     key = fn k -> Inflex.camelize(k, :lower) end
+    map = Map.delete(map, :map_as_input_object)
+    map = Map.new(map, fn {k, v} -> {key.(k), v} end)
 
     Enum.map(map, fn
       {k, [%{} | _] = l} ->


### PR DESCRIPTION
## Changes
Add a `jsonData` JSON field to the watchlist's settings. It can hold arbitrary JSON data.
```graphql
{
  watchlist(id: 1) {
     settings{
       pageSize
       tableColumns
       timeWindow
       jsonData
     }
  }
}
```
```graphql
 mutation {
  updateWatchlistSettings(id: 1, settings: {json: "{\"key\": 2}"}){
    pageSize
    tableColumns
    timeWindow
    jsonData
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
