### PR TITLE
Do not cache user and single watchlists

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/user/user_list_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/user_list_resolver.ex
@@ -56,20 +56,24 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserListResolver do
   def watchlist(_root, %{id: id}, %{
         context: %{auth: %{current_user: current_user}}
       }) do
+    Process.put(:do_not_cache_query, true)
     UserList.user_list(id, current_user)
   end
 
   def watchlist(_root, %{id: id}, _resolution) do
+    Process.put(:do_not_cache_query, true)
     UserList.user_list(id, %User{id: nil})
   end
 
   def watchlist_by_slug(_root, %{slug: slug}, %{
         context: %{auth: %{current_user: current_user}}
       }) do
+    Process.put(:do_not_cache_query, true)
     UserList.user_list_by_slug(slug, current_user)
   end
 
   def watchlist_by_slug(_root, %{slug: slug}, _resolution) do
+    Process.put(:do_not_cache_query, true)
     UserList.user_list_by_slug(slug, %User{id: nil})
   end
 


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

Problem: Updating watchlists saves new settings in db but when they are fetched the updated settings are not visible immediately due to cache. 

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
