### PR TITLE
Add docs_link to metrics metadata

### DIFF
--- a/lib/sanbase/clickhouse/metric/file_handler.ex
+++ b/lib/sanbase/clickhouse/metric/file_handler.ex
@@ -181,6 +181,8 @@ defmodule Sanbase.Clickhouse.MetricAdapter.FileHandler do
               )
 
   @table_map Helper.name_to_field_map(@metrics_json, "table")
+  @docs_links_map Helper.name_to_field_map(@metrics_json, "docs_link", required?: false)
+
   @aggregation_map Helper.name_to_field_map(@metrics_json, "aggregation",
                      transform_fn: &String.to_atom/1
                    )
@@ -264,6 +266,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter.FileHandler do
   def min_interval_map(), do: @min_interval_map |> transform()
   def min_plan_map(), do: @min_plan_map |> transform()
   def name_to_metric_map(), do: @name_to_metric_map |> transform()
+  def docs_links_map(), do: @docs_links_map |> transform()
 
   def metric_to_names_map(),
     do: @metric_to_names_map |> transform(metric_name_in_map_value_list: true)

--- a/lib/sanbase/clickhouse/metric/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/metric/metric_adapter.ex
@@ -27,6 +27,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
   @free_metrics FileHandler.metrics_with_access(:free)
   @restricted_metrics FileHandler.metrics_with_access(:restricted)
   @aggregation_map FileHandler.aggregation_map()
+  @docs_links_map FileHandler.docs_links_map()
   @human_readable_name_map FileHandler.human_readable_name_map()
   @metrics_data_type_map FileHandler.metrics_data_type_map()
   @metrics_name_list (@histogram_metrics_name_list ++
@@ -182,7 +183,8 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
        required_selectors: Map.get(@required_selectors_map, metric, []),
        data_type: Map.get(@metrics_data_type_map, metric),
        is_timebound: Map.get(@timebound_flag_map, metric),
-       complexity_weight: @default_complexity_weight
+       complexity_weight: @default_complexity_weight,
+       docs_link: Map.get(@docs_links_map, metric)
      }}
   end
 

