### PR TITLE
Add /monitored_twitter_handles endpoint

### DIFF
--- a/lib/sanbase/monitored_twitter_handle/monitored_twitter_handle.ex
+++ b/lib/sanbase/monitored_twitter_handle/monitored_twitter_handle.ex
@@ -86,6 +86,20 @@ defmodule Sanbase.MonitoredTwitterHandle do
     end
   end
 
+  def list_all_approved() do
+    # Requested by the social data team -- do not include handles that are approved, but with a
+    # comment. These could be handles that are sharing content not in english, not crypto, or
+    # crypto and english, but self-promotion. The only times comments are used are to provide
+    # info why the handle should not end up in our social data pipelines
+    query =
+      from(
+        m in __MODULE__,
+        where: m.status == "approved" and m.comment == ""
+      )
+
+    Repo.all(query)
+  end
+
   def list_all_submissions() do
     query = from(m in __MODULE__, where: m.origin == "graphql_api", preload: [:user])
 

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -170,6 +170,7 @@ defmodule SanbaseWeb.Router do
     get("/api_metric_name_mapping", MetricNameController, :api_metric_name_mapping)
     get("/projects_data", DataController, :projects_data)
     get("/projects_twitter_handles", DataController, :projects_twitter_handles)
+    get("/monitored_twitter_handles/:secret", DataController, :monitored_twitter_handles)
     get("/ecosystems_data", DataController, :ecosystems_data)
 
     get(


### PR DESCRIPTION
## Changes

Add /monitored_twitter_handles/<secret> endpoint.
It will be used to build a Clickhouse dictionary.
The secret is added so this endpoint is not publicly available.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
