### PR TITLE
rework dashboards cache

### DIFF
--- a/docs/sanbase-local-development.md
+++ b/docs/sanbase-local-development.md
@@ -92,7 +92,7 @@ If you are reading this then most probably you have followed the [Getting Starte
 ) and specifically the VPN part. All you need to do in order to connect to the stage clickhouse is connect to the stage VPN and add the following line to the `.env.dev` file:
 
 ```bash
-CLICKHOUSE_DATABASE_URL="ecto://default@clickhouse.stage.san:30901/default"
+CLICKHOUSE_DATABASE_URL="ecto://sanbase@clickhouse.stage.san:30901/default"
 ```
 
 All the ENV vars for connecting to the stage/prod services with VPN can be found in the `.env.example` file. When some env var is needed, it can be copied from the `.env.example` to the `.env.dev` file and remove the comment (`#`) in order to enable it.

--- a/lib/sanbase/dashboards/dashboard/dashboard.ex
+++ b/lib/sanbase/dashboards/dashboard/dashboard.ex
@@ -175,6 +175,22 @@ defmodule Sanbase.Dashboards.Dashboard do
     |> maybe_preload(opts)
   end
 
+  @doc ~s"""
+  Get a query in order to update its cache.
+  Only the owner of the query can do that when the dashboard is private.
+  Public dashboard's cache can be refreshed by anyone.
+  """
+  @spec get_for_cache_update(dashboard_id, user_id, opts) :: Ecto.Query.t()
+  def get_for_cache_update(dashboard_id, querying_user_id, opts)
+      when not is_nil(querying_user_id) do
+    from(
+      d in base_query(),
+      where: d.id == ^dashboard_id and (d.user_id == ^querying_user_id or d.is_public == true),
+      lock: "FOR UPDATE"
+    )
+    |> maybe_preload(opts)
+  end
+
   @spec get_user_dashboards(dashboard_id, user_id | nil, opts) :: Ecto.Query.t()
   def get_user_dashboards(user_id, querying_user_id, opts) do
     where =

--- a/lib/sanbase/dashboards/dashboard/dashboard_cache.ex
+++ b/lib/sanbase/dashboards/dashboard/dashboard_cache.ex
@@ -167,8 +167,8 @@ defmodule Sanbase.Dashboards.DashboardCache do
         |> maybe_transform_error()
 
       _ ->
-        {:error, "Dashboard with id #{dashboard_id} does not exist or the dashboard\
-         is private and the user with id #{querying_user_id} is not the owner of it."}
+        {:error,
+         "Dashboard with id #{dashboard_id} does not exist or the dashboard is private and the user with id #{querying_user_id} is not the owner of it."}
     end
   end
 

--- a/lib/sanbase/dashboards/dashboard/dashboard_cache.ex
+++ b/lib/sanbase/dashboards/dashboard/dashboard_cache.ex
@@ -21,6 +21,7 @@ defmodule Sanbase.Dashboards.DashboardCache do
 
   @type user_id :: Sanbase.Accounts.User.user_id()
   @type dashboard_id :: Dashboard.dashboard_id()
