### PR TITLE
Make issuer a mandatory param for XRP balances

### DIFF
--- a/docs/user-triggers-api.md
+++ b/docs/user-triggers-api.md
@@ -50,7 +50,7 @@ These are the fields describing a trigger.
 ### Settings fields
 
 - **type** Defines the type of the trigger. Can be one of: `["trending_words", "metric_signal", "daily_metric_signal", "wallet_movement", "signal_data"]`
-- **target**: Slug or list of slugs or watchlist or ethereum addresses or list of ethereum addresses - `{"slug": "naga"} | {"slug": ["ethereum", "santiment"]} | {"watchlist_id": watchlsit_id} | {"eth_address": "0x123"} | {"eth_address": ["0x123", "0x234"]}`.
+- **target**: Slug or list of slugs or watchlist or ethereum addresses or list of ethereum addresses - `{"slug": "naga"} | {"slug": ["ethereum", "santiment"]} | {"watchlist_id": watchlsit_id} | {"eth_address": "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f"} | {"eth_address": ["0x4efb548a2cb8f0af7c591cef21053f6875b5d38f", "0x234"]}`.
 - **channel**: A channel where the alert is sent. Can be one of `"telegram" | "email" | "web_push" | {"webhook": <webhook_url>}` | `{"telegram_channel": "@<channel_name>"}` or a list of any combination. In case of telegram_channel, the bot must be an admin that has post messages priviliges.
 - **time_window**: `1d`, `4w`, `1h` - Time string we use throughout the API for `interval`
 - **operation** - A map describing the operation that triggers the alert. Check the examples.

--- a/lib/sanbase/alerts/evaluator/scheduler.ex
+++ b/lib/sanbase/alerts/evaluator/scheduler.ex
@@ -379,7 +379,7 @@ defmodule Sanbase.Alert.Scheduler do
       send_results_list
       |> Enum.reduce({last_triggered, _total = 0, _failed = 0}, fn
         {identifier_or_list, _result = :ok}, {acc, total, failed} ->
-          # Example: {["elem1", "elem2"], :ok} or {"0x123", :ok}
+          # Example: {["elem1", "elem2"], :ok} or {"0x4efb548a2cb8f0af7c591cef21053f6875b5d38f", :ok}
           # This case happens when multiple identifiers (for example emerging words)
           # are handled in one notification.
           list = identifier_or_list |> List.wrap()

--- a/lib/sanbase/blockchain_address/blockchain_address.ex
+++ b/lib/sanbase/blockchain_address/blockchain_address.ex
@@ -24,11 +24,14 @@ defmodule Sanbase.BlockchainAddress do
     "polygon"
   ]
 
+  # XRP addresses exclude zero and capital O, as well as capital I and lowercase l
+  @xrp_regex ~r/^([r])([1-9A-HJ-NP-Za-km-z]{24,34})$/
   @ethereum_regex ~r/^0x([A-Fa-f0-9]{40})$/
   @bitcoin_regex ~r/^(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}$/
 
   def ethereum_regex(), do: @ethereum_regex
   def bitcoin_regex(), do: @bitcoin_regex
+  def xrp_regex(), do: @xrp_regex
 
   schema "blockchain_addresses" do
     field(:address, :string)

--- a/lib/sanbase/clickhouse/historical_balance/behaviour.ex
+++ b/lib/sanbase/clickhouse/historical_balance/behaviour.ex
@@ -20,10 +20,9 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.Behaviour do
   @type decimals :: non_neg_integer()
   @type datetime :: DateTime.t()
 
-  @type currency :: String.t()
   @type contract :: String.t()
