### PR TITLE
Implement Dry Run for Metric Registry syncs

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -3,7 +3,7 @@ import Config
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 
-config :phoenix, :stacktrace_depth, 60
+config :phoenix, :stacktrace_depth, 20
 
 config :sanbase,
   available_slugs_module: Sanbase.DirectAvailableSlugs

--- a/lib/sanbase/metric/registry/sync_run.ex
+++ b/lib/sanbase/metric/registry/sync_run.ex
@@ -14,12 +14,14 @@ defmodule Sanbase.Metric.Registry.SyncRun do
     field(:actual_changes, :string)
     field(:errors, :string)
 
+    field(:is_dry_run, :boolean)
+
     timestamps()
   end
 
   def changeset(%__MODULE__{} = sync, attrs) do
     sync
-    |> cast(attrs, [:uuid, :content, :actual_changes, :status, :errors, :sync_type])
+    |> cast(attrs, [:uuid, :content, :actual_changes, :status, :errors, :sync_type, :is_dry_run])
     |> validate_inclusion(:status, ["scheduled", "executing", "completed", "failed", "cancelled"])
     |> validate_inclusion(:sync_type, ["outgoing", "incoming"])
   end

--- a/lib/sanbase_web/components/core_components.ex
+++ b/lib/sanbase_web/components/core_components.ex
@@ -274,6 +274,7 @@ defmodule SanbaseWeb.CoreComponents do
   attr(:name, :any)
   attr(:label, :string, default: nil)
   attr(:value, :any)
+  attr(:outer_div_class, :string, default: "")
 
   attr(:type, :string,
     default: "text",
@@ -374,7 +375,7 @@ defmodule SanbaseWeb.CoreComponents do
   # All other inputs text, datetime-local, url, password, etc. are handled here...
   def input(assigns) do
     ~H"""
-    <div>
+    <div class={@outer_div_class}>
       <.label for={@id}>{@label}</.label>
       <input
         type={@type}

--- a/lib/sanbase_web/live/metric_registry/metric_registry_form_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_form_live.ex
@@ -258,38 +258,36 @@ defmodule SanbaseWeb.MetricRegistryFormLive do
   end
 
   attr :name, :string, required: true
-  attr :text, :string, required: true
   attr :ef, :map, required: false, default: nil
 
   def inputs_for_drop_button(assigns) do
     ~H"""
     <button
       type="button"
-      class="text-gray-900 my-1 bg-white hover:bg-red-100 border border-gray-200 font-medium rounded-lg text-sm px-4 py-2 text-center inline-flex items-center"
+      class="mt-2.5 mr-2 bg-white border border-gray-300 hover:bg-gray-50  rounded-xl text-sm px-3 py-2.5 inline-flex items-center"
       name={@name}
       value={@ef.index}
       phx-click={JS.dispatch("change")}
     >
-      <.icon name="hero-x-mark" class="w-6 h-6 relative bg-red-700" />
-      {@text}
+      <.icon name="hero-x-mark" class="w-4 h-4 text-red-700" />
     </button>
     """
   end
 
   attr :name, :string, required: true
-  attr :text, :string, required: true
 
   def inputs_for_add_button(assigns) do
     ~H"""
-    <hr class="h-px my-8 bg-gray-200 border-0 dark:bg-gray-700" />
     <button
       type="button"
       name={@name}
       value="new"
       phx-click={JS.dispatch("change")}
-      class="text-gray-900 bg-white hover:bg-gray-100 border border-gray-200 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center"
+      class="mt-4 mr-2 bg-white border border-gray-300 hover:bg-gray-50 hover:text-gray-700 text-gray-600 font-semibold rounded-xl text-sm px-5 py-2.5 inline-flex items-center "
     >
-      {@text}
+      <.icon name="hero-plus-circle" class="w-4 h-4 text-gray-500 mr-2" />
+      <!-- Update icon to 'plus' for 'Add' -->
+      Add
     </button>
     """
   end
@@ -311,18 +309,20 @@ defmodule SanbaseWeb.MetricRegistryFormLive do
       </span>
       <.inputs_for :let={ef} field={@form[@form_field]}>
         <input type="hidden" name={"registry[#{@sort_param}][]"} value={ef.index} />
-        <.input type="text" field={ef[@embeded_schema_field]} placeholder={@placeholder || @singular} />
-
-        <.inputs_for_drop_button
-          ef={ef}
-          name={"registry[#{@drop_param}][]"}
-          text={"Remove #{@singular}"}
-        />
+        <div class="flex flex-grow min-w-0 items-start">
+          <.inputs_for_drop_button ef={ef} name={"registry[#{@drop_param}][]"} />
+          <.input
+            type="text"
+            outer_div_class="flex-grow"
+            field={ef[@embeded_schema_field]}
+            placeholder={@placeholder || @singular}
+          />
+        </div>
       </.inputs_for>
 
       <input type="hidden" name={"registry[#{@drop_param}][]"} />
 
-      <.inputs_for_add_button name={"registry[#{@sort_param}][]"} text={"Add new #{@singular}"} />
+      <.inputs_for_add_button name={"registry[#{@sort_param}][]"} />
     </div>
     """
   end

--- a/lib/sanbase_web/live/metric_registry/metric_registry_history_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_history_live.ex
@@ -86,7 +86,7 @@ defmodule SanbaseWeb.MetricRegistryHistoryLive do
     <span
       :if={@change_trigger}
       class={[
-        "px-3 py-2 text-xs font-semibold text-white rounded-full",
+        "px-3 py-2 text-xs font-semibold text-white rounded-full text-nowrap",
         get_bg_color(@change_trigger)
       ]}
     >

--- a/lib/sanbase_web/live/metric_registry/metric_registry_index_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_index_live.ex
@@ -297,7 +297,7 @@ defmodule SanbaseWeb.MetricRegistryIndexLive do
       <div>{@html_safe_changes}</div>
       """
     else
-      _ ->
+      _err ->
         ~H"""
         <div>
           <div>

--- a/priv/repo/migrations/20250226111103_add_dry_run_sync.exs
+++ b/priv/repo/migrations/20250226111103_add_dry_run_sync.exs
@@ -1,0 +1,9 @@
+defmodule Sanbase.Repo.Migrations.AddDryRunSync do
+  use Ecto.Migration
+
+  def change do
+    alter table(:metric_registry_sync_runs) do
+      add(:is_dry_run, :boolean, default: false)
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2450,7 +2450,8 @@ CREATE TABLE public.metric_registry_sync_runs (
     actual_changes text,
     errors text,
     inserted_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    is_dry_run boolean DEFAULT false
 );
 
 
@@ -9933,3 +9934,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20250207134654);
 INSERT INTO public."schema_migrations" (version) VALUES (20250219075723);
 INSERT INTO public."schema_migrations" (version) VALUES (20250219155459);
 INSERT INTO public."schema_migrations" (version) VALUES (20250220134051);
