### PR TITLE
Change the start order of the apps

### DIFF
--- a/lib/sanbase/application/application.ex
+++ b/lib/sanbase/application/application.ex
@@ -277,23 +277,14 @@ defmodule Sanbase.Application do
       end
 
     [
-      # Start the PubSub
-      {Phoenix.PubSub, name: Sanbase.PubSub},
-
-      # Start the Presence
-      SanbaseWeb.Presence,
-
-      # Start the endpoint when the application starts
-      SanbaseWeb.Endpoint,
+      # Telemetry metrics
+      SanbaseWeb.Telemetry,
 
       # Prometheus metrics
       SanbaseWeb.Prometheus,
 
       # Start the Postgres Ecto repository
       Sanbase.Repo,
-
-      # Telemetry metrics
-      SanbaseWeb.Telemetry,
 
       # Start the main ClickhouseRepo. This is started in all
       # pods as each pod will need it.
@@ -308,6 +299,15 @@ defmodule Sanbase.Application do
 
       # Start the clickhouse read-only repos for different plans
       clickhouse_readonly_per_plan_children,
+
+      # Start the PubSub
+      {Phoenix.PubSub, name: Sanbase.PubSub},
+
+      # Start the Presence
+      SanbaseWeb.Presence,
+
+      # Start the endpoint when the application starts
+      SanbaseWeb.Endpoint,
 
       # Star the API call service
       Sanbase.ApiCallLimit.ETS,


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Whe have errors like:

```
RuntimeError
could not lookup Ecto repo Sanbase.Repo because it was not started or it does not exist
```
which most probably happen on k8s pod start/shutdown.
Start `Sanbase.Repo` before the `Endpoint` as an attempt to fix them.

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
