### PR TITLE
Fix labeled balances metrics specs

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/labeled_intraday_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/labeled_intraday_metrics.json
@@ -2,7 +2,7 @@
   {
     "human_readable_name": "Labelled Historical Balance",
     "name": "labelled_historical_balance",
-    "metric": "labeled_balance",
+    "metric": "combined_labeled_balance",
     "version": "2020-01-01",
     "access": "restricted",
     "selectors": [
@@ -28,7 +28,7 @@
   {
     "human_readable_name": "Labelled Historical Balance Changes",
     "name": "labelled_historical_balance_changes",
-    "metric": "labeled_balance_delta",
+    "metric": "combined_labeled_balance_delta",
     "version": "2020-01-01",
     "access": "restricted",
     "selectors": [


### PR DESCRIPTION
In labeled_intraday_metrics_v2 table we have 3 metrics:
1. labeled_balance - label balances arisen from address balance changes.
2. balanced_labels -  label balances arisen from label changes (add/remove addresses).
3. combined_labeled_balance = labeled_balance + balanced_labels

So if we want to show final label balances we need to use combined_labeled_balance.

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