+INSERT INTO public."schema_migrations" (version) VALUES (20250226111103);

--- a/test/sanbase/metric_registry/metric_registry_sync_test.exs
+++ b/test/sanbase/metric_registry/metric_registry_sync_test.exs
@@ -4,169 +4,297 @@ defmodule Sanbase.MetricRegistrySyncTest do
 
   @moduletag capture_log: true
 
-  test "syncing", _context do
-    [m1_id, m2_id] = create_sync_requirements()
+  describe "dry run" do
+    test "mocked sync content", _context do
+      {:ok, m} = Registry.by_name("price_usd_5m")
+      # Make it ready to sync.
+      # Use a changeset as the update/create functrions do not allow to manually play
+      # with these fields
+      {:ok, m} =
+        Registry.changeset(m, %{is_verified: true, sync_status: "not_synced"})
+        |> Sanbase.Repo.update()
 
-    {:ok, m1} = Registry.by_id(m1_id)
-    {:ok, m2} = Registry.by_id(m2_id)
+      # This is used for mock when taking the records to be synced
+      # As the initiating and receiving databases in test env are the same
+      # only with mocks we can ensure some changes are actually applied
+      changed_m = %{
+        m
+        | min_interval: "1d",
+          exposed_environments: "stage",
+          aliases: [%Registry.Alias{name: "new_alias"}]
+      }
 
-    assert m1.sync_status == "not_synced"
-    assert m2.sync_status == "not_synced"
+      Sanbase.Mock.prepare_mock2(&Registry.by_ids/1, [changed_m])
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        # Check some fields before sync
+        {:ok, m} = Registry.by_id(m.id)
+        assert m.sync_status == "not_synced"
+        assert m.min_interval != "1d"
+        assert not Enum.any?(m.aliases, &(&1.name == "new_alias"))
 
