### PR TITLE
Extend Metric.Registry.Changelog usage

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -60,6 +60,8 @@ config :sanbase, Sanbase.EventBus.MetricRegistrySubscriber,
 config :sanbase, Sanbase.ExternalServices.RateLimiting.Server,
   implementation_module: Sanbase.ExternalServices.RateLimiting.TestServer
 
+config :sanbase, Sanbase.Metric.Registry.ChangeSuggestion, debug_applying_changes: true
+
 # Configure postgres database
 config :sanbase, Sanbase.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,

--- a/lib/sanbase/metric/registry/changelog.ex
+++ b/lib/sanbase/metric/registry/changelog.ex
@@ -6,9 +6,13 @@ defmodule Sanbase.Metric.Registry.Changelog do
 
   alias Sanbase.Metric.Registry
 
+  @change_triggers ["sync_apply", "change_request_approve", "change_request_undo"]
+
   schema "metric_registry_changelog" do
     field(:old, :string)
     field(:new, :string)
+
+    field(:change_trigger, :string)
 
     belongs_to(:metric_registry, Registry, foreign_key: :metric_registry_id)
 
@@ -17,18 +21,26 @@ defmodule Sanbase.Metric.Registry.Changelog do
 
   def changeset(%__MODULE__{} = changelog, attrs) do
     changelog
-    |> cast(attrs, [:old, :new, :metric_registry_id])
+    |> cast(attrs, [:old, :new, :metric_registry_id, :change_trigger])
     |> validate_required([:new, :metric_registry_id])
+    |> validate_inclusion(:change_trigger, @change_triggers)
   end
 
-  def create_changest(%Ecto.Changeset{} = changeset) do
+  def create_changeset(%Ecto.Changeset{} = changeset, opts) do
+    change_trigger = Keyword.fetch!(opts, :change_trigger)
+
     old = changeset.data
     new = changeset |> Ecto.Changeset.apply_changes()
 
     old = Jason.encode!(old)
     new = Jason.encode!(new)
 
-    attrs = %{metric_registry_id: changeset.data.id, old: old, new: new}
+    attrs = %{
+      metric_registry_id: changeset.data.id,
+      old: old,
+      new: new,
+      change_trigger: change_trigger
+    }
 
     changeset(%__MODULE__{}, attrs)
   end

--- a/lib/sanbase/metric/registry/registry.ex
+++ b/lib/sanbase/metric/registry/registry.ex
@@ -71,6 +71,7 @@ defmodule Sanbase.Metric.Registry do
              :id,
              :inserted_at,
              :updated_at,
+             :is_verified,
              :sync_status,
              :last_sync_datetime,
              :change_suggestions
@@ -227,16 +228,21 @@ defmodule Sanbase.Metric.Registry do
     |> maybe_emit_event(:create_metric_registry, opts)
   end
 
+  def mark_as_synced_params() do
+    %{
+      "sync_status" => "synced",
+      "last_sync_datetime" => DateTime.utc_now() |> DateTime.truncate(:second)
+    }
+  end
+
   def mark_as_synced(metric_registry) do
     metric_registry
-    |> changeset(%{
-      sync_status: "synced",
-      sync_last_datetime: DateTime.utc_now() |> DateTime.truncate(:second)
-    })
+    |> changeset(mark_as_synced_params())
     |> Repo.update()
   end
 
-  def update_is_verified(metric_registry, is_verified) do
+  def update_is_verified(%__MODULE__{} = metric_registry, is_verified)
+      when is_boolean(is_verified) do
     metric_registry
     |> changeset(%{is_verified: is_verified})
     |> Repo.update()

--- a/lib/sanbase/metric/registry/sync.ex
+++ b/lib/sanbase/metric/registry/sync.ex
@@ -132,7 +132,11 @@ defmodule Sanbase.Metric.Registry.Sync do
         new = changeset |> Ecto.Changeset.apply_changes()
 
         key = Map.take(changeset.data, [:metric, :data_type, :fixed_parameters])
-        {key, ExAudit.Diff.diff(old, new)}
+        # When sync is applied, the logic for applying function also handles
+        # the sync status related fields. They are not important for the actual changes
+        diff = ExAudit.Diff.diff(old, new) |> Map.drop([:sync_status, :last_sync_datetime])
+
+        {key, diff}
       end)
 
     {:ok, changes}

