### PR TITLE
Stop asset_price_pairs cryptocompare exporter

### DIFF
--- a/lib/sanbase/cryptocompare/price/price_websocket_scraper.ex
+++ b/lib/sanbase/cryptocompare/price/price_websocket_scraper.ex
@@ -26,7 +26,6 @@ defmodule Sanbase.Cryptocompare.Price.WebsocketScraper do
   # giving it a name makes sure only one instance of the scraper is alive at a time
   @name :cryptocompare_websocket_scraper
 
-  @asset_price_pairs_exporter :asset_price_pairs_exporter
   @asset_price_pairs_only_exporter :asset_price_pairs_only_exporter
   @asset_prices_exporter :prices_exporter
 
@@ -237,7 +236,6 @@ defmodule Sanbase.Cryptocompare.Price.WebsocketScraper do
 
   defp export_data_point(point, last_points) do
     export_asset_prices_topic(point, last_points)
-    export_asset_price_pairs_topic(point)
     export_asset_price_pairs_only_topic(point)
   rescue
     e ->
@@ -278,15 +276,6 @@ defmodule Sanbase.Cryptocompare.Price.WebsocketScraper do
   end
 
   defp export_asset_prices_topic(_point, _last_points), do: :ok
-
-  defp export_asset_price_pairs_topic(point) do
-    tuple =
-      point
-      |> CryptocompareAssetPricesPoint.new()
-      |> CryptocompareAssetPricesPoint.json_kv_tuple()
-
-    :ok = Sanbase.KafkaExporter.persist_async(tuple, @asset_price_pairs_exporter)
-  end
 
   defp export_asset_price_pairs_only_topic(point) do
     tuple =

--- a/lib/sanbase/cryptocompare/supervisor.ex
+++ b/lib/sanbase/cryptocompare/supervisor.ex
@@ -46,20 +46,6 @@ defmodule Sanbase.Cryptocompare.Supervisor do
             Price.WebsocketScraper.enabled?() or Price.HistoricalScheduler.enabled?()
           end
         ),
-        # Kafka exporter for the websocket price exporter
-        start_if(
-          fn ->
-            Sanbase.KafkaExporter.child_spec(
-              id: :asset_price_pairs_exporter,
-              name: :asset_price_pairs_exporter,
-              topic: Config.module_get!(Sanbase.KafkaExporter, :asset_price_pairs_topic),
-              buffering_max_messages: 1000,
-              can_send_after_interval: 250,
-              kafka_flush_timeout: 1000
-            )
-          end,
-          fn -> Price.WebsocketScraper.enabled?() end
-        ),
         # Kafka exporter for the open interest scraper
         start_if(
           fn ->


### PR DESCRIPTION
It exports all prices and volumes into a kafka topic that has never been
used, but is very large. We still have asset_price_pairs_only which
exports only the prices, which are in active use.

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