+  @type parameters_override :: map()
   @type dashboard_query_mapping_id :: Dashboard.dashboard_query_mapping_id()
 
   @type query_cache :: %{
@@ -38,6 +39,7 @@ defmodule Sanbase.Dashboards.DashboardCache do
 
   schema "dashboards_cache" do
     field(:dashboard_id, :integer)
+    field(:parameters_override_hash, :string, default: "none")
     field(:queries, :map, default: %{})
 
     timestamps()
@@ -55,6 +57,23 @@ defmodule Sanbase.Dashboards.DashboardCache do
   # end
 
   @doc ~s"""
+  Hash the parameters map to a string.
+  The hash will be stored in the database.
+  """
+  @spec hash_parameters(map()) :: String.t()
+  def hash_parameters(%{} = params) when map_size(params) == 0, do: "none"
+
+  def hash_parameters(%{} = params) do
+    binary = :erlang.term_to_binary(params)
+
+    # Base64 encodes 6 bits of information per character, so 16 characters is 96 bits
+    # 1.3x10^13 attempts are needed (13 trillion) to have 0.1% chance of collisions
+    :crypto.hash(:sha256, binary)
+    |> Base.encode64(padding: false)
+    |> :erlang.binary_part(0, 16)
+  end
+
+  @doc ~s"""
   Fetch the latest cache values for the given dashboard.
 
   The second `opts` argument can contain the following options:
@@ -62,7 +81,7 @@ defmodule Sanbase.Dashboards.DashboardCache do
   - transform_loaded_queries - If set to true, the loaded query caches are
   transformed from having `compressed_rows` to `rows`. Defaults to true.
   """
-  @spec by_dashboard_id(dashboard_id(), user_id, Keyword.t()) :: {:ok, t()} | {:error, String.t()}
+
   # def by_dashboard_id(dashboard_id, querying_user_id, opts) do
   #   Ecto.Multi.new()
   #   |> Ecto.Multi.run(:get_dashboard_cache, fn _ ->
@@ -70,8 +89,15 @@ defmodule Sanbase.Dashboards.DashboardCache do
   #   end)
   # end
 
-  def by_dashboard_id(dashboard_id, querying_user_id, opts \\ []) do
-    query = from(d in __MODULE__, where: d.dashboard_id == ^dashboard_id)
+  @spec by_dashboard_id(dashboard_id, parameters_override, user_id, Keyword.t()) ::
+          {:ok, t()} | {:error, String.t()}
+  def by_dashboard_id(dashboard_id, parameters_override, querying_user_id, opts \\ []) do
+    hash = hash_parameters(parameters_override)
+
+    query =
+      from(d in __MODULE__,
+        where: d.dashboard_id == ^dashboard_id and d.parameters_override_hash == ^hash
+      )
 
     query =
       case Keyword.get(opts, :lock_for_update, false) do
@@ -80,7 +106,7 @@ defmodule Sanbase.Dashboards.DashboardCache do
       end
 
     case Repo.one(query) do
-      nil -> new(dashboard_id, querying_user_id)
+      nil -> new(dashboard_id, parameters_override, querying_user_id)
       %__MODULE__{} = cache -> {:ok, cache}
     end
     |> maybe_apply_function(&transform_loaded_dashboard_cache(&1, opts))
@@ -125,32 +151,46 @@ defmodule Sanbase.Dashboards.DashboardCache do
   @doc ~s"""
   Create a new empty record for the given dashboard_id.
   """
-  @spec new(non_neg_integer(), user_id) :: {:ok, t()} | {:error, any()}
-  def new(dashboard_id, querying_user_id) do
+  @spec new(dashboard_id, parameters_override, user_id) :: {:ok, t()} | {:error, any()}
+  def new(dashboard_id, parameters_override, querying_user_id) do
+    hash = hash_parameters(parameters_override)
+
     case Sanbase.Dashboards.get_visibility_data(dashboard_id) do
-      {:ok, %{user_id: ^querying_user_id}} ->
+      {:ok, %{user_id: user_id, is_public: is_public}}
+      when user_id == querying_user_id or is_public == true ->
         %__MODULE__{}
-        |> change(%{dashboard_id: dashboard_id})
+        |> change(%{
+          dashboard_id: dashboard_id,
+          parameters_override_hash: hash
+        })
         |> Repo.insert()
         |> maybe_transform_error()
 
       _ ->
-        {:error,
-         "Dashboard with id #{dashboard_id} does not exist or the user with id #{querying_user_id} is not the owner of it."}
+        {:error, "Dashboard with id #{dashboard_id} does not exist or the dashboard\
+         is private and the user with id #{querying_user_id} is not the owner of it."}
     end
   end
 
   @doc ~s"""
   Update the dashboard's query cache with the provided result.
   """
-  @spec update_query_cache(non_neg_integer(), String.t(), Result.t(), user_id(), Keyword.t()) ::
+  @spec update_query_cache(
+          dashboard_id(),
+          parameters_override,
+          dashboard_query_mapping_id,
+          Result.t(),
+          user_id,
+          Keyword.t()
+        ) ::
           {:ok, t()} | {:error, any()}
   def update_query_cache(
         dashboard_id,
+        parameters_override,
         dashboard_query_mapping_id,
         query_result,
         user_id,
-        opts \\ []
+        opts
       ) do
     query_cache =
       QueryCache.from_query_result(query_result, dashboard_query_mapping_id, dashboard_id)
@@ -159,14 +199,11 @@ defmodule Sanbase.Dashboards.DashboardCache do
     # convert `compressed_rows` to `rows`, which will be written back and break
     with true <- query_result_size_allowed?(query_cache),
          {:ok, cache} <-
-           by_dashboard_id(dashboard_id, user_id,
+           by_dashboard_id(dashboard_id, parameters_override, user_id,
              transform_loaded_queries: false,
              lock_for_update: true
            ) do
-      query_cache =
-        query_cache
-        |> Map.from_struct()
-        |> Map.delete(:rows)
+      query_cache = query_cache |> Map.from_struct() |> Map.delete(:rows)
 
       queries =
         Map.update(cache.queries, dashboard_query_mapping_id, query_cache, fn _ -> query_cache end)

--- a/lib/sanbase/dashboards/dashboard/dashboard_query_mapping.ex
+++ b/lib/sanbase/dashboards/dashboard/dashboard_query_mapping.ex
@@ -45,6 +45,7 @@ defmodule Sanbase.Dashboards.DashboardQueryMapping do
     from(d in __MODULE__,
       where: d.id == ^id
     )
+    |> maybe_lock(opts)
     |> maybe_preload(opts)
   end
 
@@ -83,6 +84,16 @@ defmodule Sanbase.Dashboards.DashboardQueryMapping do
         preload = Keyword.get(opts, :preload, @preload)
 
         query |> preload(^preload)
+
+      false ->
+        query
+    end
+  end
+
+  defp maybe_lock(query, opts) do
+    case Keyword.get(opts, :lock_for_update, false) do
+      true ->
+        query |> lock("FOR UPDATE")
 
       false ->
         query

--- a/lib/sanbase/dashboards/dashboards.ex
+++ b/lib/sanbase/dashboards/dashboards.ex
@@ -1044,7 +1044,7 @@ defmodule Sanbase.Dashboards do
 
   defp mapping_error(dashboard_query_mapping_id, dashboard_id, querying_user_id) do
     """
-    Dashboard query mapping with id #{dashboard_query_mapping_id} does not exist,
+    Dashboard query mapping with id #{dashboard_query_mapping_id} does not exist, \
     it is not part of dashboard #{dashboard_id}, or the dashboard is not owned by user #{querying_user_id}.
     """
   end

--- a/lib/sanbase/queries/queries.ex
+++ b/lib/sanbase/queries/queries.ex
@@ -176,7 +176,7 @@ defmodule Sanbase.Queries do
       _ ->
         {:error,
          """
-         Dashboard query mapping with id #{mapping_id} does not exist,
+         Dashboard query mapping with id #{mapping_id} does not exist, \
          it is not part of dashboard #{dashboard_id}, or the dashboard is not public.
          """}
     end

--- a/lib/sanbase/queries/queries.ex
+++ b/lib/sanbase/queries/queries.ex
@@ -125,6 +125,12 @@ defmodule Sanbase.Queries do
     Queries.Authorization.user_plan_to_dynamic_repo(product_code, plan_name)
   end
 
+  def process_put_dynamic_repo(product_code, plan_name) do
+    Process.put(:queries_dynamic_repo, user_plan_to_dynamic_repo(product_code, plan_name))
+
+    :ok
+  end
+
   @doc ~s"""
   Get a query in order to read or run it.
   This can be done by owner or by anyone if the query is public.
@@ -145,15 +151,26 @@ defmodule Sanbase.Queries do
   The query is identified by the dashboard_query_mapping_id. This can be
   done by owner or by anyone if the dashboard is public.
   """
-  @spec get_dashboard_query(dashboard_id, dashboard_query_mapping_id, user_id) ::
+  @spec get_dashboard_query(
+          dashboard_id,
+          dashboard_query_mapping_id,
+          user_id,
+          parameters_override :: map()
+        ) ::
           {:ok, Query.t()} | {:error, String.t()}
-  def get_dashboard_query(dashboard_id, mapping_id, querying_user_id) do
+  def get_dashboard_query(dashboard_id, mapping_id, querying_user_id, parameters_override \\ %{}) do
     query = DashboardQueryMapping.by_id(mapping_id)
 
     with %DashboardQueryMapping{dashboard: dashboard, query: query} <- Repo.one(query),
          %Dashboard{id: ^dashboard_id} <- dashboard,
          true <- dashboard.is_public or dashboard.user_id == querying_user_id,
-         {:ok, query} <- Sanbase.Dashboards.apply_global_parameters(query, dashboard, mapping_id) do
+         {:ok, query} <-
+           Sanbase.Dashboards.apply_global_parameters(
+             query,
+             dashboard,
+             mapping_id,
+             parameters_override
+           ) do
       {:ok, query}
     else
       _ ->

--- a/lib/sanbase/queries/refresh/refresh.ex
+++ b/lib/sanbase/queries/refresh/refresh.ex
@@ -61,6 +61,7 @@ defmodule Sanbase.Queries.Refresh do
     |> Enum.each(fn mapping ->
       Sanbase.Dashboards.cache_dashboard_query_execution(
         mapping.dashboard_id,
+        _parameters_override_hash = nil,
         mapping.id,
         query_result,
         user_id

--- a/lib/sanbase/run_examples.ex
+++ b/lib/sanbase/run_examples.ex
@@ -744,7 +744,8 @@ defmodule Sanbase.RunExamples do
     {:ok, query} =
       Sanbase.Queries.create_query(
         %{
-          sql_query_text: "SELECT {{big_num:human_readable}} AS big_num, {{big_num}} AS num",
+          sql_query_text:
+            "SELECT {{big_num:human_readable}} AS big_num, {{big_num}} AS num, {{slug}} AS slug",
           sql_query_parameters: %{slug: "bitcoin", big_num: 2_123_801_239_123}
         },
         user.id
@@ -768,6 +769,7 @@ defmodule Sanbase.RunExamples do
     {:ok, stored} =
       Sanbase.Dashboards.cache_dashboard_query_execution(
         dashboard.id,
+        _hash = nil,
         mapping.id,
         result,
         user.id
@@ -807,7 +809,11 @@ defmodule Sanbase.RunExamples do
     } = stored
 
     {:ok, dashboard_cache} =
-      Sanbase.Dashboards.get_cached_dashboard_queries_executions(dashboard.id, user.id)
+      Sanbase.Dashboards.get_cached_dashboard_queries_executions(
+        dashboard.id,
+        _parameters_override = %{},
+        user.id
+      )
 
     for r <- [dashboard_cache, mapping, dashboard, query],
         do: Sanbase.Repo.delete(r)

--- a/lib/sanbase_web/graphql/schema/queries/queries_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/queries_queries.ex
@@ -201,6 +201,24 @@ defmodule SanbaseWeb.Graphql.Schema.QueriesQueries do
       arg(:dashboard_id, non_null(:integer))
       arg(:dashboard_query_mapping_id, non_null(:string))
 
+      @desc ~s"""
+      A map that contains dashboard global keys as keys and
+      a new value as the value.
+      When the query is executed, the parameters here override the
+      dashboard parameters, allowing anyone to execute the dashboard query
+      with modified set of parameters.
+      """
+      arg(:parameters_override, :json)
+
+      @desc ~s"""
+      If set to true, the execution result is stored in the database.
+      The result can be later fetched by the getDashboardCachedQueriesExecutions
+
+      Alongside the cached value, the hash of the SQL query text and the hash
+      of the query parameters are also stored.
+      """
+      arg(:store_execution, :boolean, default_value: false)
+
       middleware(UserAuth)
 
       resolve(&QueriesResolver.run_dashboard_sql_query/3)
@@ -430,6 +448,7 @@ defmodule SanbaseWeb.Graphql.Schema.QueriesQueries do
     field :get_cached_dashboard_queries_executions, :dashboard_cached_executions do
       meta(access: :free)
       arg(:dashboard_id, non_null(:integer))
+      arg(:parameters_override, :json)
 
       resolve(&QueriesResolver.get_cached_dashboard_queries_executions/3)
     end

--- a/priv/repo/migrations/20240904135651_extend_dashboards_cache.exs
+++ b/priv/repo/migrations/20240904135651_extend_dashboards_cache.exs
@@ -1,0 +1,12 @@
+defmodule Sanbase.Repo.Migrations.ExtendDashboardsCache do
+  use Ecto.Migration
+
+  def change do
+    alter table(:dashboards_cache) do
+      add(:parameters_override_hash, :string, null: false, default: "none")
+    end
+
+    drop(unique_index("dashboards_cache", [:dashboard_id]))
+    create(unique_index("dashboards_cache", [:dashboard_id, :parameters_override_hash]))
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -999,7 +999,8 @@ CREATE TABLE public.dashboards_cache (
     panels jsonb DEFAULT '{}'::jsonb,
     inserted_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    queries jsonb DEFAULT '{}'::jsonb
+    queries jsonb DEFAULT '{}'::jsonb,
+    parameters_override_hash character varying(255) DEFAULT 'none'::character varying NOT NULL
 );
 
 
@@ -6861,10 +6862,10 @@ CREATE INDEX dashboard_query_mappings_query_id_index ON public.dashboard_query_m
 
 
 --
--- Name: dashboards_cache_dashboard_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: dashboards_cache_dashboard_id_parameters_override_hash_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX dashboards_cache_dashboard_id_index ON public.dashboards_cache USING btree (dashboard_id);
+CREATE UNIQUE INDEX dashboards_cache_dashboard_id_parameters_override_hash_index ON public.dashboards_cache USING btree (dashboard_id, parameters_override_hash);
 
 
 --
@@ -9562,3 +9563,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20240723122118);
 INSERT INTO public."schema_migrations" (version) VALUES (20240725122924);
 INSERT INTO public."schema_migrations" (version) VALUES (20240805115620);
 INSERT INTO public."schema_migrations" (version) VALUES (20240809122904);
+INSERT INTO public."schema_migrations" (version) VALUES (20240904135651);

--- a/test/sanbase/dashboards/dashboard_test.exs
+++ b/test/sanbase/dashboards/dashboard_test.exs
@@ -56,7 +56,7 @@ defmodule Sanbase.DashboardsTest do
 
       # Cannot get other user private dashboard
       {:error, error_msg} = Dashboards.get_dashboard(dashboard.id, user2.id)
-      assert error_msg =~ "does not exist, or it is private and owned by another user"
+      assert error_msg =~ "does not exist, or it is owned by another user"
 
       # Can get other user public dashboard
       {:ok, dashboard} =
@@ -123,7 +123,7 @@ defmodule Sanbase.DashboardsTest do
       {:error, error_msg} =
         Dashboards.update_dashboard(dashboard.id, update_args, user2.id)
 
-      assert error_msg =~ "does not exist, or it is owner by another user"
+      assert error_msg =~ "does not exist, or it is owned by another user"
     end
 
     test "delete dashboard", context do
@@ -131,7 +131,7 @@ defmodule Sanbase.DashboardsTest do
 
       # Cannot delete other users dashboards
       {:error, error_msg} = Dashboards.delete_dashboard(dashboard.id, user2.id)
-      assert error_msg =~ "does not exist, or it is owner by another user"
+      assert error_msg =~ "does not exist, or it is owned by another user"
 
       # Can delete own dashboard
       assert {:ok, _} = Dashboards.delete_dashboard(dashboard.id, user.id)
@@ -159,6 +159,7 @@ defmodule Sanbase.DashboardsTest do
         {:ok, dashboard_cache} =
           Dashboards.cache_dashboard_query_execution(
             dashboard.id,
+            _parameters_override = %{},
             dashboard_query_mapping.id,
             result,
             user.id
@@ -173,7 +174,11 @@ defmodule Sanbase.DashboardsTest do
 
       # Test outside of the mock to make sure no database queries are made
       {:ok, dashboard_cache} =
-        Dashboards.get_cached_dashboard_queries_executions(dashboard.id, user.id)
+        Dashboards.get_cached_dashboard_queries_executions(
+          dashboard.id,
+          _parameters_override = %{},
+          user.id
+        )
 
       assert %Dashboards.DashboardCache{
                queries: %{},
@@ -219,7 +224,7 @@ defmodule Sanbase.DashboardsTest do
              } = dashboard_cache.queries[dashboard_query_mapping.id]
     end
 
-    test "cannot update other people dashboard cache", context do
+    test "cannot update other people dashboard cache via cacheDashboardQueryExection", context do
       %{
         query: query,
         dashboard_query_mapping: dashboard_query_mapping,
@@ -238,12 +243,14 @@ defmodule Sanbase.DashboardsTest do
         assert {:error, error_msg} =
                  Sanbase.Dashboards.cache_dashboard_query_execution(
                    dashboard.id,
+                   _parameters_override = %{},
                    dashboard_query_mapping.id,
                    result,
                    user2.id
                  )
 
-        assert error_msg =~ "Dashboard does not exist, or it is owner by another user."
+        assert error_msg =~
+                 "Dashboard does not exist, or it is private and owned by another user."
       end)
     end
   end

--- a/test/sanbase/dashboards/dashboard_test.exs
+++ b/test/sanbase/dashboards/dashboard_test.exs
@@ -56,7 +56,7 @@ defmodule Sanbase.DashboardsTest do
 
       # Cannot get other user private dashboard
       {:error, error_msg} = Dashboards.get_dashboard(dashboard.id, user2.id)
-      assert error_msg =~ "does not exist, or it is owned by another user"
+      assert error_msg =~ "does not exist, or it is private and owned by another user"
 
       # Can get other user public dashboard
       {:ok, dashboard} =

--- a/test/sanbase_web/graphql/dashboards/dashboards_api_test.exs
+++ b/test/sanbase_web/graphql/dashboards/dashboards_api_test.exs
@@ -1,6 +1,7 @@
 defmodule SanbaseWeb.Graphql.DashboardsApiTest do
   use SanbaseWeb.ConnCase, async: false
 
+  import Mock
   import Sanbase.Factory
   import Sanbase.QueriesMocks
   import SanbaseWeb.Graphql.TestHelpers
@@ -298,8 +299,8 @@ defmodule SanbaseWeb.Graphql.DashboardsApiTest do
     end
   end
 
-  describe "Run Dashboar Queries" do
-    test "run dashboard query (resolve global params)", context do
+  describe "Run Dashboard Queries" do
+    test "run dashboard query (override params via the run query)", context do
       # In test env the storing runs not async and there's a 7500ms sleep
       Application.put_env(:__sanbase_queries__, :__store_execution_details__, false)
 
@@ -310,68 +311,107 @@ defmodule SanbaseWeb.Graphql.DashboardsApiTest do
       {:ok, dashboard} =
         Sanbase.Dashboards.create_dashboard(%{name: "My Dashboard"}, context.user.id)
 
-      query_id = query.id
-      dashboard_id = dashboard.id
-
-      # Add a query to a dashboard
-      mapping =
-        execute_dashboard_query_mutation(context.conn, :create_dashboard_query, %{
-          dashboard_id: dashboard.id,
-          query_id: query.id,
-          settings: %{layout: [0, 1, 2, 3, 4]}
-        })
-        |> get_in(["data", "createDashboardQuery"])
-
-      assert %{
-               "dashboard" => %{"id" => ^dashboard_id, "parameters" => %{}},
-               "id" => _,
-               "query" => %{"id" => ^query_id},
-               "settings" => %{"layout" => [0, 1, 2, 3, 4]}
-             } = mapping
+      {:ok, mapping} = create_dashboard_query(context.conn, dashboard, query)
 
       # Add global parameters and override the query's local parameters
-      dashboard_with_params =
-        execute_global_parameter_mutation(
-          context.conn,
-          :add_dashboard_global_parameter,
-          %{
-            dashboard_id: dashboard.id,
-            key: "slug",
-            value: %{string: "santiment", map_as_input_object: true}
-          }
-        )
-        |> get_in(["data", "addDashboardGlobalParameter"])
+      dashboard_key = "slug"
+      query_key = "slug"
+      param_value = "santiment"
 
-      assert dashboard_with_params == %{
-               "parameters" => %{"slug" => %{"overrides" => [], "value" => "santiment"}}
-             }
+      {:ok, _dashboard_with_params} =
+        add_dashboard_global_parameter(
+          context.conn,
+          dashboard,
+          dashboard_key,
+          :string,
+          param_value
+        )
 
       # Add global parameter override for a query local parameter
       param_override_args = %{
         dashboard_id: dashboard.id,
         dashboard_query_mapping_id: mapping["id"],
-        dashboard_parameter_key: "slug",
-        query_parameter_key: "slug"
+        dashboard_parameter_key: dashboard_key,
+        query_parameter_key: query_key
       }
 
-      override =
-        execute_global_parameter_mutation(
+      {:ok, _} =
+        add_dashboard_global_parameter_override(
           context.conn,
-          :add_dashboard_global_parameter_override,
-          param_override_args
+          param_override_args,
+          param_value
         )
-        |> get_in(["data", "addDashboardGlobalParameterOverride"])
 
-      assert override == %{
-               "parameters" => %{
-                 "slug" => %{
-                   "overrides" => [
-                     %{"dashboard_query_mapping_id" => mapping["id"], "parameter" => "slug"}
-                   ],
-                   "value" => "santiment"
-                 }
-               }
-             }
+      mock_fun =
+        Sanbase.Mock.wrap_consecutives(
+          [
+            fn -> {:ok, mocked_clickhouse_result()} end,
+            fn -> {:ok, mocked_execution_details_result()} end
+          ],
+          arity: 2
+        )
+
+      # Run a dashboard query. Expect the dashboard parameter to override
+      # the query local parameter
+      Sanbase.Mock.prepare_mock(Sanbase.ClickhouseRepo, :query, mock_fun)
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result =
+          run_sql_query(context.conn, :run_dashboard_sql_query, %{
+            dashboard_id: dashboard.id,
+            dashboard_query_mapping_id: mapping["id"],
+            # store_execution: true,
+            parameters_override: %{slug: "new_value_from_query_bitcoin"}
+          })
+
+        assert "errors" not in Map.keys(result)
+        assert is_map(get_in(result, ["data", "runDashboardSqlQuery"]))
+
+        # Check that the used argument is the one provided in the API
+        assert_called(Sanbase.ClickhouseRepo.query(:_, ["new_value_from_query_bitcoin", 10]))
+      end)
+    end
+
+    test "run and store dashboard query, even if not owner", context do
+      # In test env the storing runs not async and there's a 7500ms sleep
+      Application.put_env(:__sanbase_queries__, :__store_execution_details__, false)
+
+      on_exit(fn -> Application.delete_env(:__sanbase_queries__, :__store_execution_details__) end)
+
+      {:ok, query} = create_query(context.user.id)
+
+      {:ok, dashboard} =
+        Sanbase.Dashboards.create_dashboard(%{name: "My Dashboard"}, context.user.id)
+
+      {:ok, mapping} = create_dashboard_query(context.conn, dashboard, query)
+
+      # Add global parameters and override the query's local parameters
+      dashboard_key = "slug"
+      query_key = "slug"
+      param_value = "santiment"
+
+      {:ok, _dashboard_with_params} =
+        add_dashboard_global_parameter(
+          context.conn,
+          dashboard,
+          dashboard_key,
+          :string,
+          param_value
+        )
+
+      # Add global parameter override for a query local parameter
+      param_override_args = %{
+        dashboard_id: dashboard.id,
+        dashboard_query_mapping_id: mapping["id"],
+        dashboard_parameter_key: dashboard_key,
+        query_parameter_key: query_key
+      }
+
+      {:ok, _} =
+        add_dashboard_global_parameter_override(
+          context.conn,
+          param_override_args,
+          param_value
+        )
 
       # Delete global parameter override for a query local parameter
       override =
@@ -420,8 +460,8 @@ defmodule SanbaseWeb.Graphql.DashboardsApiTest do
                  "columns" => ["asset_id", "metric_id", "dt", "value", "computed_at"],
                  "columnTypes" => ["UInt64", "UInt64", "DateTime", "Float64", "DateTime"],
                  "rows" => [
-                   [2503, 250, "2008-12-10T00:00:00Z", +0.0, "2020-02-28T15:18:42Z"],
-                   [2503, 250, "2008-12-10T00:05:00Z", +0.0, "2020-02-28T15:18:42Z"]
+                   ["bitcoin", 250, "2008-12-10T00:00:00Z", +0.0, "2020-02-28T15:18:42Z"],
+                   ["bitcoin", 250, "2008-12-10T00:05:00Z", +0.0, "2020-02-28T15:18:42Z"]
                  ],
                  "summary" => %{
                    "read_bytes" => +0.0,
@@ -432,6 +472,182 @@ defmodule SanbaseWeb.Graphql.DashboardsApiTest do
                  }
                } = result
       end)
+    end
+
+    test "run dashboard query (resolve global parameters)", context do
+      # In test env the storing runs not async and there's a 7500ms sleep
+      Application.put_env(:__sanbase_queries__, :__store_execution_details__, false)
+
+      on_exit(fn -> Application.delete_env(:__sanbase_queries__, :__store_execution_details__) end)
+
+      {:ok, query} = create_query(context.user.id)
+
+      {:ok, dashboard} =
+        Sanbase.Dashboards.create_dashboard(%{name: "My Dashboard"}, context.user.id)
+
+      {:ok, mapping} = create_dashboard_query(context.conn, dashboard, query)
+
+      # Add global parameters and override the query's local parameters
+      dashboard_key = "slug"
+      query_key = "slug"
+      param_value = "santiment"
+
+      {:ok, _dashboard_with_params} =
+        add_dashboard_global_parameter(
+          context.conn,
+          dashboard,
+          dashboard_key,
+          :string,
+          param_value
+        )
+
+      # Add global parameter override for a query local parameter
+      param_override_args = %{
+        dashboard_id: dashboard.id,
+        dashboard_query_mapping_id: mapping["id"],
+        dashboard_parameter_key: dashboard_key,
+        query_parameter_key: query_key
+      }
+
+      {:ok, _} =
+        add_dashboard_global_parameter_override(
+          context.conn,
+          param_override_args,
+          param_value
+        )
+
+      # Delete global parameter override for a query local parameter
+      override =
+        execute_global_parameter_mutation(
+          context.conn,
+          :delete_dashboard_global_parameter_override,
+          param_override_args |> Map.delete(:query_parameter_key)
+        )
+        |> get_in(["data", "deleteDashboardGlobalParameterOverride"])
+
+      assert override == %{
+               "parameters" => %{
+                 "slug" => %{"overrides" => [], "value" => "santiment"}
+               }
+             }
+
+      # Add back the deleted param override
+      execute_global_parameter_mutation(
+        context.conn,
+        :add_dashboard_global_parameter_override,
+        param_override_args
+      )
+
+      mock_fun =
+        Sanbase.Mock.wrap_consecutives(
+          [
+            fn -> {:ok, mocked_clickhouse_result()} end,
+            fn -> {:ok, mocked_execution_details_result()} end
+          ],
+          arity: 2
+        )
+
+      # Run a dashboard query. Expect the dashboard parameter to override
+      # the query local parameter
+      Sanbase.Mock.prepare_mock(Sanbase.ClickhouseRepo, :query, mock_fun)
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result =
+          run_sql_query(context.conn, :run_dashboard_sql_query, %{
+            dashboard_id: dashboard.id,
+            dashboard_query_mapping_id: mapping["id"]
+          })
+          |> get_in(["data", "runDashboardSqlQuery"])
+
+        assert %{
+                 "clickhouseQueryId" => "177a5a3d-072b-48ac-8cf5-d8375c8314ef",
+                 "columns" => ["asset_id", "metric_id", "dt", "value", "computed_at"],
+                 "columnTypes" => ["UInt64", "UInt64", "DateTime", "Float64", "DateTime"],
+                 "rows" => [
+                   ["bitcoin", 250, "2008-12-10T00:00:00Z", +0.0, "2020-02-28T15:18:42Z"],
+                   ["bitcoin", 250, "2008-12-10T00:05:00Z", +0.0, "2020-02-28T15:18:42Z"]
+                 ],
+                 "summary" => %{
+                   "read_bytes" => +0.0,
+                   "read_rows" => +0.0,
+                   "total_rows_to_read" => +0.0,
+                   "written_bytes" => +0.0,
+                   "written_rows" => +0.0
+                 }
+               } = result
+      end)
+    end
+
+    defp create_dashboard_query(conn, dashboard, query) do
+      query_id = query.id
+      dashboard_id = dashboard.id
+
+      # Add a query to a dashboard
+      mapping =
+        execute_dashboard_query_mutation(conn, :create_dashboard_query, %{
+          dashboard_id: dashboard.id,
+          query_id: query.id,
+          settings: %{layout: [0, 1, 2, 3, 4]}
+        })
+        |> get_in(["data", "createDashboardQuery"])
+
+      assert %{
+               "dashboard" => %{"id" => ^dashboard_id, "parameters" => %{}},
+               "id" => _,
+               "query" => %{"id" => ^query_id},
+               "settings" => %{"layout" => [0, 1, 2, 3, 4]}
+             } = mapping
+
+      {:ok, mapping}
+    end
+
+    defp add_dashboard_global_parameter(conn, dashboard, key, type, value) do
+      dashboard_with_params =
+        execute_global_parameter_mutation(
+          conn,
+          :add_dashboard_global_parameter,
+          %{
+            dashboard_id: dashboard.id,
+            key: key,
+            value: %{type => value, map_as_input_object: true}
+          }
+        )
+        |> get_in(["data", "addDashboardGlobalParameter"])
+
+      %{"parameters" => parameters} = dashboard_with_params
+      assert parameters[key] == %{"overrides" => [], "value" => value}
+
+      {:ok, dashboard_with_params}
+    end
+
+    defp add_dashboard_global_parameter_override(
+           conn,
+           param_override_args,
+           parameter_value
+         ) do
+      override =
+        execute_global_parameter_mutation(
+          conn,
+          :add_dashboard_global_parameter_override,
+          param_override_args
+        )
+        |> get_in(["data", "addDashboardGlobalParameterOverride"])
+
+      assert override == %{
+               "parameters" => %{
+                 param_override_args[:dashboard_parameter_key] => %{
+                   "overrides" => [
+                     %{
+                       "dashboard_query_mapping_id" =>
+                         param_override_args[:dashboard_query_mapping_id],
+                       "parameter" => param_override_args[:query_parameter_key]
+                     }
+                   ],
+                   "value" => parameter_value
+                 }
+               }
+             }
+
+      {:ok, override}
     end
   end
 
@@ -498,8 +714,8 @@ defmodule SanbaseWeb.Graphql.DashboardsApiTest do
                      "queryEndTime" => query_end_time,
                      "queryId" => ^query_id,
                      "rows" => [
-                       [2503, 250, "2008-12-10T00:00:00Z", +0.0, "2020-02-28T15:18:42Z"],
-                       [2503, 250, "2008-12-10T00:05:00Z", +0.0, "2020-02-28T15:18:42Z"]
+                       ["bitcoin", 250, "2008-12-10T00:00:00Z", +0.0, "2020-02-28T15:18:42Z"],
+                       ["bitcoin", 250, "2008-12-10T00:05:00Z", +0.0, "2020-02-28T15:18:42Z"]
                      ]
                    }
                  ]
