### PR TITLE
Put the Generic Admin Edit in a 2-column grid

### DIFF
--- a/lib/sanbase_web/components/admin/admin_components.ex
+++ b/lib/sanbase_web/components/admin/admin_components.ex
@@ -142,7 +142,7 @@ defmodule SanbaseWeb.AdminComponents do
       )
 
     ~H"""
-    <.input
+    <SanbaseWeb.Admin.GriddableInputComponents.input
       name={@resource <> "[" <> to_string(@field) <> "]"}
       id={@resource <> "_" <> to_string(@field)}
       label={humanize(@field)}

--- a/lib/sanbase_web/components/admin/griddable_input_components.ex
+++ b/lib/sanbase_web/components/admin/griddable_input_components.ex
@@ -1,0 +1,165 @@
+defmodule SanbaseWeb.Admin.GriddableInputComponents do
+  use Phoenix.Component
+
+  alias Phoenix.LiveView.JS
+  import SanbaseWeb.Gettext
+
+  attr(:id, :any, default: nil)
+  attr(:name, :any)
+  attr(:label, :string, default: nil)
+  attr(:value, :any)
+
+  attr(:type, :string,
+    default: "text",
+    values: ~w(checkbox color date datetime-local email file hidden month number password
+               range radio search select tel text textarea time url week)
+  )
+
+  attr(:field, Phoenix.HTML.FormField,
+    doc: "a form field struct retrieved from the form, for example: @form[:email]"
+  )
+
+  attr(:errors, :list, default: [])
+  attr(:checked, :boolean, doc: "the checked flag for checkbox inputs")
+  attr(:prompt, :string, default: nil, doc: "the prompt for select inputs")
+  attr(:options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2")
+  attr(:multiple, :boolean, default: false, doc: "the multiple flag for select inputs")
+
+  attr(:rest, :global,
+    include: ~w(autocomplete cols disabled form list max maxlength min minlength
+                pattern placeholder readonly required rows size step)
+  )
+
+  slot(:inner_block)
+
+  def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
+    assigns
+    |> assign(field: nil, id: assigns.id || field.id)
+    |> assign(:errors, Enum.map(field.errors, &SanbaseWeb.CoreComponents.translate_error(&1)))
+    |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
+    |> assign_new(:value, fn -> field.value end)
+    |> input()
+  end
+
+  def input(%{type: "checkbox", value: value} = assigns) do
+    assigns =
+      assign_new(assigns, :checked, fn -> Phoenix.HTML.Form.normalize_value("checkbox", value) end)
+
+    ~H"""
+    <div>
+      <.label for={@id}><%= @label %></.label>
+    </div>
+    <div phx-feedback-for={@name}>
+      <input type="hidden" name={@name} value="false" />
+      <input
+        type="checkbox"
+        id={@id}
+        name={@name}
+        value="true"
+        checked={@checked}
+        class="rounded border-zinc-300 text-zinc-900 focus:ring-0"
+        {@rest}
+      />
+      <.error :for={msg <- @errors}><%= msg %></.error>
+    </div>
+    """
+  end
+
+  def input(%{type: "select"} = assigns) do
+    ~H"""
+    <div>
+      <.label for={@id}><%= @label %></.label>
+    </div>
+    <option :if={@prompt} value=""><%= @prompt %></option>
+    <%= Phoenix.HTML.Form.options_for_select(@options, @value) %>
+    <div phx-feedback-for={@name}>
+      <select
+        id={@id}
+        name={@name}
+        class="mt-1 block w-full rounded-md border border-gray-300 bg-white shadow-sm focus:border-zinc-400 focus:ring-0 sm:text-sm"
+        multiple={@multiple}
+        {@rest}
+      >
+      </select>
+      <.error :for={msg <- @errors}><%= msg %></.error>
+    </div>
+    """
+  end
+
+  def input(%{type: "textarea"} = assigns) do
+    ~H"""
+    <div>
+      <.label for={@id}><%= @label %></.label>
+    </div>
+    <div phx-feedback-for={@name}>
+      <textarea
+        id={@id}
+        name={@name}
+        class={[
+          "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
+          "phx-no-feedback:border-zinc-300 phx-no-feedback:focus:border-zinc-400",
+          "min-h-[6rem] border-zinc-300 focus:border-zinc-400",
+          @errors != [] && "border-rose-400 focus:border-rose-400"
+        ]}
+        {@rest}
+      ><%= Phoenix.HTML.Form.normalize_value("textarea", @value) %></textarea>
+      <.error :for={msg <- @errors}><%= msg %></.error>
+    </div>
+    """
+  end
+
+  # All other inputs text, datetime-local, url, password, etc. are handled here...
+  def input(assigns) do
+    ~H"""
+    <.label for={@id}><%= @label %></.label>
+
+    <div phx-feedback-for={@name}>
+      <input
+        type={@type}
+        name={@name}
+        id={@id}
+        value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+        class={[
+          "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
+          "phx-no-feedback:border-zinc-300 phx-no-feedback:focus:border-zinc-400",
+          "border-zinc-300 focus:border-zinc-400",
+          @errors != [] && "border-rose-400 focus:border-rose-400"
+        ]}
+        {@rest}
+      />
+      <.error :for={msg <- @errors}><%= msg %></.error>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders a label.
+  """
+  attr(:for, :string, default: nil)
+  slot(:inner_block, required: true)
+
+  def label(assigns) do
+    ~H"""
+    <label for={@for} class="block text-sm font-semibold leading-6 text-zinc-800">
+      <%= render_slot(@inner_block) %>
+    </label>
+    """
+  end
+
+  @doc """
+  Generates a generic error message.
+  """
+  slot(:inner_block, required: true)
+
+  def error(assigns) do
+    ~H"""
+    <p class="mt-3 flex gap-3 text-sm leading-6 text-rose-600 phx-no-feedback:hidden">
+      <SanbaseWeb.CoreComponents.icon
+        name="hero-exclamation-circle-mini"
+        class="mt-0.5 h-5 w-5 flex-none"
+      />
+      <%= render_slot(@inner_block) %>
+    </p>
+    """
+  end
+end

--- a/lib/sanbase_web/components/admin/live_select.ex
+++ b/lib/sanbase_web/components/admin/live_select.ex
@@ -2,28 +2,25 @@ defmodule SanbaseWeb.LiveSelect do
   use SanbaseWeb, :live_view
   use Phoenix.HTML
 
-  import SanbaseWeb.CoreComponents
   import Ecto.Query
 
   def render(assigns) do
     ~H"""
