### PR TITLE
Increase the batch size and timeout for some Clickhouse queries

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/metric/metric_adapter.ex
@@ -322,12 +322,12 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
   end
 
   defp get_aggregated_timeseries_data(metric, slugs, from, to, aggregation, filters)
-       when is_list(slugs) and length(slugs) > 50 do
+       when is_list(slugs) and length(slugs) > 1000 do
     result =
-      Enum.chunk_every(slugs, 50)
+      Enum.chunk_every(slugs, 1000)
       |> Sanbase.Parallel.map(
         &get_aggregated_timeseries_data(metric, &1, from, to, aggregation, filters),
-        timeout: 25_000,
+        timeout: 55_000,
         max_concurrency: 8,
         ordered: false,
         on_timeout: :kill_task

--- a/lib/sanbase/prices/price.ex
+++ b/lib/sanbase/prices/price.ex
@@ -305,14 +305,14 @@ defmodule Sanbase.Price do
   def aggregated_metric_timeseries_data([], _, _, _, _), do: {:ok, %{}}
 
   def aggregated_metric_timeseries_data(slugs, metric, from, to, opts)
-      when is_list(slugs) and length(slugs) > 50 do
+      when is_list(slugs) and length(slugs) > 1000 do
     # Break here otherwise the Enum.filter/2 will remove all errors and report a wrong result
     with {:ok, _source} <- opts_to_source(opts) do
       result =
-        Enum.chunk_every(slugs, 50)
+        Enum.chunk_every(slugs, 1000)
         |> Sanbase.Parallel.map(
           &aggregated_metric_timeseries_data(&1, metric, from, to, opts),
-          timeout: 25_000,
+          timeout: 55_000,
           max_concurrency: 8,
           ordered: false
         )

--- a/lib/sanbase/prices/price_pair/price_pair.ex
+++ b/lib/sanbase/prices/price_pair/price_pair.ex
@@ -103,12 +103,12 @@ defmodule Sanbase.PricePair do
   def aggregated_timeseries_data([], _, _, _, _), do: {:ok, []}
 
   def aggregated_timeseries_data(slugs, quote_asset, from, to, opts)
-      when is_list(slugs) and length(slugs) > 50 do
+      when is_list(slugs) and length(slugs) > 1000 do
     result =
-      Enum.chunk_every(slugs, 50)
+      Enum.chunk_every(slugs, 1000)
       |> Sanbase.Parallel.map(
         &aggregated_timeseries_data(&1, quote_asset, from, to, opts),
-        timeout: 25_000,
+        timeout: 55_000,
         max_concurrency: 8,
         ordered: false
       )


### PR DESCRIPTION
## Changes
Sometimes we have an `allProject query with many metrics.

At the moment, when an `aggregated_timeseries_data` query with many slugs is made, it is split into multiple concurrent queries with up to 50 slugs in it. This causes an excessive amount of queries. For example, if there are 3000 assets and 16 metrics queried, the example below will generate `16 * (3000/50) = 960` clickhouse queries.

This PR reworks it so the size of the chunks is increased to 1000 .

```graphql
{
  allProjects {
    slug
    ticker
    usdPriceCoinmarcetcap: aggregatedTimeseriesData(selector: {source: "coinmarketcap"}, metric: "price_usd", from: "utc_now-24h", to: "utc_now", aggregation: LAST, cachingParams: {baseTtl: 5, maxTtlOffset: 5})
    usdAVGUpdatedCoinmarcetcap: aggregatedTimeseriesData(selector: {source: "coinmarketcap"}, metric: "price_usd", from: "utc_now-24h", to: "utc_now", aggregation: COUNT)
    usdtPriceCoinmarcetcap: aggregatedTimeseriesData(selector: {source: "coinmarketcap"}, metric: "price_usdt", from: "utc_now-24h", to: "utc_now", aggregation: LAST, cachingParams: {baseTtl: 5, maxTtlOffset: 5})
    usdtAVGUpdatedCoinmarcetcap: aggregatedTimeseriesData(selector: {source: "coinmarketcap"}, metric: "price_usdt", from: "utc_now-24h", to: "utc_now", aggregation: COUNT)
    ethPriceCoinmarcetcap: aggregatedTimeseriesData(selector: {source: "coinmarketcap"}, metric: "price_eth", from: "utc_now-24h", to: "utc_now", aggregation: LAST, cachingParams: {baseTtl: 5, maxTtlOffset: 5})
    ethAVGUpdatedCoinmarcetcap: aggregatedTimeseriesData(selector: {source: "coinmarketcap"}, metric: "price_eth", from: "utc_now-24h", to: "utc_now", aggregation: COUNT)
    btcPriceCoinarketcap: aggregatedTimeseriesData(selector: {source: "coinmarketcap"}, metric: "price_btc", from: "utc_now-24h", to: "utc_now", aggregation: LAST, cachingParams: {baseTtl: 5, maxTtlOffset: 5})
    btcAVGUpdatedCoinmarcetcap: aggregatedTimeseriesData(selector: {source: "coinmarketcap"}, metric: "price_btc", from: "utc_now-24h", to: "utc_now", aggregation: COUNT)
    usdPrice: aggregatedTimeseriesData(selector: {source: "cryptocompare"}, metric: "price_usd", from: "utc_now-24h", to: "utc_now", aggregation: LAST, cachingParams: {baseTtl: 5, maxTtlOffset: 5})
    usdAVGUpdated: aggregatedTimeseriesData(selector: {source: "cryptocompare"}, metric: "price_usd", from: "utc_now-24h", to: "utc_now", aggregation: COUNT)
    usdtPrice: aggregatedTimeseriesData(selector: {source: "cryptocompare"}, metric: "price_usdt", from: "utc_now-24h", to: "utc_now", aggregation: LAST, cachingParams: {baseTtl: 5, maxTtlOffset: 5})
    usdtAVGUpdated: aggregatedTimeseriesData(selector: {source: "cryptocompare"}, metric: "price_usdt", from: "utc_now-24h", to: "utc_now", aggregation: COUNT)
    ethPrice: aggregatedTimeseriesData(selector: {source: "cryptocompare"}, metric: "price_eth", from: "utc_now-24h", to: "utc_now", aggregation: LAST, cachingParams: {baseTtl: 5, maxTtlOffset: 5})
    ethAVGUpdated: aggregatedTimeseriesData(selector: {source: "cryptocompare"}, metric: "price_eth", from: "utc_now-24h", to: "utc_now", aggregation: COUNT)
    btcPrice: aggregatedTimeseriesData(selector: {source: "cryptocompare"}, metric: "price_btc", from: "utc_now-24h", to: "utc_now", aggregation: LAST, cachingParams: {baseTtl: 5, maxTtlOffset: 5})
    btcAVGUpdated: aggregatedTimeseriesData(selector: {source: "cryptocompare"}, metric: "price_btc", from: "utc_now-24h", to: "utc_now", aggregation: COUNT)
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
