### PR TITLE
Add tweetId to getMostTweets

### DIFF
--- a/lib/sanbase/social_data/tweet.ex
+++ b/lib/sanbase/social_data/tweet.ex
@@ -37,6 +37,7 @@ defmodule Sanbase.SocialData.Tweet do
       tweets =
         Enum.map(list, fn map ->
           %{
+            tweet_id: Map.fetch!(map, "tweet_id") |> to_string(),
             text: Map.fetch!(map, "text"),
             screen_name: Map.fetch!(map, "screen_name"),
             datetime:

--- a/lib/sanbase_web/graphql/schema/types/social_data_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/social_data_types.ex
@@ -48,6 +48,7 @@ defmodule SanbaseWeb.Graphql.SocialDataTypes do
   end
 
   object :tweet do
+    field(:tweet_id, non_null(:string))
     field(:datetime, non_null(:datetime))
     field(:text, non_null(:string))
     field(:screen_name, non_null(:string))

--- a/test/sanbase_web/graphql/social_data/most_tweets_test.exs
+++ b/test/sanbase_web/graphql/social_data/most_tweets_test.exs
@@ -28,6 +28,7 @@ defmodule SanbaseWeb.Graphql.MostTweetsSocialDataTest do
           size: 2){
             slug
             tweets{
+              tweetId
               datetime
               text
               screenName
@@ -50,6 +51,17 @@ defmodule SanbaseWeb.Graphql.MostTweetsSocialDataTest do
                "slug" => "bitcoin",
                "tweets" => [
                  %{
+                   "datetime" => "2024-11-27T21:19:50Z",
+                   "repliesCount" => 0,
+                   "retweetsCount" => 0,
+                   "screenName" => "CryptoLifer33",
+                   "sentimentNegative" => 0.0044069796,
+                   "sentimentPositive" => 0.9955930204,
+                   "text" =>
+                     "Life is good. I made thousands trading today and life is good. Thank God, thanks to Bitcoin, my family and #Florida What do you do to celebrate your wins? https://t.co/gY5c5Eb8Dh",
+                   "tweetId" => "1861882647930085536"
+                 },
+                 %{
                    "datetime" => "2024-11-26T18:21:30Z",
                    "repliesCount" => 0,
                    "retweetsCount" => 0,
@@ -57,17 +69,8 @@ defmodule SanbaseWeb.Graphql.MostTweetsSocialDataTest do
                    "sentimentNegative" => 0.0171372827,
                    "sentimentPositive" => 0.9828627173,
                    "text" =>
-                     "Whipsaw wick completed, lets continue. \n\n$BTC https://t.co/e8mH8RUKjO"
-                 },
-                 %{
-                   "datetime" => "2024-11-26T19:07:51Z",
-                   "repliesCount" => 0,
-                   "retweetsCount" => 0,
-                   "screenName" => "IIICapital",
-                   "sentimentNegative" => 0.0222001588,
-                   "sentimentPositive" => 0.9777998412,
-                   "text" =>
-                     "Incredible podcast with two of the sharpest minds in bitcoin.\n\nThank you both for the time @Excellion and @dhruvbansal.\n\nTune in and comment whether you think bitcoin was an invention or discovery!"
+                     "Whipsaw wick completed, lets continue. \n\n$BTC https://t.co/e8mH8RUKjO",
+                   "tweetId" => "1861475381548851381"
                  }
                ]
              } in result
@@ -83,7 +86,8 @@ defmodule SanbaseWeb.Graphql.MostTweetsSocialDataTest do
                    "sentimentNegative" => 0.0269591219,
                    "sentimentPositive" => 0.9730408781,
                    "text" =>
-                     "Thanks for hosting this debate @laurashin! While I think Justin and I share a similar vision of what Ethereum should ideally become in a couple of years, he thinks we are on track for it - I believe decisive action is needed now to achieve that vision."
+                     "Thanks for hosting this debate @laurashin! While I think Justin and I share a similar vision of what Ethereum should ideally become in a couple of years, he thinks we are on track for it - I believe decisive action is needed now to achieve that vision.",
+                   "tweetId" => "1861456784457654773"
                  },
                  %{
                    "datetime" => "2024-11-27T14:00:12Z",
@@ -93,7 +97,8 @@ defmodule SanbaseWeb.Graphql.MostTweetsSocialDataTest do
                    "sentimentNegative" => 0.0277438289,
                    "sentimentPositive" => 0.9722561711,
                    "text" =>
-                     "New Launch Alert ✈️\n\nA big welcome to @doge_eth_gov who have launched an $DOGE - $WETH pool on Aerodrome.\n\nBridge $DOGE from Ethereum mainnet to @base, powered by @axelar: https://t.co/wejMHuq62H\n\nLiquidity has been added and LP rewards incoming. https://t.co/A5lpoDZakD"
+                     "New Launch Alert ✈️\n\nA big welcome to @doge_eth_gov who have launched an $DOGE - $WETH pool on Aerodrome.\n\nBridge $DOGE from Ethereum mainnet to @base, powered by @axelar: https://t.co/wejMHuq62H\n\nLiquidity has been added and LP rewards incoming. https://t.co/A5lpoDZakD",
+                   "tweetId" => "1861772012814991729"
                  }
                ]
              } in result