--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -339,7 +339,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_article": "https://academy.santiment.net/metrics/mvrv"
+    "docs_link": "https://academy.santiment.net/metrics/mvrv"
   },
   {
     "human_readable_name": "MVRV",
@@ -359,7 +359,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_article": "https://academy.santiment.net/metrics/mvrv"
+    "docs_link": "https://academy.santiment.net/metrics/mvrv"
   },
   {
     "human_readable_name": "MVRV for coins that moved in the past {{timebound:human_readable}}",
@@ -415,7 +415,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_article": "https://academy.santiment.net/metrics/mvrv"
+    "docs_link": "https://academy.santiment.net/metrics/mvrv"
   },
   {
     "human_readable_name": "MVRV",
@@ -435,7 +435,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "docs_article": "https://academy.santiment.net/metrics/mvrv"
+    "docs_link": "https://academy.santiment.net/metrics/mvrv"
   },
   {
     "human_readable_name": "MVRV Intraday for coins that moved in the past {{timebound:human_readable}}",
@@ -491,7 +491,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "docs_article": "https://academy.santiment.net/metrics/mvrv"
+    "docs_link": "https://academy.santiment.net/metrics/mvrv"
   },
   {
     "human_readable_name": "Circulation",
@@ -511,7 +511,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_article": "https://academy.santiment.net/metrics/circulation"
+    "docs_link": "https://academy.santiment.net/metrics/circulation"
   },
   {
     "human_readable_name": "Circulation for coins that moved in the past {{timebound:human_readable}}",
@@ -567,7 +567,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_article": "https://academy.santiment.net/metrics/circulation"
+    "docs_link": "https://academy.santiment.net/metrics/circulation"
   },
   {
     "human_readable_name": "Circulation for coins that have not moved in the past {{timebound:human_readable}}",
@@ -611,7 +611,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_article": "https://academy.santiment.net/metrics/dormant-circulation"
+    "docs_link": "https://academy.santiment.net/metrics/dormant-circulation"
   },
   {
     "human_readable_name": "Mean Age in days",
@@ -632,7 +632,7 @@
     "has_incomplete_data": true,
     "data_type": "timeseries",
     "unit": "days",
-    "docs_article": "https://academy.santiment.net/metrics/mean-coin-age"
+    "docs_link": "https://academy.santiment.net/metrics/mean-coin-age"
   },
   {
     "human_readable_name": "Mean Dollar Invested Age in days for coins that moved",
@@ -653,7 +653,7 @@
     "has_incomplete_data": true,
     "data_type": "timeseries",
     "unit": "days",
-    "docs_article": "https://academy.santiment.net/metrics/mean-coin-age"
+    "docs_link": "https://academy.santiment.net/metrics/mean-coin-age"
   },
   {
     "human_readable_name": "Realized Value",
@@ -673,7 +673,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_article": "https://academy.santiment.net/metrics/realized-value"
+    "docs_link": "https://academy.santiment.net/metrics/realized-value"
   },
   {
     "human_readable_name": "Realized Value for coins that moved in the past {{timebound:human_readable}}",
@@ -729,7 +729,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_article": "https://academy.santiment.net/metrics/realized-value"
+    "docs_link": "https://academy.santiment.net/metrics/realized-value"
   },
   {
     "human_readable_name": "Velocity",
@@ -749,7 +749,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_article": "https://academy.santiment.net/metrics/velocity"
+    "docs_link": "https://academy.santiment.net/metrics/velocity"
   },
   {
     "human_readable_name": "On-Chain Transaction Volume",
@@ -769,7 +769,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "docs_article": "https://academy.santiment.net/metrics/transaction-volume"
+    "docs_link": "https://academy.santiment.net/metrics/transaction-volume"
   },
   {
     "human_readable_name": "On-Chain Transaction Volume in USD",

--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -338,7 +338,8 @@
     "min_interval": "1d",
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "docs_article": "https://academy.santiment.net/metrics/mvrv"
   },
   {
     "human_readable_name": "MVRV",
@@ -357,7 +358,8 @@
     "min_interval": "1d",
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "docs_article": "https://academy.santiment.net/metrics/mvrv"
   },
   {
     "human_readable_name": "MVRV for coins that moved in the past {{timebound:human_readable}}",
@@ -412,7 +414,8 @@
     "min_interval": "1d",
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "docs_article": "https://academy.santiment.net/metrics/mvrv"
   },
   {
     "human_readable_name": "MVRV",
@@ -431,7 +434,8 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "docs_article": "https://academy.santiment.net/metrics/mvrv"
   },
   {
     "human_readable_name": "MVRV Intraday for coins that moved in the past {{timebound:human_readable}}",
@@ -486,7 +490,8 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "docs_article": "https://academy.santiment.net/metrics/mvrv"
   },
   {
     "human_readable_name": "Circulation",
@@ -505,7 +510,8 @@
     "min_interval": "1d",
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "docs_article": "https://academy.santiment.net/metrics/circulation"
   },
   {
     "human_readable_name": "Circulation for coins that moved in the past {{timebound:human_readable}}",
@@ -560,7 +566,8 @@
     "min_interval": "1d",
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "docs_article": "https://academy.santiment.net/metrics/circulation"
   },
   {
     "human_readable_name": "Circulation for coins that have not moved in the past {{timebound:human_readable}}",
@@ -603,7 +610,8 @@
     "min_interval": "1d",
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "docs_article": "https://academy.santiment.net/metrics/dormant-circulation"
   },
   {
     "human_readable_name": "Mean Age in days",
@@ -623,7 +631,8 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "unit": "days"
+    "unit": "days",
+    "docs_article": "https://academy.santiment.net/metrics/mean-coin-age"
   },
   {
     "human_readable_name": "Mean Dollar Invested Age in days for coins that moved",
@@ -643,7 +652,8 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "unit": "days"
+    "unit": "days",
+    "docs_article": "https://academy.santiment.net/metrics/mean-coin-age"
   },
   {
     "human_readable_name": "Realized Value",
@@ -662,7 +672,8 @@
     "min_interval": "1d",
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "docs_article": "https://academy.santiment.net/metrics/realized-value"
   },
   {
     "human_readable_name": "Realized Value for coins that moved in the past {{timebound:human_readable}}",
@@ -717,7 +728,8 @@
     "min_interval": "1d",
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "docs_article": "https://academy.santiment.net/metrics/realized-value"
   },
   {
     "human_readable_name": "Velocity",
@@ -736,7 +748,8 @@
     "min_interval": "1d",
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "docs_article": "https://academy.santiment.net/metrics/velocity"
   },
   {
     "human_readable_name": "On-Chain Transaction Volume",
@@ -755,7 +768,8 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "docs_article": "https://academy.santiment.net/metrics/transaction-volume"
   },
   {
     "human_readable_name": "On-Chain Transaction Volume in USD",

--- a/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
@@ -26,6 +26,19 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver do
     maybe_register_and_get(cache_key, fun, slug, query)
   end
 
+  def available_metrics_extended(%Project{} = project, args, resolution) do
+    with {:ok, metrics} <- available_metrics(project, args, resolution) do
+      list =
+        Enum.map(metrics, fn m ->
+          {:ok, m} = Metric.metadata(m)
+
+          m
+        end)
+
+      {:ok, list}
+    end
+  end
+
   def available_timeseries_metrics(%Project{slug: slug}, _args, _resolution) do
     # TEMP 02.02.2023: Handle ripple -> xrp rename
     {:ok, %{slug: slug}} = Sanbase.Project.Selector.args_to_selector(%{slug: slug})

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -292,6 +292,14 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:values, list_of(list_of(:float)))
   end
 