-    assert {:ok, %{status: "executing", uuid: uuid}} = Registry.Sync.sync([m1_id, m2_id])
+        # Run the Sync
+        assert {:ok, %{status: "executing", uuid: uuid, is_dry_run: true}} =
+                 Registry.Sync.sync([m.id], dry_run: true)
 
-    Process.sleep(100)
+        Process.sleep(100)
 
-    assert {:ok, %{status: "completed", uuid: ^uuid}} = Registry.Sync.by_uuid(uuid)
-    {:ok, m1} = Registry.by_id(m1_id)
-    {:ok, m2} = Registry.by_id(m2_id)
-    assert m1.sync_status == "synced"
-    assert m2.sync_status == "synced"
+        # Make sure both the outgoing and the incoming syncs are looking good
+        # In test env we have both outgoing and incoming as the sync happens from and to
+        # the same database.
+        assert {:ok,
+                %{
+                  status: "completed",
+                  uuid: ^uuid,
+                  is_dry_run: true,
+                  actual_changes: actual_changes
+                }} =
+                 Registry.Sync.by_uuid(uuid, "outgoing")
+
+        assert {:ok,
+                %{
+                  status: "completed",
+                  uuid: ^uuid,
+                  is_dry_run: true,
+                  actual_changes: ^actual_changes
+                }} =
+                 Registry.Sync.by_uuid(uuid, "incoming")
+
+        # The actual changes in one sync can contain many encoded {key, changes} pairs.
+        # The key points to the metric. The id is not used, because by this key it should be
+        # possible to fetch the record on stage and on prod, where the ids differ
+        # NOTE: The changes are stored in the sync runs but they are listed as DRY RUN
+        # so they are not actually applied
+        assert {:ok, [{changes_key, changes_value}]} =
+                 Registry.Sync.decode_changes(actual_changes)
+
+        assert changes_key ==
+                 %{data_type: "timeseries", metric: "price_usd_5m", fixed_parameters: %{}}
+
+        assert changes_value == %{
+                 aliases:
+                   {:changed,
+                    [{:added_to_list, 0, %Sanbase.Metric.Registry.Alias{name: "new_alias"}}]},
+                 min_interval: {:changed, {:primitive_change, "1s", "1d"}},
+                 exposed_environments: {:changed, {:primitive_change, "all", "stage"}}
+               }
+
+        # After dry run sync the sync status MUST NOT be synced, it should still be not_synced
+        {:ok, m} = Registry.by_id(m.id)
+        assert m.sync_status == "not_synced"
+        assert m.min_interval != "1d"
+        assert not Enum.any?(m.aliases, &(&1.name == "new_alias"))
+
+        # No changelog was generated as no real changes were applied
+        {:ok, list} = Registry.Changelog.by_metric_registry_id(m.id)
+        assert [] == list
+      end)
+    end
   end
 
-  defp create_sync_requirements() do
-    # Get 3 records
-    {:ok, m1} = Registry.by_name("price_usd_5m")
-    {:ok, m2} = Registry.by_name("mvrv_usd")
-    {:ok, m3} = Registry.by_name("social_volume_total")
+  describe "not dry run" do
+    test "sync not_synced", _context do
+      {:ok, m} = Registry.by_name("price_usd_5m")
+      # Just mark it as not synced and sync.
+      # This exercises the case where there are no actual changes
+      assert {:ok, _} =
+               Registry.changeset(m, %{sync_status: "not_synced"}) |> Sanbase.Repo.update()
 
-    # Create change suggestions
-    {:ok, ch1} =
-      Registry.ChangeSuggestion.create_change_suggestion(
-        m1,
-        %{"min_interval" => "5m"},
-        "for tests",
-        "ivan@santiment.net"
-      )
+      assert {:ok, %{status: "executing", uuid: uuid}} =
+               Registry.Sync.sync([m.id], dry_run: false)
 
