### PR TITLE
Rework the availableMetricsExtended format

### DIFF
--- a/lib/sanbase/clickhouse/metric/file_handler.ex
+++ b/lib/sanbase/clickhouse/metric/file_handler.ex
@@ -181,7 +181,10 @@ defmodule Sanbase.Clickhouse.MetricAdapter.FileHandler do
               )
 
   @table_map Helper.name_to_field_map(@metrics_json, "table")
-  @docs_links_map Helper.name_to_field_map(@metrics_json, "docs_link", required?: false)
+  @docs_links_map Helper.name_to_field_map(@metrics_json, "docs_links",
+                    required?: false,
+                    transform_fn: fn list -> Enum.map(list, fn l -> %{link: l} end) end
+                  )
 
   @aggregation_map Helper.name_to_field_map(@metrics_json, "aggregation",
                      transform_fn: &String.to_atom/1

--- a/lib/sanbase/clickhouse/metric/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/metric/metric_adapter.ex
@@ -184,7 +184,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
        data_type: Map.get(@metrics_data_type_map, metric),
        is_timebound: Map.get(@timebound_flag_map, metric),
        complexity_weight: @default_complexity_weight,
-       docs_link: Map.get(@docs_links_map, metric)
+       docs: Map.get(@docs_links_map, metric)
      }}
   end
 

--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -16,8 +16,10 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "docs_links": ["https://academy.santiment.net/metrics/price"]
   },
