### PR TITLE
Fix aggregations in Metric.Helper

### DIFF
--- a/lib/sanbase/metric/helper.ex
+++ b/lib/sanbase/metric/helper.ex
@@ -21,8 +21,8 @@ defmodule Sanbase.Metric.Helper do
   # This way the default data shown is for the metrics from the Price module
   # This way the behavior is backward compatible
   @modules [
-    Sanbase.Price.MetricAdapter,
     Sanbase.PricePair.MetricAdapter,
+    Sanbase.Price.MetricAdapter,
     Sanbase.Clickhouse.Github.MetricAdapter,
     Sanbase.SocialData.MetricAdapter,
     Sanbase.Twitter.MetricAdapter,
@@ -156,7 +156,7 @@ defmodule Sanbase.Metric.Helper do
         # If there is a metric that has a different set of aggregations compared to
         # the other metrics in the module, this needs to be reworked to call
         # module.metadata(metric)
-        Map.put_new(acc, metric, [nil] ++ module.available_aggregations())
+        Map.put(acc, metric, [nil] ++ module.available_aggregations())
     end
   end
 
@@ -199,7 +199,7 @@ defmodule Sanbase.Metric.Helper do
         metric <- module.available_metrics(),
         reduce: %{} do
       acc ->
-        Map.put_new(acc, metric, module)
+        Map.put(acc, metric, module)
     end
   end
 
@@ -218,7 +218,7 @@ defmodule Sanbase.Metric.Helper do
         metric <- module.available_timeseries_metrics(),
         reduce: %{} do
       acc ->
-        Map.put_new(acc, metric, module)
+        Map.put(acc, metric, module)
     end
   end
 
@@ -237,7 +237,7 @@ defmodule Sanbase.Metric.Helper do
         metric <- module.available_histogram_metrics(),
         reduce: %{} do
       acc ->
-        Map.put_new(acc, metric, module)
+        Map.put(acc, metric, module)
     end
   end
 
@@ -256,7 +256,7 @@ defmodule Sanbase.Metric.Helper do
         metric <- module.available_table_metrics(),
         reduce: %{} do
       acc ->
-        Map.put_new(acc, metric, module)
+        Map.put(acc, metric, module)
     end
   end
 

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -13,7 +13,7 @@ defmodule Sanbase.SocialData.MetricAdapter do
   alias Sanbase.SocialData.SocialHelper
   alias Sanbase.Project
 
-  @aggregations [:sum]
+  @aggregations [:sum, :avg]
   @sources ["total"] ++ SocialHelper.sources()
   @social_volume_timeseries_metrics ["nft_social_volume"] ++
                                       Enum.map(@sources, fn source ->
@@ -323,13 +323,20 @@ defmodule Sanbase.SocialData.MetricAdapter do
         _ -> "5m"
       end
 
+    default_aggregation =
+      cond do
+        String.contains?(metric, "social_dominance") -> :avg
+        String.contains?(metric, "volume_consumed") -> :avg
+        true -> :sum
+      end
+
     {:ok,
      %{
        metric: metric,
        internal_metric: metric,
        has_incomplete_data: has_incomplete_data?(metric),
        min_interval: min_interval,
-       default_aggregation: :sum,
+       default_aggregation: default_aggregation,
        available_aggregations: @aggregations,
        available_selectors: selectors,
        required_selectors: [],


### PR DESCRIPTION
## Changes

Use Map.put/2 instead of Map.put_new/3 in order to respect the order of
the modules. The Clickhouse.MetricAdapter must take precedence over the
SocialData.MetricAdapter

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