-    {:ok, _unused} =
-      Registry.ChangeSuggestion.create_change_suggestion(
-        m1,
-        %{"min_interval" => "10m"},
-        "for tests",
-        "ivan@santiment.net"
-      )
-
-    {:ok, ch2} =
-      Registry.ChangeSuggestion.create_change_suggestion(
-        m2,
-        %{"min_interval" => "5m"},
-        "for tests",
-        "ivan@santiment.net"
-      )
-
-    {:ok, ch3} =
-      Registry.ChangeSuggestion.create_change_suggestion(
-        m2,
-        %{"aliases" => [%{name: "mvrv_usd_new_alias"}]},
-        "for tests",
-        "ivan@santiment.net"
-      )
-
-    {:ok, ch4} =
-      Registry.ChangeSuggestion.create_change_suggestion(
-        m1,
-        %{"aliases" => [%{name: "price_usd_gap_filled"}]},
-        "for tests",
-        "ivan@santiment.net"
-      )
-
-    {:ok, ch5} =
-      Registry.ChangeSuggestion.create_change_suggestion(
-        m3,
-        %{"min_interval" => "2h"},
-        "for tests",
-        "ivan@santiment.net"
-      )
-
-    # Approve all 4 suggestions
-    {:ok, _} = Registry.ChangeSuggestion.update_status(ch1.id, "approved")
-    {:ok, _} = Registry.ChangeSuggestion.update_status(ch2.id, "approved")
-    {:ok, _} = Registry.ChangeSuggestion.update_status(ch3.id, "approved")
-    {:ok, _} = Registry.ChangeSuggestion.update_status(ch4.id, "approved")
-    {:ok, _} = Registry.ChangeSuggestion.update_status(ch5.id, "approved")
-
-    # Verify only price_usd_5m and mvrv_usd metrics to properly test
-    # that sync only affects verified metrics
-    {:ok, _} = Sanbase.Metric.Registry.update_is_verified(m1, true)
-    {:ok, _} = Sanbase.Metric.Registry.update_is_verified(m2, true)
-
-    [m1.id, m2.id]
-  end
-
-  test "mocked sync content", _context do
-    {:ok, m} = Registry.by_name("price_usd_5m")
-    # Make it ready to sync.
-    # Use a changeset as the update/create functrions do not allow to manually play
-    # with these fields
-    {:ok, m} =
-      Registry.changeset(m, %{is_verified: true, sync_status: "not_synced"})
-      |> Sanbase.Repo.update()
-
-    # This is used for mock when taking the records to be synced
-    # As the initiating and receiving databases in test env are the same
-    # only with mocks we can ensure some changes are actually applied
-    changed_m = %{
-      m
-      | min_interval: "1d",
-        exposed_environments: "stage",
-        aliases: [%Registry.Alias{name: "new_alias"}]
-    }
-
-    Sanbase.Mock.prepare_mock2(&Registry.by_ids/1, [changed_m])
-    |> Sanbase.Mock.run_with_mocks(fn ->
-      # Check some fields before sync
-      {:ok, m} = Registry.by_id(m.id)
-      assert m.sync_status == "not_synced"
-      assert m.min_interval != "1d"
-      assert not Enum.any?(m.aliases, &(&1.name == "new_alias"))
-
-      # Run the Sync
-      assert {:ok, %{status: "executing", uuid: uuid}} = Registry.Sync.sync([m.id])
       Process.sleep(100)
 
-      assert {:ok, %{status: "completed", uuid: ^uuid, actual_changes: actual_changes}} =
-               Registry.Sync.by_uuid(uuid)
-
-      # The actual changes in one sync can contain many encoded {key, changes} pairs.
-      # The key points to the metric. The id is not used, because by this key it should be
-      # possible to fetch the record on stage and on prod, where the ids differ
-      assert {:ok, [{changes_key, changes_value}]} = Registry.Sync.decode_changes(actual_changes)
-
-      assert changes_key ==
-               %{data_type: "timeseries", metric: "price_usd_5m", fixed_parameters: %{}}
-
-      assert changes_value == %{
-               aliases:
-                 {:changed,
-                  [{:added_to_list, 0, %Sanbase.Metric.Registry.Alias{name: "new_alias"}}]},
-               min_interval: {:changed, {:primitive_change, "1s", "1d"}},
-               exposed_environments: {:changed, {:primitive_change, "all", "stage"}}
-             }
-
-      # Check some fields after sync
+      assert {:ok, %{status: "completed", uuid: ^uuid}} = Registry.Sync.by_uuid(uuid)
       {:ok, m} = Registry.by_id(m.id)
       assert m.sync_status == "synced"
-      assert m.min_interval == "1d"
+    end
 
-      assert Enum.any?(m.aliases, &(&1.name == "new_alias"))
+    test "syncing", _context do
+      [m1_id, m2_id] = create_sync_requirements()
 
-      # Check that the changelog records the actual sync changes for that metric
-      {:ok, list} = Registry.Changelog.by_metric_registry_id(m.id)
-      assert [changelog] = list
+      {:ok, m1} = Registry.by_id(m1_id)
+      {:ok, m2} = Registry.by_id(m2_id)
 
-      changes =
-        ExAudit.Diff.diff(
-          Jason.decode!(changelog.old),
-          Jason.decode!(changelog.new)
+      assert m1.sync_status == "not_synced"
+      assert m2.sync_status == "not_synced"
+
+      assert {:ok, %{status: "executing", uuid: uuid}} =
+               Registry.Sync.sync([m1_id, m2_id], dry_run: false)
+
+      Process.sleep(100)
+
+      assert {:ok, %{status: "completed", uuid: ^uuid}} = Registry.Sync.by_uuid(uuid)
+      {:ok, m1} = Registry.by_id(m1_id)
+      {:ok, m2} = Registry.by_id(m2_id)
+      assert m1.sync_status == "synced"
+      assert m2.sync_status == "synced"
+    end
+
+    defp create_sync_requirements() do
+      # Get 3 records
+      {:ok, m1} = Registry.by_name("price_usd_5m")
+      {:ok, m2} = Registry.by_name("mvrv_usd")
+      {:ok, m3} = Registry.by_name("social_volume_total")
+
+      # Create change suggestions
+      {:ok, ch1} =
+        Registry.ChangeSuggestion.create_change_suggestion(
+          m1,
+          %{"min_interval" => "5m"},
+          "for tests",
+          "ivan@santiment.net"
         )
 
-      assert changes ==
-               %{
-                 "aliases" => {:changed, [{:added_to_list, 0, %{"name" => "new_alias"}}]},
-                 "exposed_environments" => {:changed, {:primitive_change, "all", "stage"}},
-                 "min_interval" => {:changed, {:primitive_change, "1s", "1d"}}
+      {:ok, _unused} =
+        Registry.ChangeSuggestion.create_change_suggestion(
+          m1,
+          %{"min_interval" => "10m"},
+          "for tests",
+          "ivan@santiment.net"
+        )
+
+      {:ok, ch2} =
+        Registry.ChangeSuggestion.create_change_suggestion(
+          m2,
+          %{"min_interval" => "5m"},
+          "for tests",
+          "ivan@santiment.net"
+        )
+
+      {:ok, ch3} =
+        Registry.ChangeSuggestion.create_change_suggestion(
+          m2,
+          %{"aliases" => [%{name: "mvrv_usd_new_alias"}]},
+          "for tests",
+          "ivan@santiment.net"
+        )
+
+      {:ok, ch4} =
+        Registry.ChangeSuggestion.create_change_suggestion(
+          m1,
+          %{"aliases" => [%{name: "price_usd_gap_filled"}]},
+          "for tests",
+          "ivan@santiment.net"
+        )
+
+      {:ok, ch5} =
+        Registry.ChangeSuggestion.create_change_suggestion(
+          m3,
+          %{"min_interval" => "2h"},
+          "for tests",
+          "ivan@santiment.net"
+        )
+
+      # Approve all 4 suggestions
+      {:ok, _} = Registry.ChangeSuggestion.update_status(ch1.id, "approved")
+      {:ok, _} = Registry.ChangeSuggestion.update_status(ch2.id, "approved")
+      {:ok, _} = Registry.ChangeSuggestion.update_status(ch3.id, "approved")
+      {:ok, _} = Registry.ChangeSuggestion.update_status(ch4.id, "approved")
+      {:ok, _} = Registry.ChangeSuggestion.update_status(ch5.id, "approved")
+
+      # Verify only price_usd_5m and mvrv_usd metrics to properly test
+      # that sync only affects verified metrics
+      {:ok, _} = Sanbase.Metric.Registry.update_is_verified(m1, true)
+      {:ok, _} = Sanbase.Metric.Registry.update_is_verified(m2, true)
+
+      [m1.id, m2.id]
+    end
+
+    test "mocked sync content", _context do
+      {:ok, m} = Registry.by_name("price_usd_5m")
+      # Make it ready to sync.
+      # Use a changeset as the update/create functrions do not allow to manually play
+      # with these fields
+      {:ok, m} =
+        Registry.changeset(m, %{is_verified: true, sync_status: "not_synced"})
+        |> Sanbase.Repo.update()
+
+      # This is used for mock when taking the records to be synced
+      # As the initiating and receiving databases in test env are the same
+      # only with mocks we can ensure some changes are actually applied
+      changed_m = %{
+        m
+        | min_interval: "1d",
+          exposed_environments: "stage",
+          aliases: [%Registry.Alias{name: "new_alias"}]
+      }
+
+      Sanbase.Mock.prepare_mock2(&Registry.by_ids/1, [changed_m])
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        # Check some fields before sync
+        {:ok, m} = Registry.by_id(m.id)
+        assert m.sync_status == "not_synced"
+        assert m.min_interval != "1d"
+        assert not Enum.any?(m.aliases, &(&1.name == "new_alias"))
+
+        # Run the Sync
+        assert {:ok, %{status: "executing", is_dry_run: false, uuid: uuid}} =
+                 Registry.Sync.sync([m.id], dry_run: false)
+
+        Process.sleep(100)
+
+        # Make sure both the outgoing and the incoming syncs are looking good
+        # In test env we have both outgoing and incoming as the sync happens from and to
+        # the same database.
+        assert {:ok,
+                %{
+                  status: "completed",
+                  uuid: ^uuid,
+                  is_dry_run: false,
+                  actual_changes: actual_changes
+                }} =
+                 Registry.Sync.by_uuid(uuid, "outgoing")
+
+        assert {:ok,
+                %{
+                  status: "completed",
+                  uuid: ^uuid,
+                  is_dry_run: false,
+                  actual_changes: actual_changes
+                }} =
+                 Registry.Sync.by_uuid(uuid, "incoming")
+
+        # The actual changes in one sync can contain many encoded {key, changes} pairs.
+        # The key points to the metric. The id is not used, because by this key it should be
+        # possible to fetch the record on stage and on prod, where the ids differ
+        assert {:ok, [{changes_key, changes_value}]} =
+                 Registry.Sync.decode_changes(actual_changes)
+
+        assert changes_key ==
+                 %{data_type: "timeseries", metric: "price_usd_5m", fixed_parameters: %{}}
+
+        assert changes_value == %{
+                 aliases:
+                   {:changed,
+                    [{:added_to_list, 0, %Sanbase.Metric.Registry.Alias{name: "new_alias"}}]},
+                 min_interval: {:changed, {:primitive_change, "1s", "1d"}},
+                 exposed_environments: {:changed, {:primitive_change, "all", "stage"}}
                }
-    end)
+
+        # Check some fields after sync
+        {:ok, m} = Registry.by_id(m.id)
+        assert m.sync_status == "synced"
+        assert m.min_interval == "1d"
+
+        assert Enum.any?(m.aliases, &(&1.name == "new_alias"))
+
+        # Check that the changelog records the actual sync changes for that metric
+        {:ok, list} = Registry.Changelog.by_metric_registry_id(m.id)
+        assert [changelog] = list
+
+        changes =
+          ExAudit.Diff.diff(
+            Jason.decode!(changelog.old),
+            Jason.decode!(changelog.new)
+          )
+
+        assert changes ==
+                 %{
+                   "aliases" => {:changed, [{:added_to_list, 0, %{"name" => "new_alias"}}]},
+                   "exposed_environments" => {:changed, {:primitive_change, "all", "stage"}},
+                   "min_interval" => {:changed, {:primitive_change, "1s", "1d"}}
+                 }
+      end)
+    end
   end
 end


### PR DESCRIPTION
## Changes
- Implement Sync Dry Runs
- UI improvements for Sync Runs and Edit

---
Sync Runs now show whether this is dry run or not:
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/2a5b92b5-f0e8-4031-b400-8da4b53a9a0d" />

---
The Metric Edits has a little bit improved UI for the list inputs (supporting 0, 1 or more values).

Old:
<img width="288" alt="image" src="https://github.com/user-attachments/assets/065d9d68-f835-42c7-a2a4-cd04430f0ea2" />

New:
<img width="511" alt="image" src="https://github.com/user-attachments/assets/2bf29f48-5df1-42e8-8684-8044b9ac61fd" />


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