@@ -104,9 +109,9 @@ defmodule SanbaseWeb.Graphql.MostTweetsSocialDataTest do
     %{
       "data" => %{
         "bitcoin" =>
-          "[{\"screen_name\":\"take_gains\",\"text\":\"Whipsaw wick completed, lets continue. \\n\\n$BTC https:\\/\\/t.co\\/e8mH8RUKjO\",\"reply\":0,\"retweet\":0,\"timestamp\":\"2024-11-26T18:21:30\",\"sentiment_neg\":0.0171372827,\"sentiment_pos\":0.9828627173},{\"screen_name\":\"IIICapital\",\"text\":\"Incredible podcast with two of the sharpest minds in bitcoin.\\n\\nThank you both for the time @Excellion and @dhruvbansal.\\n\\nTune in and comment whether you think bitcoin was an invention or discovery!\",\"reply\":0,\"retweet\":0,\"timestamp\":\"2024-11-26T19:07:51\",\"sentiment_neg\":0.0222001588,\"sentiment_pos\":0.9777998412}]",
+          "[{\"tweet_id\":1861882647930085536,\"screen_name\":\"CryptoLifer33\",\"text\":\"Life is good. I made thousands trading today and life is good. Thank God, thanks to Bitcoin, my family and #Florida What do you do to celebrate your wins? https:\\/\\/t.co\\/gY5c5Eb8Dh\",\"reply\":0,\"retweet\":0,\"timestamp\":\"2024-11-27T21:19:50\",\"sentiment_neg\":0.0044069796,\"sentiment_pos\":0.9955930204},{\"tweet_id\":1861475381548851381,\"screen_name\":\"take_gains\",\"text\":\"Whipsaw wick completed, lets continue. \\n\\n$BTC https:\\/\\/t.co\\/e8mH8RUKjO\",\"reply\":0,\"retweet\":0,\"timestamp\":\"2024-11-26T18:21:30\",\"sentiment_neg\":0.0171372827,\"sentiment_pos\":0.9828627173}]",
         "ethereum" =>
-          "[{\"screen_name\":\"koeppelmann\",\"text\":\"Thanks for hosting this debate @laurashin! While I think Justin and I share a similar vision of what Ethereum should ideally become in a couple of years, he thinks we are on track for it - I believe decisive action is needed now to achieve that vision.\",\"reply\":0,\"retweet\":0,\"timestamp\":\"2024-11-26T17:07:36\",\"sentiment_neg\":0.0269591219,\"sentiment_pos\":0.9730408781},{\"screen_name\":\"AerodromeFi\",\"text\":\"New Launch Alert \\u2708\\ufe0f\\n\\nA big welcome to @doge_eth_gov who have launched an $DOGE - $WETH pool on Aerodrome.\\n\\nBridge $DOGE from Ethereum mainnet to @base, powered by @axelar: https:\\/\\/t.co\\/wejMHuq62H\\n\\nLiquidity has been added and LP rewards incoming. https:\\/\\/t.co\\/A5lpoDZakD\",\"reply\":0,\"retweet\":1,\"timestamp\":\"2024-11-27T14:00:12\",\"sentiment_neg\":0.0277438289,\"sentiment_pos\":0.9722561711}]"
+          "[{\"tweet_id\":1861456784457654773,\"screen_name\":\"koeppelmann\",\"text\":\"Thanks for hosting this debate @laurashin! While I think Justin and I share a similar vision of what Ethereum should ideally become in a couple of years, he thinks we are on track for it - I believe decisive action is needed now to achieve that vision.\",\"reply\":0,\"retweet\":0,\"timestamp\":\"2024-11-26T17:07:36\",\"sentiment_neg\":0.0269591219,\"sentiment_pos\":0.9730408781},{\"tweet_id\":1861772012814991729,\"screen_name\":\"AerodromeFi\",\"text\":\"New Launch Alert \\u2708\\ufe0f\\n\\nA big welcome to @doge_eth_gov who have launched an $DOGE - $WETH pool on Aerodrome.\\n\\nBridge $DOGE from Ethereum mainnet to @base, powered by @axelar: https:\\/\\/t.co\\/wejMHuq62H\\n\\nLiquidity has been added and LP rewards incoming. https:\\/\\/t.co\\/A5lpoDZakD\",\"reply\":0,\"retweet\":1,\"timestamp\":\"2024-11-27T14:00:12\",\"sentiment_neg\":0.0277438289,\"sentiment_pos\":0.9722561711}]"
       }
     }
   end


### PR DESCRIPTION
## Changes
Add tweetId to the tweets in getMostTweets:

```graphql
{
  getMostTweets(
    tweetType: MOST_POSITIVE
    selector: {slugs: ["bitcoin", "ethereum"]}
    from: "2024-11-24T00:00:00Z"
    to: "2024-11-27T00:00:00Z"
    size:10
    ){
      slug
      tweets{
        tweetId
        datetime
        text
        screenName
        sentimentPositive
        sentimentNegative
        repliesCount
        retweetsCount
      }
    }
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
