### PR TITLE
Absinthe Dataloader use :tuples get_policy to propagate errors

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/blockchain_address_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/blockchain_address_resolver.ex
@@ -267,28 +267,29 @@ defmodule SanbaseWeb.Graphql.Resolvers.BlockchainAddressResolver do
         loader
         |> Dataloader.load(SanbaseDataloader, :address_labels, address)
         |> on_load(fn loader ->
-          santiment_labels =
-            Dataloader.get(loader, SanbaseDataloader, :address_labels, address) ||
-              []
+          with {:ok, santiment_labels} <-
+                 Dataloader.get(loader, SanbaseDataloader, :address_labels, address) do
+            santiment_labels = santiment_labels || []
 
-          # The root can be built either from a BlockchainAddress in case the
-          # `blockchain_address` query is used, or from a BlockchainAddressUserPair
-          # in casethe address is part of a watchlist. In the second case, the root
-          # has an additional `labels` key which holds the list of user-defined labels
-          # for that address. The santiment defined labels from CH are provided with a
-          # `origin: "santiment"` key-value pair so they could be distinguished from
-          # the user-defined labels.
-          user_labels =
-            Map.get(root, :labels, [])
-            |> Enum.map(fn label ->
-              label |> Map.put(:origin, "user")
-            end)
+            # The root can be built either from a BlockchainAddress in case the
+            # `blockchain_address` query is used, or from a BlockchainAddressUserPair
+            # in casethe address is part of a watchlist. In the second case, the root
+            # has an additional `labels` key which holds the list of user-defined labels
+            # for that address. The santiment defined labels from CH are provided with a
+            # `origin: "santiment"` key-value pair so they could be distinguished from
+            # the user-defined labels.
+            user_labels =
+              Map.get(root, :labels, [])
+              |> Enum.map(fn label ->
+                label |> Map.put(:origin, "user")
+              end)
 
-          labels =
-            (user_labels ++ santiment_labels)
-            |> Enum.sort_by(& &1.name)
+            labels =
+              (user_labels ++ santiment_labels)
+              |> Enum.sort_by(& &1.name)
 
-          {:ok, labels}
+            {:ok, labels}
+          end
         end)
     end
   end

--- a/lib/sanbase_web/graphql/resolvers/comment_entity_id_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/comment_entity_id_resolver.ex
@@ -32,7 +32,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.CommentEntityIdResolver do
     loader
     |> Dataloader.load(SanbaseDataloader, entity_id_name, id)
     |> on_load(fn loader ->
-      {:ok, Dataloader.get(loader, SanbaseDataloader, entity_id_name, id)}
+      Dataloader.get(loader, SanbaseDataloader, entity_id_name, id)
     end)
   end
 end

--- a/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
@@ -283,9 +283,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.InsightResolver do
     loader
     |> Dataloader.load(SanbaseDataloader, :insights_count_per_user, id)
     |> on_load(fn loader ->
-      {:ok,
-       Dataloader.get(loader, SanbaseDataloader, :insights_count_per_user, id) ||
-         %{total_count: 0, draft_count: 0, pulse_count: 0, paywall_count: 0}}
+      case Dataloader.get(loader, SanbaseDataloader, :insights_count_per_user, id) do
+        {:ok, val} ->
+          val = val || %{total_count: 0, draft_count: 0, pulse_count: 0, paywall_count: 0}
+          {:ok, val}
+
+        {:error, error} ->
+          {:error, error}
+      end
     end)
   end
 
@@ -302,7 +307,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.InsightResolver do
     loader
     |> Dataloader.load(SanbaseDataloader, :insights_comments_count, id)
     |> on_load(fn loader ->
-      {:ok, Dataloader.get(loader, SanbaseDataloader, :insights_comments_count, id) || 0}
+      case Dataloader.get(loader, SanbaseDataloader, :insights_comments_count, id) do
+        {:ok, val} -> {:ok, val || 0}
+        {:error, error} -> {:error, error}
+      end
     end)
   end
 

--- a/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
@@ -145,10 +145,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver do
   defp aggregated_metric_from_loader(loader, data, error_on_data_fetch_fail) do
     %{selector: selector, slug: slug, metric: metric} = data
 
-    loader
-    |> Dataloader.get(SanbaseDataloader, :aggregated_metric, selector)
-    |> case do
-      map when is_map(map) ->
+    case Dataloader.get(loader, SanbaseDataloader, :aggregated_metric, selector) do
+      {:ok, map} when is_map(map) ->
         aggregated_metric_from_loader_map(map, slug, metric, data[:opts])
 
       _ignored when error_on_data_fetch_fail == false ->

--- a/lib/sanbase_web/graphql/resolvers/social_data_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/social_data_resolver.ex
@@ -106,7 +106,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.SocialDataResolver do
     loader
     |> Dataloader.load(SanbaseDataloader, :project_by_slug, slug)
     |> on_load(fn loader ->
-      {:ok, Dataloader.get(loader, SanbaseDataloader, :project_by_slug, slug)}
+      Dataloader.get(loader, SanbaseDataloader, :project_by_slug, slug)
     end)
   end
 

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -143,7 +143,7 @@ defmodule SanbaseWeb.Graphql.Schema do
   def dataloader(request_context \\ nil) do
     # No `timeout:` — Dataloader ignores it and derives the run timeout as
     # max(source timeouts) + 1s. Set on the sources. See docs/timeouts.md.
-    Dataloader.new(get_policy: :return_nil_on_error)
+    Dataloader.new(get_policy: :tuples)
     |> Dataloader.add_source(SanbaseRepo, SanbaseRepo.data())
     |> Dataloader.add_source(SanbaseDataloader, SanbaseDataloader.data(request_context))
   end


### PR DESCRIPTION
## Changes

- **Change Absinthe Dataloader get_policy to :tuples**


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
