### PR TITLE
Add priceUsd to getNftTrades API

### DIFF
--- a/lib/sanbase/queries/refresh/worker.ex
+++ b/lib/sanbase/queries/refresh/worker.ex
@@ -47,7 +47,8 @@ defmodule Sanbase.Queries.RefreshWorker do
       "(UNKNOWN_IDENTIFIER)",
       "(ACCESS_DENIED)",
       "(UNKNOWN_TABLE)",
-      "(MEMORY_LIMIT_EXCEEDED)"
+      "(MEMORY_LIMIT_EXCEEDED)",
+      "(AMBIGUOUS_COLUMN_NAME)"
     ]
 
     has_non_retryable_error? =

--- a/lib/sanbase_web/graphql/schema/types/nft_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/nft_types.ex
@@ -55,6 +55,7 @@ defmodule SanbaseWeb.Graphql.NftTypes do
     field(:amount, :float)
     field(:quantity, :float)
     field(:quantities, list_of(:nft_quantity))
+    field(:price_usd, :float)
     field(:nft, :nft)
   end
 

--- a/test/sanbase_web/graphql/nft/nft_trades_api_test.exs
+++ b/test/sanbase_web/graphql/nft/nft_trades_api_test.exs
@@ -27,7 +27,8 @@ defmodule SanbaseWeb.Graphql.NftTradesApiTest do
         "0xa1d4657e0e6507d5a94d06da93e94dc7c8c44b51",
         "nft contract name",
         "opensea",
-        ["buy"]
+        ["buy"],
+        1.5
       ],
       [
         1_637_831_576,
@@ -41,7 +42,8 @@ defmodule SanbaseWeb.Graphql.NftTradesApiTest do
         "0xad9fd7cb4fc7a0fbce08d64068f60cbde22ed34c",
         "nft contract name2",
         "opensea",
-        ["sell"]
+        ["sell"],
+        1.65
       ]
     ]
 
@@ -80,7 +82,9 @@ defmodule SanbaseWeb.Graphql.NftTradesApiTest do
                    "address" => "0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459",
                    "labelKey" => "NFT_INFLUENCER"
                  },
-                 "trxHash" => "0xa497bf3e9ea849361fc78fc405861abf97ed08addb5ca4e3da688331ffa38344"
+                 "trxHash" =>
+                   "0xa497bf3e9ea849361fc78fc405861abf97ed08addb5ca4e3da688331ffa38344",
+                 "priceUsd" => 1.5
                },
                %{
                  "amount" => 16.4,
@@ -101,7 +105,9 @@ defmodule SanbaseWeb.Graphql.NftTradesApiTest do
                    "address" => "0x694cd849bc80f3f772ab9aef4be2df3af054dc6b",
                    "labelKey" => nil
                  },
-                 "trxHash" => "0xc98a6ed5c0a139d7437d96d67e120f0ba568915daeb46182bdb27ad37367c0c8"
+                 "trxHash" =>
+                   "0xc98a6ed5c0a139d7437d96d67e120f0ba568915daeb46182bdb27ad37367c0c8",
+                 "priceUsd" => 1.65
                }
              ]
     end)
@@ -146,6 +152,7 @@ defmodule SanbaseWeb.Graphql.NftTradesApiTest do
         amount
         quantity
         quantities{ tokenId quantity }
+        priceUsd
       }
     }
     """


### PR DESCRIPTION
## Changes

The SQL is taken from PR #3081

```graphql
{
  getNftTrades(
    labelKey: NFT_INFLUENCER,
    from: "utc_now-7d",
    to: "utc_now"
  	page: 1
  	pageSize: 2) {
    	priceUsd
    	fromAddress{ address }
    	toAddress{ address }
    	nft{ contractAddress }
        quantities {
          tokenId
          quantity
        }
  }
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
