### PR TITLE
Implement retryable clickhouse queries

### DIFF
--- a/test/sanbase/clickhouse/api_call_data_test.exs
+++ b/test/sanbase/clickhouse/api_call_data_test.exs
@@ -71,7 +71,7 @@ defmodule Sanbase.Clickhouse.ApiCallDataTest do
                {:error, error} =
                  ApiCallData.api_call_history(context.user.id, dt1, dt3, "1d", :all)
 
-               assert error =~ "Cannot execute database query."
+               assert error =~ "Cannot execute ClickHouse database query."
              end) =~ error_msg
     end)
   end

--- a/test/sanbase/clickhouse/clickhouse_repo_test.exs
+++ b/test/sanbase/clickhouse/clickhouse_repo_test.exs
@@ -14,7 +14,7 @@ defmodule Sanbase.Clickhouse.ClickhouseRepoTest do
           {:error, error} = ClickhouseRepo.query_transform("SELECT NOW()", [], & &1)
 
           assert error =~
-                   "Cannot execute database query. If issue persists please contact Santiment Support"
+                   "Cannot execute ClickHouse database query. If issue persists please contact Santiment Support"
 
           # assert returned error message does not contain internal details
           refute error =~ error_msg
@@ -38,7 +38,7 @@ defmodule Sanbase.Clickhouse.ClickhouseRepoTest do
           {:error, error} = ClickhouseRepo.query_transform("SELECT NOW()", [], & &1)
 
           assert error =~
-                   "Cannot execute database query. If issue persists please contact Santiment Support"
+                   "Cannot execute ClickHouse database query. If issue persists please contact Santiment Support"
 
           # assert returned error message does not contain internal details
           refute error =~ error_msg

--- a/test/sanbase/social_data/trending_words/trending_words_test.exs
+++ b/test/sanbase/social_data/trending_words/trending_words_test.exs
@@ -178,7 +178,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
       |> Sanbase.Mock.run_with_mocks(fn ->
         {:error, error} = TrendingWords.get_trending_words(dt1, dt3, "1d", 2, :all)
 
-        assert error =~ "Cannot execute database query."
+        assert error =~ "Cannot execute ClickHouse database query."
       end)
     end
   end
@@ -250,7 +250,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
       |> Sanbase.Mock.run_with_mocks(fn ->
         {:error, error} = TrendingWords.get_currently_trending_words(10, :all)
 
-        assert error =~ "Cannot execute database query."
+        assert error =~ "Cannot execute ClickHouse database query."
       end)
     end
   end
@@ -281,7 +281,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
         {:error, error} =
           TrendingWords.get_word_trending_history("word", dt1, dt2, "1h", 10, :all)
 
-        assert error =~ "Cannot execute database query."
+        assert error =~ "Cannot execute ClickHouse database query."
       end)
     end
   end
@@ -316,7 +316,7 @@ defmodule Sanbase.SocialData.TrendingWordsTest do
         {:error, error} =
           TrendingWords.get_project_trending_history(project.slug, dt1, dt2, "1h", 10, :all)
 
-        assert error =~ "Cannot execute database query."
+        assert error =~ "Cannot execute ClickHouse database query."
       end)
     end
   end


### PR DESCRIPTION
## Changes

In case there is no problem with syntax, table/column names or other non-retryable errors, retry Clickhouse queries once, before returning an error.

This will also retry some timeout errors. In case of API calls and timeout errors, the process running the API query and the database query will be terminated, so the retried query will also be terminated.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
