### PR TITLE
Better handle Oban max_attempts

### DIFF
--- a/lib/sanbase/cryptocompare/funding_rate/funding_rate_historical_worker.ex
+++ b/lib/sanbase/cryptocompare/funding_rate/funding_rate_historical_worker.ex
@@ -17,6 +17,7 @@ defmodule Sanbase.Cryptocompare.FundingRate.HistoricalWorker do
   @queue :cryptocompare_funding_rate_historical_jobs_queue
   use Oban.Worker,
     queue: @queue,
+    max_attempts: 20,
     unique: [period: 60 * 86_400]
 
   alias Sanbase.Utils.Config

--- a/lib/sanbase/cryptocompare/open_interest/open_interest_historical_worker.ex
+++ b/lib/sanbase/cryptocompare/open_interest/open_interest_historical_worker.ex
@@ -17,6 +17,7 @@ defmodule Sanbase.Cryptocompare.OpenInterest.HistoricalWorker do
   @queue :cryptocompare_open_interest_historical_jobs_queue
   use Oban.Worker,
     queue: @queue,
+    max_attempts: 20,
     unique: [period: 60 * 86_400]
 
   alias Sanbase.Utils.Config

--- a/lib/sanbase/cryptocompare/price/price_historical_worker.ex
+++ b/lib/sanbase/cryptocompare/price/price_historical_worker.ex
@@ -31,16 +31,25 @@ defmodule Sanbase.Cryptocompare.Price.HistoricalWorker do
   def conf_name(), do: @oban_conf_name
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: args}) do
+  def perform(%Oban.Job{args: args, attempt: attempt}) do
     %{"base_asset" => base_asset, "quote_asset" => quote_asset, "date" => date} = args
     t1 = System.monotonic_time(:millisecond)
     should_snooze? = base_asset not in available_base_assets()
 
-    case should_snooze? do
-      true ->
+    cond do
+      attempt > 30 ->
+        Logger.info(
+          "[Cryptocompare Historical] The job for #{base_asset}/#{quote_asset} and date #{date} has been snoozed too many times. \
+          Marking it as complete so it's no longer scheduled."
+        )
+
+        {:canceled,
+         "Snoozed too many times because the base asset is not in the list of available assets on Santiment."}
+
+      should_snooze? ->
         {:snooze, 86_400}
 
-      false ->
+      true ->
         case get_data(base_asset, quote_asset, date) do
           {:ok, data} ->
             t2 = System.monotonic_time(:millisecond)
@@ -50,7 +59,16 @@ defmodule Sanbase.Cryptocompare.Price.HistoricalWorker do
             result
 
           :snooze ->
-            {:snooze, 86_400}
+            if attempt > 30 do
+              Logger.info(
+                "[Cryptocompare Historical] The job for #{base_asset}/#{quote_asset} and date #{date} has been snoozed too many times due to errors in the response format. \
+          Marking it as complete so it's no longer scheduled."
+              )
+
+              {:canceled, "Snoozed too many times because the response format is malformed."}
+            else
+              {:snooze, 86_400}
+            end
 
           {:error, error} ->
             {:error, error}

--- a/lib/sanbase/cryptocompare/price/price_historical_worker.ex
+++ b/lib/sanbase/cryptocompare/price/price_historical_worker.ex
@@ -16,6 +16,7 @@ defmodule Sanbase.Cryptocompare.Price.HistoricalWorker do
   """
   use Oban.Worker,
     queue: :cryptocompare_historical_jobs_queue,
+    max_attempts: 20,
     unique: [period: 60 * 86_400]
 
   import Sanbase.Cryptocompare.HTTPHeaderUtils, only: [parse_value_list: 1]


### PR DESCRIPTION
## Changes

- **Add explicit max_attempts to some Oban workers**
- **Avoid snoozing Oban jobs too many times**
  - There are cases on prod where a job has been snoozed over 500 times. Put a limit to that.
  - Snoozed jobs are kept in the `oban_jobs` table, so it has a lot of records.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
