### PR TITLE
Add disconnectTelegramBot mutation

### DIFF
--- a/lib/sanbase/accounts/accounts_event_emitter.ex
+++ b/lib/sanbase/accounts/accounts_event_emitter.ex
@@ -45,6 +45,22 @@ defmodule Sanbase.Accounts.EventEmitter do
     |> notify()
   end
 
+  def handle_event(
+        {:ok, user},
+        :disconnect_telegram_bot,
+        %{telegram_chat_id: telegram_chat_id} = args
+      ) do
+    Map.merge(
+      %{
+        event_type: :disconnect_telegram_bot,
+        user_id: user.id,
+        telegram_chat_id: telegram_chat_id
+      },
+      args
+    )
+    |> notify()
+  end
+
   def handle_event({:ok, user}, :update_email_candidate, %{email_candidate: _} = args) do
     Map.merge(%{event_type: :update_email_candidate, user_id: user.id}, args)
     |> notify()

--- a/lib/sanbase/event_bus/event_validation.ex
+++ b/lib/sanbase/event_bus/event_validation.ex
@@ -20,6 +20,13 @@ defmodule Sanbase.EventBus.EventValidation do
   def valid?(%{event_type: :update_email_candidate, user_id: id, email_candidate: email}),
     do: valid_integer_id?(id) and is_binary(email)
 
+  def valid?(%{
+        event_type: :disconnect_telegram_bot,
+        user_id: id,
+        telegram_chat_id: telegram_chat_id
+      }),
+      do: valid_integer_id?(id) and is_integer(telegram_chat_id)
+
   def valid?(%{event_type: :register_user, user_id: id, login_origin: login_origin}),
     do: valid_integer_id?(id) and (is_atom(login_origin) or is_binary(login_origin))
 

--- a/lib/sanbase/event_bus/user_events_subscriber.ex
+++ b/lib/sanbase/event_bus/user_events_subscriber.ex
@@ -114,6 +114,26 @@ defmodule Sanbase.EventBus.UserEventsSubscriber do
     state
   end
 
+  defp handle_event(
+         %{
+           data: %{
+             event_type: :disconnect_telegram_bot,
+             user_id: _,
+             telegram_chat_id: chat_id
+           }
+         },
+         event_shadow,
+         state
+       ) do
+    Sanbase.Telegram.send_message_to_chat_id(
+      chat_id,
+      "You have successfully disconnected your Telegram bot from your Sanbase profile."
+    )
+
+    EventBus.mark_as_completed({__MODULE__, event_shadow})
+    state
+  end
+
   defp handle_event(_event, event_shadow, state) do
     # The unhandled events are marked as completed
     EventBus.mark_as_completed({__MODULE__, event_shadow})

--- a/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
@@ -174,6 +174,21 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserResolver do
     end
   end
 
+  def disconnect_telegram_bot(_root, _args, %{context: %{auth: %{current_user: user}}}) do
+    case UserSettings.disconnect_telegram_bot(user) do
+      {:ok, _user_settings} ->
+        # Refresh the data in the user
+        Sanbase.Accounts.get_user(user.id)
+
+      {:error, changeset} ->
+        {
+          :error,
+          message: "Cannot disconnect current user's telegram bot",
+          details: changeset_errors(changeset)
+        }
+    end
+  end
+
   def change_name(_root, %{name: new_name}, %{context: %{auth: %{current_user: user}}}) do
     case User.change_name(user, new_name) do
       {:ok, user} ->

--- a/lib/sanbase_web/graphql/schema/queries/user_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/user_queries.ex
@@ -66,6 +66,12 @@ defmodule SanbaseWeb.Graphql.Schema.UserQueries do
   end
 
   object :user_mutations do
+    field :disconnect_telegram_bot, :user do
+      middleware(JWTAuth)
+
+      resolve(&UserResolver.disconnect_telegram_bot/3)
+    end
+
     field :change_username, :user do
       arg(:username, non_null(:string))
 


### PR DESCRIPTION
## Changes

Add a mutation that will disconnect the user and the telegram bot that sends alerts.
```graphql
mutation{
  disconnecTelegramBot{
    settings{
      hasTelegramConnected
    }
  }
}
```

When disconnected, the telegram bot will send one last message informing the user
that the bot is disconnected.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
