### PR TITLE
Do not show the *_shard* tables in getClickhouseDatabaseMetadata

### DIFF
--- a/lib/sanbase/queries/autocomplete.ex
+++ b/lib/sanbase/queries/autocomplete.ex
@@ -17,7 +17,7 @@ defmodule Sanbase.Clickhouse.Autocomplete do
     sql = """
     SELECT name, engine, partition_key, sorting_key, primary_key
     FROM system.tables
-    WHERE database = 'default'
+    WHERE database = 'default' AND name NOT LIKE '%_shard%'
     """
 
     query_struct = Sanbase.Clickhouse.Query.new(sql, %{})


### PR DESCRIPTION
## Changes

These tables don't need to be shown:
<img width="304" alt="image" src="https://github.com/santiment/sanbase2/assets/6518376/70e9fd6a-cd6f-460c-9897-78f9f31b5f1d">

They are available because if the user does not have access to them, they cannot use the tables that are built on those shards.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
