### PR TITLE
Use assetRefId instead of issuerCurrency

### DIFF
--- a/lib/sanbase/clickhouse/historical_balance/xrp_balance.ex
+++ b/lib/sanbase/clickhouse/historical_balance/xrp_balance.ex
@@ -155,9 +155,8 @@ defmodule Sanbase.Clickhouse.HistoricalBalance.XrpBalance do
     PREWHERE
       address = {{address}} AND
       currency = {{currency}} AND
-      issuerCurrency = {{issuer_currency}} AND
-      dt <= toDateTime({{datetime}}) AND
-      dt >= toDateTime({{datetime}}) - INTERVAL 3 YEAR
+      assetRefId = cityHash64('XRP_' || {{issuer_currency}}) AND
+      dt <= toDateTime({{datetime}})
     ORDER BY dt DESC
     LIMIT 1
     """


### PR DESCRIPTION
## Changes

assetRefId is constructed from issuerCurrency, but it is in the second
place in the ORDER BY of the xrp_balances shard table


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
