### PR TITLE
Add whale transaction volumes to API

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
+++ b/lib/sanbase/clickhouse/metric/metric_files/available_v2_metrics.json
@@ -1604,7 +1604,47 @@
     "table": "intraday_metrics",
     "has_incomplete_data": false,
     "data_type": "timeseries",
-    "docs_links": ["https://academy.santiment.net/metrics/whale-transaction-count"]
+    "docs_links": ["https://academy.santiment.net/metrics/whale-transaction-volume"]
+  },
+  {
+    "human_readable_name": "Total USD volume of Transactions Transferring More Than 100k USD",
+    "name": "whale_transaction_volume_100k_usd_to_inf",
+    "metric": "whale_transaction_volume_more_than_100k_usd",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "sum",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries",
+    "docs_links": ["https://academy.santiment.net/metrics/whale-transaction-volume"]
+  },
+  {
+    "human_readable_name": "Total USD volume of Transactions Transferring More Than 1 million USD",
+    "name": "whale_transaction_volume_1m_usd_to_inf",
+    "metric": "whale_transaction_volume_more_than_1m_usd",
+    "version": "2019-01-01",
+    "access": "restricted",
+    "selectors": [
+      "slug"
+    ],
+    "min_plan": {
+      "SANAPI": "free",
+      "SANBASE": "free"
+    },
+    "aggregation": "sum",
+    "min_interval": "5m",
+    "table": "intraday_metrics",
+    "has_incomplete_data": false,
+    "data_type": "timeseries",
+    "docs_links": ["https://academy.santiment.net/metrics/whale-transaction-volume"]
   },
   {
     "human_readable_name": "Price in ETH",

--- a/test/sanbase/billing/metric_access_level_test.exs
+++ b/test/sanbase/billing/metric_access_level_test.exs
@@ -804,6 +804,8 @@ defmodule Sanbase.Billing.MetricAccessLevelTest do
         "median_transfer_5m",
         "whale_transaction_count_100k_usd_to_inf",
         "whale_transaction_count_1m_usd_to_inf",
+        "whale_transaction_volume_100k_usd_to_inf",
+        "whale_transaction_volume_1m_usd_to_inf",
         "mvrv_usd_z_score",
         "stock_to_flow",
         "miners_total_supply",


### PR DESCRIPTION
## Changes
Add two metrics to API:
- whale_transaction_volume_100k_usd_to_inf
- whale_transaction_volume_1m_usd_to_inf
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
