### PR TITLE
Allow filtering availableFounders by slug

### DIFF
--- a/lib/sanbase/clickhouse/founders/founders.ex
+++ b/lib/sanbase/clickhouse/founders/founders.ex
@@ -1,18 +1,28 @@
 defmodule Sanbase.Clickhouse.Founders do
-  def get_founders() do
-    query = get_founders_query()
+  def get_founders(slug \\ nil) do
+    query = get_founders_query(slug)
 
-    Sanbase.ClickhouseRepo.query_transform(query, fn [name, slug] ->
-      %{name: name, slug: slug}
+    Sanbase.ClickhouseRepo.query_transform(query, fn [name, project_slug] ->
+      %{name: name, slug: project_slug}
     end)
   end
 
-  defp get_founders_query() do
+  defp get_founders_query(nil) do
     sql = """
     SELECT name, slug
     FROM founder_metadata
     """
 
     Sanbase.Clickhouse.Query.new(sql, %{})
+  end
+
+  defp get_founders_query(slug) do
+    sql = """
+    SELECT name, slug
+    FROM founder_metadata
+    WHERE slug = {{slug}}
+    """
+
+    Sanbase.Clickhouse.Query.new(sql, %{slug: slug})
   end
 end

--- a/lib/sanbase/utils/math_aggregation.ex
+++ b/lib/sanbase/utils/math_aggregation.ex
@@ -1,0 +1,20 @@
+defmodule Sanbase.MathAggregation do
+  def compute(list, aggregation, fun \\ & &1)
+  def compute(list, :max, fun), do: Enum.map(list, fun) |> Enum.max()
+  def compute(list, :min, fun), do: Enum.map(list, fun) |> Enum.min()
+  def compute(list, :avg, fun), do: Enum.map(list, fun) |> Sanbase.Math.mean()
+  def compute(list, :median, fun), do: Enum.map(list, fun) |> Sanbase.Math.median()
+  def compute(list, :count, _fun), do: Enum.count(list)
+  def compute(list, :sum, fun), do: Enum.map(list, fun) |> Enum.sum()
+  def compute(list, :first, fun), do: Enum.map(list, fun) |> List.first()
+  def compute(list, :last, fun), do: Enum.map(list, fun) |> List.last()
+
+  def compute(list, :ohlc, fun) do
+    %{
+      open: compute(list, :first, fun),
+      high: compute(list, :max, fun),
+      low: compute(list, :min, fun),
+      close: compute(list, :last, fun)
+    }
+  end
+end

--- a/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
@@ -107,11 +107,13 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     end
   end
 
-  def get_available_founders(_root, _args, %{source: %{metric: metric}}) do
+  def get_available_founders(_root, args, %{source: %{metric: metric}}) do
     with {:ok, selectors} <- Metric.available_selectors(metric) do
       case :founders in selectors do
         true ->
-          with {:ok, data} <- Sanbase.Clickhouse.Founders.get_founders() do
+          slug = Map.get(args, :slug, nil)
+
+          with {:ok, data} <- Sanbase.Clickhouse.Founders.get_founders(slug) do
             slugs = Enum.map(data, & &1.slug)
             projects = Sanbase.Project.List.by_slugs(slugs)
             slug_to_project_map = Map.new(projects, &{&1.slug, &1})

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -417,6 +417,10 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     end
 
     field :available_founders, list_of(:founder) do
+      @desc ~s"""
+      Filter the founders for which slug should be returned
+      """
+      arg(:slug, :string, default_value: nil)
       cache_resolve(&MetricResolver.get_available_founders/3)
     end
 


### PR DESCRIPTION
## Changes

#### Allow filter availableFounders by slug

```graphql
{
  getMetric(metric: "social_volume_total") {
    metadata {
      availableFounders(slug: "ethereum") {
        name
      }
    }
  }
}
```

#### Allow aggregated_timeseries_data for more social metrics
```graphql
{
  getMetric(metric: "sentiment_positive_total") {
    aggregatedTimeseriesData(
      selector: {founders: ["satoshi nakamoto"]}
      from:"utc_now-40d"
      to: "utc_now") 
  }
}
```
Now providing a different `aggregation` also has effect. Before the aggregatedTimeseriesData used to ignore the provided aggregation and was using a hardcoded one instead.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