+  @desc ~s"""
+  Check the metric_metadata type for description
+  """
+  object :metric_metadata_subset do
+    field(:metric, non_null(:string))
+    field(:docs_link, :string)
+  end
+
   object :metric_metadata do
     @desc ~s"""
     The public name of the metric. The public name is the name that is used
@@ -402,6 +410,11 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
         a range and a value.
     """
     field(:data_type, :metric_data_type)
+
+    @desc ~s"""
+    A link to the documentation of the metric
+    """
+    field(:docs_link, :string)
 
     @desc ~s"""
     A metric is considered timebound, if it is computed on the set of coins/tokens

--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -203,6 +203,10 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       cache_resolve(&ProjectMetricsResolver.available_metrics/3, ttl: 300)
     end
 
+    field :available_metrics_extended, list_of(:metric_metadata_subset) do
+      cache_resolve(&ProjectMetricsResolver.available_metrics_extended/3, ttl: 300)
+    end
+
     @desc ~s"""
     Returns a subset of the availableMetrics that are fetchable by getMetric's
     timeseriesData


### PR DESCRIPTION
## Changes

- Start adding links to documentation in the metric definition
- Expose the docs links in the metric metadata 
- Add a new alternative to `project{ availableMetrics }` -- `project{ availableMetricsExtended {..} }` which returns an object. It can be extended in the future without breaking existing APIs. This is needed so the FE can know which metrics have documentation without the need to ask for each metric separately.

This PR introduces the API and a **few** links to documentation to metrics. 
It will be deployed without all links, so we can enable the frontend to work with the API.

In a subsequent PR the following will be added:
- More links
- More tests

```graphql
{
  getMetric(metric: "mvrv_usd") {
    metadata {
      docsLink
    }
  }
}
```
```json
{
  "data": {
    "getMetric": {
      "metadata": {
        "docsLink": "https://academy.santiment.net/metrics/mvrv"
      }
    }
  }
}
```

```graphql
{
  projectBySlug(slug: "ethereum") {
    availableMetricsExtended{
      metric
      docsLink
    }
  }
}
```
```json
{
  "data": {
    "projectBySlug": {
      "availableMetricsExtended": [
      ...
       {
          "docsLink": "https://academy.santiment.net/metrics/mvrv",
          "metric": "mvrv_usd_2y"
        },
       ...
     ]
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
