### PR TITLE
Improve performance of metric alerts

### DIFF
--- a/lib/sanbase/alerts/trigger/settings/metric/metric_trigger_helper.ex
+++ b/lib/sanbase/alerts/trigger/settings/metric/metric_trigger_helper.ex
@@ -44,35 +44,35 @@ defmodule Sanbase.Alert.Trigger.MetricTriggerHelper do
     end
   end
 
-  def get_data(%{} = settings) do
-    %{filtered_target: %{list: target_list, type: type}} = settings
+  def get_data(%{filtered_target: %{list: target_list, type: type}} = settings) do
+    case fetch_metric(%{type => target_list}, settings) do
+      {:error, {:disable_alert, _reason}} = error ->
+        error
 
-    data =
-      target_list
-      |> Enum.map(fn identifier ->
-        {identifier, fetch_metric(%{type => identifier}, settings)}
-      end)
-      |> Enum.reject(fn
-        {_, nil} -> true
-        _ -> false
-      end)
+      {:error, _error} = error ->
+        error
 
-    disable_alert_error = Enum.find(data, &match?({_, {:error, {:disable_alert, _}}}, &1))
-    any_alert_error = Enum.find(data, &match?({_, {:error, _}}, &1))
-
-    # If any of the errors is a disable_alert error, return it directly.
-    # If there is no disable_alert error, return the first error.
-    # If there are no errors at all, return ok
-    case disable_alert_error do
-      {_, {:error, {:disable_alert, reason}}} ->
-        {:error, {:disable_alert, reason}}
-
-      nil ->
-        if any_alert_error, do: any_alert_error, else: {:ok, data}
+      {:ok, data} ->
+        # The target_list could be a list of many identifiers, i.e. slugs.
+        # This unfolding will map this map of slug => value pairs to
+        # one element per identifier
+        result = unfold_result(data)
+        {:ok, result}
     end
   end
 
   # Private functions
+
+  def unfold_result(data) do
+    [
+      %{datetime: dt1, value: data1},
+      %{datetime: dt2, value: data2}
+    ] = data
+
+    Enum.map(data1, fn {k, v} ->
+      {k, [%{datetime: dt1, value: v}, %{datetime: dt2, value: Map.get(data2, k)}]}
+    end)
+  end
 
   # Return a list of the `settings.metric` values for the necessary time range
 
@@ -93,19 +93,12 @@ defmodule Sanbase.Alert.Trigger.MetricTriggerHelper do
       second_end: second_end
     } = timerange_params(settings)
 
-    to_value = fn %{} = map ->
-      [{_slug, value}] = Map.to_list(map)
-      value
-    end
-
     Cache.get_or_store(cache_key, fn ->
       with {:ok, data1} when is_proper_metric_data(data1) <-
              Metric.aggregated_timeseries_data(metric, selector, first_start, first_end),
            {:ok, data2} when is_proper_metric_data(data2) <-
-             Metric.aggregated_timeseries_data(metric, selector, second_start, second_end),
-           value1 when not is_nil(value1) <- to_value.(data1),
-           value2 when not is_nil(value2) <- to_value.(data2) do
-        [%{datetime: first_start, value: value1}, %{datetime: second_start, value: value2}]
+             Metric.aggregated_timeseries_data(metric, selector, second_start, second_end) do
+        {:ok, [%{datetime: first_start, value: data1}, %{datetime: second_start, value: data2}]}
       else
         {:error, error} when is_binary(error) ->
           handle_fetch_metric_error(error, metric, selector)

--- a/livebooks/watchlist-with-unsupported-metrics.livemd
+++ b/livebooks/watchlist-with-unsupported-metrics.livemd
@@ -7,6 +7,10 @@ watchlists = Sanbase.Repo.all(Sanbase.UserList)
 ```
 
 ```elixir
+watchlists = watchlists |> Enum.reject(& &1.is_deleted)
+```
+
+```elixir
 metrics = Sanbase.Metric.available_metrics() |> MapSet.new()
 ```
 
@@ -40,6 +44,10 @@ list_with_deprecated_metrics =
   Enum.filter(list_with_metrics, fn l ->
     Enum.any?(l.metrics, &(&1 not in metrics))
   end)
+```
+
+```elixir
+length(list_with_deprecated_metrics)
 ```
 
 ```elixir


### PR DESCRIPTION
## Changes

When running alerts for watchlists, before the code did execute 2 DB queries for each asset in the watchlist.
For big watchlists this can cause too many DB calls and the alert could just timeout.

It is straightforward to rework the alert so all the data for all assets if fetched at once, in just 2 DB calls, regardless whether we ask for data for 1 asset or for 100.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