@@ -510,28 +726,168 @@ defmodule SanbaseWeb.Graphql.DashboardsApiTest do
 
         cache =
           get_cached_dashboard_queries_executions(context.conn, %{dashboard_id: dashboard.id})
-          |> get_in(["data", "getCachedDashboardQueriesExecutions"])
+          |> get_in(["data", "getCachedDashboardQueriesExecutions", "queries"])
 
-        assert %{
-                 "queries" => [
-                   %{
-                     "queryId" => ^query_id,
-                     "dashboardQueryMappingId" => ^dashboard_query_mapping_id,
-                     "clickhouseQueryId" => "177a5a3d-072b-48ac-8cf5-d8375c8314ef",
-                     "columnTypes" => ["UInt64", "UInt64", "DateTime", "Float64", "DateTime"],
-                     "columns" => ["asset_id", "metric_id", "dt", "value", "computed_at"],
-                     "queryStartTime" => query_start_time,
-                     "queryEndTime" => query_end_time,
-                     "rows" => [
-                       [2503, 250, "2008-12-10T00:00:00Z", +0.0, "2020-02-28T15:18:42Z"],
-                       [2503, 250, "2008-12-10T00:05:00Z", +0.0, "2020-02-28T15:18:42Z"]
-                     ]
-                   }
-                 ]
-               } = cache
+        assert [
+                 %{
+                   "queryId" => ^query_id,
+                   "dashboardQueryMappingId" => ^dashboard_query_mapping_id,
+                   "clickhouseQueryId" => "177a5a3d-072b-48ac-8cf5-d8375c8314ef",
+                   "columnTypes" => ["UInt64", "UInt64", "DateTime", "Float64", "DateTime"],
+                   "columns" => ["asset_id", "metric_id", "dt", "value", "computed_at"],
+                   "queryStartTime" => query_start_time,
+                   "queryEndTime" => query_end_time,
+                   "rows" => [
+                     ["bitcoin", 250, "2008-12-10T00:00:00Z", +0.0, "2020-02-28T15:18:42Z"],
+                     ["bitcoin", 250, "2008-12-10T00:05:00Z", +0.0, "2020-02-28T15:18:42Z"]
+                   ]
+                 }
+               ] = cache
 
         assert datetime_close_to_now?(Sanbase.DateTimeUtils.from_iso8601!(query_start_time))
         assert datetime_close_to_now?(Sanbase.DateTimeUtils.from_iso8601!(query_end_time))
