### PR TITLE
Fix projects count sql

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/project/project_list_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_list_resolver.ex
@@ -59,6 +59,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectListResolver do
 
   def projects_count(_root, args, _resolution) do
     with {:ok, opts} <- Project.ListSelector.args_to_opts(args) do
+      # Remove ordered_slugs from opts in case we need only the count
+      opts = Keyword.replace(opts, :ordered_slugs, nil)
+
       {:ok,
        %{
          erc20_projects_count: Project.List.erc20_projects_count(opts),

--- a/lib/sanbase_web/live/upload_image_live.ex
+++ b/lib/sanbase_web/live/upload_image_live.ex
@@ -162,10 +162,6 @@ defmodule SanbaseWeb.UploadImageLive do
     {:noreply, cancel_upload(socket, :images, ref)}
   end
 
-  defp assign_form(socket, %Ecto.Changeset{} = changeset) do
-    assign(socket, :form, to_form(changeset))
-  end
-
   def gen_filename(name, entry) do
     "image/" <> extension = entry.client_type
     client_name = String.trim_trailing(entry.client_name, Path.extname(entry.client_name))


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

The following query results in an SQL error. details: http://sentry.production.san:31080/organizations/sentry/issues/7318 
```
{
  projectsCount(selector: {baseProjects: {slugs: ["bitcoin"]}}) {
    projectsCount
  }
}

```

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
