### PR TITLE
Enforce min_interval in getMetric's timeseriesData

### DIFF
--- a/lib/sanbase/social_data/active_users.ex
+++ b/lib/sanbase/social_data/active_users.ex
@@ -10,7 +10,7 @@ defmodule Sanbase.SocialData.ActiveUsers do
   @recv_timeout 25_000
 
   def social_active_users(%{source: source}, from, to, interval)
-      when source in ["telegram", "twitter_crypto"] do
+      when source in ["telegram", "twitter_crypto", "twitter", "reddit", "bitcointalk"] do
     case active_users_request(from, to, interval, source) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, result} = Jason.decode(body)

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -317,12 +317,18 @@ defmodule Sanbase.SocialData.MetricAdapter do
         _ -> [:slug, :text]
       end
 
+    min_interval =
+      case metric do
+        "social_active_users" -> "1d"
+        _ -> "5m"
+      end
+
     {:ok,
      %{
        metric: metric,
        internal_metric: metric,
        has_incomplete_data: has_incomplete_data?(metric),
-       min_interval: "5m",
+       min_interval: min_interval,
        default_aggregation: :sum,
        available_aggregations: @aggregations,
        available_selectors: selectors,


### PR DESCRIPTION
## Changes

- **Set social_active_users min_interval to 1d**
- **Allow more sources in social_active_users**
- **Enforce min_interval. If smaller is provided, replace it with min_interval**

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