+      end)
+    end
+
+    test "run dashboard query with storeExecution: true", context do
+      # In test env the storing runs not async and there's a 7500ms sleep
+      Application.put_env(:__sanbase_queries__, :__store_execution_details__, false)
+
+      on_exit(fn ->
+        Application.delete_env(:__sanbase_queries__, :__store_execution_details__)
+      end)
+
+      {:ok, query} = create_query(context.user.id)
+      {:ok, dashboard} = Sanbase.Dashboards.create_dashboard(%{name: "Dash"}, context.user.id)
+      {:ok, mapping} = create_dashboard_query(context.conn, dashboard, query)
+
+      # Add global parameters and override the query's local parameters
+      dashboard_key = "slug"
+      query_key = "slug"
+      param_value = "santiment"
+
+      {:ok, _dashboard_with_params} =
+        add_dashboard_global_parameter(
+          context.conn,
+          dashboard,
+          dashboard_key,
+          :string,
+          param_value
+        )
+
+      # Add global parameter override for a query local parameter
+      param_override_args = %{
+        dashboard_id: dashboard.id,
+        dashboard_query_mapping_id: mapping["id"],
+        dashboard_parameter_key: dashboard_key,
+        query_parameter_key: query_key
+      }
+
+      {:ok, _} =
+        add_dashboard_global_parameter_override(
+          context.conn,
+          param_override_args,
+          param_value
+        )
+
+      mock_fun =
+        Sanbase.Mock.wrap_consecutives(
+          [
+            fn -> {:ok, mocked_clickhouse_result("bitcoin")} end,
+            fn -> {:ok, mocked_clickhouse_result("santiment")} end,
+            fn -> {:ok, mocked_execution_details_result()} end,
+            fn -> {:ok, mocked_execution_details_result()} end
+          ],
+          arity: 2
+        )
+
+      # Run a dashboard query. Expect the dashboard parameter to override
+      # the query local parameter
+      Sanbase.Mock.prepare_mock(Sanbase.ClickhouseRepo, :query, mock_fun)
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        # Check that the used argument is the one provided in the API
+        parameters_override = %{slug: "bitcoin"}
+
+        result1 =
+          run_sql_query(context.conn, :run_dashboard_sql_query, %{
+            dashboard_id: dashboard.id,
+            dashboard_query_mapping_id: mapping["id"],
+            store_execution: true,
+            parameters_override: parameters_override
+          })
+
+        # Only one cache record
+        assert [_] = Sanbase.Repo.all(Sanbase.Dashboards.DashboardCache)
+
+        assert "errors" not in Map.keys(result1)
+        assert is_map(get_in(result1, ["data", "runDashboardSqlQuery"]))
+
+        assert_called(Sanbase.ClickhouseRepo.query(:_, ["bitcoin", 10]))
+        refute called(Sanbase.ClickhouseRepo.query(:_, ["santiment", 10]))
+
+        result2 =
+          run_sql_query(context.conn, :run_dashboard_sql_query, %{
+            dashboard_id: dashboard.id,
+            dashboard_query_mapping_id: mapping["id"],
+            store_execution: true
+          })
+
+        # Now a second cache record appears.
+        assert [_, _] = Sanbase.Repo.all(Sanbase.Dashboards.DashboardCache)
+
+        # No parameters_override, so the original param is used
+        assert_called(Sanbase.ClickhouseRepo.query(:_, ["santiment", 10]))
+
+        assert "errors" not in Map.keys(result2)
+        assert is_map(get_in(result2, ["data", "runDashboardSqlQuery"]))
+
+        cache1 =
+          get_cached_dashboard_queries_executions(context.conn, %{
+            dashboard_id: dashboard.id,
+            parameters_override: parameters_override
+          })
+          |> get_in(["data", "getCachedDashboardQueriesExecutions", "queries"])
+
+        assert [
+                 %{
+                   "clickhouseQueryId" => _,
+                   "columnTypes" => ["UInt64", "UInt64", "DateTime", "Float64", "DateTime"],
+                   "columns" => ["asset_id", "metric_id", "dt", "value", "computed_at"],
+                   "dashboardQueryMappingId" => _mapping_id,
+                   "queryEndTime" => _end_time,
+                   "queryId" => _query_id,
+                   "queryStartTime" => _start_time,
+                   "rows" => [
+                     ["bitcoin", 250, "2008-12-10T00:00:00Z", +0.0, "2020-02-28T15:18:42Z"],
+                     ["bitcoin", 250, "2008-12-10T00:05:00Z", +0.0, "2020-02-28T15:18:42Z"]
+                   ]
+                 }
+               ] =
+                 cache1
+
+        # Fetched without the parameters override
+        cache2 =
+          get_cached_dashboard_queries_executions(context.conn, %{
+            dashboard_id: dashboard.id
+          })
+          |> get_in(["data", "getCachedDashboardQueriesExecutions", "queries"])
+
+        assert [
+                 %{
+                   "clickhouseQueryId" => _,
+                   "columnTypes" => ["UInt64", "UInt64", "DateTime", "Float64", "DateTime"],
+                   "columns" => ["asset_id", "metric_id", "dt", "value", "computed_at"],
+                   "dashboardQueryMappingId" => _mapping_id,
+                   "queryEndTime" => _end_time,
+                   "queryId" => _query_id,
+                   "queryStartTime" => _start_time,
+                   "rows" => [
+                     ["santiment", 250, "2008-12-10T00:00:00Z", +0.0, "2020-02-28T15:18:42Z"],
+                     ["santiment", 250, "2008-12-10T00:05:00Z", +0.0, "2020-02-28T15:18:42Z"]
+                   ]
+                 }
+               ] =
+                 cache2
       end)
     end
 