--- a/lib/sanbase/metric/registry/sync.ex
+++ b/lib/sanbase/metric/registry/sync.ex
@@ -156,8 +156,8 @@ defmodule Sanbase.Metric.Registry.Sync do
           # Update existing metric
           {:ok, metric_registry} ->
             # Working directly with changesets allow to manually put sync_status
-            # Using the update/create functions do not
-            params = Map.put(params, "sync_status", "synced")
+            # Using the update/create functions do not allow manually setting it
+            params = Map.merge(params, Registry.mark_as_synced_params())
             registry_changeset = Registry.changeset(metric_registry, params)
 
             changelog_changeset =
@@ -181,8 +181,8 @@ defmodule Sanbase.Metric.Registry.Sync do
           # There is no such metric. This is creating a new metric
           {:error, _} ->
             # Working directly with changesets allow to manually put sync_status
-            # Using the update/create functions do not
-            params = Map.put(params, "sync_status", "synced")
+            # Using the update/create functions do not allow manually setting it
+            params = Map.merge(params, Registry.mark_as_synced_params())
             registry_changeset = Registry.changeset(%Registry{}, params)
 
             updated_multi =

--- a/lib/sanbase/metric/registry/validation.ex
+++ b/lib/sanbase/metric/registry/validation.ex
@@ -1,17 +1,6 @@
 defmodule Sanbase.Metric.Registry.Validation do
   import Ecto.Changeset
 
-  @sync_statuses ["synced", "not_synced"]
-  def validate_sync_status(:sync_status, status) do
-    if status in @sync_statuses do
-      []
-    else
-      [
-        sync_status: "The provided sync_status #{status} is not supported."
-      ]
-    end
-  end
-
   def validate_min_interval(:min_interval, min_interval) do
     if Sanbase.DateTimeUtils.valid_compound_duration?(min_interval) do
       if Sanbase.DateTimeUtils.str_to_days(min_interval) > 30 do

