### PR TITLE
Rework the topExchangesByBalance query

### DIFF
--- a/lib/sanbase/clickhouse/exchanges/exchanges.ex
+++ b/lib/sanbase/clickhouse/exchanges/exchanges.ex
@@ -1,20 +1,21 @@
 defmodule Sanbase.Clickhouse.Exchanges do
   alias Sanbase.Clickhouse.MetricAdapter.FileHandler
 
-  import Sanbase.Metric.SqlQuery.Helper, only: [asset_id_filter: 2, additional_filters: 3]
+  import Sanbase.Metric.SqlQuery.Helper, only: [asset_id_filter: 2]
 
   require Sanbase.ClickhouseRepo, as: ClickhouseRepo
 
   @name_to_metric_map FileHandler.name_to_metric_map()
   @table_map FileHandler.table_map()
 
-  def top_exchanges_by_balance(%{slug: slug_or_slugs}, limit, opts \\ []) do
-    filters = Keyword.get(opts, :additional_filters, [])
-    query_struct = top_exchanges_by_balance_query(slug_or_slugs, limit, filters)
+  def top_exchanges_by_balance(%{slug: slug}, limit, _opts \\ []) when is_binary(slug) do
+    query_struct = top_exchanges_by_balance_query(slug, limit)
 
     ClickhouseRepo.query_transform(
       query_struct,
-      fn [owner, label, balance, change_1d, change_7d, change_30d, ts, days] ->
+      fn [owner, label, balance, change_1d, change_7d, change_30d, first_seen_ts] ->
+        first_seen_dt = if first_seen_ts, do: DateTime.from_unix!(first_seen_ts)
+
         %{
           owner: owner,
           label: label,
@@ -22,8 +23,9 @@ defmodule Sanbase.Clickhouse.Exchanges do
           balance_change1d: change_1d,
           balance_change7d: change_7d,
           balance_change30d: change_30d,
-          datetime_of_first_transfer: if(ts, do: ts |> DateTime.from_unix!()),
-          days_since_first_transfer: days
+          datetime_of_first_transfer: first_seen_dt,
+          days_since_first_transfer:
+            if(first_seen_dt, do: DateTime.diff(DateTime.utc_now(), first_seen_dt, :day) |> abs())
         }
       end
     )
@@ -62,85 +64,84 @@ defmodule Sanbase.Clickhouse.Exchanges do
     Sanbase.Clickhouse.Query.new(sql, params)
   end
 
