### PR TITLE
Expose metric required selectors

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/fixed_parameters_labelled_balance_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/fixed_parameters_labelled_balance_metrics.json
@@ -64,8 +64,8 @@
     },
     "version": "2020-05-27",
     "access": "restricted",
-    "selectors": ["slug"],
-    "required_selectors": ["slug"],
+    "selectors": ["slug", "label_fqn", "label_fqns"],
+    "required_selectors": ["slug", "label_fqn|label_fqns"],
     "min_plan": {
       "SANAPI": "free",
       "SANBASE": "free"

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -396,7 +396,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:available_aggregations, list_of(:aggregation))
 
     @desc ~s"""
-    The supported selector types for the metric. It is used to choose the
+    The list of supported selector types for the metric. It is used to choose the
     target for which the metric is computed. Available selectors are:
       - slug - Identifies an asset/project
       - text - Provides random text/search term for the social metrics
@@ -406,6 +406,35 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     which of the selectors can be used.
     """
     field(:available_selectors, list_of(:selector_name))
+
+    @desc ~s"""
+    The list of required selectors for the metric. It is used to show the list
+    of selectors that is required in order to fetch the metric.
+
+    The result is a list of lists of selectors, like this:
+      {
+        "data": {
+          "getMetric": {
+            "metadata": {
+              "requiredSelectors": [
+                [
+                  "SLUG"
+                ],
+                [
+                  "LABEL_FQN",
+                  "LABEL_FQNS"
+                ]
+              ]
+            }
+          }
+        }
+      }
+    When the element is a list of more than 1 selectors, only one of those selectors
+    is required. In the example above, the required selectors are:
+    - SLUG and LABEL_FQN
+    - or SLUG and LABEL_FQNS
+    """
+    field(:required_selectors, list_of(list_of(:selector_name)))
 
     @desc ~s"""
     A metric can be marked as deprecated. If this is the case, the metric


### PR DESCRIPTION
## Changes

Expose `requiredSelectors` for metrics:
```graphql
{
  getMetric(metric: "combined_historical_balance_centralized_exchanges") {
    metadata {
      requiredSelectors
    }
  }
}
```
```json
{
  "data": {
    "getMetric": {
      "metadata": {
        "requiredSelectors": [
          [
            "SLUG"
          ],
          [
            "LABEL_FQN",
            "LABEL_FQNS"
          ]
        ]
      }
    }
  }
}
```

The result is a list of lists. When the sublist has more than 1 element, it means that the presence of only one of the selectors in that sublist is required. In most cases these 2 or more element lists contain the singular and plural selectors of the same kind.

In the example above, it means that we require `SLUG` and one of `LABEL_FQN` or `LABEL_FQNS`. So the following 2 selector sets are ok:
- SLUG and LABEL_FQN
- SLUG and LABEL_FQNS
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