--- a/test/sanbase_web/graphql/queries/queries_api_test.exs
+++ b/test/sanbase_web/graphql/queries/queries_api_test.exs
@@ -192,8 +192,8 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
                  "columns" => ["asset_id", "metric_id", "dt", "value", "computed_at"],
                  "columnTypes" => ["UInt64", "UInt64", "DateTime", "Float64", "DateTime"],
                  "rows" => [
-                   [2503, 250, "2008-12-10T00:00:00Z", +0.0, "2020-02-28T15:18:42Z"],
-                   [2503, 250, "2008-12-10T00:05:00Z", +0.0, "2020-02-28T15:18:42Z"]
+                   ["bitcoin", 250, "2008-12-10T00:00:00Z", +0.0, "2020-02-28T15:18:42Z"],
+                   ["bitcoin", 250, "2008-12-10T00:05:00Z", +0.0, "2020-02-28T15:18:42Z"]
                  ],
                  "summary" => %{
                    "read_bytes" => +0.0,
@@ -235,8 +235,8 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
                  "columns" => ["asset_id", "metric_id", "dt", "value", "computed_at"],
                  "columnTypes" => ["UInt64", "UInt64", "DateTime", "Float64", "DateTime"],
                  "rows" => [
-                   [2503, 250, "2008-12-10T00:00:00Z", +0.0, "2020-02-28T15:18:42Z"],
-                   [2503, 250, "2008-12-10T00:05:00Z", +0.0, "2020-02-28T15:18:42Z"]
+                   ["bitcoin", 250, "2008-12-10T00:00:00Z", +0.0, "2020-02-28T15:18:42Z"],
+                   ["bitcoin", 250, "2008-12-10T00:05:00Z", +0.0, "2020-02-28T15:18:42Z"]
                  ],
                  "summary" => %{
                    "read_bytes" => +0.0,
@@ -434,8 +434,8 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
                    "columnTypes" => ["UInt64", "UInt64", "DateTime", "Float64", "DateTime"],
                    "columns" => ["asset_id", "metric_id", "dt", "value", "computed_at"],
                    "rows" => [
-                     [2503, 250, "2008-12-10T00:00:00Z", +0.0, "2020-02-28T15:18:42Z"],
-                     [2503, 250, "2008-12-10T00:05:00Z", +0.0, "2020-02-28T15:18:42Z"]
+                     ["bitcoin", 250, "2008-12-10T00:00:00Z", +0.0, "2020-02-28T15:18:42Z"],
+                     ["bitcoin", 250, "2008-12-10T00:05:00Z", +0.0, "2020-02-28T15:18:42Z"]
                    ]
                  },
                  "user" => %{"id" => ^owner_user_id}
@@ -449,8 +449,8 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
                    "columnTypes" => ["UInt64", "UInt64", "DateTime", "Float64", "DateTime"],
                    "columns" => ["asset_id", "metric_id", "dt", "value", "computed_at"],
                    "rows" => [
-                     [2503, 250, "2008-12-10T00:00:00Z", +0.0, "2020-02-28T15:18:42Z"],
-                     [2503, 250, "2008-12-10T00:05:00Z", +0.0, "2020-02-28T15:18:42Z"]
+                     ["bitcoin", 250, "2008-12-10T00:00:00Z", +0.0, "2020-02-28T15:18:42Z"],
+                     ["bitcoin", 250, "2008-12-10T00:05:00Z", +0.0, "2020-02-28T15:18:42Z"]
                    ]
                  },
                  "user" => %{"id" => ^own_user_id}