-  defp top_exchanges_by_balance_query(slug_or_slugs, limit, filters) do
-    params = %{slug: slug_or_slugs, limit: limit}
-
-    {additional_filters_str, params} = additional_filters(filters, params, trailing_and: false)
+  defp top_exchanges_by_balance_query(slug, limit) do
+    params = %{
+      slug: slug,
+      limit: limit,
+      blockchain: Sanbase.Project.slug_to_blockchain(slug)
+    }
 
     sql = """
-    SELECT
-      owner,
-      label2 as label,
-      SUM( balance ) AS balance,
-      SUM( change_1d ) AS change_1d,
-      SUM( change_7d ) AS balance_7d,
-      SUM( change_30d ) AS balance_30d,
-      min( unix_ts_of_first_transfer ) AS unix_ts_of_first_transfer,
-      max( days_since_first_transfer ) AS days_since_first_transfer
-    FROM (
-      SELECT
-        owner,
-        if(
-            label='deposit',
-            'centralized_exchange',
-            label
-          ) AS label2,
-        argMaxIf( value2, dt, metric_name = 'labelled_exchange_balance_sum' ) AS balance,
-        sumIf( value2, metric_name = 'labelled_exchange_balance' and dt > now() - INTERVAL 1 DAY ) AS change_1d,
-        sumIf( value2, metric_name = 'labelled_exchange_balance' and dt > now() - INTERVAL 7 DAY ) AS change_7d,
-        sumIf( value2, metric_name = 'labelled_exchange_balance' and dt > now() - INTERVAL 30 DAY) AS change_30d,
-        toUnixTimestamp(if(
-          minIf( dt, metric_name = 'labelled_exchange_balance' and abs(value2) > 0 ) = 0,
-          NULL,
-          minIf( dt, metric_name = 'labelled_exchange_balance' and abs(value2) > 0 )
-        )) AS unix_ts_of_first_transfer,
-        if(
-            unix_ts_of_first_transfer > 0,
-            intDivOrZero( now() - toDateTime(unix_ts_of_first_transfer), 86400 ),
-            NULL
-      ) AS days_since_first_transfer
-      FROM (
-        SELECT
-          asset_id,
-          label,
-          owner,
-          dt,
-          metric_name,
-          argMax( value, computed_at ) AS value2
-
-        FROM intraday_label_based_metrics
-
-        ANY LEFT JOIN ( SELECT name AS metric_name, metric_id FROM metric_metadata FINAL ) USING metric_id
-        PREWHERE
-          #{asset_id_filter(%{slug: slug_or_slugs}, argument_name: "slug")} AND
-          label IN ('deposit', 'centralized_exchange', 'decentralized_exchange') AND
-          dt < now() AND
-          dt != toDateTime('1970-01-01 00:00:00') AND
-          (
-            (
-              metric_id IN (
-                SELECT metric_id
-                FROM metric_metadata FINAL
-                PREWHERE name IN ('labelled_exchange_balance_sum')
-              ) AND
-              dt >= now() - INTERVAL 7 DAY
+    WITH address_hashes AS (
+        SELECT cityHash64(address)
+        FROM current_label_addresses
+        WHERE blockchain = {{blockchain}}
+            AND label_id IN (
+                dictGet('default.labels_by_fqn', 'label_id', tuple('santiment/centralized_exchange:v1')),
+                dictGet('default.labels_by_fqn', 'label_id', tuple('santiment/decentralized_exchange:v1'))
             )
-            OR
-            (
-              metric_id IN (
-                SELECT metric_id
-                FROM metric_metadata FINAL
-                PREWHERE name IN ('labelled_exchange_balance')
-              )
-            )
-          )
-        GROUP BY asset_id, metric_id, label, owner, dt, metric_name
-      )
-      #{if(additional_filters_str != "", do: "WHERE #{additional_filters_str}")}
-      GROUP BY asset_id, label, owner
+    ),
+    exchange_label_ids AS (
+        SELECT label_id
+        FROM current_label_addresses
+        WHERE
+            blockchain = {{blockchain}}
+            AND label_id IN (SELECT label_id FROM label_metadata WHERE key = 'owner')
+            AND cityHash64(address) IN address_hashes
+            AND dictGet('labels', 'value', label_id) != ''
+    ),
+    interesting_metrics AS (
+        SELECT *
+        FROM labeled_intraday_metrics_v2
+        WHERE
+            label_id IN (exchange_label_ids)
+            AND blockchain = {{blockchain}}
+            AND #{asset_id_filter(%{slug: slug}, argument_name: "slug")}
+            AND metric_id = dictGet(metrics_by_name, 'metric_id', 'combined_labeled_balance')
+    ),
+    latest_balance AS (
+        SELECT label_id, argMax(value, dt) AS latest_balance
+        FROM interesting_metrics
+        WHERE dt >= today() - INTERVAL 7 DAY
+        GROUP BY label_id
+    ),
+    balance_1d AS (
+        SELECT label_id, argMin(value, dt) AS balance_1d
+        FROM interesting_metrics
+        WHERE dt >= today() - INTERVAL 1 DAY
+        GROUP BY label_id
+    ),
+    balance_7d AS (
+        SELECT label_id, argMin(value, dt) AS balance_7d
+        FROM interesting_metrics
+        WHERE dt >= today() - INTERVAL 7 DAY
+        GROUP BY label_id
+    ),
+    balance_30d AS (
+        SELECT label_id, argMin(value, dt) AS balance_30d
+        FROM interesting_metrics
+        WHERE dt >= today() - INTERVAL 30 DAY
+        GROUP BY label_id
+    ),
+    first_seen AS (
+        SELECT label_id, min(dt) AS first_seen
+        FROM interesting_metrics
+        GROUP BY label_id
     )
-    GROUP BY label, owner
-    ORDER BY balance DESC
+    SELECT
+        dictGet(labels, 'value', latest_balance.label_id) AS AS owner, # the exchange name
+        '' AS cex_or_dex_label, # TODO: Implement
+        latest_balance.latest_balance,
+        balance_1d.balance_1d - latest_balance AS balance_change_1d,
+        balance_7d.balance_7d - latest_balance AS balance_change_7d,
+        balance_30d.balance_30d - latest_balance AS balance_change_30d,
+        toUnixTimestamp(first_seen.first_seen) AS first_seen_ts
+    FROM latest_balance
+    LEFT JOIN balance_1d ON (balance_1d.label_id = latest_balance.label_id)
+    LEFT JOIN balance_7d ON (balance_7d.label_id = latest_balance.label_id)
+    LEFT JOIN balance_30d ON (balance_30d.label_id = latest_balance.label_id)
+    LEFT JOIN first_seen ON (first_seen.label_id = latest_balance.label_id)
+    ORDER BY latest_balance DESC
     LIMIT {{limit}}
     """
 

--- a/lib/sanbase_web/graphql/schema/queries/exchange_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/exchange_queries.ex
@@ -12,14 +12,12 @@ defmodule SanbaseWeb.Graphql.Schema.ExchangeQueries do
 
       arg(:slug, :string)
       arg(:selector, :metric_target_selector_input_object)
-      arg(:label, list_of(:string))
-      arg(:owner, list_of(:string))
-      arg(:limit, :integer, default_value: 100)
+      arg(:limit, :integer, default_value: 10)
 
       middleware(AccessControl)
 
       cache_resolve(&ExchangeResolver.top_exchanges_by_balance/3,
-        ttl: 120,
+        ttl: 600,
         max_ttl_offset: 120
       )
     end


### PR DESCRIPTION
## Changes
- Rework the SQL behind topExchangesByBalance
- Drop the unused by the frontend `label` and `owner` param
- Only use the `slug` param. Error if `selector` param is used. It cannot be deleted because the frontend includes it in the query types (but does not use it). Will be removed later.
- TODO: Properly list if each owner is CEX or DEX
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
