### PR TITLE
Add Fraxlend total supplied and borrowed metrics to the API

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -5212,6 +5212,106 @@
     "docs_links": ["https://academy.santiment.net/metrics/lending-and-borrowing-protocols/fraxlend"]
   },
   {
+    "human_readable_name": "Fraxlend total supplied",
+    "name": "fraxlend_total_supplied",
+    "metric": "fraxlend_total_supplied",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries",
+    "docs_links": ["https://academy.santiment.net/metrics/lending-and-borrowing-protocols/fraxlend"]
+  },
+  {
+    "human_readable_name": "Fraxlend total supplied in USD",
+    "name": "fraxlend_total_supplied_usd",
+    "metric": "fraxlend_total_supplied_usd",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries",
+    "docs_links": ["https://academy.santiment.net/metrics/lending-and-borrowing-protocols/fraxlend"]
+  },
+  {
+    "human_readable_name": "Fraxlend total borrowed against collateral",
+    "name": "fraxlend_total_borrowed_against_collateral",
+    "metric": "fraxlend_total_borrowed_against_collateral",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries",
+    "docs_links": ["https://academy.santiment.net/metrics/lending-and-borrowing-protocols/fraxlend"]
+  },
+  {
+    "human_readable_name": "Fraxlend protocol total supplied in USD",
+    "name": "fraxlend_protocol_total_supplied_usd",
+    "metric": "fraxlend_total_protocol_supplied_usd",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries",
+    "docs_links": ["https://academy.santiment.net/metrics/lending-and-borrowing-protocols/fraxlend"]
+  },
+  {
+    "human_readable_name": "Fraxlend protocol total borrowed",
+    "name": "fraxlend_protocol_total_borrowed",
+    "metric": "fraxlend_total_protocol_borrowed",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "pro",
+      "SANBASE": "free"
+    },
+    "aggregation": "last",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries",
+    "docs_links": ["https://academy.santiment.net/metrics/lending-and-borrowing-protocols/fraxlend"]
+  },
+  {
     "human_readable_name": "Fraxlend borrow APY",
     "name": "fraxlend_borrow_apy",
     "metric": "fraxlend_borrow_apy",

--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -5292,9 +5292,9 @@
     "docs_links": ["https://academy.santiment.net/metrics/lending-and-borrowing-protocols/fraxlend"]
   },
   {
-    "human_readable_name": "Fraxlend protocol total borrowed",
-    "name": "fraxlend_protocol_total_borrowed",
-    "metric": "fraxlend_total_protocol_borrowed",
+    "human_readable_name": "Fraxlend protocol total borrowed in USD",
+    "name": "fraxlend_protocol_total_borrowed_usd",
+    "metric": "fraxlend_total_protocol_borrowed_usd",
     "version": "2019-01-01",
     "access": "restricted",
     "selectors": [

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -1586,6 +1586,11 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "fraxlend_total_liquidations_usd",
         "fraxlend_total_new_debt_usd",
         "fraxlend_total_repayments_usd",
+        "fraxlend_total_supplied",
+        "fraxlend_total_supplied_usd",
+        "fraxlend_total_borrowed_against_collateral",
+        "fraxlend_protocol_total_supplied_usd",
+        "fraxlend_protocol_total_borrowed",
         "fraxlend_borrow_apy",
         "fraxlend_active_addresses",
         # Spark metrics

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -1590,7 +1590,7 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "fraxlend_total_supplied_usd",
         "fraxlend_total_borrowed_against_collateral",
         "fraxlend_protocol_total_supplied_usd",
-        "fraxlend_protocol_total_borrowed",
+        "fraxlend_protocol_total_borrowed_usd",
         "fraxlend_borrow_apy",
         "fraxlend_active_addresses",
         # Spark metrics


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Add Fraxlend total supplied and borrowed metrics to the API

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
