### PR TITLE
Pass words to wordsSocialVolume in the POST body to avoid big URL

### DIFF
--- a/test/sanbase_web/graphql/social_data/words_social_volume_api_test.exs
+++ b/test/sanbase_web/graphql/social_data/words_social_volume_api_test.exs
@@ -33,9 +33,10 @@ defmodule SanbaseWeb.Graphql.WordsSocialVolumeApiTest do
 
     resp = %HTTPoison.Response{status_code: 200, body: body}
 
-    Sanbase.Mock.prepare_mock(HTTPoison, :get, fn _url, _headers, options ->
+    Sanbase.Mock.prepare_mock(HTTPoison, :post, fn _url, body, _headers, _options ->
       search_texts =
-        Map.new(options[:params])
+        body
+        |> Jason.decode!()
         |> Map.get("search_texts")
 
       # Assert that the words are lowercased before they are sent
@@ -113,9 +114,10 @@ defmodule SanbaseWeb.Graphql.WordsSocialVolumeApiTest do
 
     resp = %HTTPoison.Response{status_code: 200, body: body}
 
-    Sanbase.Mock.prepare_mock(HTTPoison, :get, fn _url, _headers, options ->
+    Sanbase.Mock.prepare_mock(HTTPoison, :post, fn _url, body, _headers, _options ->
       search_texts =
-        Map.new(options[:params])
+        body
+        |> Jason.decode!()
         |> Map.get("search_texts")
 
       # Assert that the words are **not** lowercased before they are sent


### PR DESCRIPTION
## Changes
All the parameters to metricshub were encoded in the URL. Some very big queries (like the one below) can generate extremely long URLs which cause the request to fail.
Fix by transporting the params via the body, which is supported since https://github.com/santiment/metrics-hub-server/pull/162

```graphql
query($words: [String], $from: DateTime!, $interval: interval, $treatWordAsLuceneQuery: Boolean = true) {
    wordsSocialVolume(
      selector: {words: $words},
      interval: $interval
      from: $from,
      to: "utc_now",
      treatWordAsLuceneQuery: $treatWordAsLuceneQuery
    ) {
      word
      data: timeseriesData {
    	  value: mentionsCount
      }
    }
}
```
```json
{
  "from": "utc_now-7d",
  "interval": "5h",
  "treatWordAsLuceneQuery": true,
  "words": [
    "60k OR 62K OR 65K OR 70K OR 75k OR 80K OR 85K OR 88K",
    "(buy OR bought) AND (dip OR dips)",
    "korea OR (korea AND south) OR korean or (martial AND law)",
    "quant OR anon",
    "fet OR fetch OR agix OR nmr OR imgnai OR ai OR alita OR bullbear OR (bad AND idea AND ai) OR corgiai OR (artificial AND intelligence AND tokens) OR (artificial AND intelligence AND token) OR (artificial AND intelligence AND coin) OR (commune AND ai) OR aidoge OR SingularityNET OR (Ocean AND Protocol) OR Bittensor OR 0x0 OR cortex OR Oraichain OR orai OR Alethea OR ChainGPT OR vaiot OR (World AND App) OR (world AND coin) OR (World AND ID) OR (Tools AND for AND Humanity) OR TFH OR (Max AND Novendstern) OR (Alex AND Blania) OR wld OR worldcoin OR (ORB AND Connect) OR Altman OR gpt",
    "memecoins OR (meme AND coins) OR memecoin OR (meme AND coin) OR memes OR Dogecoin OR doge OR Shiba OR shib OR bonk OR CorgiAI OR pepe OR dogwifhat OR wif OR floki OR myro OR babydoge OR Dogelon OR (Silly AND Dragon) OR silly OR coq OR snek OR HarryPotterObamaSonic10Inu OR Toshi OR (Milady AND Meme) OR Samoyedcoin OR ladys OR samo OR (Jesus AND Coin) OR WEN OR Bone OR ShibaSwap OR PepeFork OR PORK OR Smog OR ArbDoge OR AIDOGE OR Turbo OR KISHU",
    "depin OR (Decentralized AND Physical AND Infrastructure) OR Filecoin OR fil OR render OR rndr OR Theta OR Helium OR hnt OR Siacoin OR iota OR Arweave OR akash OR pokt OR (pocket AND network) OR IoTeX OR iotx OR grass OR DeComp OR Hivemapper OR (Crust AND Network)",
    "maker OR dsr OR mkr OR rwa OR rwas OR (real AND world AND (assets OR asset)) OR (real-world AND assets) OR (maple OR mpl) OR klaytn OR ondo OR creditcoin OR Centrifuge OR CFG OR Goldfinch OR GFI OR Pendle OR CANTO OR Polymesh OR polyx OR LCX OR AllianceBlock OR nexera OR nxra OR dusk OR Sologenic OR solo OR (IX AND Swap) OR ixs OR TrueFi OR tru OR CHEX  OR Clearpool OR cpool OR Opulous OR opul OR Polytrade OR lto OR StrikeX OR Pendle",
    "ETF OR ETFs OR Grayscale OR iShares OR blackrock OR vaneck OR fidelity OR btc-ETF OR eth-ETF OR GBTC OR IBIT OR FBTC OR ARKB OR BTCO OR BITB",
    "xrp OR ripple",
    "jump",
    "BTC",
    "donald OR trump OR assassination",
    "depin OR (Decentralized AND Physical AND Infrastructure) OR Filecoin OR fil OR render OR rndr OR Theta OR Helium OR hnt OR Siacoin OR iota OR Arweave OR akash OR pokt OR (pocket AND network) OR IoTeX OR iotx OR grass",
    "Airdrop OR Airdrops OR (air AND drop)",
    "nft OR Non-fungible OR opensea OR rarible OR SuperRare OR blur OR tensor OR MOOAR OR (magic AND eden) OR (element AND market) OR (immutable AND x) OR looksrare OR x2y2 OR yawww OR MakersPlace OR KnownOrigin OR Mintable OR Portion",
    "modularity OR modular OR TIA OR fuel OR Celestia OR (Polygon AND Avail) OR zkPorter OR (StarkEx AND DAC) OR (Arbitrum AND Anytrust) OR Cevmos OR Fuel OR Dymension OR Eclipse OR EigenDA OR Assembly OR Mantle OR (HeLa AND Labs) OR GameSwift",
    "LSD OR eigenlayer OR Blast OR Manta OR lido OR rpl OR rocketpool OR Frax OR lido OR lsdfi OR lst OR (Liquid AND Staking) OR (rocket AND pool) OR lsts OR restaking OR restake OR (Staked  AND Ether) OR steth",
    "Ethereum OR Eth OR erc20 OR erc-20 OR (erc AND 20) OR Vitalik OR Buterin OR vitalik.eth OR EVM OR Ether OR eth2 OR devcon OR gas OR eth-ETF",
    "(stable AND coin) OR (stable AND coins) OR stablecoins OR stablecoin OR Tether OR usdt OR Circle OR usdc OR dai OR (First AND Digital AND USD) OR fdusd OR trueusd OR tusd OR usdd OR frax OR xaut OR pax OR paxg",
    "(eth AND killer) OR (Layer AND 1) OR L1 OR layer1 OR Cardano OR Avalanche OR TRON OR Polkadot OR (Bitcoin AND Cash) OR Cosmos OR avax OR trx OR dot OR bch OR atom OR Injective OR inj OR near",
    "GameFi OR gaming OR (game AND fi) OR (play AND 2 AND earn) OR play-2-earn OR guildfi OR (yield AND guild) OR (crypto AND guild) OR sanbox OR (axie AND Infinity) OR SAND OR AXS OR beam OR meritcircle OR (merit AND circle) OR gala OR ronin OR Illuvium"
  ]
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