+
   {
     "human_readable_name": "USD Trading Volume",
     "name": "volume_usd_5m",
@@ -35,7 +37,8 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "docs_links": ["https://academy.santiment.net/metrics/trading-volume"]
   },
   {
     "human_readable_name": "Daily Average USD Marketcap",
@@ -245,7 +248,8 @@
     "min_interval": "5m",
     "table": "intraday_metrics",
     "has_incomplete_data": false,
-    "data_type": "timeseries"
+    "data_type": "timeseries",
+    "docs_links": ["https://academy.santiment.net/metrics/active-addresses-24h"]
   },
   {
     "human_readable_name": "Mean Realized USD Price",
@@ -339,7 +343,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_link": "https://academy.santiment.net/metrics/mvrv"
+    "docs_links": ["https://academy.santiment.net/metrics/mvrv"]
   },
   {
     "human_readable_name": "MVRV",
@@ -359,7 +363,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_link": "https://academy.santiment.net/metrics/mvrv"
+    "docs_links": ["https://academy.santiment.net/metrics/mvrv"]
   },
   {
     "human_readable_name": "MVRV for coins that moved in the past {{timebound:human_readable}}",
@@ -415,7 +419,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_link": "https://academy.santiment.net/metrics/mvrv"
+    "docs_links": ["https://academy.santiment.net/metrics/mvrv"]
   },
   {
     "human_readable_name": "MVRV",
@@ -435,7 +439,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "docs_link": "https://academy.santiment.net/metrics/mvrv"
+    "docs_links": ["https://academy.santiment.net/metrics/mvrv"]
   },
   {
     "human_readable_name": "MVRV Intraday for coins that moved in the past {{timebound:human_readable}}",
@@ -491,7 +495,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "docs_link": "https://academy.santiment.net/metrics/mvrv"
+    "docs_links": ["https://academy.santiment.net/metrics/mvrv"]
   },
   {
     "human_readable_name": "Circulation",
@@ -511,7 +515,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_link": "https://academy.santiment.net/metrics/circulation"
+    "docs_links": ["https://academy.santiment.net/metrics/circulation"]
   },
   {
     "human_readable_name": "Circulation for coins that moved in the past {{timebound:human_readable}}",
@@ -567,7 +571,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_link": "https://academy.santiment.net/metrics/circulation"
+    "docs_links": ["https://academy.santiment.net/metrics/circulation"]
   },
   {
     "human_readable_name": "Circulation for coins that have not moved in the past {{timebound:human_readable}}",
@@ -611,7 +615,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_link": "https://academy.santiment.net/metrics/dormant-circulation"
+    "docs_links": ["https://academy.santiment.net/metrics/dormant-circulation"]
   },
   {
     "human_readable_name": "Mean Age in days",
@@ -632,7 +636,7 @@
     "has_incomplete_data": true,
     "data_type": "timeseries",
     "unit": "days",
-    "docs_link": "https://academy.santiment.net/metrics/mean-coin-age"
+    "docs_links": ["https://academy.santiment.net/metrics/mean-coin-age"]
   },
   {
     "human_readable_name": "Mean Dollar Invested Age in days for coins that moved",
@@ -653,7 +657,7 @@
     "has_incomplete_data": true,
     "data_type": "timeseries",
     "unit": "days",
-    "docs_link": "https://academy.santiment.net/metrics/mean-coin-age"
+    "docs_links": ["https://academy.santiment.net/metrics/mean-coin-age"]
   },
   {
     "human_readable_name": "Realized Value",
@@ -673,7 +677,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_link": "https://academy.santiment.net/metrics/realized-value"
+    "docs_links": ["https://academy.santiment.net/metrics/realized-value"]
   },
   {
     "human_readable_name": "Realized Value for coins that moved in the past {{timebound:human_readable}}",
@@ -729,7 +733,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_link": "https://academy.santiment.net/metrics/realized-value"
+    "docs_links": ["https://academy.santiment.net/metrics/realized-value"]
   },
   {
     "human_readable_name": "Velocity",
@@ -749,7 +753,7 @@
     "table": "daily_metrics_v2",
     "has_incomplete_data": true,
     "data_type": "timeseries",
-    "docs_link": "https://academy.santiment.net/metrics/velocity"
+    "docs_links": ["https://academy.santiment.net/metrics/velocity"]
   },
   {
     "human_readable_name": "On-Chain Transaction Volume",
@@ -769,7 +773,7 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "docs_link": "https://academy.santiment.net/metrics/transaction-volume"
+    "docs_links": ["https://academy.santiment.net/metrics/transaction-volume"]
   },
   {
     "human_readable_name": "On-Chain Transaction Volume in USD",

--- a/lib/sanbase/metric/behaviour.ex
+++ b/lib/sanbase/metric/behaviour.ex
@@ -42,7 +42,9 @@ defmodule Sanbase.Metric.Behaviour do
           is_deprecated: boolean(),
           # A metric can be hard-deprecated, which means that it will no
           # longer be accessible after this datetime.
-          hard_deprecate_after: DateTime.t() | nil
+          hard_deprecate_after: DateTime.t() | nil,
+          # A link to documentation, most cases should be links to our academy
+          docs: list(map()) | nil
         }
 
   @type histogram_value :: String.t() | float() | integer()

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -292,12 +292,16 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:values, list_of(list_of(:float)))
   end
 
+  object :metric_documentation do
+    field(:link, non_null(:string))
+  end
+
   @desc ~s"""
   Check the metric_metadata type for description
   """
   object :metric_metadata_subset do
     field(:metric, non_null(:string))
-    field(:docs_link, :string)
+    field(:docs, list_of(:metric_documentation))
   end
 
   object :metric_metadata do
@@ -414,7 +418,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     @desc ~s"""
     A link to the documentation of the metric
     """
-    field(:docs_link, :string)
+    field(:docs, list_of(:metric_documentation))
 
     @desc ~s"""
     A metric is considered timebound, if it is computed on the set of coins/tokens


### PR DESCRIPTION
Instead of a {metric docsLink} it now returns {metric docs { link }},
allowing to have multiple docs links, as well as attach some more
metadata in the future.

```graphql
{
  projectBySlug(slug: "ethereum"){
    availableMetricsExtended{
      metric
      docs { link }
    }
  }
}
```
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
