### PR TITLE
Replace eth_transfers_to with eth_transfers

### DIFF
--- a/lib/sanbase/dashboard-old/database/tables.json
+++ b/lib/sanbase/dashboard-old/database/tables.json
@@ -101,32 +101,6 @@
         "primaryKey": "UInt64"
     },
     {
-        "table": "eth_transfers_to",
-        "description": "Provide the on-chain transfers for Ethereum itself with a different `order_by`",
-        "engine": "Distributed",
-        "partition_by": "toStartOfMonth(dt)",
-        "order_by": [
-            "from",
-            "type",
-            "to",
-            "dt",
-            "transactionHash",
-            "primaryKey"
-        ],
-        "columns": {
-            "dt": "DateTime",
-            "from": "String",
-            "to": "String",
-            "value": "Float64",
-            "valueExactBase36": "String",
-            "blockNumber": "UInt32",
-            "transactionHash": "String",
-            "transactionPosition": "UInt32",
-            "type": "Enum8('call' = 0, 'fee' = 1, 'genesis' = 2, 'suicide' = 3, 'reward' = 4, 'create' = 5, 'dao_hack' = 6, 'fee_burnt' = 7)"
-        },
-        "primaryKey": "UInt64"
-    },
-    {
         "table": "erc20_transfers",
         "description": "Provide the on-chain transfers for Ethereum itself",
         "engine": "Distributed",

--- a/lib/sanbase/transfers/eth_transfers.ex
+++ b/lib/sanbase/transfers/eth_transfers.ex
@@ -249,7 +249,7 @@ defmodule Sanbase.Transfers.EthTransfers do
       UNION ALL
 
       SELECT dt, any(value) AS incoming, 0 AS outgoing
-      FROM eth_transfers_to
+      FROM eth_transfers
       PREWHERE
         to in ({{addresses}}) AND
         dt >= toDateTime({{from}}) AND
@@ -276,10 +276,10 @@ defmodule Sanbase.Transfers.EthTransfers do
         :transfers_count -> "transfers_count"
       end
 
-    {select_column, filter_column, table} =
+    {select_column, filter_column} =
       case type do
-        :incoming -> {"from", "to", "eth_transfers_to"}
-        :outgoing -> {"to", "from", "eth_transfers"}
+        :incoming -> {"from", "to"}
+        :outgoing -> {"to", "from"}
       end
 
     sql = """
@@ -290,7 +290,7 @@ defmodule Sanbase.Transfers.EthTransfers do
       COUNT(*) AS transfers_count
     FROM (
       SELECT dt, type, from, to, anyLast(value) AS value
-      FROM #{table}
+      FROM eth_transfers
       WHERE
         #{filter_column} = {{address}} AND
         type != 'fee' AND


### PR DESCRIPTION
## Changes
Now the eth_transfers uses the PROJECTION Clickhouse feature, which
speeds up queries on columns that are not part of the primary key:
https://clickhouse.com/docs/en/sql-reference/statements/alter/projection


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