-
-  @type target :: contract | currency
+  @type xrp_target :: %{currency: String.t(), issuer: String.t()}
+  @type target :: contract | xrp_target
 
   @type slug_balance_map :: %{
           slug: slug,

--- a/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
@@ -25,6 +25,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
   @type selector :: %{
           optional(:infrastructure) => String.t(),
           optional(:currency) => String.t(),
+          optional(:issuer) => String.t(),
           optional(:slug) => String.t(),
           optional(:contract) => String.t(),
           optional(:decimals) => non_neg_integer()
@@ -253,10 +254,14 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
   def selector_to_args(%{infrastructure: "XRP"} = selector) do
     %{
       module: XrpBalance,
-      asset: Map.get(selector, :currency, "XRP"),
+      asset: %{
+        currency: Map.get(selector, :currency, "XRP"),
+        issuer: Map.get(selector, :issuer, "XRP")
+      },
       currency: Map.get(selector, :currency, "XRP"),
+      issuer: Map.get(selector, :issuer, "XRP"),
       blockchain: BlockchainAddress.blockchain_from_infrastructure("XRP"),
-      slug: "xrp",
+      slug: Map.get(selector, :slug, "xrp"),
       decimals: 0
     }
   end
@@ -353,7 +358,9 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
     data
   end
 
-  defp get_project_details(%{slug: slug}) do
+  defp get_project_details(%{slug: slug} = m) do
+    IO.inspect(m)
+
     with {:ok, contract, decimals, infrastructure} <-
            Project.contract_info_infrastructure_by_slug(slug) do
       %{

--- a/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/historical_balance.ex
@@ -358,9 +358,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance do
     data
   end
 
-  defp get_project_details(%{slug: slug} = m) do
-    IO.inspect(m)
-
+  defp get_project_details(%{slug: slug}) do
     with {:ok, contract, decimals, infrastructure} <-
            Project.contract_info_infrastructure_by_slug(slug) do
       %{

--- a/lib/sanbase/clickhouse/historical_balance/xrp_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/xrp_balance.ex
@@ -4,25 +4,13 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
   """
 
   @behaviour Sanbase.Clickhouse.HistoricalBalance.Behaviour
-  use Ecto.Schema
 
   import Sanbase.Clickhouse.HistoricalBalance.Utils
   import Sanbase.Metric.SqlQuery.Helper, only: [timerange_parameters: 3]
+
   alias Sanbase.ClickhouseRepo
 
   @table "xrp_balances"
-  schema @table do
-    field(:datetime, :utc_datetime, source: :dt)
-    field(:balance, :float)
-    field(:old_balance, :float, source: :oldBalance)
-    field(:address, :string)
-    field(:currency, :string)
-  end
-
-  @doc false
-  @spec changeset(any(), any()) :: no_return()
-  def changeset(_, _),
-    do: raise("Should not try to change xrp balances")
 
   @impl Sanbase.Clickhouse.HistoricalBalance.Behaviour
   def assets_held_by_address(address) do
@@ -52,17 +40,31 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
   def historical_balance([], _, _, _, _, _), do: {:ok, []}
 
   @impl Sanbase.Clickhouse.HistoricalBalance.Behaviour
-  def historical_balance(addresses, currency, decimals, from, to, interval)
+  def historical_balance(
+        addresses,
+        %{currency: _, issuer: _} = target_map,
+        decimals,
+        from,
+        to,
+        interval
+      )
       when is_list(addresses) do
     combine_historical_balances(addresses, fn address ->
-      historical_balance(address, currency, decimals, from, to, interval)
+      historical_balance(address, target_map, decimals, from, to, interval)
     end)
   end
 
   @impl Sanbase.Clickhouse.HistoricalBalance.Behaviour
-  def historical_balance(address, currency, _decimals, from, to, interval)
+  def historical_balance(
+        address,
+        %{currency: currency, issuer: issuer},
+        _decimals,
+        from,
+        to,
+        interval
+      )
       when is_binary(address) do
-    query_struct = historical_balance_query(address, currency, from, to, interval)
+    query_struct = historical_balance_query(address, currency, issuer, from, to, interval)
 
     ClickhouseRepo.query_transform(query_struct, fn [dt, balance, has_changed] ->
       %{
@@ -72,7 +74,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
       }
     end)
     |> maybe_update_first_balance(fn ->
-      last_balance_before(address, currency, 0, from)
+      last_balance_before(address, %{currency: currency, issuer: issuer}, 0, from)
     end)
     |> maybe_fill_gaps_last_seen_balance()
   end
@@ -81,9 +83,15 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
   def balance_change([], _, _, _, _), do: {:ok, []}
 
   @impl Sanbase.Clickhouse.HistoricalBalance.Behaviour
-  def balance_change(address_or_addresses, currency, _decimals, from, to)
+  def balance_change(
+        address_or_addresses,
+        %{currency: currency, issuer: issuer},
+        _decimals,
+        from,
+        to
+      )
       when is_binary(address_or_addresses) or is_list(address_or_addresses) do
-    query_struct = balance_change_query(address_or_addresses, currency, from, to)
+    query_struct = balance_change_query(address_or_addresses, currency, issuer, from, to)
 
     ClickhouseRepo.query_transform(query_struct, fn
       [address, balance_start, balance_end, balance_change] ->
@@ -102,7 +110,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
 
   def historical_balance_change(
         address_or_addresses,
-        currency,
+        %{currency: currency, issuer: issuer},
         _decimals,
         from,
         to,
@@ -113,6 +121,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
       historical_balance_change_query(
         address_or_addresses,
         currency,
+        issuer,
         from,
         to,
         interval
@@ -127,8 +136,8 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
   end
 
   @impl Sanbase.Clickhouse.HistoricalBalance.Behaviour
-  def last_balance_before(address, currency, _decimals, datetime) do
-    query_struct = last_balance_before_query(address, currency, datetime)
+  def last_balance_before(address, %{currency: currency, issuer: issuer}, _decimals, datetime) do
+    query_struct = last_balance_before_query(address, currency, issuer, datetime)
 
     case ClickhouseRepo.query_transform(query_struct, & &1) do
       {:ok, [[balance]]} -> {:ok, balance}
@@ -139,14 +148,16 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
 
   # Private functions
 
-  defp last_balance_before_query(address, currency, datetime) do
+  defp last_balance_before_query(address, currency, issuer, datetime) do
     sql = """
     SELECT balance
     FROM #{@table}
     PREWHERE
       address = {{address}} AND
       currency = {{currency}} AND
-      dt <=toDateTime({{datetime}})
+      issuerCurrency = {{issuer_currency}} AND
+      dt <= toDateTime({{datetime}}) AND
+      dt >= toDateTime({{datetime}}) - INTERVAL 3 YEAR
     ORDER BY dt DESC
     LIMIT 1
     """
@@ -154,7 +165,8 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
     params = %{
       address: address,
       currency: currency,
-      datetime: DateTime.to_unix(datetime)
+      datetime: DateTime.to_unix(datetime),
+      issuer_currency: get_issuer_currency(issuer, currency)
     }
 
     Sanbase.Clickhouse.Query.new(sql, params)
@@ -171,11 +183,15 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
     GROUP BY address
     """
 
-    params = %{address: address, currency: currency}
+    params = %{
+      address: address,
+      currency: currency
+    }
+
     Sanbase.Clickhouse.Query.new(sql, params)
   end
 
-  defp historical_balance_query(address, currency, from, to, interval)
+  defp historical_balance_query(address, currency, issuer, from, to, interval)
        when is_binary(address) do
     # The balances table is like a stack. For each balance change there is a record
     # with sign = -1 that is the old balance and with sign = 1 which is the new balance
@@ -199,7 +215,8 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
         address = {{address}} AND
         dt >= toDateTime({{from}}) AND
         dt < toDateTime({{to}}) AND
-        currency = {{currency}}
+        currency = {{currency}} AND
+        assetRefId = cityHash64('XRP_' || {{issuer_currency}})
       GROUP BY time
     )
     GROUP BY time
@@ -214,13 +231,14 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
       address: address,
       from: from,
       to: to,
-      currency: currency
+      currency: currency,
+      issuer_currency: get_issuer_currency(issuer, currency)
     }
 
     Sanbase.Clickhouse.Query.new(sql, params)
   end
 
-  defp balance_change_query(address_or_addresses, currency, from, to) do
+  defp balance_change_query(address_or_addresses, currency, issuer, from, to) do
     sql = """
     SELECT
       address,
@@ -230,13 +248,15 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
     FROM #{@table}
     PREWHERE
       address IN ({{addresses}}) AND
-      currency = {{currency}}
+      currency = {{currency}} AND
+      assetRefId = cityHash64('XRP_' || {{issuer_currency}})
     GROUP BY address
     """
 
     params = %{
       addresses: address_or_addresses |> List.wrap() |> List.flatten(),
       currency: currency,
+      issuer_currency: get_issuer_currency(issuer, currency),
       from: from,
       to: to
     }
@@ -247,6 +267,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
   defp historical_balance_change_query(
          address_or_addresses,
          currency,
+         issuer,
          from,
          to,
          interval
@@ -272,6 +293,7 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
         PREWHERE
           address IN ({addresses}) AND
           currency = {{currency}} AND
+          assetRefId = cityHash64('XRP_' || {{issuer_currency}}) AND
           dt >= toDateTime({{from}}) AND
           dt <= toDateTime({{to}})
       )
@@ -288,10 +310,14 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
       interval: interval,
       span: span,
       currency: currency,
+      issuer_currency: get_issuer_currency(issuer, currency),
       from: from,
       to: to
     }
 
     Sanbase.Clickhouse.Query.new(sql, params)
   end
+
+  defp get_issuer_currency("XRP", "XRP"), do: "XRP"
+  defp get_issuer_currency(issuer, currency), do: "#{issuer}/#{currency}}"
 end

--- a/lib/sanbase/run_examples.ex
+++ b/lib/sanbase/run_examples.ex
@@ -32,6 +32,7 @@ defmodule Sanbase.RunExamples do
     :top_addresses,
     :ecosystem_metrics
   ]