--- a/lib/sanbase_web/live/available_metrics/available_metrics_description.ex
+++ b/lib/sanbase_web/live/available_metrics/available_metrics_description.ex
@@ -442,4 +442,12 @@ defmodule SanbaseWeb.AvailableMetricsDescription do
     </pre>
     """
   end
+
+  def get_popover_text(%{key: "Last Sync Datetime"} = assigns) do
+    ~H"""
+    <pre>
+    If the metric has been synced, shows the last datetime of the sync
+    </pre>
+    """
+  end
 end

--- a/lib/sanbase_web/live/metric_registry/metric_registry_diff_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_diff_live.ex
@@ -20,7 +20,6 @@ defmodule SanbaseWeb.MetricRegistryDiffLive do
 
               diff_changes =
                 ExAudit.Diff.diff(old_state_json, metric_registry_map)
-                |> dbg()
 
               html_safe_changes = Sanbase.ExAudit.Patch.format_patch(%{patch: diff_changes})
 

--- a/lib/sanbase_web/live/metric_registry/metric_registry_diff_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_diff_live.ex
@@ -1,0 +1,120 @@
+defmodule SanbaseWeb.MetricRegistryDiffLive do
+  use SanbaseWeb, :live_view
+
+  alias SanbaseWeb.AvailableMetricsComponents
+  alias Sanbase.Metric.Registry
+  @impl true
+  def mount(%{"id" => metric_registry_id}, _session, socket) do
+    {:ok, %{id: id, last_sync_datetime: last_sync_datetime} = metric_registry} =
+      Registry.by_id(metric_registry_id)
+
+    socket =
+      case metric_registry.sync_status do
+        "synced" ->
+          socket |> assign(html_safe_changes: nil, has_changes: false)
+
+        "not_synced" ->
+          case Registry.Changelog.state_before_last_sync(id, last_sync_datetime) do
+            {:ok, old_state_json} ->
+              metric_registry_map = Jason.encode!(metric_registry) |> Jason.decode!()
+
+              diff_changes =
+                ExAudit.Diff.diff(old_state_json, metric_registry_map)
+                |> dbg()
+
+              html_safe_changes = Sanbase.ExAudit.Patch.format_patch(%{patch: diff_changes})
+
+              socket
+              |> assign(
+                html_safe_changes: html_safe_changes,
+                has_changes: diff_changes != :not_changed
+              )
+
+            {:error, _} ->
+              # If a new metric has been just created it is in `not synced` state
+              # but there are no changes being made so far.
+              # Note: Maybe improve visualization here?
+              socket |> assign(html_safe_changes: nil, has_changes: false, has_syncs: false)
+          end
+      end
+
+    {:ok,
+     socket
+     |> assign(
+       page_title: "Metric Registry | Diff",
+       metric_registry: metric_registry
+     )}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="flex flex-col ">
+      <h1 class="text-blue-700 text-2xl mb-4">
+        Metric Registry Diff Since Last Sync | {@metric_registry.metric}
+      </h1>
+      <SanbaseWeb.MetricRegistryComponents.user_details
+        current_user={@current_user}
+        current_user_role_names={@current_user_role_names}
+      />
+      <div class="my-4">
+        <AvailableMetricsComponents.available_metrics_button
+          text="Back to Metric Registry"
+          href={~p"/admin2/metric_registry"}
+          icon="hero-home"
+        />
+
+        <AvailableMetricsComponents.available_metrics_button
+          text="Back to Metric Page"
+          href={~p"/admin2/metric_registry/show/#{@metric_registry.id}"}
+          icon="hero-list-bullet"
+        />
+      </div>
+
+      <.formatted_differences
+        metric_registry={@metric_registry}
+        has_changes={@has_changes}
+        html_safe_changes={@html_safe_changes}
+      />
+    </div>
+    """
+  end
+
+  defp formatted_differences(assigns) do
+    ~H"""
+    <div>
+      <span class="text-amber-800 font-bold text-xl">Diff Since Last Sync</span>
+      <hr class="h-px my-2 bg-gray-200 border-0 dark:bg-gray-700" />
+      <!-- In synced status. -->
+      <div :if={@metric_registry.sync_status == "synced"}>
+        <span class="text-blue-900 font-bold text-xl">
+          The metric is in Synced state!
+        </span>
+      </div>
+      
+    <!-- Not synced with changes -->
+      <div :if={@metric_registry.sync_status == "not_synced" and @has_changes}>
+        {@html_safe_changes}
+      </div>
+      
+    <!-- Not synced, but without changes-->
+      <div :if={@metric_registry.sync_status == "not_synced" and !@has_changes}>
+        <span class="text-blue-900 font-bold text-xl">
+          No changes!
+        </span>
+        <div class="max-w-2xl text-gray-800">
+          The metric is in not synced state, but there are no changes.
+          Maybe the chain of change requests approved and undone have put the metric
+          in a state that is the same as the last sync.
+        </div>
+      </div>
+
+      <div :if={@metric_registry.sync_status == "synced" and @has_changes}>
+        <span class="text-blue-900 font-bold text-xl">
+          You should never see this! If seen, report to backend team!
+        </span>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/sanbase_web/live/metric_registry/metric_registry_form_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_form_live.ex
@@ -190,12 +190,6 @@ defmodule SanbaseWeb.MetricRegistryFormLive do
             label="Notes"
             placeholder="Explanation why the changes are submitted"
           />
-          <.input
-            type="email"
-            label="Submitted by (enter your email address)"
-            name="submitted_by"
-            value={@email}
-          />
           <.button phx-disable-with="Submitting...">Submit Change Request</.button>
         </div>
         <.error :for={{field, [reason]} <- @save_errors}>
@@ -406,7 +400,7 @@ defmodule SanbaseWeb.MetricRegistryFormLive do
 
   def handle_event(
         "save",
-        %{"registry" => params, "notes" => notes, "submitted_by" => submitted_by},
+        %{"registry" => params, "notes" => notes},
         socket
       )
       when socket.assigns.live_action == :new do
@@ -420,7 +414,7 @@ defmodule SanbaseWeb.MetricRegistryFormLive do
                %Registry{id: nil},
                params,
                notes,
-               submitted_by
+               socket.assigns.current_user.email
              ) do
           {:ok, _change_suggestion} ->
             {:noreply,
@@ -447,7 +441,7 @@ defmodule SanbaseWeb.MetricRegistryFormLive do
 
   def handle_event(
         "save",
-        %{"registry" => params, "notes" => notes, "submitted_by" => submitted_by},
+        %{"registry" => params, "notes" => notes},
         socket
       )
       when socket.assigns.live_action == :edit do
@@ -461,7 +455,7 @@ defmodule SanbaseWeb.MetricRegistryFormLive do
                socket.assigns.metric_registry,
                params,
                notes,
-               submitted_by
+               socket.assigns.current_user.email
              ) do
           {:ok, _change_suggestion} ->
             {:noreply,

--- a/lib/sanbase_web/live/metric_registry/metric_registry_history_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_history_live.ex
@@ -49,7 +49,7 @@ defmodule SanbaseWeb.MetricRegistryHistoryLive do
           {row.id}
         </:col>
         <:col :let={row} label="Datetime">
-          {row.inserted_at}
+          {Timex.format!(row.inserted_at, "%F %T%:z", :strftime)}
         </:col>
         <:col :let={row} label="Change Trigger">
           <.change_trigger_formatted change_trigger={row.change_trigger} />
@@ -66,7 +66,9 @@ defmodule SanbaseWeb.MetricRegistryHistoryLive do
     {:ok, list} = Sanbase.Metric.Registry.Changelog.by_metric_registry_id(metric_registry_id)
 
     data =
-      Enum.map(list, fn %{old: old, new: new} = struct ->
+      list
+      |> Enum.sort_by(& &1.id, :desc)
+      |> Enum.map(fn %{old: old, new: new} = struct ->
         new = Jason.decode!(new)
         old = Jason.decode!(old)
 

--- a/lib/sanbase_web/live/metric_registry/metric_registry_index_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_index_live.ex
@@ -219,11 +219,13 @@ defmodule SanbaseWeb.MetricRegistryIndexLive do
       # Explicitly put the old is_verified status in the first argument otherwise Ecto
       # will decide that the value does not change and will not mutate the DB
       {:ok, _} =
-        Sanbase.Metric.Registry.update(
+        Sanbase.Metric.Registry.update_is_verified(
+          # Put the old is_verified here so after a few toggles we still know
+          # how it started
           %{metric | is_verified: map.old},
-          %{is_verified: map.new},
-          emit_event: false
+          %{is_verified: map.new}
         )
+        |> Sanbase.Repo.update()
     end
 
     {:noreply,

--- a/lib/sanbase_web/live/metric_registry/metric_registry_index_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_index_live.ex
@@ -73,6 +73,7 @@ defmodule SanbaseWeb.MetricRegistryIndexLive do
             metric={row.metric}
             internal_metric={row.internal_metric}
             human_readable_name={row.human_readable_name}
+            status={row.status}
           />
         </:col>
         <:col
@@ -223,9 +224,8 @@ defmodule SanbaseWeb.MetricRegistryIndexLive do
           # Put the old is_verified here so after a few toggles we still know
           # how it started
           %{metric | is_verified: map.old},
-          %{is_verified: map.new}
+          map.new
         )
-        |> Sanbase.Repo.update()
     end
 
     {:noreply,
@@ -268,6 +268,7 @@ defmodule SanbaseWeb.MetricRegistryIndexLive do
               metric={row.metric}
               internal_metric={row.internal_metric}
               human_readable_name={row.human_readable_name}
+              status={row.status}
             />
           </:col>
           <:col :let={row} label="New Status">
@@ -483,7 +484,15 @@ defmodule SanbaseWeb.MetricRegistryIndexLive do
   defp metric_names(assigns) do
     ~H"""
     <div class="flex flex-col break-normal">
