### PR TITLE
improve metric registry resillience

### DIFF
--- a/lib/sanbase/clickhouse/metric/registry/registry.ex
+++ b/lib/sanbase/clickhouse/metric/registry/registry.ex
@@ -147,9 +147,13 @@ defmodule Sanbase.Clickhouse.MetricAdapter.Registry do
     Keyword.validate!(opts, [:remove_hard_deprecated])
 
     Sanbase.Cache.get_or_store(registry_cache_key(opts), fn ->
-      data =
+      # TODO: Show somewhere that the registries with errors.
+      {data, _registires_with_errors} =
         Sanbase.Metric.Registry.all()
-        |> Sanbase.Metric.Registry.resolve()
+        |> Sanbase.Metric.Registry.resolve_safe()
+
+      data =
+        data
         |> filter_exposed_environments(opts)
         |> filter_hard_deprecated(opts)
 
@@ -198,8 +202,8 @@ defmodule Sanbase.Clickhouse.MetricAdapter.Registry do
           end
         end)
         |> Enum.reject(&is_nil/1)
-        |> Sanbase.Metric.Registry.resolve()
-        |> then(fn list ->
+        |> Sanbase.Metric.Registry.resolve_safe()
+        |> then(fn {list, _registries_with_errors} ->
           if Keyword.get(opts, :remove_hard_deprecated, true),
             do: remove_hard_deprecated(list),
             else: list

--- a/lib/sanbase/utils/datetime/datetime_utils.ex
+++ b/lib/sanbase/utils/datetime/datetime_utils.ex
@@ -204,8 +204,11 @@ defmodule Sanbase.DateTimeUtils do
 
   def valid_compound_duration?(value) do
     case Integer.parse(value) do
-      {int, string} when is_integer(int) and string in ["ns", "s", "m", "h", "d", "w"] -> true
-      _ -> false
+      {int, string} when is_integer(int) and string in ["ns", "s", "m", "h", "d", "w", "y"] ->
+        true
+
+      _ ->
+        false
     end
   end
 


### PR DESCRIPTION
## Changes

- **Improve validations of Metric.Registry parameters**
- **getMetric works when resolving of some metrics fails** -- when a metric fails to resolve (mostly errors in parameters) this does not break the API for the other metrics.

![image](https://github.com/user-attachments/assets/29eb8919-bb35-47ff-bc8e-c9c8c627e328)

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
