### PR TITLE
improve sanr subscription

### DIFF
--- a/lib/sanbase/billing/subscription/nft_subscription.ex
+++ b/lib/sanbase/billing/subscription/nft_subscription.ex
@@ -18,9 +18,13 @@ defmodule Sanbase.Billing.Subscription.NFTSubscription do
   end
 
   @doc ~s"""
-
+  Create a subscription of NFT type for a user.
+  Before invoking this function, the caller must have made sure
+  that the user is eligible for the subscription.
   """
-  def create_nft_subscription(user_id, type, current_period_end) do
+  @spec create_nft_subscription(non_neg_integer, atom, DateTime.t()) :: %Subscription{}
+  def create_nft_subscription(user_id, type, current_period_end)
+      when type in [:sanr_points_nft, :burning_nft] do
     Subscription.create(
       %{
         user_id: user_id,
@@ -34,9 +38,14 @@ defmodule Sanbase.Billing.Subscription.NFTSubscription do
   end
 
   @doc ~s"""
-
+  Remove an NFT subscription.
+  This is done when the user no longer holds an NFT token that grants
+  a subscription.
+  Before invoking this function, the caller must have made sure that the user
+  is no longer eligible for the subscription
   """
-  def remove_nft_subscription(nft_subscription) do
+  def remove_nft_subscription(%Subscription{} = nft_subscription)
+      when nft_subscription.type in [:sanr_points_nft, :burning_nft] do
     Subscription.delete(
       nft_subscription,
       event_args: %{type: :nft_subscription}

--- a/lib/sanbase/san_lang/environment.ex
+++ b/lib/sanbase/san_lang/environment.ex
@@ -1,6 +1,11 @@
 defmodule Sanbase.SanLang.Environment do
   defstruct env_bindings: %{}, local_bindings: %{}
 
+  @type t :: %__MODULE__{
+          env_bindings: map(),
+          local_bindings: map()
+        }
+
   def new() do
     %__MODULE__{}
   end

--- a/lib/sanbase/smart_contracts/sanr_nft.ex
+++ b/lib/sanbase/smart_contracts/sanr_nft.ex
@@ -1,9 +1,101 @@
 defmodule Sanbase.SmartContracts.SanrNFT do
   @doc ~s"""
+  Checks if some of the given addresses have a valid NFT token.
+  A user can have one or more connected addresses. The user has
+  a valid NFT token if any of those addresses holds a valid NFT token.
+  """
+  @spec get_latest_valid_nft_token(addresses :: list(String.t())) ::
+          {:ok, map()} | {:error, atom()}
+  def get_latest_valid_nft_token(addresses) do
+    addresses = Enum.map(addresses, &Sanbase.BlockchainAddress.to_internal_format/1)
+    {:ok, nft_owners} = get_all_nft_owners()
+    {:ok, nft_metadata} = get_all_nft_expiration_dates()
+
+    addresses_with_token =
+      MapSet.intersection(
+        MapSet.new(Map.keys(nft_owners)),
+        MapSet.new(addresses)
+      )
+      |> Enum.to_list()
+
+    case addresses_with_token do
+      [] ->
+        {:error, :no_token}
+
+      [_ | _] ->
+        map =
+          Enum.map(addresses_with_token, fn address ->
+            token_id = nft_owners[address].token_id
+            end_date = nft_metadata[token_id].end_date
+
+            %{
+              address: address,
+              token_id: token_id,
+              end_date: end_date
+            }
+          end)
+
+        case map do
+          _ when map_size(map) == 0 -> {:error, :all_tokens_expired}
+          _ -> {:ok, Enum.max_by(map, & &1.end_date)}
+        end
+    end
+  end
+
+  @doc ~s"""
   Get all the owners of NFTs obtained by spending SanR reward points
   Returns a map where the address is the key, and a map with token_id is the value
   """
+  @spec get_all_nft_owners() :: {:ok, map()} | {:error, any()}
   def get_all_nft_owners() do
+    key = {__MODULE__, :get_all_nft_owners} |> Sanbase.Cache.hash()
+    # 10 seconds cache
+    key = {key, 10}
+    Sanbase.Cache.get_or_store(key, &do_get_all_nft_owners/0)
+  end
+
+  @doc ~s"""
+  Get all the issued NFTs' start date and end dates.
+  Returns a map where the token id is the key and the value is a map with start_date and end_date.
+  End date is 12 months after start date. Holding this NFT grants you Sanbae PRO subscription
+  until its end date.
+  """
+  @spec get_all_nft_owners() :: {:ok, map()} | {:error, any()}
+  def get_all_nft_expiration_dates() do
+    key = {__MODULE__, :get_all_nft_expiration_dates} |> Sanbase.Cache.hash()
+    # 10 seconds cache
+    key = {key, 10}
+    Sanbase.Cache.get_or_store(key, &do_get_all_nft_expiration_dates/0)
+  end
+
+  defp do_get_all_nft_expiration_dates() do
+    req =
+      Req.new(
+        base_url:
+          "https://sanrnew-api.production.internal.santiment.net/api/v1/SanbaseSubscriptionNFTCollection/all"
+      )
+
+    result = Req.get(req, [])
+
+    case result do
+      {:ok, %{status: 200, body: body}} ->
+        map =
+          Map.new(body, fn m ->
+            {m["id"],
+             %{
+               start_date: Sanbase.DateTimeUtils.from_iso8601!(m["subscription_start_date"]),
+               end_date: Sanbase.DateTimeUtils.from_iso8601!(m["subscription_end_date"])
+             }}
+          end)
+
+        {:ok, map}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  defp do_get_all_nft_owners() do
     req = Req.new(base_url: "https://zksync-mainnet.g.alchemy.com")
 
     params = [
@@ -34,39 +126,6 @@ defmodule Sanbase.SmartContracts.SanrNFT do
 
             _ ->
               {nil, nil}
-          end)
-
-        {:ok, map}
-
-      {:error, error} ->
-        {:error, error}
-    end
-  end
-
-  @doc ~s"""
-  Get all the issued NFTs' start date and end dates.
-  Returns a map where the token id is the key and the value is a map with start_date and end_date.
-  End date is 12 months after start date. Holding this NFT grants you Sanbae PRO subscription
-  until its end date.
-  """
-  def get_all_nft_expiration_dates() do
-    req =
-      Req.new(
-        base_url:
-          "https://sanrnew-api.production.internal.santiment.net/api/v1/SanbaseSubscriptionNFTCollection/all"
-      )
-
-    result = Req.get(req, [])
-
-    case result do
-      {:ok, %{status: 200, body: body}} ->
-        map =
-          Map.new(body, fn m ->
-            {m["id"],
-             %{
-               start_date: Sanbase.DateTimeUtils.from_iso8601!(m["subscription_start_date"]),
-               end_date: Sanbase.DateTimeUtils.from_iso8601!(m["subscription_end_date"])
-             }}
           end)
 
         {:ok, map}

--- a/lib/sanbase_web/graphql/schema/queries/billing_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/billing_queries.ex
@@ -90,9 +90,33 @@ defmodule SanbaseWeb.Graphql.Schema.BillingQueries do
 
       resolve(&BillingResolver.get_subscription_with_payment_intent/3)
     end
+
+    field :check_sanr_nft_subscription_eligibility, :boolean do
+      meta(access: :free)
+
+      middleware(JWTAuth)
+
+      resolve(&BillingResolver.check_sanr_nft_subscription_eligibility/3)
+    end
   end
 
   object :billing_mutations do
+    @desc ~s"""
+    Try to obtain a Sanbase Pro subscription for holding SanR NFT tokens.
+    When executed, the mutation checks that the user:
+    - has a blockchain address connected
+    - has no sanbase subscripotion
+    If any of these preconditions is not met, an appropriate error is returned.
+    If these conditions are met, the mutation checks whether the user holds a valid SanR NFT token
+    on ZK mainnet.
+    """
+    field :obtain_sanr_nft_subscription, :subscription_plan do
+      meta(access: :free)
+      middleware(JWTAuth)
+
+      resolve(&BillingResolver.obtain_sanr_nft_subscription/3)
+    end
+
     @desc ~s"""
     Subscribe logged in user to a chosen plan.
     Some plans have free trial and doesn't need credit card.

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -167,7 +167,8 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           :run_dashboard_sql_query,
           :run_raw_sql_query,
           :run_sql_query,
-          :get_cached_query_executions
+          :get_cached_query_executions,
+          :check_sanr_nft_subscription_eligibility
         ]
         |> Enum.sort()
 

--- a/test/sanbase/billing/sanr_nft_subscription_test.exs
+++ b/test/sanbase/billing/sanr_nft_subscription_test.exs
@@ -33,10 +33,10 @@ defmodule Sanbase.Billing.SanrNFTSubscriptionTest do
       fn req, _params ->
         case req.options.base_url do
           "https://zksync-mainnet.g.alchemy.com" ->
-            get_owners_for_contract_mock(address)
+            Sanbase.SanrNFTMocks.get_owners_for_contract_mock(address)
 
           "https://sanrnew-api.production.internal.santiment.net/api/v1/SanbaseSubscriptionNFTCollection/all" ->
-            sanr_nft_collections_mock(start_date, end_date)
+            Sanbase.SanrNFTMocks.sanr_nft_collections_mock(start_date, end_date)
         end
       end
     )
@@ -75,54 +75,5 @@ defmodule Sanbase.Billing.SanrNFTSubscriptionTest do
 
       assert Subscription.user_has_active_sanbase_subscriptions?(user.id) == false
     end)
-  end
-
-  defp get_owners_for_contract_mock(address) do
-    {:ok,
-     %Req.Response{
-       status: 200,
-       headers: %{},
-       body: %{
-         "owners" => [
-           %{
-             "ownerAddress" => address,
-             "tokenBalances" => [
-               %{"balance" => "1", "tokenId" => "1"},
-               %{"balance" => "1", "tokenId" => "2"}
-             ]
-           }
-         ],
-         "pageKey" => nil
-       },
-       trailers: %{},
-       private: %{}
-     }}
-  end
-
-  defp sanr_nft_collections_mock(start_date, end_date) do
-    {:ok,
-     %Req.Response{
-       status: 200,
-       headers: %{},
-       body: [
-         %{
-           "id" => 1,
-           "sanr_points_amount" => 10000,
-           "subscription_end_date" => end_date,
-           "subscription_start_date" => start_date
-         },
-
-         # This one is expired. Added here so we can test what happens when
-         # one address holds multiple NFTs
-         %{
-           "id" => 2,
-           "sanr_points_amount" => 10000,
-           "subscription_end_date" => ~U[2024-05-05 00:00:00Z],
-           "subscription_start_date" => ~U[2023-05-05 00:00:00Z]
-         }
-       ],
-       trailers: %{},
-       private: %{}
-     }}
   end
 end

--- a/test/sanbase_web/graphql/billing/sanr_nft_subscription_api_test.exs
+++ b/test/sanbase_web/graphql/billing/sanr_nft_subscription_api_test.exs
@@ -1,0 +1,134 @@
+defmodule Sanbase.Billing.SanrNftSubscriptionsApiTest do
+  use SanbaseWeb.ConnCase, async: false
+  import Sanbase.Factory
+  import SanbaseWeb.Graphql.TestHelpers
+
+  alias Sanbase.Billing.Subscription
+
+  setup do
+    user = insert(:user)
+
+    address =
+      "0x23918E95d234eEc054566DDe0841d69311814495"
+      |> Sanbase.BlockchainAddress.to_internal_format()
+
+    start_date = DateTime.utc_now()
+    end_date = DateTime.shift(start_date, month: 12) |> DateTime.truncate(:second)
+
+    %{
+      user: user,
+      conn: setup_jwt_auth(build_conn(), user),
+      address: address,
+      start_date: start_date,
+      end_date: end_date
+    }
+  end
+
+  test "checkSanrNftSubscriptionEligibility", context do
+    query = """
+    { checkSanrNftSubscriptionEligibility }
+    """
+
+    Sanbase.Mock.prepare_mock(
+      Req,
+      :get,
+      fn req, _params ->
+        case req.options.base_url do
+          "https://zksync-mainnet.g.alchemy.com" ->
+            Sanbase.SanrNFTMocks.get_owners_for_contract_mock(context.address)
+
+          "https://sanrnew-api.production.internal.santiment.net/api/v1/SanbaseSubscriptionNFTCollection/all" ->
+            Sanbase.SanrNFTMocks.sanr_nft_collections_mock(context.start_date, context.end_date)
+        end
+      end
+    )
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      # The user does not have an active subscription, not such will be granted
+      assert Subscription.user_has_active_sanbase_subscriptions?(context.user.id) == false
+      # The user has no account, so their are not eligible
+      result =
+        context.conn
+        |> post("/graphql", query_skeleton(query))
+        |> json_response(200)
+        |> get_in(["data", "checkSanrNftSubscriptionEligibility"])
+
+      assert result == false
+
+      # Add a random address to the account without NFT, still not eligible
+      random_address = "0x" <> rand_hex_str(38)
+      {:ok, _} = Sanbase.Accounts.EthAccount.create(context.user.id, random_address)
+
+      result =
+        context.conn
+        |> post("/graphql", query_skeleton(query))
+        |> json_response(200)
+        |> get_in(["data", "checkSanrNftSubscriptionEligibility"])
+
+      assert result == false
+
+      # Add the address that actually holds an NFT, user is not eligible
+      {:ok, _} = Sanbase.Accounts.EthAccount.create(context.user.id, context.address)
+
+      result =
+        context.conn
+        |> post("/graphql", query_skeleton(query))
+        |> json_response(200)
+        |> get_in(["data", "checkSanrNftSubscriptionEligibility"])
+
+      assert result == true
+
+      # The user does not have an active subscription, not such will be granted
+      assert Subscription.user_has_active_sanbase_subscriptions?(context.user.id) == false
+    end)
+  end
+
+  test "obtainSanrNftSubscription", context do
+    mutation = """
+    mutation{
+      obtainSanrNftSubscription {
+        type
+      }
+    }
+    """
+
+    Sanbase.Mock.prepare_mock(
+      Req,
+      :get,
+      fn req, _params ->
+        case req.options.base_url do
+          "https://zksync-mainnet.g.alchemy.com" ->
+            Sanbase.SanrNFTMocks.get_owners_for_contract_mock(context.address)
+
+          "https://sanrnew-api.production.internal.santiment.net/api/v1/SanbaseSubscriptionNFTCollection/all" ->
+            Sanbase.SanrNFTMocks.sanr_nft_collections_mock(context.start_date, context.end_date)
+        end
+      end
+    )
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      # The user does not have an active subscription
+      assert Subscription.user_has_active_sanbase_subscriptions?(context.user.id) == false
+      # The user has no account, so their are not eligible
+      error_msg =
+        context.conn
+        |> post("/graphql", mutation_skeleton(mutation))
+        |> json_response(200)
+        |> get_in(["errors", Access.at(0), "message"])
+
+      assert error_msg =~ "user does not have any blockchain addresses connected"
+      # Add the address that actually holds an NFT, user is not eligible
+      {:ok, _} = Sanbase.Accounts.EthAccount.create(context.user.id, context.address)
+
+      result =
+        context.conn
+        |> post("/graphql", mutation_skeleton(mutation))
+        |> json_response(200)
+        |> get_in(["data", "obtainSanrNftSubscription"])
+
+      # Now a subscription has been created
+      assert result == %{"type" => "SANR_POINTS_NFT"}
+
+      # The user now has an active subscription
+      assert Subscription.user_has_active_sanbase_subscriptions?(context.user.id) == true
+    end)
+  end
+end

--- a/test/support/sanr_nft_mocks.ex
+++ b/test/support/sanr_nft_mocks.ex
@@ -1,0 +1,50 @@
+defmodule Sanbase.SanrNFTMocks do
+  def get_owners_for_contract_mock(address) do
+    {:ok,
+     %Req.Response{
+       status: 200,
+       headers: %{},
+       body: %{
+         "owners" => [
+           %{
+             "ownerAddress" => address,
+             "tokenBalances" => [
+               %{"balance" => "1", "tokenId" => "1"},
+               %{"balance" => "1", "tokenId" => "2"}
+             ]
+           }
+         ],
+         "pageKey" => nil
+       },
+       trailers: %{},
+       private: %{}
+     }}
+  end
+
+  def sanr_nft_collections_mock(start_date, end_date) do
+    {:ok,
+     %Req.Response{
+       status: 200,
+       headers: %{},
+       body: [
+         %{
+           "id" => 1,
+           "sanr_points_amount" => 10000,
+           "subscription_end_date" => end_date,
+           "subscription_start_date" => start_date
+         },
+
+         # This one is expired. Added here so we can test what happens when
+         # one address holds multiple NFTs
+         %{
+           "id" => 2,
+           "sanr_points_amount" => 10000,
+           "subscription_end_date" => ~U[2024-05-05 00:00:00Z],
+           "subscription_start_date" => ~U[2023-05-05 00:00:00Z]
+         }
+       ],
+       trailers: %{},
+       private: %{}
+     }}
+  end
+end


### PR DESCRIPTION
## Changes

- **Support addresses with multiple SanR NFTs**
- **Add query and mutation related to SanR NFT subscriptions**

Add a query that returns boolean whether the user is eligible for obtaining
SanR NFT subscription. Returns true if the user has an address that holds a valid NFT:
```graphql
{
  checkSanrNftSubscriptionEligibility
}
```

Add a mutation that will obtain a SanR NFT subscription, if possible.
It performs the check for eligibility and if it passes - creates the subscription.
```graphql
mutation{
  obtainSanrNftSubscription {
    type
  }
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
