### PR TITLE
Add versioning to open interest exporter

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -87,6 +87,8 @@ config :sanbase, Sanbase.KafkaExporter,
   asset_ohlcv_price_pairs_topic:
     {:system, "KAFKA_ASSET_OHLCV_PRICE_POINTS_TOPIC", "asset_ohlcv_price_pairs"},
   open_interest_topic: {:system, "KAFKA_OPEN_INTEREST_TOPIC", "open_interest_cryptocompare"},
+  open_interest_topic_v2:
+    {:system, "KAFKA_OPEN_INTEREST_TOPIC_V2", "open_interest_cryptocompare_v2"},
   funding_rate_topic: {:system, "KAFKA_FUNDING_RATE_TOPIC", "funding_rate_cryptocompare"},
   api_call_data_topic: {:system, "KAFKA_API_CALL_DATA_TOPIC", "sanbase_api_call_data"},
   twitter_followers_topic: {:system, "KAFKA_TWITTER_FOLLOWERS_TOPIC", "twitter_followers"}

--- a/lib/sanbase/cryptocompare/handler.ex
+++ b/lib/sanbase/cryptocompare/handler.ex
@@ -26,7 +26,9 @@ defmodule Sanbase.Cryptocompare.Handler do
           | {:ok, min_timestamp :: non_neg_integer(), data_list :: list()}
   def get_data(url, process_json_response_function, opts)
       when is_function(process_json_response_function, 1) do
-    timestamps_key = "#{opts[:market]}_#{opts[:instrument]}"
+    # For open_interest we support versioning, so the key might differ by having _v2 suffix
+    timestamps_key =
+      Keyword.get(opts, :exporter_progress_key, "#{opts[:market]}_#{opts[:instrument]}")
 
     case execute_http_request(url, opts) do
       {:ok, %{status_code: 200} = http_response} ->

--- a/lib/sanbase/cryptocompare/open_interest/open_interest_historical_scheduler.ex
+++ b/lib/sanbase/cryptocompare/open_interest/open_interest_historical_scheduler.ex
@@ -57,8 +57,10 @@ defmodule Sanbase.Cryptocompare.OpenInterest.HistoricalScheduler do
 
     {:ok, markets_and_instruments} = Handler.get_markets_and_instruments()
 
-    for {market, instruments} <- markets_and_instruments, instrument <- instruments do
-      new_job(market, instrument, beginning_of_day, schedule_next_job, limit)
+    for {market, instruments} <- markets_and_instruments,
+        instrument <- instruments,
+        version <- ["v1", "v2"] do
+      new_job(market, instrument, beginning_of_day, schedule_next_job, limit, version)
     end
     |> Enum.chunk_every(200)
     |> Enum.each(&Oban.insert_all(@oban_conf_name, &1))
@@ -70,28 +72,29 @@ defmodule Sanbase.Cryptocompare.OpenInterest.HistoricalScheduler do
     schedule_next_job = Keyword.get(opts, :schedule_next_job, false)
     to_datetime = Keyword.get(opts, :to_datetime, DateTime.utc_now())
     to_timestamp = to_datetime |> DateTime.to_unix()
-
+    version = Keyword.get(opts, :version, "v1")
     {:ok, markets_and_instruments} = Handler.get_markets_and_instruments()
 
     for {market, instruments} <- markets_and_instruments, instrument <- instruments do
-      new_job(market, instrument, to_timestamp, schedule_next_job, limit)
+      new_job(market, instrument, to_timestamp, schedule_next_job, limit, version)
     end
     |> Enum.chunk_every(200)
     |> Enum.each(&Oban.insert_all(@oban_conf_name, &1))
   end
 
-  def add_job(market, instrument, timestamp, schedule_next_job, limit) do
-    job = new_job(market, instrument, timestamp, schedule_next_job, limit)
+  def add_job(market, instrument, timestamp, schedule_next_job, limit, version \\ "v1") do
+    job = new_job(market, instrument, timestamp, schedule_next_job, limit, version)
     Oban.insert(@oban_conf_name, job)
   end
 
-  defp new_job(market, instrument, timestamp, schedule_next_job, limit) do
+  defp new_job(market, instrument, timestamp, schedule_next_job, limit, version \\ "v1") do
     Sanbase.Cryptocompare.OpenInterest.HistoricalWorker.new(%{
       market: market,
       instrument: instrument,
       timestamp: timestamp,
       schedule_next_job: schedule_next_job,
-      limit: limit
+      limit: limit,
+      version: version
     })
   end
 end


### PR DESCRIPTION
## Changes
We need to re-export open_interest data into a new kafka topic - `open_interest_cryptocompare_v2` while also exporting data to the old topic.

To do this, introduce `version` to the Oban job.
If no version is provided, `v1` is considered the version. 
In case of `v1` the exporter works the same.
In case the job has version `v2` - it exports to the new kafka topic. Jobs for the same args with different version can work in parallel.

To start an export, we need to schedule manually the historical scrape once:
```elixir
Sanbase.Cryptocompare.OpenInterest.HistoricalScheduler.schedule_jobs(
  limit: 2000,
  version: "v2",
  schedule_next_job: true
)
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
