### PR TITLE
Reduce contributors_count metrics min_interval

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -951,7 +951,7 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Development Activity Weekly Contributors Count",
+    "human_readable_name": "Development Activity Weekly Contributors Count (Sliding Window)",
     "name": "dev_activity_contributors_count_7d",
     "metric": "dev_activity_contributors_count",
     "version": "2019-01-01",
@@ -964,7 +964,7 @@
       "SANBASE": "free"
     },
     "aggregation": "last",
-    "min_interval": "7d",
+    "min_interval": "1d",
     "table": "intraday_metrics",
     "has_incomplete_data": true,
     "data_type": "timeseries"
@@ -989,7 +989,7 @@
     "data_type": "timeseries"
   },
   {
-    "human_readable_name": "Github Activity Weekly Contributors Count",
+    "human_readable_name": "Github Activity Weekly Contributors Count (Sliding Window)",
     "name": "github_activity_contributors_count_7d",
     "metric": "github_activity_contributors_count",
     "version": "2019-01-01",
@@ -1002,7 +1002,7 @@
       "SANBASE": "free"
     },
     "aggregation": "last",
-    "min_interval": "7d",
+    "min_interval": "1d",
     "table": "intraday_metrics",
     "has_incomplete_data": true,
     "data_type": "timeseries"


### PR DESCRIPTION
## Changes

- The metrics are computed each day, using the previous 7 days of data
- Improve the handling of daily metrics in the intraday_metrics table by
  allowing them to have any min_interval that is whole days, not only 1d

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