-      <div class="text-black text-base">{@human_readable_name}</div>
+      <div class="text-black text-base">
+        {@human_readable_name}
+        <span
+          :if={@status in ["alpha", "beta"]}
+          class={if @status == "alpha", do: "text-amber-600 text-sm", else: "text-violet-600 text-sm"}
+        >
+          ({String.upcase(@status)})
+        </span>
+      </div>
       <div class="text-gray-900 text-sm">{@metric} (API)</div>
       <div class="text-gray-900 text-sm">{@internal_metric} (DB)</div>
     </div>

--- a/lib/sanbase_web/live/metric_registry/metric_registry_show_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_show_live.ex
@@ -54,6 +54,13 @@ defmodule SanbaseWeb.MetricRegistryShowLive do
         />
 
         <AvailableMetricsComponents.available_metrics_button
+          :if={Permissions.can?(:see_history, roles: @current_user_role_names)}
+          text="Changes Since Last Sync"
+          href={~p"/admin2/metric_registry/diff/#{@metric_registry}"}
+          icon="hero-list-bullet"
+        />
+
+        <AvailableMetricsComponents.available_metrics_button
           :if={Permissions.can?(:edit, roles: @current_user_role_names)}
           text="Duplicate Metric"
           href={

--- a/lib/sanbase_web/live/metric_registry/metric_registry_show_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_show_live.ex
@@ -25,8 +25,8 @@ defmodule SanbaseWeb.MetricRegistryShowLive do
   def render(assigns) do
     ~H"""
     <div class="flex flex-col justify-center w-7/8">
-      <h1 class="text-gray-800 text-2xl">
-        Showing details for <span class="text-blue-700">{@metric_registry.metric}</span>
+      <h1 class="text-blue-700 text-2xl mb-4">
+        Metric Registry Details | {@metric_registry.metric}
       </h1>
       <SanbaseWeb.MetricRegistryComponents.user_details
         current_user={@current_user}
@@ -55,9 +55,9 @@ defmodule SanbaseWeb.MetricRegistryShowLive do
 
         <AvailableMetricsComponents.available_metrics_button
           :if={Permissions.can?(:see_history, roles: @current_user_role_names)}
-          text="Changes Since Last Sync"
+          text="Diff Since Last Sync"
           href={~p"/admin2/metric_registry/diff/#{@metric_registry}"}
-          icon="hero-list-bullet"
+          icon="hero-code-bracket-square"
         />
 
         <AvailableMetricsComponents.available_metrics_button
@@ -144,9 +144,15 @@ defmodule SanbaseWeb.MetricRegistryShowLive do
       },
       %{
         key: "Sync Status",
-        value: metric_registry.sync_status,
+        value: String.upcase(metric_registry.sync_status) |> String.replace("_", " "),
         popover_target: "popover-sync-status",
         popover_target_text: get_popover_text(%{key: "Sync Status"})
+      },
+      %{
+        key: "Last Sync Datetime",
+        value: metric_registry.last_sync_datetime || "No Syncs",
+        popover_target: "popover-last-sync-datetime",
+        popover_target_text: get_popover_text(%{key: "Last Sync Datetime"})
       },
       %{
         key: "Aliases",

--- a/lib/sanbase_web/live/metric_registry/metric_registry_sync_runs_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_sync_runs_live.ex
@@ -44,7 +44,7 @@ defmodule SanbaseWeb.MetricRegistrySyncRunsLive do
       </div>
       <.table id="metrics_registry_sync_runs" rows={@syncs}>
         <:col :let={row} label="Datetime">
-          {row.inserted_at}
+          {Timex.format!(row.inserted_at, "%F %T%:z", :strftime)}
         </:col>
 
         <:col :let={row} label="UUID">

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -79,6 +79,7 @@ defmodule SanbaseWeb.Router do
         live("/show/:id", MetricRegistryShowLive)
         live("/edit/:id", MetricRegistryFormLive, :edit)
         live("/history/:id", MetricRegistryHistoryLive)
+        live("/diff/:id", MetricRegistryDiffLive)
         live("/new", MetricRegistryFormLive, :new)
         live("/sync", MetricRegistrySyncLive, :new)
         live("/sync_runs", MetricRegistrySyncRunsLive, :new)

--- a/priv/repo/migrations/20250219155459_extend_registry_changelog_table.exs
+++ b/priv/repo/migrations/20250219155459_extend_registry_changelog_table.exs
@@ -1,0 +1,9 @@
+defmodule Sanbase.Repo.Migrations.ExtendRegistryChangelogTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:metric_registry_changelog) do
+      add(:change_trigger, :string)
+    end
+  end
+end

--- a/priv/repo/migrations/20250220134051_extend_metric_registry_table.exs
+++ b/priv/repo/migrations/20250220134051_extend_metric_registry_table.exs
@@ -1,0 +1,9 @@
+defmodule Sanbase.Repo.Migrations.ExtendMetricRegistryTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:metric_registry) do
+      add(:last_sync_datetime, :utc_datetime)
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2344,7 +2344,8 @@ CREATE TABLE public.metric_registry (
     updated_at timestamp with time zone NOT NULL,
     is_verified boolean DEFAULT true NOT NULL,
     sync_status character varying(255) DEFAULT 'synced'::character varying NOT NULL,
-    status character varying(255) DEFAULT 'released'::character varying NOT NULL
+    status character varying(255) DEFAULT 'released'::character varying NOT NULL,
+    last_sync_datetime timestamp(0) without time zone
 );
 
 
@@ -2393,7 +2394,8 @@ CREATE TABLE public.metric_registry_changelog (
     old text,
     new text,
     inserted_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    change_trigger character varying(255)
 );
 
 
@@ -9929,3 +9931,5 @@ INSERT INTO public."schema_migrations" (version) VALUES (20250207100755);
 INSERT INTO public."schema_migrations" (version) VALUES (20250207134446);
 INSERT INTO public."schema_migrations" (version) VALUES (20250207134654);
 INSERT INTO public."schema_migrations" (version) VALUES (20250219075723);
+INSERT INTO public."schema_migrations" (version) VALUES (20250219155459);
+INSERT INTO public."schema_migrations" (version) VALUES (20250220134051);

--- a/test/sanbase/metric_registry/metric_registry_sync_test.exs
+++ b/test/sanbase/metric_registry/metric_registry_sync_test.exs
@@ -141,9 +141,7 @@ defmodule Sanbase.MetricRegistrySyncTest do
                  {:changed,
                   [{:added_to_list, 0, %Sanbase.Metric.Registry.Alias{name: "new_alias"}}]},
                min_interval: {:changed, {:primitive_change, "1s", "1d"}},
-               exposed_environments: {:changed, {:primitive_change, "all", "stage"}},
-               # TODO: Mayber exclude?
-               sync_status: {:changed, {:primitive_change, "not_synced", "synced"}}
+               exposed_environments: {:changed, {:primitive_change, "all", "stage"}}
              }
 
       # Check some fields after sync

--- a/test/sanbase/metric_registry/metric_registry_sync_test.exs
+++ b/test/sanbase/metric_registry/metric_registry_sync_test.exs
@@ -88,9 +88,8 @@ defmodule Sanbase.MetricRegistrySyncTest do
 
     # Verify only price_usd_5m and mvrv_usd metrics to properly test
     # that sync only affects verified metrics
-    {:ok, _} = Sanbase.Metric.Registry.update(m1, %{is_verified: true}, emit_event: false)
-
-    {:ok, _} = Sanbase.Metric.Registry.update(m2, %{is_verified: true}, emit_event: false)
+    {:ok, _} = Sanbase.Metric.Registry.update_is_verified(m1, true)
+    {:ok, _} = Sanbase.Metric.Registry.update_is_verified(m2, true)
 
     [m1.id, m2.id]
   end
@@ -98,7 +97,11 @@ defmodule Sanbase.MetricRegistrySyncTest do
   test "mocked sync content", _context do
     {:ok, m} = Registry.by_name("price_usd_5m")
     # Make it ready to sync.
-    {:ok, m} = Registry.update(m, %{is_verified: true, sync_status: "not_synced"})
+    # Use a changeset as the update/create functrions do not allow to manually play
+    # with these fields
+    {:ok, m} =
+      Registry.changeset(m, %{is_verified: true, sync_status: "not_synced"})
+      |> Sanbase.Repo.update()
 
     # This is used for mock when taking the records to be synced
     # As the initiating and receiving databases in test env are the same


### PR DESCRIPTION
## Changes

- Use the Changelog to also record changes when Change Requests are applied.
- Add `last_sync_datetime` column to track the last sync datetime
- Also internally rework how `sync_status` and `is_verified` are set and changed.
- Use this info to compute difference what will be synced for metrics in `NOT SYNCED` state.
- Allow checking the diff of a metric since the last sync (or since creation if no syncs) from the index page.

---

#### Improve Metric Registry History

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/61c34a6f-fddb-4c48-907d-1f4bd3ebff15" />
<img width="814" alt="image" src="https://github.com/user-attachments/assets/09850c4f-c6cc-4b79-a897-49702c3aa4e2" />

---

#### Click to see diff since last sync for not synced metrics

<img width="1761" alt="image" src="https://github.com/user-attachments/assets/525f4a81-a8c8-4099-9f26-eafbca5972fb" />
<img width="1587" alt="image" src="https://github.com/user-attachments/assets/541a993a-6c77-4f25-95ab-54d82444e084" />

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
