### PR TITLE
Do not use _union tables

### DIFF
--- a/bin/clickhouse/tables_used
+++ b/bin/clickhouse/tables_used
@@ -11,7 +11,7 @@ daily_metrics_v2
 distribution_deltas_5min
 erc20_balances - still present, not used
 eth_balances - still present, not used
-eth_top_holders_daily_union
+eth_top_holders_daily
 eth2_staking_transfers_v2
 github_v2
 intraday_label_based_metrics

--- a/lib/sanbase/clickhouse/fees/fees.ex
+++ b/lib/sanbase/clickhouse/fees/fees.ex
@@ -88,7 +88,7 @@ defmodule Sanbase.Clickhouse.Fees do
             ANY LEFT JOIN
             (
                 SELECT transactionHash, contract, assetRefId
-                FROM erc20_transfers_union
+                FROM erc20_transfers
                 WHERE dt >= toDateTime({{from}}) and dt < toDateTime({{to}})
             ) USING (transactionHash)
             GROUP BY assetRefId, contract

--- a/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
@@ -19,7 +19,7 @@ defmodule Sanbase.Clickhouse.TopHolders.MetricAdapter do
   def supported_infrastructures(), do: @supported_infrastructures
 
   @infrastructure_to_table %{
-    "ETH" => "eth_top_holders_daily_union",
+    "ETH" => "eth_top_holders_daily",
     "BNB" => "bnb_top_holders",
     "BEP2" => "bnb_top_holders"
   }

--- a/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
@@ -177,6 +177,7 @@ defmodule Sanbase.Clickhouse.TopHolders.MetricAdapter do
     with {:ok, contract, _decimals, infr} <- Project.contract_info_infrastructure_by_slug(slug),
          true <- chain_supported?(infr, slug, metric) do
       table = Map.get(@infrastructure_to_table, infr)
+      table = if slug != "ethereum" and infr == "ETH", do: "erc20_top_holders_daily", else: table
       query_struct = first_datetime_query(table, contract)
 
       ClickhouseRepo.query_transform(query_struct, fn [timestamp] ->
@@ -191,6 +192,7 @@ defmodule Sanbase.Clickhouse.TopHolders.MetricAdapter do
     with {:ok, contract, _decimals, infr} <- Project.contract_info_infrastructure_by_slug(slug),
          true <- chain_supported?(infr, slug, metric) do
       table = Map.get(@infrastructure_to_table, infr)
+      table = if slug != "ethereum" and infr == "ETH", do: "erc20_top_holders_daily", else: table
       query_struct = last_datetime_computed_at_query(table, contract)
 
       ClickhouseRepo.query_transform(query_struct, fn [timestamp] ->

--- a/lib/sanbase/clickhouse/top_holders/top_holders.ex
+++ b/lib/sanbase/clickhouse/top_holders/top_holders.ex
@@ -11,7 +11,7 @@ defmodule Sanbase.Clickhouse.TopHolders do
   import Sanbase.Utils.Transform, only: [opts_to_limit_offset: 1]
   import Sanbase.DateTimeUtils, only: [str_to_sec: 1]
 
-  @table "eth_top_holders_daily_union"
+  @table "eth_top_holders_daily"
 
   @type percent_of_total_supply :: %{
           datetime: DateTime.t(),


### PR DESCRIPTION
## Changes

The _union tables were combining data from the base table and the _exact
tables. Now the _exact tables' data is directly imported in the other
tables, so the _union is no longer needed

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
