### PR TITLE
Put notification templates in db

### DIFF
--- a/lib/sanbase/notifications.ex
+++ b/lib/sanbase/notifications.ex
@@ -204,4 +204,123 @@ defmodule Sanbase.Notifications do
   def change_notification(%Notification{} = notification, attrs \\ %{}) do
     Notification.changeset(notification, attrs)
   end
+
+  alias Sanbase.Notifications.NotificationTemplate
+
+  @doc """
+  Returns the list of notification_templates.
+
+  ## Examples
+
+      iex> list_notification_templates()
+      [%NotificationTemplate{}, ...]
+
+  """
+  def list_notification_templates do
+    Repo.all(NotificationTemplate)
+  end
+
+  @doc """
+  Gets a single notification_template.
+
+  Raises `Ecto.NoResultsError` if the Notification template does not exist.
+
+  ## Examples
+
+      iex> get_notification_template!(123)
+      %NotificationTemplate{}
+
+      iex> get_notification_template!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_notification_template!(id), do: Repo.get!(NotificationTemplate, id)
+
+  @doc """
+  Creates a notification_template.
+
+  ## Examples
+
+      iex> create_notification_template(%{field: value})
+      {:ok, %NotificationTemplate{}}
+
+      iex> create_notification_template(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_notification_template(attrs \\ %{}) do
+    %NotificationTemplate{}
+    |> NotificationTemplate.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a notification_template.
+
+  ## Examples
+
+      iex> update_notification_template(notification_template, %{field: new_value})
+      {:ok, %NotificationTemplate{}}
+
+      iex> update_notification_template(notification_template, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_notification_template(%NotificationTemplate{} = notification_template, attrs) do
+    notification_template
+    |> NotificationTemplate.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a notification_template.
+
+  ## Examples
+
+      iex> delete_notification_template(notification_template)
+      {:ok, %NotificationTemplate{}}
+
+      iex> delete_notification_template(notification_template)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_notification_template(%NotificationTemplate{} = notification_template) do
+    Repo.delete(notification_template)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking notification_template changes.
+
+  ## Examples
+
+      iex> change_notification_template(notification_template)
+      %Ecto.Changeset{data: %NotificationTemplate{}}
+
+  """
+  def change_notification_template(%NotificationTemplate{} = notification_template, attrs \\ %{}) do
+    NotificationTemplate.changeset(notification_template, attrs)
+  end
+
+  @doc """
+  Gets a template for specific action_type, step, and channel.
+  If no channel-specific template is found, falls back to "all" channel template.
+  """
+  def get_template(action_type, step, channel \\ "all") do
+    # fetch by specific channel
+    case Repo.get_by(NotificationTemplate,
+           action_type: action_type,
+           step: step,
+           channel: channel
+         ) do
+      nil ->
+        Repo.get_by(NotificationTemplate,
+          action_type: action_type,
+          step: step,
+          channel: "all"
+        )
+
+      template ->
+        template
+    end
+  end
 end

--- a/lib/sanbase/notifications/notification_template.ex
+++ b/lib/sanbase/notifications/notification_template.ex
@@ -1,0 +1,26 @@
+defmodule Sanbase.Notifications.NotificationTemplate do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @channels ["email", "telegram", "discord", "all"]
+
+  schema "notification_templates" do
+    field(:channel, :string)
+    field(:action_type, :string)
+    field(:step, :string)
+    field(:template, :string)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(notification_template, attrs) do
+    notification_template
+    |> cast(attrs, [:channel, :action_type, :step, :template])
+    |> validate_required([:channel, :action_type, :template])
+    |> validate_inclusion(:channel, @channels)
+    |> unique_constraint([:action_type, :step, :channel],
+      message: "template already exists for this action_type/step/channel combination"
+    )
+  end
+end

--- a/lib/sanbase_web/generic_admin/notification_template.ex
+++ b/lib/sanbase_web/generic_admin/notification_template.ex
@@ -1,0 +1,28 @@
+defmodule SanbaseWeb.GenericAdmin.NotificationTemplate do
+  def schema_module, do: Sanbase.Notifications.NotificationTemplate
+
+  def resource() do
+    %{
+      actions: [:new, :edit, :delete],
+      new_fields: [:channel, :action_type, :step, :template],
+      edit_fields: [:channel, :action_type, :step, :template],
+      fields_override: %{
+        template: %{
+          type: :text
+        },
+        channel: %{
+          type: :select,
+          collection: ["email", "telegram", "discord", "all"]
+        },
+        action_type: %{
+          type: :select,
+          collection: NotificationActionTypeEnum.__enum_map__() |> Enum.map(&to_string(&1))
+        },
+        step: %{
+          type: :select,
+          collection: NotificationStepEnum.__enum_map__() |> Enum.map(&to_string(&1))
+        }
+      }
+    }
+  end
+end

--- a/lib/sanbase_web/generic_admin/project.ex
+++ b/lib/sanbase_web/generic_admin/project.ex
@@ -81,7 +81,7 @@ defmodule SanbaseWeb.GenericAdmin.Project do
       ],
       fields_override: %{
         long_description: %{
-          type: :textarea
+          type: :text
         },
         infrastructure_id: %{
           value_modifier: &__MODULE__.link/1
@@ -469,10 +469,10 @@ defmodule SanbaseWeb.GenericAdmin.Ico do
       },
       fields_override: %{
         comments: %{
-          type: :textarea
+          type: :text
         },
         contract_abi: %{
-          type: :textarea
+          type: :text
         },
         project_id: %{
           value_modifier: &SanbaseWeb.GenericAdmin.Project.project_link/1

--- a/priv/repo/migrations/20241029080754_create_notification_templates.exs
+++ b/priv/repo/migrations/20241029080754_create_notification_templates.exs
@@ -1,0 +1,19 @@
+defmodule Sanbase.Repo.Migrations.CreateNotificationTemplates do
+  use Ecto.Migration
+
+  def change do
+    create table(:notification_templates) do
+      add(:channel, :string)
+      add(:action_type, :string)
+      add(:step, :string)
+      add(:template, :text)
+
+      timestamps()
+    end
+
+    create(index(:notification_templates, [:action_type, :step]))
+    create(index(:notification_templates, [:channel]))
+
+    create(unique_index(:notification_templates, [:action_type, :step, :channel]))
+  end
+end

--- a/priv/repo/migrations/20241029082533_populate_notification_templates.exs
+++ b/priv/repo/migrations/20241029082533_populate_notification_templates.exs
@@ -1,0 +1,110 @@
+defmodule Sanbase.Repo.Migrations.PopulateNotificationTemplates do
+  use Ecto.Migration
+  alias Sanbase.Notifications.NotificationTemplate
+  alias Sanbase.Repo
+
+  import Ecto.Query
+
+  def up do
+    setup()
+
+    templates = [
+      %{
+        channel: "all",
+        action_type: "create",
+        step: nil,
+        template: """
+        In the latest update the following metrics have been added:
+        {{metrics_list}}
+        For more information, please visit #changelog
+        """
+      },
+      %{
+        channel: "all",
+        action_type: "update",
+        step: "before",
+        template: """
+        In order to make our data more precise, we're going to run a recalculation of the following metrics:
+        {{metrics_list}}
+        This will be done on {{scheduled_at}} and will take approximately {{duration}}
+        """
+      },
+      %{
+        channel: "all",
+        action_type: "update",
+        step: "after",
+        template: """
+        Recalculation of the following metrics has been completed successfully:
+        {{metrics_list}}
+        """
+      },
+      %{
+        channel: "all",
+        action_type: "delete",
+        step: "before",
+        template: """
+        Due to lack of usage, we made a decision to deprecate the following metrics:
+        {{metrics_list}}
+        This is planned to take place on {{scheduled_at}}. Please make sure that you adjust your data consumption accordingly. If you have strong objections, please contact us.
+        """
+      },
+      %{
+        channel: "all",
+        action_type: "delete",
+        step: "reminder",
+        template: """
+        This is a reminder about the scheduled deprecation of the following metrics:
+        {{metrics_list}}
+        It will happen on {{scheduled_at}}. Please make sure to adjust accordingly.
+        """
+      },
+      %{
+        channel: "all",
+        action_type: "delete",
+        step: "after",
+        template: """
+        Deprecation of the following metrics has been completed successfully:
+        {{metrics_list}}
+        """
+      },
+      %{
+        channel: "all",
+        action_type: "alert",
+        step: "detected",
+        template: """
+        Metric delay alert: {{metric_name}} is experiencing a delay due to technical issues. Affected assets: {{asset_categories}}
+        """
+      },
+      %{
+        channel: "all",
+        action_type: "alert",
+        step: "resolved",
+        template: """
+        Metric delay resolved: {{metric_name}} is back to normal
+        """
+      }
+    ]
+
+    templates
+    |> Enum.each(fn template_attrs ->
+      %NotificationTemplate{}
+      |> NotificationTemplate.changeset(template_attrs)
+      |> Repo.insert!()
+    end)
+  end
+
+  def down do
+    setup()
+
+    from(t in NotificationTemplate,
+      where:
+        t.channel == "all" and
+          t.action_type in ["create", "update", "delete", "alert"]
+    )
+    |> Repo.delete_all()
+  end
+
+  defp setup do
+    Application.ensure_all_started(:tzdata)
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2412,6 +2412,40 @@ ALTER SEQUENCE public.notification_actions_id_seq OWNED BY public.notification_a
 
 
 --
+-- Name: notification_templates; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.notification_templates (
+    id bigint NOT NULL,
+    channel character varying(255),
+    action_type character varying(255),
+    step character varying(255),
+    template text,
+    inserted_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: notification_templates_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.notification_templates_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: notification_templates_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.notification_templates_id_seq OWNED BY public.notification_templates.id;
+
+
+--
 -- Name: notifications; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5149,6 +5183,13 @@ ALTER TABLE ONLY public.notification_actions ALTER COLUMN id SET DEFAULT nextval
 
 
 --
+-- Name: notification_templates id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notification_templates ALTER COLUMN id SET DEFAULT nextval('public.notification_templates_id_seq'::regclass);
+
+
+--
 -- Name: notifications id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -6040,6 +6081,14 @@ ALTER TABLE ONLY public.newsletter_tokens
 
 ALTER TABLE ONLY public.notification_actions
     ADD CONSTRAINT notification_actions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: notification_templates notification_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notification_templates
+    ADD CONSTRAINT notification_templates_pkey PRIMARY KEY (id);
 
 
 --
@@ -7096,6 +7145,27 @@ CREATE UNIQUE INDEX metrics_name_index ON public.metrics USING btree (name);
 --
 
 CREATE UNIQUE INDEX monitored_twitter_handles_handle_index ON public.monitored_twitter_handles USING btree (handle);
+
+
+--
+-- Name: notification_templates_action_type_step_channel_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX notification_templates_action_type_step_channel_index ON public.notification_templates USING btree (action_type, step, channel);
+
+
+--
+-- Name: notification_templates_action_type_step_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX notification_templates_action_type_step_index ON public.notification_templates USING btree (action_type, step);
+
+
+--
+-- Name: notification_templates_channel_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX notification_templates_channel_index ON public.notification_templates USING btree (channel);
 
 
 --
@@ -9465,3 +9535,5 @@ INSERT INTO public."schema_migrations" (version) VALUES (20240926135951);
 INSERT INTO public."schema_migrations" (version) VALUES (20241017092520);
 INSERT INTO public."schema_migrations" (version) VALUES (20241018073651);
 INSERT INTO public."schema_migrations" (version) VALUES (20241018075640);
+INSERT INTO public."schema_migrations" (version) VALUES (20241029080754);
+INSERT INTO public."schema_migrations" (version) VALUES (20241029082533);

--- a/test/sanbase/notifications/actions_test.exs
+++ b/test/sanbase/notifications/actions_test.exs
@@ -1,9 +1,16 @@
 defmodule Sanbase.Notifications.ActionsTest do
   use Sanbase.DataCase, async: false
   import Mox
+  import Sanbase.NotificationsFixtures
   alias Sanbase.Notifications
 
   setup :verify_on_exit!
+
+  setup do
+    # Create all required templates before each test
+    create_default_templates()
+    :ok
+  end
 
   test "sends create notification once on Discord" do
     metrics_list = ["Metric A", "Metric B"]
@@ -115,7 +122,7 @@ defmodule Sanbase.Notifications.ActionsTest do
     |> expect(:send_message, 2, fn _webhook, message, _opts ->
       if String.contains?(message, "In order to make our data more precise") do
         expected_before_content = """
-        In order to make our data more precise, we’re going to run a recalculation of the following metrics:
+        In order to make our data more precise, we're going to run a recalculation of the following metrics:
         Metric X, Metric Y
         This will be done on #{scheduled_at_str} and will take approximately #{duration_str}
         """

--- a/test/sanbase/notifications_test.exs
+++ b/test/sanbase/notifications_test.exs
@@ -228,4 +228,91 @@ defmodule Sanbase.NotificationsTest do
       assert %Ecto.Changeset{} = Sanbase.Notifications.change_notification(notification)
     end
   end
+
+  describe "notification_templates" do
+    alias Sanbase.Notifications.NotificationTemplate
+
+    import Sanbase.NotificationsFixtures
+
+    @invalid_attrs %{template: nil, step: nil, channel: nil, action_type: nil}
+
+    test "list_notification_templates/0 returns all notification_templates" do
+      notification_template = notification_template_fixture()
+      assert Notifications.list_notification_templates() == [notification_template]
+    end
+
+    test "get_notification_template!/1 returns the notification_template with given id" do
+      notification_template = notification_template_fixture()
+
+      assert Notifications.get_notification_template!(notification_template.id) ==
+               notification_template
+    end
+
+    test "create_notification_template/1 with valid data creates a notification_template" do
+      valid_attrs = %{
+        template: "some template",
+        step: "some step",
+        channel: "some channel",
+        action_type: "some action_type"
+      }
+
+      assert {:ok, %NotificationTemplate{} = notification_template} =
+               Notifications.create_notification_template(valid_attrs)
+
+      assert notification_template.template == "some template"
+      assert notification_template.step == "some step"
+      assert notification_template.channel == "some channel"
+      assert notification_template.action_type == "some action_type"
+    end
+
+    test "create_notification_template/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} =
+               Notifications.create_notification_template(@invalid_attrs)
+    end
+
+    test "update_notification_template/2 with valid data updates the notification_template" do
+      notification_template = notification_template_fixture()
+
+      update_attrs = %{
+        template: "some updated template",
+        step: "some updated step",
+        channel: "some updated channel",
+        action_type: "some updated action_type"
+      }
+
+      assert {:ok, %NotificationTemplate{} = notification_template} =
+               Notifications.update_notification_template(notification_template, update_attrs)
+
+      assert notification_template.template == "some updated template"
+      assert notification_template.step == "some updated step"
+      assert notification_template.channel == "some updated channel"
+      assert notification_template.action_type == "some updated action_type"
+    end
+
+    test "update_notification_template/2 with invalid data returns error changeset" do
+      notification_template = notification_template_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               Notifications.update_notification_template(notification_template, @invalid_attrs)
+
+      assert notification_template ==
+               Notifications.get_notification_template!(notification_template.id)
+    end
+
+    test "delete_notification_template/1 deletes the notification_template" do
+      notification_template = notification_template_fixture()
+
+      assert {:ok, %NotificationTemplate{}} =
+               Notifications.delete_notification_template(notification_template)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Notifications.get_notification_template!(notification_template.id)
+      end
+    end
+
+    test "change_notification_template/1 returns a notification_template changeset" do
+      notification_template = notification_template_fixture()
+      assert %Ecto.Changeset{} = Notifications.change_notification_template(notification_template)
+    end
+  end
 end

--- a/test/sanbase/notifications_test.exs
+++ b/test/sanbase/notifications_test.exs
@@ -3,6 +3,7 @@ defmodule Sanbase.NotificationsTest do
 
   alias Sanbase.Notifications.NotificationAction
   alias Sanbase.Repo
+  alias Sanbase.Notifications.NotificationTemplate
 
   describe "notification_actions" do
     import Sanbase.NotificationsFixtures
@@ -237,14 +238,14 @@ defmodule Sanbase.NotificationsTest do
     @invalid_attrs %{template: nil, step: nil, channel: nil, action_type: nil}
 
     test "list_notification_templates/0 returns all notification_templates" do
-      notification_template = notification_template_fixture()
-      assert Notifications.list_notification_templates() == [notification_template]
+      {:ok, notification_template} = notification_template_fixture()
+      assert Sanbase.Notifications.list_notification_templates() == [notification_template]
     end
 
     test "get_notification_template!/1 returns the notification_template with given id" do
-      notification_template = notification_template_fixture()
+      {:ok, notification_template} = notification_template_fixture()
 
-      assert Notifications.get_notification_template!(notification_template.id) ==
+      assert Sanbase.Notifications.get_notification_template!(notification_template.id) ==
                notification_template
     end
 
@@ -252,67 +253,75 @@ defmodule Sanbase.NotificationsTest do
       valid_attrs = %{
         template: "some template",
         step: "some step",
-        channel: "some channel",
+        channel: "all",
         action_type: "some action_type"
       }
 
       assert {:ok, %NotificationTemplate{} = notification_template} =
-               Notifications.create_notification_template(valid_attrs)
+               Sanbase.Notifications.create_notification_template(valid_attrs)
 
       assert notification_template.template == "some template"
       assert notification_template.step == "some step"
-      assert notification_template.channel == "some channel"
+      assert notification_template.channel == "all"
       assert notification_template.action_type == "some action_type"
     end
 
     test "create_notification_template/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} =
-               Notifications.create_notification_template(@invalid_attrs)
+               Sanbase.Notifications.create_notification_template(@invalid_attrs)
     end
 
     test "update_notification_template/2 with valid data updates the notification_template" do
-      notification_template = notification_template_fixture()
+      {:ok, notification_template} = notification_template_fixture()
 
       update_attrs = %{
         template: "some updated template",
         step: "some updated step",
-        channel: "some updated channel",
+        channel: "all",
         action_type: "some updated action_type"
       }
 
       assert {:ok, %NotificationTemplate{} = notification_template} =
-               Notifications.update_notification_template(notification_template, update_attrs)
+               Sanbase.Notifications.update_notification_template(
+                 notification_template,
+                 update_attrs
+               )
 
       assert notification_template.template == "some updated template"
       assert notification_template.step == "some updated step"
-      assert notification_template.channel == "some updated channel"
+      assert notification_template.channel == "all"
       assert notification_template.action_type == "some updated action_type"
     end
 
     test "update_notification_template/2 with invalid data returns error changeset" do
-      notification_template = notification_template_fixture()
+      {:ok, notification_template} = notification_template_fixture()
 
       assert {:error, %Ecto.Changeset{}} =
-               Notifications.update_notification_template(notification_template, @invalid_attrs)
+               Sanbase.Notifications.update_notification_template(
+                 notification_template,
+                 @invalid_attrs
+               )
 
       assert notification_template ==
-               Notifications.get_notification_template!(notification_template.id)
+               Sanbase.Notifications.get_notification_template!(notification_template.id)
     end
 
     test "delete_notification_template/1 deletes the notification_template" do
-      notification_template = notification_template_fixture()
+      {:ok, notification_template} = notification_template_fixture()
 
       assert {:ok, %NotificationTemplate{}} =
-               Notifications.delete_notification_template(notification_template)
+               Sanbase.Notifications.delete_notification_template(notification_template)
 
       assert_raise Ecto.NoResultsError, fn ->
-        Notifications.get_notification_template!(notification_template.id)
+        Sanbase.Notifications.get_notification_template!(notification_template.id)
       end
     end
 
     test "change_notification_template/1 returns a notification_template changeset" do
-      notification_template = notification_template_fixture()
-      assert %Ecto.Changeset{} = Notifications.change_notification_template(notification_template)
+      {:ok, notification_template} = notification_template_fixture()
+
+      assert %Ecto.Changeset{} =
+               Sanbase.Notifications.change_notification_template(notification_template)
     end
   end
 end

--- a/test/support/fixtures/notifications_fixtures.ex
+++ b/test/support/fixtures/notifications_fixtures.ex
@@ -45,4 +45,109 @@ defmodule Sanbase.NotificationsFixtures do
     })
     |> Notifications.create_notification()
   end
+
+  @doc """
+  Creates all the default notification templates needed for testing.
+  """
+  def create_default_templates do
+    # Create template
+    notification_template_fixture(%{
+      channel: "all",
+      action_type: "create",
+      step: "once",
+      template: """
+      In the latest update the following metrics have been added:
+      {{metrics_list}}
+      For more information, please visit #changelog
+      """
+    })
+
+    # Update templates
+    notification_template_fixture(%{
+      channel: "all",
+      action_type: "update",
+      step: "before",
+      template: """
+      In order to make our data more precise, we're going to run a recalculation of the following metrics:
+      {{metrics_list}}
+      This will be done on {{scheduled_at}} and will take approximately {{duration}}
+      """
+    })
+
+    notification_template_fixture(%{
+      channel: "all",
+      action_type: "update",
+      step: "after",
+      template: """
+      Recalculation of the following metrics has been completed successfully:
+      {{metrics_list}}
+      """
+    })
+
+    # Delete templates
+    notification_template_fixture(%{
+      channel: "all",
+      action_type: "delete",
+      step: "before",
+      template: """
+      Due to lack of usage, we made a decision to deprecate the following metrics:
+      {{metrics_list}}
+      This is planned to take place on {{scheduled_at}}. Please make sure that you adjust your data consumption accordingly. If you have strong objections, please contact us.
+      """
+    })
+
+    notification_template_fixture(%{
+      channel: "all",
+      action_type: "delete",
+      step: "reminder",
+      template: """
+      This is a reminder about the scheduled deprecation of the following metrics:
+      {{metrics_list}}
+      It will happen on {{scheduled_at}}. Please make sure to adjust accordingly.
+      """
+    })
+
+    notification_template_fixture(%{
+      channel: "all",
+      action_type: "delete",
+      step: "after",
+      template: """
+      Deprecation of the following metrics has been completed successfully:
+      {{metrics_list}}
+      """
+    })
+
+    # Alert templates
+    notification_template_fixture(%{
+      channel: "all",
+      action_type: "alert",
+      step: "detected",
+      template: """
+      Metric delay alert: {{metric_name}} is experiencing a delay due to technical issues. Affected assets: {{asset_categories}}
+      """
+    })
+
+    notification_template_fixture(%{
+      channel: "all",
+      action_type: "alert",
+      step: "resolved",
+      template: """
+      Metric delay resolved: {{metric_name}} is back to normal
+      """
+    })
+  end
+
+  @doc """
+  Generate a notification_template.
+  """
+  def notification_template_fixture(attrs \\ %{}) do
+    attrs
+    |> Enum.into(%{
+      action_type: "some action_type",
+      channel: "all",
+      step: "some step",
+      template: "some template"
+    })
+    |> Sanbase.Notifications.create_notification_template()
+  end
 end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

Add notifications templates in db

![image](https://github.com/user-attachments/assets/bef07f9e-c332-411b-8491-86339c0d189c)


## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
