### PR TITLE
Add type to subscriptions in the GrpahQL API

### DIFF
--- a/lib/sanbase_web/graphql/schema/types/billing_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/billing_types.ex
@@ -19,6 +19,14 @@ defmodule SanbaseWeb.Graphql.BillingTypes do
     value(:unpaid)
   end
 
+  enum :subscription_type do
+    value(:fiat)
+    value(:liquidity)
+    value(:burning_regular)
+    value(:burning_nft)
+    value(:sanr_points_nft)
+  end
+
   enum :promo_email_lang_enum do
     value(:en)
     value(:jp)
@@ -44,6 +52,7 @@ defmodule SanbaseWeb.Graphql.BillingTypes do
     field(:id, :id)
     field(:user, :user)
     field(:plan, :plan)
+    field(:type, :subscription_type)
     field(:current_period_end, :datetime)
     field(:cancel_at_period_end, :boolean)
     field(:status, :billing_status)

--- a/test/sanbase_web/graphql/billing/current_user_subscriptions_api_test.exs
+++ b/test/sanbase_web/graphql/billing/current_user_subscriptions_api_test.exs
@@ -1,0 +1,74 @@
+defmodule Sanbase.Billing.CurrentUserSubscriptionsApiTest do
+  use SanbaseWeb.ConnCase, async: false
+  import Sanbase.Factory
+  import SanbaseWeb.Graphql.TestHelpers
+
+  setup do
+    user = insert(:user)
+    conn = setup_jwt_auth(build_conn(), user)
+
+    %{user: user, conn: conn}
+  end
+
+  test "no subscriptions", context do
+    subscriptions =
+      current_user_subscriptions(context.conn)
+      |> get_in(["data", "currentUser", "subscriptions"])
+
+    assert subscriptions == []
+  end
+
+  test "sanbase subscription", context do
+    insert(:subscription_pro_sanbase,
+      user: context.user,
+      status: "active",
+      type: :sanr_points_nft,
+      current_period_end: DateTime.shift(DateTime.utc_now(), day: 20)
+    )
+
+    insert(:subscription_business_max_monthly,
+      user: context.user,
+      status: "active",
+      type: :fiat
+    )
+
+    subscriptions =
+      current_user_subscriptions(context.conn)
+      |> get_in(["data", "currentUser", "subscriptions"])
+
+    assert %{
+             "plan" => %{
+               "name" => "BUSINESS_MAX",
+               "product" => %{"name" => "Sanapi by Santiment"}
+             },
+             "type" => "FIAT"
+           } in subscriptions
+
+    assert %{
+             "plan" => %{"name" => "PRO", "product" => %{"name" => "Sanbase by Santiment"}},
+             "type" => "SANR_POINTS_NFT"
+           } in subscriptions
+  end
+
+  defp current_user_subscriptions(conn) do
+    query = """
+    {
+      currentUser{
+        subscriptions{
+          type
+          plan {
+            name
+            product{
+              name
+            }
+          }
+        }
+      }
+    }
+    """
+
+    conn
+    |> post("/graphql", query_skeleton(query))
+    |> json_response(200)
+  end
+end


### PR DESCRIPTION
## Changes

Add `type` to the `currentUser` `subscriptions` field.
It can be one of:
- FIAT
- LIQUIDITY
- BURNING_REGULAR
- BURNING_NFT
- SANR_POINTS_NFT

This field shows how the subscription has been paid.

```graphql
{
  currentUser{
    subscriptions{
      type
      plan {
        name
        product{
          name
        }
      }
    }
  }
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
