### PR TITLE
Rewrite assets_held_by_address SQL to not use balances_aggregated

### DIFF
--- a/lib/sanbase/balances/balance.ex
+++ b/lib/sanbase/balances/balance.ex
@@ -447,8 +447,12 @@ defmodule Sanbase.Balance do
     end)
     |> maybe_update_first_balance(fn ->
       case do_last_balance_before(address, slug, decimals, blockchain, from) do
-        {:ok, %{^address => balance}} -> {:ok, balance}
-        {:error, error} -> {:error, error}
+        {:ok, %{} = address_balance_maps} ->
+          balance = Map.values(address_balance_maps) |> Enum.sum()
+          {:ok, balance}
+
+        {:error, error} ->
+          {:error, error}
       end
     end)
     |> maybe_fill_gaps_last_seen_balance()

--- a/lib/sanbase/balances/balance.ex
+++ b/lib/sanbase/balances/balance.ex
@@ -534,7 +534,7 @@ defmodule Sanbase.Balance do
 
   defp address_supported_tables(address) do
     case Sanbase.BlockchainAddress.to_infrastructure(address) do
-      "ETH" -> ["erc20_balances_yearly_test", "eth_balances"]
+      "ETH" -> ["erc20_balances_address", "eth_balances"]
       "BTC" -> ["btc_balances", "ltc_balances", "doge_balances"]
       "XRP" -> ["xrp_balances"]
       _ -> []

--- a/lib/sanbase/balances/balance_sql_query.ex
+++ b/lib/sanbase/balances/balance_sql_query.ex
@@ -6,7 +6,7 @@ defmodule Sanbase.Balance.SqlQuery do
 
   def blockchain_to_table(blockchain, slug) do
     case blockchain do
-      "ethereum" -> if slug == "ethereum", do: "eth_balances", else: "erc20_balances"
+      "ethereum" -> if slug == "ethereum", do: "eth_balances", else: "erc20_balances_address"
       "bitcoin" -> "btc_balances"
       "litecoin" -> "ltc_balances"
       "dogecoin" -> "doge_balances"


### PR DESCRIPTION
## Changes

Stop using `balances_aggregated`.
Instead, use the raw balances tables.
`assets_held*` functions need to return **all** assets held by an address. This data need to be aggregated across multiple tables in some cases (ERC20 tokens, forks, etc.).

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
