### PR TITLE
add get metric rounding

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/label_based_metric_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/label_based_metric_metrics.json
@@ -6,6 +6,7 @@
     "version": "2019-12-22",
     "access": "restricted",
     "selectors": ["slug", "owner", "label"],
+    "required_selectors": ["slug", "owner|label"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -23,6 +24,7 @@
     "version": "2019-12-22",
     "access": "restricted",
     "selectors": ["slug", "owner", "label"],
+    "required_selectors": ["slug", "owner|label"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -40,6 +42,7 @@
     "version": "2019-12-22",
     "access": "restricted",
     "selectors": ["slug", "owner", "label"],
+    "required_selectors": ["slug", "owner|label"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -57,6 +60,7 @@
     "version": "2019-12-22",
     "access": "restricted",
     "selectors": ["slug", "owner", "label"],
+    "required_selectors": ["slug", "owner|label"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -75,6 +79,7 @@
     "version": "2019-01-01",
     "access": "restricted",
     "selectors": ["slug", "owner", "label"],
+    "required_selectors": ["slug", "owner|label"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -94,6 +99,7 @@
     "version": "2019-01-01",
     "access": "restricted",
     "selectors": ["slug", "owner", "label"],
+    "required_selectors": ["slug", "owner|label"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -113,6 +119,7 @@
     "version": "2019-01-01",
     "access": "restricted",
     "selectors": ["slug", "owner", "label"],
+    "required_selectors": ["slug", "owner|label"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"
@@ -131,6 +138,7 @@
     "version": "2019-01-01",
     "access": "restricted",
     "selectors": ["slug", "owner", "label"],
+    "required_selectors": ["slug", "owner|label"],
     "min_plan": {
       "SANAPI": "pro",
       "SANBASE": "free"

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -163,6 +163,7 @@ defmodule Sanbase.Metric do
             interval,
             opts
           )
+          |> maybe_round_floats(:timeseries_data)
         end
 
         execute_if_aggregation_valid(fun, metric, aggregation)
@@ -202,6 +203,7 @@ defmodule Sanbase.Metric do
             interval,
             opts
           )
+          |> maybe_round_floats(:timeseries_data_per_slug)
         end
 
         execute_if_aggregation_valid(fun, metric, aggregation)
@@ -239,6 +241,7 @@ defmodule Sanbase.Metric do
             to,
             opts
           )
+          |> maybe_round_floats(:aggregated_timeseries_data)
         end
 
         execute_if_aggregation_valid(fun, metric, aggregation)
@@ -891,4 +894,35 @@ defmodule Sanbase.Metric do
     |> Map.put(:is_deprecated, is_deprecated)
     |> Map.put(:hard_deprecate_after, hard_deprecate_after)
   end
+
+  defp maybe_round_floats({:error, error}, _), do: {:error, error}
+
+  defp maybe_round_floats({:ok, result}, :timeseries_data) do
+    result =
+      Enum.map(result, fn m ->
+        Map.update!(m, :value, &round_value/1)
+      end)
+
+    {:ok, result}
+  end
+
+  defp maybe_round_floats({:ok, result}, :aggregated_timeseries_data) do
+    result = Map.new(result, fn {k, v} -> {k, round_value(v)} end)
+    {:ok, result}
+  end
+
+  defp maybe_round_floats({:ok, result}, :timeseries_data_per_slug) do
+    result =
+      Enum.map(result, fn %{data: data} = map ->
+        # Each element is %{datetime: dt, [%{slug: slug, value: value}]}
+        data = Enum.map(data, fn m -> Map.update!(m, :value, &round_value/1) end)
+
+        %{map | data: data}
+      end)
+
+    {:ok, result}
+  end
+
+  defp round_value(num) when is_float(num), do: Float.round(num, 6)
+  defp round_value(num), do: num
 end

--- a/test/sanbase/metric/metric_rounding_test.exs
+++ b/test/sanbase/metric/metric_rounding_test.exs
@@ -1,0 +1,34 @@
+defmodule Sanbase.MetricRoundingTest do
+  use Sanbase.DataCase
+
+  test "data is rounded up to 6 decimals" do
+    # Define this in a separate file to avoid conflicts with the global setup_all mock
+    # in the metric_test.exs
+    rows = [
+      # rounded to 6 decimal digits
+      [1_711_756_800, 830_224.712938719283719280],
+      # does not change
+      [1_711_843_200, 696_766.0123],
+      # Should be rounded to just .1
+      [1_711_929_600, 469_393.100000000003]
+    ]
+
+    Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/2, {:ok, %{rows: rows}})
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      {:ok, data} =
+        Sanbase.Metric.timeseries_data(
+          "daily_active_addresses",
+          %{slug: "bitcoin"},
+          ~U[2024-03-31 00:00:00Z],
+          ~U[2024-04-01 23:59:59Z],
+          "1d"
+        )
+
+      assert data == [
+               %{value: 830_224.712939, datetime: ~U[2024-03-30 00:00:00Z]},
+               %{value: 696_766.0123, datetime: ~U[2024-03-31 00:00:00Z]},
+               %{value: 469_393.1, datetime: ~U[2024-04-01 00:00:00Z]}
+             ]
+    end)
+  end
+end

--- a/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
@@ -22,6 +22,29 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesDataTest do
     ]
   end
 
+  @tag capture_log: true
+  test "missing required selector", context do
+    query = """
+    {
+      getMetric(metric: "exchange_balance_per_exchange"){
+        timeseriesData(slug: "#{context.slug}" from: "utc_now-7d" to: "utc_now" interval: "1d"){
+          datetime
+          value
+        }
+      }
+    }
+    """
+
+    error_msg =
+      context.conn
+      |> post("/graphql", query_skeleton(query))
+      |> json_response(200)
+      |> get_in(["errors", Access.at(0), "message"])
+
+    assert error_msg =~
+             "must have at least one of the following fields in the selector: owner, label"
+  end
+
   test "price_usd when the source is cryptocompare", context do
     # Test that when the source is cryptocompare the prices are served from the
     # PricePair module instead of the Price module

--- a/test/support/graphql_test_helpers.ex
+++ b/test/support/graphql_test_helpers.ex
@@ -258,6 +258,22 @@ defmodule SanbaseWeb.Graphql.TestHelpers do
     end
   end
 
+  defp add_missing_selector(:owner, selector) do
+    Map.put(
+      selector,
+      :owner,
+      "binance"
+    )
+  end
+
+  defp add_missing_selector(:label, selector) do
+    Map.put(
+      selector,
+      :label,
+      "centralized_exchange"
+    )
+  end
+
   defp add_missing_selector(:contract_address, selector),
     do:
       Map.put(


### PR DESCRIPTION
## Changes

- **Add rounding to Sanbase.Metric**
  - Add rounding to 6 decimals as it turns out we have metrics stored with up to 18 decimals
- **Unsupported selectors in getMetric do not cause Internal Server Error**
  - Querying `dev_activity_1d` while providing `owner`/`label` causes an internal server error. This PR reworks it to have no error. We should improve the `available_selectors` and reject anything that is not fit for this metric.
- **Add required_selectors to some exchange label metrics**

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
