### PR TITLE
Fix fit_from_datetime call when interval is empty

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
@@ -351,7 +351,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
          {:ok, result} <-
            apply(Metric, function, [metric, selector, from, to, interval, opts]),
          {:ok, result} <- MetricTransform.apply_transform(transform, result),
-         {:ok, result} <- fit_from_datetime(result, args) do
+         {:ok, result} <- fit_from_datetime(result, %{args | interval: interval}) do
       {:ok, result |> Enum.reject(&is_nil/1)}
     end
     |> maybe_handle_graphql_error(fn error ->


### PR DESCRIPTION
## Changes

Address http://sentry.production.san:31080/organizations/sentry/issues/10324/?project=3&query=is%3Aunresolved

If `interval: ""`, then the interval is computed by the calibration done in `transform_datetime_params/4`. This new interval must be provided to the `fit_from_datetime/2` function

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
