### PR TITLE
Add treatWordAsLuceneQuery to wordsSocialVolume

### DIFF
--- a/lib/sanbase/social_data/social_helper.ex
+++ b/lib/sanbase/social_data/social_helper.ex
@@ -16,17 +16,12 @@ defmodule Sanbase.SocialData.SocialHelper do
 
   def sources_total_string(), do: @sources |> Enum.join(",")
 
-  def replace_words_with_original_casing({:error, error}, _words), do: {:error, error}
+  def replace_words_with_original_casing(result, words) do
+    Enum.map(result, fn %{word: lowercase_word} = map ->
+      original_word = Enum.find(words, fn w -> String.downcase(w) == lowercase_word end)
 
-  def replace_words_with_original_casing({:ok, result}, words) do
-    result =
-      Enum.map(result, fn %{word: lowercase_word} = map ->
-        original_word = Enum.find(words, fn w -> String.downcase(w) == lowercase_word end)
-
-        Map.put(map, :word, original_word)
-      end)
-
-    {:ok, result}
+      Map.put(map, :word, original_word)
+    end)
   end
 
   def social_metrics_selector_handler(%{slug: slugs}) when is_list(slugs) do

--- a/lib/sanbase/social_data/social_volume.ex
+++ b/lib/sanbase/social_data/social_volume.ex
@@ -71,8 +71,7 @@ defmodule Sanbase.SocialData.SocialVolume do
   end
 
   defp handle_response(response, selector) do
-    response
-    |> case do
+    case response do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         body
         |> Jason.decode!()

--- a/lib/sanbase_web/graphql/resolvers/social_data_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/social_data_resolver.ex
@@ -78,10 +78,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.SocialDataResolver do
 
   def words_social_volume(
         _root,
-        %{selector: %{words: _words} = selector, from: from, to: to, interval: interval},
+        %{selector: %{words: _words} = selector, from: from, to: to, interval: interval} = args,
         _resolution
       ) do