+  def queries(), do: @queries
 
   @from ~U[2023-01-01 00:00:00Z]
   @closer_to ~U[2023-01-01 08:00:00Z]
@@ -93,10 +94,10 @@ defmodule Sanbase.RunExamples do
       do: raise("Do not run the examples against prod postgres!")
 
     if ch =~ "production",
-      do: raise("Do not run the examples against prod postgres!")
+      do: raise("Do not run the examples against prod clikhouse")
 
     if ch_ro =~ "production",
-      do: raise("Do not run the examples against prod readonly CH!")
+      do: raise("Do not run the examples against prod readonly clickhouse")
 
     :ok
   end
@@ -502,15 +503,18 @@ defmodule Sanbase.RunExamples do
   end
 
   defp do_run(:historical_balance) do
-    for {slug, address} <- [
-          {"ethereum", @null_address},
-          {"santiment", @null_address},
-          {"xrp", "rMQ98K56yXJbDGv49ZSmW51sLn94Xe1mu1"},
-          {"bitcoin", "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"}
+    xrp_addr = "r3LeQsVdYzeCrKVAh49pNpAX6vfph1vUSH"
+    btc_addr = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+
+    for {selector, address} <- [
+          {%{infrastrucutre: "ETH", slug: "ethereum"}, @null_address},
+          {%{infrastrucutre: "ETH", slug: "santiment"}, @null_address},
+          {%{infrastructure: "XRP", currency: "XRP", issuer: "XRP"}, xrp_addr},
+          {%{infrastructure: "BTC", slug: "bitcoin"}, btc_addr}
         ] do
       {:ok, [_ | _]} =
         Sanbase.Clickhouse.HistoricalBalance.historical_balance(
-          %{slug: slug},
+          selector,
           address,
           @from,
           @closer_to,
@@ -520,8 +524,24 @@ defmodule Sanbase.RunExamples do
 
     {:ok, [_ | _]} =
       Sanbase.Clickhouse.HistoricalBalance.balance_change(
-        %{slug: "ethereum"},
+        %{infrastructure: "ETH", slug: "ethereum"},
         @null_address,
+        @from,
+        @closer_to
+      )
+
+    {:ok, [_ | _]} =
+      Sanbase.Clickhouse.HistoricalBalance.balance_change(
+        %{infrastructure: "XRP", currency: "XRP", issuer: "XRP"},
+        xrp_addr,
+        @from,
+        @closer_to
+      )
+
+    {:ok, [_ | _]} =
+      Sanbase.Clickhouse.HistoricalBalance.balance_change(
+        %{infrastructure: "BTC", slug: "bitcoin"},
+        btc_addr,
         @from,
         @closer_to
       )

--- a/lib/sanbase/utils/datetime/blockchain_address_utils.ex
+++ b/lib/sanbase/utils/datetime/blockchain_address_utils.ex
@@ -6,15 +6,15 @@ defmodule Sanbase.Utils.BlockchainAddressUtils do
   Additionally, the provided `infrastructure` is added as a key to every map
 
     ## Example
-    iex> Sanbase.Utils.BlockchainAddressUtils.transform_address_to_map([%{address: "0x123"}, %{address: "0x1234"}], "ETH")
-    [%{address: %{address: "0x123", infrastructure: "ETH"}}, %{address: %{address: "0x1234", infrastructure: "ETH"}}]
+    iex> Sanbase.Utils.BlockchainAddressUtils.transform_address_to_map([%{address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f"}, %{address: "0x1234"}], "ETH")
+    [%{address: %{address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f", infrastructure: "ETH"}}, %{address: %{address: "0x1234", infrastructure: "ETH"}}]
 
-    iex> Sanbase.Utils.BlockchainAddressUtils.transform_address_to_map([%{from_address: "0x123"}, %{from_address: "0x1234"}], "ETH")
-    [%{from_address: %{address: "0x123", infrastructure: "ETH"}}, %{from_address: %{address: "0x1234", infrastructure: "ETH"}}]
+    iex> Sanbase.Utils.BlockchainAddressUtils.transform_address_to_map([%{from_address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f"}, %{from_address: "0x1234"}], "ETH")
+    [%{from_address: %{address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f", infrastructure: "ETH"}}, %{from_address: %{address: "0x1234", infrastructure: "ETH"}}]
 
 
-    iex> Sanbase.Utils.BlockchainAddressUtils.transform_address_to_map([%{to_address: "0x123"}, %{to_address: "0x1234"}], "ETH")
-    [%{to_address: %{address: "0x123", infrastructure: "ETH"}}, %{to_address: %{address: "0x1234", infrastructure: "ETH"}}]
+    iex> Sanbase.Utils.BlockchainAddressUtils.transform_address_to_map([%{to_address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f"}, %{to_address: "0x1234"}], "ETH")
+    [%{to_address: %{address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f", infrastructure: "ETH"}}, %{to_address: %{address: "0x1234", infrastructure: "ETH"}}]
   """
   def transform_address_to_map(list, infrastructure \\ nil) do
     address_to_map =

--- a/lib/sanbase_web/graphql/resolvers/historical_balance_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/historical_balance_resolver.ex
@@ -9,19 +9,19 @@ defmodule SanbaseWeb.Graphql.Resolvers.HistoricalBalanceResolver do
   alias SanbaseWeb.Graphql.SanbaseDataloader
 
   def assets_held_by_address(_root, args, _resolution) do
-    selector = args_to_address_selector(args)
+    with {:ok, selector} <- args_to_address_selector(args) do
+      case HistoricalBalance.assets_held_by_address(selector,
+             show_assets_with_zero_balance: args.show_assets_with_zero_balance
+           ) do
+        {:ok, result} ->
+          {:ok, result}
 
-    case HistoricalBalance.assets_held_by_address(selector,
-           show_assets_with_zero_balance: args.show_assets_with_zero_balance
-         ) do
-      {:ok, result} ->
-        {:ok, result}
-
-      {:error, error} ->
-        {:error,
-         handle_graphql_error("Assets held by address", selector.address, error,
-           description: "address"
-         )}
+        {:error, error} ->
+          {:error,
+           handle_graphql_error("Assets held by address", selector.address, error,
+             description: "address"
+           )}
+      end
     end
   end
 
@@ -40,60 +40,47 @@ defmodule SanbaseWeb.Graphql.Resolvers.HistoricalBalanceResolver do
     end
   end
 
-  defp args_to_address_selector(args) do
-    case Map.get(args, :selector) do
-      nil ->
-        address = args.address
-        infrastructure = Sanbase.BlockchainAddress.to_infrastructure(address)
-        %{infrastructure: infrastructure, address: address}
-
-      selector ->
-        selector
-    end
-  end
-
   def historical_balance(
         _root,
         %{from: from, to: to, interval: interval, address: address} = args,
         _resolution
       ) do
-    selector =
-      case args do
-        %{selector: selector} -> selector
-        %{slug: slug} -> %{slug: slug}
-      end
-
-    HistoricalBalance.historical_balance(
-      selector,
-      address,
-      from,
-      to,
-      interval
-    )
-    |> maybe_handle_graphql_error(fn error ->
-      handle_graphql_error(
-        "Historical Balances",
-        inspect(selector),
-        error,
-        description: "selector"
+    with {:ok, selector} <- args_to_historical_balance_selector(args) do
+      HistoricalBalance.historical_balance(
+        selector,
+        address,
+        from,
+        to,
+        interval
       )
-    end)
+      |> maybe_handle_graphql_error(fn error ->
+        handle_graphql_error(
+          "Historical Balances",
+          inspect(selector),
+          error,
+          description: "selector"
+        )
+      end)
+      |> dbg()
+    end
   end
 
   def address_historical_balance_change(
         _root,
-        %{selector: selector, from: from, to: to, addresses: addresses},
+        %{from: from, to: to, addresses: addresses} = args,
         _resolution
       ) do
-    HistoricalBalance.balance_change(selector, addresses, from, to)
-    |> maybe_handle_graphql_error(fn error ->
-      handle_graphql_error(
-        "Historical Balance Change per Address",
-        inspect(selector),
-        error,
-        description: "selector"
-      )
-    end)
+    with {:ok, selector} <- args_to_historical_balance_selector(args) do
+      HistoricalBalance.balance_change(selector, addresses, from, to)
+      |> maybe_handle_graphql_error(fn error ->
+        handle_graphql_error(
+          "Historical Balance Change per Address",
+          inspect(selector),
+          error,
+          description: "selector"
+        )
+      end)
+    end
   end
 
   def miners_balance(root, %{} = args, resolution) do
@@ -119,4 +106,87 @@ defmodule SanbaseWeb.Graphql.Resolvers.HistoricalBalanceResolver do
       {:ok, price_usd && balance * price_usd}
     end)
   end
+
+  # Private functions
+
+  defp args_to_historical_balance_selector(args) do
+    case Map.get(args, :selector) do
+      nil ->
+        address = args.address
+        infrastructure = Sanbase.BlockchainAddress.to_infrastructure(address)
+        %{infrastructure: infrastructure, address: address}
+
+      selector ->
+        selector |> Map.put(:address, args[:address]) |> Map.put(:addresses, args[:addresses])
+    end
+    |> IO.inspect()
+    |> validate_historical_balance_selector()
+  end
+
+  defp args_to_address_selector(args) do
+    case Map.get(args, :selector) do
+      nil ->
+        address = args.address
+        infrastructure = Sanbase.BlockchainAddress.to_infrastructure(address)
+        %{infrastructure: infrastructure, address: address}
+
+      selector ->
+        selector
+    end
+  end
+
+  defp validate_historical_balance_selector(%{infrastructure: "XRP"} = selector) do
+    cond do
+      not address_matches_regex?(selector, Sanbase.BlockchainAddress.xrp_regex()) ->
+        {:error, "Invalid XRP address(es): #{format_address(selector)}"}
+
+      not Map.has_key?(selector, :currency) ->
+        {:error, "When getting data for the XRPL blockchain, the currency parameter is mandatory"}
+
+      not Map.has_key?(selector, :issuer) ->
+        {:error, "When getting data for the XRPL blockchain, the issuer parameter is mandatory"}
+
+      selector.currency == "XRP" and selector.issuer != "XRP" ->
+        {:error, "The only issuer for XRP is XRP"}
+
+      true ->
+        {:ok, selector}
+    end
+  end
+
+  defp validate_historical_balance_selector(%{infrastructure: "ETH"} = selector) do
+    cond do
+      not Regex.match?(Sanbase.BlockchainAddress.ethereum_regex(), selector.address) ->
+        {:error, "Invalid Ethereum address: #{selector.address}"}
+
+      true ->
+        {:ok, selector}
+    end
+  end
+
+  defp validate_historical_balance_selector(%{infrastructure: "BTC"} = selector) do
+    IO.inspect(selector)
+
+    cond do
+      not Regex.match?(Sanbase.BlockchainAddress.bitcoin_regex(), selector.address) ->
+        {:error, "Invalid Bitcoin address: #{selector.address}"}
+
+      selector[:slug] not in [nil, "bitcoin"] ->
+        {:error,
+         "When fetching Bitcoin historical balances, do not provide slug or provide the `bitcoin` slug."}
+
+      true ->
+        {:ok, selector}
+    end
+  end
+
+  defp validate_historical_balance_selector(selector), do: {:ok, selector}
+
+  def address_matches_regex?(%{address: address}, regex), do: String.match?(address, regex)
+
+  def address_matches_regex?(%{addresses: addresses}, regex),
+    do: Enum.all?(addresses, &String.match?(&1, regex))
+
+  defp format_address(%{address: address}), do: address
+  defp format_address(%{addresses: addresses}), do: Enum.join(addresses, ", ")
 end

--- a/lib/sanbase_web/graphql/schema/types/historical_balance_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/historical_balance_types.ex
@@ -57,6 +57,7 @@ defmodule SanbaseWeb.Graphql.HistoricalBalanceTypes do
   input_object :historical_balance_selector do
     field(:infrastructure, :string)
     field(:currency, :string)
+    field(:issuer, :string)
     field(:contract, :string)
     field(:decimals, :integer)
     field(:slug, :string)

--- a/test/sanbase/billing/san_burn_credit_trx_test.exs
+++ b/test/sanbase/billing/san_burn_credit_trx_test.exs
@@ -13,7 +13,7 @@ defmodule Sanbase.Billing.SanBurnCreditTransactionTest do
       )
 
     timestamp = ~U[2022-05-23 05:43:40Z] |> DateTime.to_unix()
-    rows = [[timestamp, "0x1", 1000, "0x123"]]
+    rows = [[timestamp, "0x1", 1000, "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f"]]
 
     data = %{price_usd: 4, price_btc: 0.03, marketcap: 100, volume: 100}
 
@@ -42,7 +42,7 @@ defmodule Sanbase.Billing.SanBurnCreditTransactionTest do
                san_amount: 1000,
                san_price: 4,
                trx_datetime: ~U[2022-05-23 05:43:40Z],
-               trx_hash: "0x123",
+               trx_hash: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f",
                user_id: user.id
              }
     end)

--- a/test/sanbase/clickhouse/historical_balance/assets_held_by_address_test.exs
+++ b/test/sanbase/clickhouse/historical_balance/assets_held_by_address_test.exs
@@ -37,7 +37,10 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.AssetsHeldByAdderssTest do
        ]}
     )
     |> Sanbase.Mock.run_with_mocks(fn ->
-      assert HistoricalBalance.assets_held_by_address(%{address: "0x123", infrastructure: "ETH"}) ==
+      assert HistoricalBalance.assets_held_by_address(%{
+               address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f",
+               infrastructure: "ETH"
+             }) ==
                {:ok,
                 [
                   %{slug: context.eth_project.slug, balance: 1000.0},
@@ -50,7 +53,10 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.AssetsHeldByAdderssTest do
   test "clickhouse returns no results", _context do
     Sanbase.Mock.prepare_mock2(&Sanbase.Balance.assets_held_by_address/2, {:ok, []})
     |> Sanbase.Mock.run_with_mocks(fn ->
-      assert HistoricalBalance.assets_held_by_address(%{address: "0x123", infrastructure: "BTC"}) ==
+      assert HistoricalBalance.assets_held_by_address(%{
+               address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f",
+               infrastructure: "BTC"
+             }) ==
                {:ok, []}
     end)
   end
@@ -61,7 +67,10 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.AssetsHeldByAdderssTest do
       {:error, "Something went wrong"}
     )
     |> Sanbase.Mock.run_with_mocks(fn ->
-      assert HistoricalBalance.assets_held_by_address(%{address: "0x123", infrastructure: "LTC"}) ==
+      assert HistoricalBalance.assets_held_by_address(%{
+               address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f",
+               infrastructure: "LTC"
+             }) ==
                {:error, "Something went wrong"}
     end)
   end

--- a/test/sanbase/social_data/sentiment_test.exs
+++ b/test/sanbase/social_data/sentiment_test.exs
@@ -11,7 +11,7 @@ defmodule Sanbase.SentimentTest do
       insert(:project, %{
         slug: "santiment",
         ticker: "SAN",
-        main_contract_address: "0x123"
+        main_contract_address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f"
       })
 
     [

--- a/test/sanbase/social_data/social_volume_test.exs
+++ b/test/sanbase/social_data/social_volume_test.exs
@@ -13,7 +13,7 @@ defmodule Sanbase.SocialVolumeTest do
       insert(:project, %{
         slug: "santiment",
         ticker: "SAN",
-        main_contract_address: "0x123"
+        main_contract_address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f"
       })
 
     [

--- a/test/sanbase_web/graphql/blockchain_address/blockchain_address_api_test.exs
+++ b/test/sanbase_web/graphql/blockchain_address/blockchain_address_api_test.exs
@@ -47,12 +47,12 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressApiTest do
     |> Sanbase.Mock.run_with_mocks(fn ->
       result =
         blockchain_address(context.conn, %{
-          address: "0x123",
+          address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f",
           infrastructure: "ETH"
         })
         |> get_in(["data", "blockchainAddress"])
 
-      assert result["address"] == "0x123"
+      assert result["address"] == "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f"
       assert result["infrastructure"] == "ETH"
       assert result["labels"] == []
       assert result["notes"] == nil
@@ -64,7 +64,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressApiTest do
     |> Sanbase.Mock.run_with_mocks(fn ->
       address_id =
         blockchain_address(context.conn, %{
-          address: "0x123",
+          address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f",
           infrastructure: "ETH"
         })
         |> get_in(["data", "blockchainAddress", "id"])
@@ -76,7 +76,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressApiTest do
       # The same address if fetched and a new one is not created
       assert result["id"] == address_id
 
-      assert result["address"] == "0x123"
+      assert result["address"] == "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f"
       assert result["infrastructure"] == "ETH"
       assert result["labels"] == []
       assert result["notes"] == nil
@@ -87,7 +87,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressApiTest do
        context do
     blockchain_address =
       insert(:blockchain_address,
-        address: "0x123",
+        address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f",
         infrastructure: context.eth_infrastructure
       )
 
@@ -95,14 +95,14 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressApiTest do
     |> Sanbase.Mock.run_with_mocks(fn ->
       result =
         blockchain_address(context.conn, %{
-          address: "0x123",
+          address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f",
           infrastructure: context.eth_infrastructure.code
         })
         |> get_in(["data", "blockchainAddress"])
 
       # The same address if fetched and a new one is not created
       assert result["id"] == blockchain_address.id
-      assert result["address"] == "0x123"
+      assert result["address"] == "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f"
       assert result["infrastructure"] == "ETH"
       assert result["labels"] == []
       assert result["notes"] == nil
@@ -112,7 +112,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressApiTest do
   test "update a blockchain address user pair", context do
     blockchain_address =
       insert(:blockchain_address,
-        address: "0x123",
+        address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f",
         infrastructure: context.eth_infrastructure
       )
 

--- a/test/sanbase_web/graphql/blockchain_address/blockchain_address_label_changes_test.exs
+++ b/test/sanbase_web/graphql/blockchain_address/blockchain_address_label_changes_test.exs
@@ -47,7 +47,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressLabelChangesApiTest do
       result =
         blockchain_address_label_changes(
           context.conn,
-          %{address: "0x123", infrastructure: "ETH"},
+          %{address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f", infrastructure: "ETH"},
           ~U[2015-01-01 00:00:00Z],
           ~U[2021-05-01 00:00:00Z]
         )

--- a/test/sanbase_web/graphql/clickhouse/historical_balance/assets_held_by_address_api_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/historical_balance/assets_held_by_address_api_test.exs
@@ -37,7 +37,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
       {:ok, %{eth_project.slug => ethereum_usd_price}}
     )
     |> Sanbase.Mock.run_with_mocks(fn ->
-      query = assets_held_by_address_query("0x123", "ETH")
+      query = assets_held_by_address_query("0x4efb548a2cb8f0af7c591cef21053f6875b5d38f", "ETH")
 
       result =
         conn
@@ -72,7 +72,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
       {:ok, %{btc_project.slug => bitcoin_usd_price}}
     )
     |> Sanbase.Mock.run_with_mocks(fn ->
-      query = assets_held_by_address_query("0x123", "BTC")
+      query = assets_held_by_address_query("0x4efb548a2cb8f0af7c591cef21053f6875b5d38f", "BTC")
 
       result =
         conn
@@ -101,7 +101,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
     Sanbase.Mock.prepare_mock2(&Sanbase.Balance.assets_held_by_address/2, {:ok, data_btc})
     |> Sanbase.Mock.prepare_mock2(&Sanbase.Metric.aggregated_timeseries_data/5, {:ok, %{}})
     |> Sanbase.Mock.run_with_mocks(fn ->
-      query = assets_held_by_address_query("0x123", "BTC")
+      query = assets_held_by_address_query("0x4efb548a2cb8f0af7c591cef21053f6875b5d38f", "BTC")
 
       result =
         conn
@@ -125,7 +125,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
   test "historical balances returns empty list", context do
     Sanbase.Mock.prepare_mock2(&Sanbase.Balance.assets_held_by_address/2, {:ok, []})
     |> Sanbase.Mock.run_with_mocks(fn ->
-      address = "0x123"
+      address = "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f"
 
       query = assets_held_by_address_query(address, "ETH")
 
@@ -140,15 +140,15 @@ defmodule SanbaseWeb.Graphql.Clickhouse.AssetsHeldByAdderssApiTest do
 
   defp assets_held_by_address_query(address, infrastructure) do
     """
-      {
-        assetsHeldByAddress(
-          selector: {infrastructure: "#{infrastructure}", address: "#{address}"}
-        ){
-            slug
-            balance
-            balanceUsd
-        }
+    {
+      assetsHeldByAddress(
+        selector: {infrastructure: "#{infrastructure}", address: "#{address}"}
+      ){
+          slug
+          balance
+          balanceUsd
       }
+    }
     """
   end
 end

--- a/test/sanbase_web/graphql/clickhouse/historical_balance/historical_balances_test.exs
+++ b/test/sanbase_web/graphql/clickhouse/historical_balance/historical_balances_test.exs
@@ -23,7 +23,9 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
     [
       project_with_contract: project_with_contract,
       project_without_contract: project_without_contract,
-      address: "0x321321321",
+      eth_address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f",
+      btc_address: "1H9NmjBiMfbNNayVsXshJF8NyQ4FA9TWDT",
+      xrp_address: "rwq9nH3qKM3QqFoo6GZSEVCjczSE75v5rc",
       from: ~U[2017-05-11T00:00:00Z],
       to: ~U[2017-05-20T00:00:00Z],
       interval: "1d"
@@ -40,8 +42,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
       %{infrastructure: "BCH"},
       %{infrastructure: "BNB"},
       %{infrastructure: "BNB", slug: "binance-coin"},
-      %{infrastructure: "XRP"},
-      %{infrastructure: "XRP", currency: "BTC"}
+      %{infrastructure: "XRP", currency: "XRP", issuer: "XRP"}
     ]
 
     dt1 = ~U[2019-01-01 00:00:00Z]
@@ -62,7 +63,14 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
       to = dt4
 
       for selector <- selectors do
-        query = historical_balances_query(selector, context.address, from, to, "1d")
+        address =
+          case selector.infrastructure do
+            "BTC" -> context.btc_address
+            "XRP" -> context.xrp_address
+            _ -> context.eth_address
+          end
+
+        query = historical_balances_query(selector, address, from, to, "1d")
 
         result =
           context.conn
@@ -103,7 +111,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
       query =
         historical_balances_query(
           selector,
-          context.address,
+          context.eth_address,
           context.from,
           context.to,
           context.interval
@@ -146,7 +154,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
       from = ~U[2017-05-13T00:00:00Z]
       to = ~U[2017-05-18T00:00:00Z]
       selector = %{infrastructure: "ETH", slug: "ethereum"}
-      query = historical_balances_query(selector, context.address, from, to, "2d")
+      query = historical_balances_query(selector, context.eth_address, from, to, "2d")
 
       result =
         context.conn
@@ -173,7 +181,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
       query =
         historical_balances_query(
           selector,
-          context.address,
+          context.eth_address,
           context.from,
           context.to,
           context.interval
@@ -205,7 +213,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
       query =
         historical_balances_query(
           selector,
-          context.address,
+          context.eth_address,
           context.from,
           context.to,
           context.interval
@@ -245,7 +253,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
       query =
         historical_balances_query(
           selector,
-          context.address,
+          context.eth_address,
           context.from,
           context.to,
           context.interval
@@ -279,7 +287,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
     query =
       historical_balances_query(
         selector,
-        context.address,
+        context.eth_address,
         context.from,
         context.to,
         context.interval
@@ -314,7 +322,7 @@ defmodule SanbaseWeb.Graphql.Clickhouse.HistoricalBalancesTest do
       query =
         historical_balances_query(
           selector,
-          context.address,
+          context.eth_address,
           context.from,
           context.to,
           context.interval

--- a/test/sanbase_web/graphql/sanbase_nft_api_test.exs
+++ b/test/sanbase_web/graphql/sanbase_nft_api_test.exs
@@ -9,7 +9,12 @@ defmodule SanbaseWeb.Graphql.SanbaseNFTApiTest do
 
   setup do
     user =
-      insert(:user, eth_accounts: [%EthAccount{address: "0x123"}, %EthAccount{address: "0x234"}])
+      insert(:user,
+        eth_accounts: [
+          %EthAccount{address: "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f"},
+          %EthAccount{address: "0x234"}
+        ]
+      )
 
     conn = setup_jwt_auth(build_conn(), user)
 


### PR DESCRIPTION
## Changes
- Make `issuer` a mandatory parameter when fetching XRP balances
- Use issuer to construct `currencyIssuer` and use that to filter by the `assetRefId` field
  - `assetRefId` is second in the `ORDER BY` list, so the queries have increased performance
  - `issuer` is also important not to miss as anyone can issue a `BTC` currency, for example.
 - Special handling for `XRP` currency as it cannot be issued by everyone -- the only issuer is `XRP`.
 - Add some checks for balance selectors where the query is directly rejected if the address provided does not match the requirements. Before it could happen that you provide an ethereum address to the XRP infrastructure and the query can run for minutes. 
 - Rework tests so the addresses and selectors used there are valid. Previously the tests were working with addresses like "0x123123"
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
