### PR TITLE
Remove goerly testnet usage

### DIFF
--- a/lib/sanbase/billing/subscription/nft_subscription.ex
+++ b/lib/sanbase/billing/subscription/nft_subscription.ex
@@ -10,8 +10,13 @@ defmodule Sanbase.Billing.Subscription.NFTSubscription do
 
   # Run every 10 minutes
   def run do
-    maybe_create()
-    maybe_remove()
+    # Only run on prod
+    if is_dev_or_stage?() do
+      :ok
+    else
+      maybe_create()
+      maybe_remove()
+    end
   end
 
   def maybe_create do
@@ -81,15 +86,11 @@ defmodule Sanbase.Billing.Subscription.NFTSubscription do
     |> Repo.all()
   end
 
-  # Sleep because testnet goerly alchemy node is unreliable
   defp balances(addresses) do
-    if is_dev_or_stage?(), do: Process.sleep(1000)
     SanbaseNFT.balances_of(addresses)
   end
 
-  # Sleep because testnet goerly alchemy node is unreliable
   defp nft_subscriptions(user_id) do
-    if is_dev_or_stage?(), do: Process.sleep(1000)
     SanbaseNFTInterface.nft_subscriptions(user_id)
   end
 

--- a/lib/sanbase/smart_contracts/sanbase_nft.ex
+++ b/lib/sanbase/smart_contracts/sanbase_nft.ex
@@ -76,7 +76,6 @@ defmodule Sanbase.SmartContracts.SanbaseNFT do
 
   alias Sanbase.Utils.Config
 
-  @contract_goerly "0x7f985e8ad29438907a2cc8ff3d526d9a1693442c"
   @contract_mainnet "0x211E14C8cc67F9EF05cC84F80Dc036Ff2F548949"
 
   @json_file "sanbase_nft_abi.json"
@@ -86,12 +85,7 @@ defmodule Sanbase.SmartContracts.SanbaseNFT do
   # test address with subscriptions: 0x89c276d6e0fda36d7796af0d27a08176cc0f1976
   def abi(), do: @abi
 
-  def contract() do
-    case is_dev_or_stage?() do
-      true -> @contract_goerly
-      false -> @contract_mainnet
-    end
-  end
+  def contract(), do: @contract_mainnet
 
   def nft_subscriptions_data(address) do
     tokens_count = balance_of(address)
@@ -150,8 +144,6 @@ defmodule Sanbase.SmartContracts.SanbaseNFT do
         function_abi(function_name).returns
       )
     end
-
-    maybe_replace_goerly(contract_call)
   end
 
   def execute_batch(function_name, args) do
@@ -164,37 +156,5 @@ defmodule Sanbase.SmartContracts.SanbaseNFT do
         transform_args_list_fun: fn list -> list ++ ["latest"] end
       )
     end
-
-    maybe_replace_goerly(contract_call)
-  end
-
-  defp maybe_replace_goerly(func) do
-    maybe_put_goerly_url()
-
-    try do
-      func.()
-    rescue
-      e ->
-        Logger.error("Error occurred while executing smart contract call: #{inspect(e)}")
-        {:error, "Error occurred while executing smart contract call."}
-    after
-      maybe_put_eth_mainnet_url()
-    end
-  end
-
-  defp maybe_put_goerly_url() do
-    if is_dev_or_stage?() do
-      Application.put_env(:ethereumex, :url, System.get_env("GOERLY_URL"))
-    end
-  end
-
-  defp maybe_put_eth_mainnet_url() do
-    if is_dev_or_stage?() do
-      Application.put_env(:ethereumex, :url, System.get_env("PARITY_URL"))
-    end
-  end
-
-  defp is_dev_or_stage?() do
-    Config.module_get(Sanbase, :deployment_env) in ["dev", "stage"]
   end
 end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

Goerly testnet was deprecated and LTS ended 31st March 2024

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