-    <div class="w-full">
-      <.input
-        type="text"
-        label={humanize(@session["field"])}
-        name={@session["parent_resource"] <> "[" <> to_string(@session["field"]) <> "_id" <> "]"}
-        value={@query || @session["initial_value"]}
-        list={"matches_" <> to_string(@session["field"])}
-        phx-keyup="suggest"
-        phx-debounce="200"
-        placeholder="Search..."
-      />
-      <datalist id={"matches_" <> to_string(@session["field"])}>
-        <%= for {id, match} <- @matches do %>
-          <option value={id}><%= match %></option>
-        <% end %>
-      </datalist>
-    </div>
+    <SanbaseWeb.Admin.GriddableInputComponents.input
+      type="text"
+      label={humanize(@session["field"])}
+      name={@session["parent_resource"] <> "[" <> to_string(@session["field"]) <> "_id" <> "]"}
+      value={@query || @session["initial_value"]}
+      list={"matches_" <> to_string(@session["field"])}
+      phx-keyup="suggest"
+      phx-debounce="200"
+      placeholder="Search..."
+    />
+    <datalist id={"matches_" <> to_string(@session["field"])}>
+      <%= for {id, match} <- @matches do %>
+        <option value={id}><%= match %></option>
+      <% end %>
+    </datalist>
     """
   end
 

--- a/lib/sanbase_web/templates/generic_admin_html/edit.html.heex
+++ b/lib/sanbase_web/templates/generic_admin_html/edit.html.heex
@@ -14,7 +14,7 @@
     <% end %>
 
     <%= for field <- @fields do %>
-      <div class="m-4">
+      <div class="mx-4 grid items-center" style="grid-template-columns: 200px 1fr" }>
         <%= if @belongs_to_fields[field] do %>
           <%= if @belongs_to_fields[field][:type] == :live_select do %>
             <% field_id = :"#{to_string(field)}_id" %>


### PR DESCRIPTION
## Changes
- TODO: The LiveSelect is done as `render_live`, so it cannot properly be put in a grid.
<img width="1616" alt="image" src="https://github.com/santiment/sanbase2/assets/6518376/3977199e-a84c-4ed6-85e9-4dc269156cc2">

<!--- Describe your changes -->


## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
