### PR TITLE
Add selfResetApiRateLimits query

### DIFF
--- a/lib/sanbase/accounts/settings.ex
+++ b/lib/sanbase/accounts/settings.ex
@@ -43,6 +43,9 @@ defmodule Sanbase.Accounts.Settings do
     field(:is_subscribed_monthly_newsletter, :boolean, default: true)
     field(:is_subscribed_biweekly_report, :boolean, default: false)
 
+    # Rate Limits Settings
+    field(:self_api_rate_limits_reset_at, :utc_datetime, default: nil)
+
     field(:sanbase_version, :string)
   end
 
@@ -68,7 +71,8 @@ defmodule Sanbase.Accounts.Settings do
       :is_subscribed_marketing_emails,
       :is_subscribed_comments_emails,
       :is_subscribed_likes_emails,
-      :sanbase_version
+      :sanbase_version,
+      :self_api_rate_limits_reset_at
     ])
   end
 

--- a/lib/sanbase/api_call_limit/api_call_limit.ex
+++ b/lib/sanbase/api_call_limit/api_call_limit.ex
@@ -150,10 +150,12 @@ defmodule Sanbase.ApiCallLimit do
   end
 
   def reset(%User{} = user) do
-    Repo.get_by(__MODULE__, user_id: user.id)
-    |> Repo.delete()
+    if struct = Repo.get_by(__MODULE__, user_id: user.id), do: Repo.delete(struct)
 
-    create(:user, user)
+    case create(:user, user) do
+      {:ok, acl} -> {:ok, acl}
+      {:error, _} -> {:error, "Failed to reset the API call limits of user #{user.id}"}
+    end
   end
 
   # Private functions

--- a/lib/sanbase_web/graphql/schema/queries/user_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/user_queries.ex
@@ -14,6 +14,7 @@ defmodule SanbaseWeb.Graphql.Schema.UserQueries do
   }
 
   alias SanbaseWeb.Graphql.Middlewares.JWTAuth
+  alias SanbaseWeb.Graphql.Middlewares.UserAuth
 
   object :user_queries do
     @desc "Returns the user currently logged in."
@@ -201,6 +202,11 @@ defmodule SanbaseWeb.Graphql.Schema.UserQueries do
 
       middleware(JWTAuth)
       resolve(&UserResolver.change_avatar/3)
+    end
+
+    field :self_reset_api_rate_limits, :user do
+      middleware(UserAuth)
+      resolve(&UserResolver.self_reset_api_rate_limits/3)
     end
   end
 end

--- a/lib/sanbase_web/graphql/schema/types/user_settings_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_settings_types.ex
@@ -26,6 +26,8 @@ defmodule SanbaseWeb.Graphql.UserSettingsTypes do
     field(:newsletter_subscription, :string, default_value: "OFF")
     field(:sanbase_version, :string)
 
+    field(:self_api_rate_limits_reset_at, :datetime)
+
     field :alerts_per_day_limit_left, :json do
       resolve(&UserSettingsResolver.alerts_per_dy_limit_left/3)
     end

--- a/lib/sanbase_web/graphql/schema/types/user_settings_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_settings_types.ex
@@ -27,6 +27,8 @@ defmodule SanbaseWeb.Graphql.UserSettingsTypes do
     field(:sanbase_version, :string)
 
     field(:self_api_rate_limits_reset_at, :datetime)
+    field(:can_self_reset_api_rate_limits, :boolean)
+    field(:can_self_reset_api_rate_limits_at, :datetime)
 
     field :alerts_per_day_limit_left, :json do
       resolve(&UserSettingsResolver.alerts_per_dy_limit_left/3)


### PR DESCRIPTION
## Changes

Allow users to reset the API call limits once every 90 days by themselves.
This will help in cases where the user has made a mistake (infinite loop), had too many tests during development or they just need a higher plan. Instead of waiting for santiment support that will reset your limits, you can do that once per 90 days yourself.

The `selfApiRateLimitsResetAt` field is exposed in the user settings which points to the last datetime when the user has reset the limits:
```graphql
{
  currentUser{
    settings{
      selfApiRateLimitsResetAt
      canSelfResetApiRateLimits
      canSelfResetApiRateLimitsAt
    }
  }
}
```
```json
{
  "data": {
    "currentUser": {
      "settings": {
        "canSelfResetApiRateLimits": false,
        "canSelfResetApiRateLimitsAt": "2024-07-21T12:24:55Z",
        "selfApiRateLimitsResetAt": "2024-04-22T12:24:55Z"
      }
    }
  }
}
```

### API for self-resetting the limits

Success:
```graphql
mutation {
  selfResetApiRateLimits {
    id
    settings {
      selfApiRateLimitsResetAt
    }
  }
}
```
```json
{
  "data": {
    "selfResetApiRateLimits": {
      "id": "7",
      "settings": {
        "selfApiRateLimitsResetAt": "2024-04-22T12:24:55Z"
      }
    }
  }
}
```

---

Fail because the last reset was less than 90 days ago:
```graphql
mutation {
  selfResetApiRateLimits {
    id
    settings {
      selfApiRateLimitsResetAt
    }
  }
}
```
```json
{
  "data": {
    "selfResetApiRateLimits": null
  },
  "errors": [
    {
      "message": "Cannot self reset the API calls rate limits.\nThe last reset was less than 90 days ago on 2024-04-22 12:24:55Z\n",
      "path": [
        "selfResetApiRateLimits"
      ],
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ]
    }
  ]
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
