### PR TITLE
Increase the rounding from 6 to 12 decimals

### DIFF
--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -933,6 +933,6 @@ defmodule Sanbase.Metric do
     end)
   end
 
-  defp round_value(num) when is_float(num), do: Float.round(num, 6)
+  defp round_value(num) when is_float(num), do: Float.round(num, 12)
   defp round_value(num), do: num
 end

--- a/test/sanbase/metric/metric_rounding_test.exs
+++ b/test/sanbase/metric/metric_rounding_test.exs
@@ -25,7 +25,7 @@ defmodule Sanbase.MetricRoundingTest do
         )
 
       assert data == [
-               %{value: 830_224.712939, datetime: ~U[2024-03-30 00:00:00Z]},
+               %{value: 830_224.7129387193, datetime: ~U[2024-03-30 00:00:00Z]},
                %{value: 696_766.0123, datetime: ~U[2024-03-31 00:00:00Z]},
                %{value: 469_393.1, datetime: ~U[2024-04-01 00:00:00Z]}
              ]


### PR DESCRIPTION
## Changes

Some metrics like percent_of_holders_distribution_100k_to_1M for
bitcoin could have values like 0.000005720502211279198

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
