### PR TITLE
wordsSocialVolume encodes the words, allowig commas in queries

### DIFF
--- a/lib/sanbase/social_data/social_volume.ex
+++ b/lib/sanbase/social_data/social_volume.ex
@@ -53,6 +53,11 @@ defmodule Sanbase.SocialData.SocialVolume do
     social_volume_list_request(selector, from, to, interval, source, opts)
     |> handle_words_social_volume_response(selector)
     |> maybe_apply_function(fn result ->
+      Enum.map(result, fn map ->
+        Map.update!(map, :word, &URI.decode_www_form/1)
+      end)
+    end)
+    |> maybe_apply_function(fn result ->
       if treat_word_as_lucene_query do
         result
       else
@@ -162,7 +167,7 @@ defmodule Sanbase.SocialData.SocialVolume do
 
     body =
       %{
-        "search_texts" => Enum.join(words, ","),
+        "encoded_search_texts" => words |> Enum.map(&URI.encode_www_form/1) |> Enum.join(","),
         "from_timestamp" => from |> DateTime.truncate(:second) |> DateTime.to_iso8601(),
         "to_timestamp" => to |> DateTime.truncate(:second) |> DateTime.to_iso8601(),
         "interval" => interval,

--- a/test/sanbase_web/graphql/social_data/words_social_volume_api_test.exs
+++ b/test/sanbase_web/graphql/social_data/words_social_volume_api_test.exs
@@ -22,7 +22,7 @@ defmodule SanbaseWeb.Graphql.WordsSocialVolumeApiTest do
             "2024-09-29T00:00:00Z" => 487,
             "2024-09-30T00:00:00Z" => 323
           },
-          "eth or nft" => %{
+          "eth OR nft OR 43,400" => %{
             "2024-09-28T00:00:00Z" => 1681,
             "2024-09-29T00:00:00Z" => 3246,
             "2024-09-30T00:00:00Z" => 1577
@@ -37,10 +37,10 @@ defmodule SanbaseWeb.Graphql.WordsSocialVolumeApiTest do
       search_texts =
         body
         |> Jason.decode!()
-        |> Map.get("search_texts")
+        |> Map.get("encoded_search_texts")
 
       # Assert that the words are lowercased before they are sent
-      assert search_texts == "eth or nft,btc"
+      assert search_texts == "eth+OR+nft+OR+43%2C400,btc"
 
       {:ok, resp}
     end)
@@ -48,10 +48,11 @@ defmodule SanbaseWeb.Graphql.WordsSocialVolumeApiTest do
       query = """
       {
         wordsSocialVolume(
-          selector: { words: ["eth OR nft", "btc"] }
+          selector: { words: ["eth OR nft OR 43,400", "btc"] }
           from: "2024-09-28T00:00:00Z"
           to: "2024-09-30T00:00:00Z"
           interval: "1d"
+          treatWordAsLuceneQuery: true
         ){
           word
           timeseriesData{
@@ -84,7 +85,7 @@ defmodule SanbaseWeb.Graphql.WordsSocialVolumeApiTest do
                        %{"datetime" => "2024-09-29T00:00:00Z", "mentionsCount" => 3246},
                        %{"datetime" => "2024-09-30T00:00:00Z", "mentionsCount" => 1577}
                      ],
-                     "word" => "eth OR nft"
+                     "word" => "eth OR nft OR 43,400"
                    }
                  ]
                }
@@ -118,10 +119,10 @@ defmodule SanbaseWeb.Graphql.WordsSocialVolumeApiTest do
       search_texts =
         body
         |> Jason.decode!()
-        |> Map.get("search_texts")
+        |> Map.get("encoded_search_texts")
 
       # Assert that the words are **not** lowercased before they are sent
-      assert search_texts == "eth OR nft,BTC"
+      assert search_texts == "eth+OR+nft,BTC"
 
       {:ok, resp}
     end)


### PR DESCRIPTION
## Changes

If words are not encoded, metricshub breaks the words on `,` and the the lucene queries including `,` get broken into many pieces
```graphql
query ($words: [String], $from: DateTime!, $interval: interval) {
  wordsSocialVolume(selector: {words: $words}, interval: $interval, from: $from, to: "utc_now", treatWordAsLuceneQuery: true) {
    word
  }
}
```

```json
{
  "from": "utc_now-1d",
  "interval": "5h",
  "words": [
    "40k OR 41K OR 42K OR 43K OR 44K OR 45K OR $40,000 OR $41,000 OR $42,000 OR $43,000 OR $44,000 OR $45,000",
    "BTC and ETH",
    "fet OR fetch OR agix OR nmr OR imgnai OR ai OR alita OR bullbear OR (bad AND idea AND ai) OR corgiai OR (artificial AND intelligence AND tokens) OR (artificial AND intelligence AND token) OR (artificial AND intelligence AND coin) OR (commune AND ai) OR aidoge OR SingularityNET OR (Ocean AND Protocol) OR Bittensor OR 0x0 OR cortex OR Oraichain OR orai OR Alethea OR ChainGPT OR vaiot OR (World AND App) OR (world AND coin) OR (World AND ID) OR (Tools AND for AND Humanity) OR TFH OR (Max AND Novendstern) OR (Alex AND Blania) OR wld OR worldcoin OR (ORB AND Connect) OR Altman OR gpt"
  ]
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
