### PR TITLE
Encode/decode social volume words to/from www form

### DIFF
--- a/lib/sanbase/social_data/social_volume.ex
+++ b/lib/sanbase/social_data/social_volume.ex
@@ -44,8 +44,19 @@ defmodule Sanbase.SocialData.SocialVolume do
 
     transformed_words =
       case Keyword.get(opts, :treat_word_as_lucene_query, false) do
-        false -> transformed_words |> Enum.map(&String.downcase/1)
-        true -> transformed_words
+        false ->
+          transformed_words
+          |> Enum.map(fn word ->
+            word
+            |> String.downcase()
+            |> URI.encode_www_form()
+          end)
+
+        true ->
+          Enum.map(transformed_words, fn word ->
+            word
+            |> URI.encode_www_form()
+          end)
       end
 
     selector = %{selector | words: transformed_words}
@@ -98,7 +109,7 @@ defmodule Sanbase.SocialData.SocialVolume do
         |> maybe_format_response(words)
         |> Enum.map(fn {word, %{} = timeseries} ->
           %{
-            word: word,
+            word: URI.decode_www_form(word),
             timeseries_data: social_volume_result(timeseries)
           }
         end)

--- a/test/sanbase_web/graphql/social_data/words_social_volume_api_test.exs
+++ b/test/sanbase_web/graphql/social_data/words_social_volume_api_test.exs
@@ -17,12 +17,12 @@ defmodule SanbaseWeb.Graphql.WordsSocialVolumeApiTest do
     body =
       %{
         "data" => %{
-          "btc" => %{
+          URI.encode_www_form("btc") => %{
             "2024-09-28T00:00:00Z" => 373,
             "2024-09-29T00:00:00Z" => 487,
             "2024-09-30T00:00:00Z" => 323
           },
-          "eth or nft" => %{
+          URI.encode_www_form("eth or nft") => %{
             "2024-09-28T00:00:00Z" => 1681,
             "2024-09-29T00:00:00Z" => 3246,
             "2024-09-30T00:00:00Z" => 1577
@@ -38,8 +38,9 @@ defmodule SanbaseWeb.Graphql.WordsSocialVolumeApiTest do
         Map.new(options[:params])
         |> Map.get("search_texts")
 
-      # Assert that the words are lowercased before they are sent
-      assert search_texts == "eth or nft,btc"
+      # Assert that the words are lowercased and www form encoded
+      assert search_texts ==
+               URI.encode_www_form("eth or nft") <> "," <> URI.encode_www_form("btc")
 
       {:ok, resp}
     end)
@@ -97,12 +98,12 @@ defmodule SanbaseWeb.Graphql.WordsSocialVolumeApiTest do
     body =
       %{
         "data" => %{
-          "BTC" => %{
+          URI.encode_www_form("BTC") => %{
             "2024-09-28T00:00:00Z" => 373,
             "2024-09-29T00:00:00Z" => 487,
             "2024-09-30T00:00:00Z" => 323
           },
-          "eth OR nft" => %{
+          URI.encode_www_form("eth OR nft") => %{
             "2024-09-28T00:00:00Z" => 1681,
             "2024-09-29T00:00:00Z" => 3246,
             "2024-09-30T00:00:00Z" => 1577
@@ -119,7 +120,8 @@ defmodule SanbaseWeb.Graphql.WordsSocialVolumeApiTest do
         |> Map.get("search_texts")
 
       # Assert that the words are **not** lowercased before they are sent
-      assert search_texts == "eth OR nft,BTC"
+      assert search_texts ==
+               URI.encode_www_form("eth OR nft") <> "," <> URI.encode_www_form("BTC")
 
       {:ok, resp}
     end)


### PR DESCRIPTION
## Changes

Otherwise words like $43,000 are considered as 2 words as the comma is
used for a separator. Encoding on our end and metricshub decoding on
its end will fix this problem.

This needs to be deployed together with the metricshub changes.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
