### PR TITLE
get metric finalized

### DIFF
--- a/lib/sanbase/template_engine/template_engine.ex
+++ b/lib/sanbase/template_engine/template_engine.ex
@@ -67,8 +67,10 @@ defmodule Sanbase.TemplateEngine do
   """
   @spec run(String.t(), opts) :: {:ok, String.t()} | {:error, String.t()}
   def run(template, opts \\ []) do
+    IO.inspect(template)
     params = Keyword.get(opts, :params, %{}) |> Map.new(fn {k, v} -> {to_string(k), v} end)
     env = Keyword.get(opts, :env, Sanbase.SanLang.Environment.new())
+    IO.inspect(params)
 
     with {:ok, captures} <- TemplateEngine.Captures.extract_captures(template) do
       template =

--- a/lib/sanbase/template_engine/template_engine.ex
+++ b/lib/sanbase/template_engine/template_engine.ex
@@ -67,10 +67,8 @@ defmodule Sanbase.TemplateEngine do
   """
   @spec run(String.t(), opts) :: {:ok, String.t()} | {:error, String.t()}
   def run(template, opts \\ []) do
-    IO.inspect(template)
     params = Keyword.get(opts, :params, %{}) |> Map.new(fn {k, v} -> {to_string(k), v} end)
     env = Keyword.get(opts, :env, Sanbase.SanLang.Environment.new())
-    IO.inspect(params)
 
     with {:ok, captures} <- TemplateEngine.Captures.extract_captures(template) do
       template =

--- a/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
@@ -272,12 +272,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
         %{source: %{metric: metric}}
       ) do
     include_incomplete_data = Map.get(args, :include_incomplete_data, false)
+    only_finalized_data = Map.get(args, :only_finalized_data, false)
 
     with {:ok, selector} <- args_to_selector(args),
          true <- all_required_selectors_present?(metric, selector),
          true <- valid_metric_selector_pair?(metric, selector),
          true <- valid_owners_labels_selection?(args),
          {:ok, opts} <- selector_args_to_opts(args),
+         opts <- Keyword.put(opts, :only_finalized_data, only_finalized_data),
          {:ok, from, to} <-
            calibrate_incomplete_data_params(
              include_incomplete_data,

--- a/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
@@ -415,6 +415,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   # from the Metric module.
   defp fetch_timeseries_data(metric, args, requested_fields, function)
        when function in [:timeseries_data, :timeseries_data_per_slug] do
+    only_finalized_data = Map.get(args, :only_finalized_data, false)
+
     with {:ok, selector} <- args_to_selector(args),
          {:ok, transform} <- MetricTransform.args_to_transform(args),
          true <- all_required_selectors_present?(metric, selector),
@@ -422,6 +424,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
          true <- valid_owners_labels_selection?(args),
          true <- valid_timeseries_selection?(requested_fields, args),
          {:ok, opts} <- selector_args_to_opts(args),
+         opts <- Keyword.put(opts, :only_finalized_data, only_finalized_data),
          {:ok, from, to, interval} <-
            transform_datetime_params(selector, metric, transform, args),
          {:ok, result} <-

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -570,6 +570,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       arg(:aggregation, :aggregation, default_value: nil)
       arg(:transform, :timeseries_metric_transform_input_object)
       arg(:include_incomplete_data, :boolean, default_value: false)
+      arg(:only_finalized_data, :boolean, default_value: false)
       arg(:caching_params, :caching_params_input_object)
 
       complexity(&Complexity.from_to_interval/3)
@@ -586,6 +587,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       arg(:aggregation, :aggregation, default_value: nil)
       arg(:transform, :timeseries_metric_transform_input_object)
       arg(:include_incomplete_data, :boolean, default_value: false)
+      arg(:only_finalized_data, :boolean, default_value: false)
       arg(:caching_params, :caching_params_input_object)
 
       complexity(&Complexity.from_to_interval/3)
@@ -609,6 +611,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       arg(:to, non_null(:datetime))
       arg(:aggregation, :aggregation, default_value: nil)
       arg(:caching_params, :caching_params_input_object)
+      arg(:only_finalized_data, :boolean, default_value: false)
 
       complexity(&Complexity.from_to_interval/3)
       middleware(AccessControl)

--- a/lib/sanbase_web/graphql/schema/types/project_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/project_types.ex
@@ -322,6 +322,7 @@ defmodule SanbaseWeb.Graphql.ProjectTypes do
       arg(:to, non_null(:datetime))
       arg(:aggregation, :aggregation, default_value: nil)
       arg(:include_incomplete_data, :boolean, default_value: false)
+      arg(:only_finalized_data, :boolean, default_value: false)
       arg(:caching_params, :caching_params_input_object)
       arg(:error_on_data_fetch_fail, :boolean, default_value: false)
 


### PR DESCRIPTION
## Changes

- **Add onlyFinalizedData flag to getMetric**
- **Add onlyFinalizedData to the Project GQL type**

The parameter controls whether or not to include only those rows from the database that have `is_finalized = true`.
By default it is `false` so it is fully backwards compatible.

```graphql
{
  getMetric(metric: "active_addresses_24h") {
    timeseriesData(
      slug: "bitcoin"
      from: "utc_now-1d"
      to: "utc_now"
      interval: "1h"
      onlyFinalizedData: true) {
        datetime
        value
    }
  }
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
