### PR TITLE
Fix issues with /available_metrics

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/metric/metric_adapter.ex
@@ -261,12 +261,14 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
 
   @impl Sanbase.Metric.Behaviour
   def available_slugs(), do: get_available_slugs()
-
   @impl Sanbase.Metric.Behaviour
   def available_slugs(metric) do
     cond do
+      "age_distribution" ->
+        # avoid infinite loop if it goes into HistogramMetric
+        get_available_slugs(metric)
+
       metric in Registry.metrics_mapset_with_data_type(:histogram) ->
-        # otherwise age_distribution causes an infinite loop
         HistogramMetric.available_slugs(metric)
 
       true ->


### PR DESCRIPTION
## Changes
- Fix infinite loop in age_distribution
- Order the metrics by first re-computing the ones that were not
  computed for the longest time


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