--- a/test/support/queries/queries_mocks.ex
+++ b/test/support/queries/queries_mocks.ex
@@ -1,5 +1,5 @@
 defmodule Sanbase.QueriesMocks do
-  def mocked_clickhouse_result() do
+  def mocked_clickhouse_result(slug \\ "bitcoin") do
     %Clickhousex.Result{
       columns: ["asset_id", "metric_id", "dt", "value", "computed_at"],
       column_types: ["UInt64", "UInt64", "DateTime", "Float64", "DateTime"],
@@ -7,8 +7,8 @@ defmodule Sanbase.QueriesMocks do
       num_rows: 2,
       query_id: "177a5a3d-072b-48ac-8cf5-d8375c8314ef",
       rows: [
-        [2503, 250, ~N[2008-12-10 00:00:00], +0.0, ~N[2020-02-28 15:18:42]],
-        [2503, 250, ~N[2008-12-10 00:05:00], +0.0, ~N[2020-02-28 15:18:42]]
+        [slug, 250, ~N[2008-12-10 00:00:00], +0.0, ~N[2020-02-28 15:18:42]],
+        [slug, 250, ~N[2008-12-10 00:05:00], +0.0, ~N[2020-02-28 15:18:42]]
       ],
       summary: %{
         "read_bytes" => "0",


### PR DESCRIPTION
## Changes

Rework how the Dashboards caching works
- Allow multiple caches of a dashboard -- each with different set of parameters overrides.
  - This allows sharing a dashboard page with changed parameters.
- Allow the dashboard cache to be refreshed by anyone. 
  - Previously the users needed to re-submit the result back with a different GraphQL call. This allows users to submit random garbage.
  - Now when any user can refresh the cache, to mitigate this problem the `runDashboardSqlQuery` GraphQL query accepts the `storeExecution` boolean flag. When it is set to `true`, the result will directly update the cache.  
  - Still, the dashboard needs to be public so other users can update its cache.
- The argument `parametersOverride` is now accepted in `runDashboardSqlQuery` and `getCachedDashboardQueriesExecutions`.

### Run & Cache dashboard queries
**Successfully updating the dashboard cache by non-owner**:
```graphql
{
  runDashboardSqlQuery(
      dashboardId: 3
      dashboardQueryMappingId: "9d7931fd-44a1-45d6-b633-ec13886e16a4"
      storeExecution: true
     ){
      clickhouseQueryId
      columnTypes
      columns
      rows
  }
}
```
```json
{
  "data": {
    "runDashboardSqlQuery": {
      "clickhouseQueryId": "3e0496bd-26ca-46d2-9fb3-20ead7719bec",
      "columnTypes": [
        "String",
        "UInt64",
        "String"
      ],
      "columns": [
        "big_num",
        "num",
        "slug"
      ],
      "rows": [
        [
          "2.12 Trillion",
          2123801239123,
          "ethereum"
        ]
      ]
    }
  }
}
```

---

**Unsuccessful cache update due to the dashboard being private and not owned by the user**:
```graphql
{
  runDashboardSqlQuery(
      dashboardId: 3
      dashboardQueryMappingId: "9d7931fd-44a1-45d6-b633-ec13886e16a4"
      storeExecution: true
     ){
      clickhouseQueryId
      columnTypes
      columns
      rows
  }
}
```
```json
{
  "data": {
    "runDashboardSqlQuery": null
  },
  "errors": [
    {
      "message": "Dashboard query mapping with id 63812020-3cf4-4115-a8ef-4e36403042ee does not exist,\nit is not part of dashboard 3, or the dashboard is not public.\n",
      "path": [
        "runDashboardSqlQuery"
      ],
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ]
    }
  ]
}
```

---

**Execute a dashboard query and store it with overridden parameters**
```graphql
{
  runDashboardSqlQuery(
    	dashboardId: 3
    	dashboardQueryMappingId: "9d7931fd-44a1-45d6-b633-ec13886e16a4"
    	storeExecution: true
    	parametersOverride: "{\"slug\": \"a_completely_new_parameter_from_params\"}"
  	){
      clickhouseQueryId
      columnTypes
      columns
      rows
  }
}
```
```json
{
  "data": {
    "runDashboardSqlQuery": {
      "clickhouseQueryId": "4f4dce59-904f-4733-bd1a-db59e0a742a3",
      "columnTypes": [
        "String",
        "UInt64",
        "String"
      ],
      "columns": [
        "big_num",
        "num",
        "slug"
      ],
      "rows": [
        [
          "2.12 Trillion",
          2123801239123,
          "a_completely_new_parameter_from_params"
        ]
      ]
    }
  }
}
```

### Get cached dashboard queries

**Get cached dashboard with the original parameters**: 
```graphql
{
  getCachedDashboardQueriesExecutions(dashboardId:3){
    queries{
      dashboardQueryMappingId
      queryId
      columns
      columnTypes
      rows
    }
  }
}
```
```json
{
  "data": {
    "getCachedDashboardQueriesExecutions": {
      "queries": [
        {
          "columnTypes": [
            "String",
            "UInt64",
            "String"
          ],
          "columns": [
            "big_num",
            "num",
            "slug"
          ],
          "dashboardQueryMappingId": "9d7931fd-44a1-45d6-b633-ec13886e16a4",
          "queryId": 4,
          "rows": [
            [
              "2.12 Trillion",
              2123801239123,
              "ethereum"
            ]
          ]
        }
      ]
    }
  }
}
```

---

**Get cached dashboard with the overriden parameters**: 
```graphql
{
  getCachedDashboardQueriesExecutions(
    dashboardId:3 
    parametersOverride: "{\"slug\": \"a_completely_new_parameter_from_params\"}"
){
    queries{
      dashboardQueryMappingId
      queryId
      columns
      columnTypes
      rows
    }
  }
}
```
```json
{
  "data": {
    "getCachedDashboardQueriesExecutions": {
      "queries": [
        {
          "columnTypes": [
            "String",
            "UInt64",
            "String"
          ],
          "columns": [
            "big_num",
            "num",
            "slug"
          ],
          "dashboardQueryMappingId": "9d7931fd-44a1-45d6-b633-ec13886e16a4",
          "queryId": 4,
          "rows": [
            [
              "2.12 Trillion",
              2123801239123,
              "a_completely_new_parameter_from_params"
            ]
          ]
        }
      ]
    }
  }
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
