### PR TITLE
Handle preview image generation timeout

### DIFF
--- a/lib/sanbase/alerts/alert.ex
+++ b/lib/sanbase/alerts/alert.ex
@@ -262,19 +262,29 @@ defimpl Sanbase.Alert, for: Any do
       image_url = "#{preview_url()}/chart/#{short_url_id}"
 
       HTTPoison.get(image_url, [basic_auth_header()], timeout: 15_000, recv_timeout: 15_000)
-      |> handle_chart_preview_response(channel, reply_to_message_id)
+      |> handle_chart_preview_response(channel, reply_to_message_id, image_url)
     end)
   end
 
-  defp handle_chart_preview_response({:ok, response}, channel, reply_to_message_id) do
-    image? = response.headers |> Enum.into(%{}) |> Map.get("Content-Type") == "image/jpeg"
+  defp handle_chart_preview_response({:error, error}, _channel, _reply_to_message_id, image_url) do
+    Logger.error("Failed to fetch chart preview image for #{image_url}: #{inspect(error)}")
+  end
 
-    if image? do
-      Sanbase.Telegram.send_photo_by_file_content(
-        channel,
-        response.body,
-        reply_to_message_id
-      )
+  defp handle_chart_preview_response({:ok, response}, channel, reply_to_message_id, image_url) do
+    content_type = response.headers |> Enum.into(%{}) |> Map.get("Content-Type")
+
+    case content_type do
+      "image/jpeg" ->
+        Sanbase.Telegram.send_photo_by_file_content(
+          channel,
+          response.body,
+          reply_to_message_id
+        )
+
+      content_type ->
+        Logger.error(
+          "Response of #{image_url} was expected to be with content type image/jpg, got #{content_type} instead"
+        )
     end
   end
 
@@ -520,7 +530,7 @@ defimpl Sanbase.Alert, for: Any do
 
   defp prod?(), do: Sanbase.Utils.Config.module_get(Sanbase, :deployment_env) == "prod"
 
-  defp preview_url do
+  defp preview_url() do
     case prod?() do
       true -> "https://preview.santiment.net"
       false -> "https://preview-stage.santiment.net"


### PR DESCRIPTION
## Changes

Handle errors that occur when trying to generate a chart preview image in alerts.
Log the preview URL that caused the error (always a timeout for now)
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
