### PR TITLE
Call first_datetime/3 if it exists

### DIFF
--- a/lib/sanbase_web/graphql/helpers/calibrate_interval.ex
+++ b/lib/sanbase_web/graphql/helpers/calibrate_interval.ex
@@ -28,7 +28,12 @@ defmodule SanbaseWeb.Graphql.Helpers.CalibrateInterval do
   end
 
   def calibrate(module, metric, slug, from, to, "", min_seconds, max_data_points) do
-    {:ok, first_datetime} = module.first_datetime(metric, slug)
+    {:ok, first_datetime} =
+      if function_exported?(module, :first_datetime, 3) do
+        module.first_datetime(metric, slug, [])
+      else
+        module.first_datetime(metric, slug)
+      end
 
     first_datetime = first_datetime || from
 


### PR DESCRIPTION
Sanbase.Metric.first_datetime/2 does not exist, so first attempt to call
the 3-arity function.

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