-    SocialData.social_volume(selector, from, to, interval, :total)
+    treat_as_lucene = Map.get(args, :treat_word_as_lucene_query, false)
+
+    SocialData.social_volume(selector, from, to, interval, :total,
+      treat_word_as_lucene_query: treat_as_lucene
+    )
   end
 
   def words_social_dominance(

--- a/lib/sanbase_web/graphql/schema/queries/social_data_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/social_data_queries.ex
@@ -170,6 +170,13 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
       arg(:to, non_null(:datetime))
       arg(:interval, :interval, default_value: "1d")
 
+      @desc ~s"""
+      If true, the word will be treated as a Lucene query. Default is false.
+      Lucene queries allows the word to be not a single word, but a query like: eth AND nft.
+      If false, the words are all lowercased and the AND/NOT/OR keywords meaning is lost.
+      """
+      arg(:treat_word_as_lucene_query, :boolean, default_value: false)
+
       complexity(&Complexity.from_to_interval/3)
       middleware(AccessControl, %{allow_realtime_data: true})
       cache_resolve(&SocialDataResolver.words_social_volume/3, ttl: 600, max_ttl_offset: 240)

--- a/test/sanbase_web/graphql/social_data/words_social_volume_api_test.exs
+++ b/test/sanbase_web/graphql/social_data/words_social_volume_api_test.exs
@@ -1,0 +1,174 @@
+defmodule SanbaseWeb.Graphql.WordsSocialVolumeApiTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import Sanbase.Factory
+  import SanbaseWeb.Graphql.TestHelpers
+
+  setup do
+    %{user: user} = insert(:subscription_pro_sanbase, user: insert(:user))
+    conn = setup_jwt_auth(build_conn(), user)
+
+    %{conn: conn}
+  end
+
+  test "successfully fetch words social volume", context do
+    # This test does not include treatWordAsLuceneQuery: true, so the
+    # words are lowercased before being send and in the response
+    body =
+      %{
+        "data" => %{
+          "btc" => %{
+            "2024-09-28T00:00:00Z" => 373,
+            "2024-09-29T00:00:00Z" => 487,
+            "2024-09-30T00:00:00Z" => 323
+          },
+          "eth or nft" => %{
+            "2024-09-28T00:00:00Z" => 1681,
+            "2024-09-29T00:00:00Z" => 3246,
+            "2024-09-30T00:00:00Z" => 1577
+          }
+        }
+      }
+      |> Jason.encode!()
+
+    resp = %HTTPoison.Response{status_code: 200, body: body}
+
+    Sanbase.Mock.prepare_mock(HTTPoison, :get, fn _url, _headers, options ->
+      search_texts =
+        Map.new(options[:params])
+        |> Map.get("search_texts")
+
+      # Assert that the words are lowercased before they are sent
+      assert search_texts == "eth or nft,btc"
+
+      {:ok, resp}
+    end)
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      query = """
+      {
+        wordsSocialVolume(
+          selector: { words: ["eth OR nft", "btc"] }
+          from: "2024-09-28T00:00:00Z"
+          to: "2024-09-30T00:00:00Z"
+          interval: "1d"
+        ){
+          word
+          timeseriesData{
+            datetime
+            mentionsCount
+          }
+        }
+      }
+      """
+
+      result =
+        context.conn
+        |> post("/graphql", query_skeleton(query))
+        |> json_response(200)
+
+      assert result == %{
+               "data" => %{
+                 "wordsSocialVolume" => [
+                   %{
+                     "timeseriesData" => [
+                       %{"datetime" => "2024-09-28T00:00:00Z", "mentionsCount" => 373},
+                       %{"datetime" => "2024-09-29T00:00:00Z", "mentionsCount" => 487},
+                       %{"datetime" => "2024-09-30T00:00:00Z", "mentionsCount" => 323}
+                     ],
+                     "word" => "btc"
+                   },
+                   %{
+                     "timeseriesData" => [
+                       %{"datetime" => "2024-09-28T00:00:00Z", "mentionsCount" => 1681},
+                       %{"datetime" => "2024-09-29T00:00:00Z", "mentionsCount" => 3246},
+                       %{"datetime" => "2024-09-30T00:00:00Z", "mentionsCount" => 1577}
+                     ],
+                     "word" => "eth OR nft"
+                   }
+                 ]
+               }
+             }
+    end)
+  end
+
+  test "successfully fetch words social volume - treatWordAsLuceneQuery: true", context do
+    # This test does not include treatWordAsLuceneQuery: true, so the
+    # words are lowercased before being send and in the response
+    body =
+      %{
+        "data" => %{
+          "BTC" => %{
+            "2024-09-28T00:00:00Z" => 373,
+            "2024-09-29T00:00:00Z" => 487,
+            "2024-09-30T00:00:00Z" => 323
+          },
+          "eth OR nft" => %{
+            "2024-09-28T00:00:00Z" => 1681,
+            "2024-09-29T00:00:00Z" => 3246,
+            "2024-09-30T00:00:00Z" => 1577
+          }
+        }
+      }
+      |> Jason.encode!()
+
+    resp = %HTTPoison.Response{status_code: 200, body: body}
+
+    Sanbase.Mock.prepare_mock(HTTPoison, :get, fn _url, _headers, options ->
+      search_texts =
+        Map.new(options[:params])
+        |> Map.get("search_texts")
+
+      # Assert that the words are **not** lowercased before they are sent
+      assert search_texts == "eth OR nft,BTC"
+
+      {:ok, resp}
+    end)
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      query = """
+      {
+        wordsSocialVolume(
+          selector: { words: ["eth OR nft", "BTC"] }
+          from: "2024-09-28T00:00:00Z"
+          to: "2024-09-30T00:00:00Z"
+          interval: "1d"
+          treatWordAsLuceneQuery: true
+        ){
+          word
+          timeseriesData{
+            datetime
+            mentionsCount
+          }
+        }
+      }
+      """
+
+      result =
+        context.conn
+        |> post("/graphql", query_skeleton(query))
+        |> json_response(200)
+
+      assert result == %{
+               "data" => %{
+                 "wordsSocialVolume" => [
+                   %{
+                     "timeseriesData" => [
+                       %{"datetime" => "2024-09-28T00:00:00Z", "mentionsCount" => 373},
+                       %{"datetime" => "2024-09-29T00:00:00Z", "mentionsCount" => 487},
+                       %{"datetime" => "2024-09-30T00:00:00Z", "mentionsCount" => 323}
+                     ],
+                     "word" => "BTC"
+                   },
+                   %{
+                     "timeseriesData" => [
+                       %{"datetime" => "2024-09-28T00:00:00Z", "mentionsCount" => 1681},
+                       %{"datetime" => "2024-09-29T00:00:00Z", "mentionsCount" => 3246},
+                       %{"datetime" => "2024-09-30T00:00:00Z", "mentionsCount" => 1577}
+                     ],
+                     "word" => "eth OR nft"
+                   }
+                 ]
+               }
+             }
+    end)
+  end
+end


### PR DESCRIPTION
## Changes

Add a boolean parameter named `treatWordAsLuceneQuery` to the `wordsSocialVolume` GraphQL query.
If the parameter is set to `true`, the words are passed to metricshub as they are, so `eth AND nft` becomes a valid input.
If the parameter is set to `false`, the words are lowercased before being sent. This was required because otherwise words that are valid Lucene keywords broke the query. For example, the ticker of notcoin is `NOT`, which is also a keyword, so it needed to be lowercased otherwise it caused a syntax error.
Defaults to `false`.

If a query like `eth OR nft` is queried without setting the flag to `true`, it is interpreted as `eth or nft`, which matches if any of those words is seen in a message, essentially turning it into `eth OR nft OR or`

```graphql
{
  wordsSocialVolume(
    from: "utc_now-2d"
    to: "utc_now"
    interval: "1d"
    selector: {words: ["eth AND nft", "btc"]}
    treatWordAsLuceneQuery: true
  ) {
      word
      timeseriesData {
        mentionsCount
        datetime
      }
  }
}
```
```json
{
  "data": {
    "wordsSocialVolume": [
      {
        "timeseriesData": [
          {
            "datetime": "2024-09-28T00:00:00Z",
            "mentionsCount": 420
          },
          {
            "datetime": "2024-09-29T00:00:00Z",
            "mentionsCount": 487
          },
          {
            "datetime": "2024-09-30T00:00:00Z",
            "mentionsCount": 281
          }
        ],
        "word": "btc"
      },
      {
        "timeseriesData": [
          {
            "datetime": "2024-09-28T00:00:00Z",
            "mentionsCount": 1
          },
          {
            "datetime": "2024-09-29T00:00:00Z",
            "mentionsCount": 2
          },
          {
            "datetime": "2024-09-30T00:00:00Z",
            "mentionsCount": 1
          }
        ],
        "word": "eth AND nft"
      }
    ]
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
