### PR TITLE
struct update deprecated sytnax

### DIFF
--- a/lib/sanbase/alerts/trigger/settings/eth_wallet_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/eth_wallet_trigger_settings.ex
@@ -164,7 +164,7 @@ defmodule Sanbase.Alert.Trigger.EthWalletTriggerSettings do
 
         _ ->
           # TODO: Handle error case
-          settings = %EthWalletTriggerSettings{settings | triggered?: false}
+          settings = %{settings | triggered?: false}
           {:ok, settings}
       end
     end

--- a/lib/sanbase/alerts/trigger/settings/eth_wallet_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/eth_wallet_trigger_settings.ex
@@ -189,11 +189,7 @@ defmodule Sanbase.Alert.Trigger.EthWalletTriggerSettings do
             end
         end)
 
-      settings = %EthWalletTriggerSettings{
-        settings
-        | template_kv: template_kv,
-          triggered?: template_kv != %{}
-      }
+      settings = %{settings | template_kv: template_kv, triggered?: template_kv != %{}}
 
       {:ok, settings}
     end

--- a/lib/sanbase/alerts/trigger/settings/raw_signal_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/raw_signal_trigger_settings.ex
@@ -147,11 +147,7 @@ defmodule Sanbase.Alert.Trigger.RawSignalTriggerSettings do
       settings =
         case template_kv != %{} do
           true ->
-            %RawSignalTriggerSettings{
-              settings
-              | triggered?: true,
-                template_kv: template_kv
-            }
+            %{settings | triggered?: true, template_kv: template_kv}
 
           false ->
             %{settings | triggered?: false}

--- a/lib/sanbase/alerts/trigger/settings/raw_signal_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/raw_signal_trigger_settings.ex
@@ -126,7 +126,7 @@ defmodule Sanbase.Alert.Trigger.RawSignalTriggerSettings do
 
         _ ->
           # TODO: Handle error case
-          settings = %RawSignalTriggerSettings{settings | triggered?: false}
+          settings = %{settings | triggered?: false}
           {:ok, settings}
       end
     end
@@ -154,7 +154,7 @@ defmodule Sanbase.Alert.Trigger.RawSignalTriggerSettings do
             }
 
           false ->
-            %RawSignalTriggerSettings{settings | triggered?: false}
+            %{settings | triggered?: false}
         end
 
       {:ok, settings}

--- a/lib/sanbase/alerts/trigger/settings/screener_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/screener_trigger_settings.ex
@@ -91,12 +91,11 @@ defmodule Sanbase.Alert.Trigger.ScreenerTriggerSettings do
     end
   end
 
-  defp fill_current_state(trigger) do
-    %{settings: settings} = trigger
+  defp fill_current_state(%Sanbase.Alert.Trigger{} = trigger) do
+    %{settings: %ScreenerTriggerSettings{} = settings} = trigger
 
     with {:ok, slugs} <- get_data(settings) do
       settings = %{settings | state: %{slugs_in_screener: slugs}}
-
       trigger = %{trigger | settings: settings}
       {:ok, trigger}
     end

--- a/lib/sanbase/alerts/trigger/settings/screener_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/screener_trigger_settings.ex
@@ -118,7 +118,7 @@ defmodule Sanbase.Alert.Trigger.ScreenerTriggerSettings do
 
         _ ->
           # {:error, _} or {:ok, []}
-          settings = %ScreenerTriggerSettings{settings | triggered?: false}
+          settings = %{settings | triggered?: false}
           {:ok, settings}
       end
     end

--- a/lib/sanbase/alerts/trigger/settings/signal_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/signal_trigger_settings.ex
@@ -132,7 +132,7 @@ defmodule Sanbase.Alert.Trigger.SignalTriggerSettings do
 
         _ ->
           # TODO: Handle error
-          settings = %SignalTriggerSettings{settings | triggered?: false}
+          settings = %{settings | triggered?: false}
           {:ok, settings}
       end
     end

--- a/lib/sanbase/alerts/trigger/settings/trending_words_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/trending_words_trigger_settings.ex
@@ -79,7 +79,7 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
     def triggered?(%TrendingWordsTriggerSettings{triggered?: triggered}), do: triggered
 
     def evaluate(%TrendingWordsTriggerSettings{filtered_target: %{list: []}} = settings, _trigger) do
-      settings = %TrendingWordsTriggerSettings{settings | triggered?: false}
+      settings = %{settings | triggered?: false}
       {:ok, settings}
     end
 
@@ -89,7 +89,7 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
           build_result(top_words, settings)
 
         _ ->
-          settings = %TrendingWordsTriggerSettings{settings | triggered?: false}
+          settings = %{settings | triggered?: false}
           {:ok, settings}
       end
     end
@@ -110,10 +110,10 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
         case Sanbase.DateTimeUtils.time_in_range?(trigger_time, now, after_15_mins) do
           true ->
             template_kv = %{settings.target => template_kv(settings, top_words)}
-            %TrendingWordsTriggerSettings{settings | triggered?: true, template_kv: template_kv}
+            %{settings | triggered?: true, template_kv: template_kv}
 
           false ->
-            %TrendingWordsTriggerSettings{settings | triggered?: false}
+            %{settings | triggered?: false}
         end
 
       {:ok, settings}
@@ -132,11 +132,11 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
       settings =
         case trending_words do
           [] ->
-            %TrendingWordsTriggerSettings{settings | triggered?: false}
+            %{settings | triggered?: false}
 
           [_ | _] = words ->
             template_kv = %{words => template_kv(settings, words)}
-            %TrendingWordsTriggerSettings{settings | triggered?: true, template_kv: template_kv}
+            %{settings | triggered?: true, template_kv: template_kv}
         end
 
       {:ok, settings}
@@ -165,7 +165,7 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
           true ->
             # If there are no trending words in the intersection there is no
             # point of checking the projects separately
-            %TrendingWordsTriggerSettings{settings | triggered?: false}
+            %{settings | triggered?: false}
 
           false ->
             template_kv =

--- a/lib/sanbase/alerts/trigger/settings/trending_words_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/trending_words_trigger_settings.ex
@@ -176,11 +176,7 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
                 end
               end)
 
-            %TrendingWordsTriggerSettings{
-              settings
-              | triggered?: template_kv != %{},
-                template_kv: template_kv
-            }
+            %{settings | triggered?: template_kv != %{}, template_kv: template_kv}
         end
 
       {:ok, settings}

--- a/lib/sanbase/alerts/trigger/settings/trending_words_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/trending_words_trigger_settings.ex
@@ -100,7 +100,9 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
 
     defp build_result(
            top_words,
-           %{operation: %{send_at_predefined_time: true, trigger_time: trigger_time}} = settings
+           %TrendingWordsTriggerSettings{
+             operation: %{send_at_predefined_time: true, trigger_time: trigger_time}
+           } = settings
          ) do
       trigger_time = Sanbase.DateTimeUtils.time_from_iso8601!(trigger_time)
       now = Time.utc_now()
@@ -121,7 +123,10 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
 
     defp build_result(
            top_words,
-           %{operation: %{trending_word: true}, filtered_target: %{list: words}} = settings
+           %TrendingWordsTriggerSettings{
+             operation: %{trending_word: true},
+             filtered_target: %{list: words}
+           } = settings
          ) do
       top_words = top_words |> Enum.map(&String.downcase(&1.word))
 
@@ -144,7 +149,10 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
 
     defp build_result(
            top_words,
-           %{operation: %{trending_project: true}, filtered_target: %{list: slugs}} = settings
+           %TrendingWordsTriggerSettings{
+             operation: %{trending_project: true},
+             filtered_target: %{list: slugs}
+           } = settings
          ) do
       projects = Project.List.by_slugs(slugs)
 
@@ -183,7 +191,9 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
     end
 
     defp template_kv(
-           %{operation: %{send_at_predefined_time: true, trigger_time: trigger_time}} = settings,
+           %TrendingWordsTriggerSettings{
+             operation: %{send_at_predefined_time: true, trigger_time: trigger_time}
+           } = settings,
            top_words
          ) do
       max_len = get_max_len(top_words)
@@ -221,7 +231,10 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
       |> maybe_extend_with_explanation(settings)
     end
 
-    defp template_kv(%{operation: %{trending_word: true}} = settings, [word]) do
+    defp template_kv(
+           %TrendingWordsTriggerSettings{operation: %{trending_word: true}} = settings,
+           [word]
+         ) do
       kv = %{
         type: TrendingWordsTriggerSettings.type(),
         operation: settings.operation,
@@ -239,7 +252,10 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
       |> maybe_extend_with_explanation(settings)
     end
 
-    defp template_kv(%{operation: %{trending_word: true}} = settings, [_, _ | _] = words) do
+    defp template_kv(
+           %TrendingWordsTriggerSettings{operation: %{trending_word: true}} = settings,
+           [_, _ | _] = words
+         ) do
       {last, previous} = List.pop_at(words, -1)
       words_str = (Enum.map(previous, &"**#{&1}**") |> Enum.join(",")) <> " and **#{last}**"
 
@@ -260,7 +276,10 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
       |> maybe_extend_with_explanation(settings)
     end
 
-    defp template_kv(%{operation: %{trending_project: true}} = settings, project) do
+    defp template_kv(
+           %TrendingWordsTriggerSettings{operation: %{trending_project: true}} = settings,
+           project
+         ) do
       kv = %{
         type: TrendingWordsTriggerSettings.type(),
         operation: settings.operation,
@@ -304,7 +323,7 @@ defmodule Sanbase.Alert.Trigger.TrendingWordsTriggerSettings do
       {template, kv}
     end
 
-    defp maybe_extend_with_explanation({template, kv}, settings) do
+    defp maybe_extend_with_explanation({template, kv}, %TrendingWordsTriggerSettings{} = settings) do
       default_explanation =
         case settings.include_default_explanation do
           true -> @default_explanation

--- a/lib/sanbase/alerts/trigger/settings/wallet/wallet_assets_held_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/wallet/wallet_assets_held_trigger_settings.ex
@@ -58,11 +58,11 @@ defmodule Sanbase.Alert.Trigger.WalletAssetsHeldTriggerSettings do
   @spec type() :: String.t()
   def type(), do: @trigger_type
 
-  def post_create_process(trigger), do: fill_current_state(trigger)
-  def post_update_process(trigger), do: fill_current_state(trigger)
+  def post_create_process(%Sanbase.Alert.Trigger{} = trigger), do: fill_current_state(trigger)
+  def post_update_process(%Sanbase.Alert.Trigger{} = trigger), do: fill_current_state(trigger)
 
-  defp fill_current_state(trigger) do
-    %{settings: settings} = trigger
+  defp fill_current_state(%Sanbase.Alert.Trigger{} = trigger) do
+    %{settings: %WalletAssetsHeldTriggerSettings{} = settings} = trigger
 
     temp_settings =
       Map.put(settings, :filtered_target, Sanbase.Alert.Trigger.get_filtered_target(trigger))
@@ -80,7 +80,7 @@ defmodule Sanbase.Alert.Trigger.WalletAssetsHeldTriggerSettings do
   @doc ~s"""
   Return a list of the `settings.metric` values for the necessary time range
   """
-  def get_data(%__MODULE__{
+  def get_data(%WalletAssetsHeldTriggerSettings{
         filtered_target: %{list: target_list},
         selector: selector
       }) do
@@ -109,7 +109,7 @@ defmodule Sanbase.Alert.Trigger.WalletAssetsHeldTriggerSettings do
     {:ok, data}
   end
 
-  defp assets_held(selector) do
+  defp assets_held(%{} = selector) do
     cache_key =
       {__MODULE__, :assets_held, selector, round_datetime(DateTime.utc_now())}
       |> Sanbase.Cache.hash()
@@ -167,7 +167,7 @@ defmodule Sanbase.Alert.Trigger.WalletAssetsHeldTriggerSettings do
       ])
     end
 
-    defp template_kv(values, settings) do
+    defp template_kv(values, %WalletAssetsHeldTriggerSettings{} = settings) do
       %{added_slugs: added_slugs, removed_slugs: removed_slugs} = values
 
       kv = %{

--- a/lib/sanbase/alerts/trigger/settings/wallet/wallet_assets_held_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/wallet/wallet_assets_held_trigger_settings.ex
@@ -134,7 +134,7 @@ defmodule Sanbase.Alert.Trigger.WalletAssetsHeldTriggerSettings do
 
         _ ->
           # TODO: Handle errror case
-          settings = %WalletAssetsHeldTriggerSettings{settings | triggered?: false}
+          settings = %{settings | triggered?: false}
           {:ok, settings}
       end
     end

--- a/lib/sanbase/alerts/trigger/settings/wallet/wallet_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/wallet/wallet_trigger_settings.ex
@@ -172,7 +172,7 @@ defmodule Sanbase.Alert.Trigger.WalletTriggerSettings do
           build_result(data, settings)
 
         _ ->
-          settings = %WalletTriggerSettings{settings | triggered?: false}
+          settings = %{settings | triggered?: false}
           {:ok, settings}
       end
     end

--- a/lib/sanbase/alerts/trigger/settings/wallet/wallet_usd_valuation_trigger_settings.ex
+++ b/lib/sanbase/alerts/trigger/settings/wallet/wallet_usd_valuation_trigger_settings.ex
@@ -143,7 +143,7 @@ defmodule Sanbase.Alert.Trigger.WalletUsdValuationTriggerSettings do
           build_result(data, settings)
 
         _ ->
-          settings = %WalletUsdValuationTriggerSettings{settings | triggered?: false}
+          settings = %{settings | triggered?: false}
           {:ok, settings}
       end
     end

--- a/lib/sanbase/alerts/trigger/trigger.ex
+++ b/lib/sanbase/alerts/trigger/trigger.ex
@@ -126,7 +126,7 @@ defmodule Sanbase.Alert.Trigger do
       _ ->
         case Sanbase.Alert.Settings.evaluate(trigger_settings, trigger) do
           {:ok, trigger_settings} ->
-            trigger = %Trigger{trigger | settings: trigger_settings}
+            trigger = %{trigger | settings: trigger_settings}
             {:ok, trigger}
 
           {:error, error} ->

--- a/lib/sanbase/dashboards/dashboards.ex
+++ b/lib/sanbase/dashboards/dashboards.ex
@@ -248,7 +248,7 @@ defmodule Sanbase.Dashboards do
 
     new_sql_query_parameters = Map.merge(query.sql_query_parameters, overrides)
 
-    query = %Query{query | sql_query_parameters: new_sql_query_parameters}
+    query = %{query | sql_query_parameters: new_sql_query_parameters}
     {:ok, query}
   end
 
@@ -1069,7 +1069,7 @@ defmodule Sanbase.Dashboards do
       dashboard.queries
       |> Enum.map(&mask_query_not_viewable_parts(&1, querying_user_id))
 
-    %Dashboard{dashboard | queries: masked_queries}
+    %{dashboard | queries: masked_queries}
   end
 
   defp mask_query_not_viewable_parts(

--- a/lib/sanbase/dashboards/dashboards.ex
+++ b/lib/sanbase/dashboards/dashboards.ex
@@ -1077,11 +1077,7 @@ defmodule Sanbase.Dashboards do
          querying_user_id
        )
        when query_owner_user_id != querying_user_id do
-    %Query{
-      query
-      | sql_query_text: "<masked>",
-        sql_query_parameters: %{}
-    }
+    %{query | sql_query_text: "<masked>", sql_query_parameters: %{}}
   end
 
   defp mask_query_not_viewable_parts(query, _dashboard_owner_user_id), do: query

--- a/lib/sanbase/external_services/coinmarketcap/scraper.ex
+++ b/lib/sanbase/external_services/coinmarketcap/scraper.ex
@@ -44,7 +44,7 @@ defmodule Sanbase.ExternalServices.Coinmarketcap.Scraper do
   def parse_project_page(html, project_info) do
     {:ok, html} = Floki.parse_document(html)
 
-    %ProjectInfo{
+    %{
       project_info
       | name: project_info.name || name(html),
         ticker: project_info.ticker || ticker(html),

--- a/lib/sanbase/external_services/etherscan/scraper.ex
+++ b/lib/sanbase/external_services/etherscan/scraper.ex
@@ -71,10 +71,10 @@ defmodule Sanbase.ExternalServices.Etherscan.Scraper do
   def parse_token_page!(html, project_info) do
     {:ok, html} = Floki.parse_document(html)
 
-    %ProjectInfo{
+    # We want to override the currently stored total_supply and that's the reason why the order is different than the rest of the fields
+    %{
       project_info
-      | # We want to override the currently stored total_supply and that's the reason why the order is different than the rest of the fields
-        total_supply: total_supply(html) || project_info.total_supply,
+      | total_supply: total_supply(html) || project_info.total_supply,
         main_contract_address: project_info.main_contract_address || main_contract_address(html),
         token_decimals: project_info.token_decimals || token_decimals(html),
         website_link: project_info.website_link || website_link(html),

--- a/lib/sanbase/external_services/etherscan/scraper.ex
+++ b/lib/sanbase/external_services/etherscan/scraper.ex
@@ -2,9 +2,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Scraper do
   # credo:disable-for-this-file
   use Tesla
 
-  alias Decimal, as: D
   alias Sanbase.ExternalServices.RateLimiting
-  alias Sanbase.ExternalServices.ProjectInfo
   alias Sanbase.ExternalServices.ErrorCatcher
 
   require Logger
@@ -131,8 +129,8 @@ defmodule Sanbase.ExternalServices.Etherscan.Scraper do
       match ->
         Floki.text(match)
         |> parse_total_supply()
-        |> D.round()
-        |> D.to_integer()
+        |> Decimal.round()
+        |> Decimal.to_integer()
     end
   end
 
@@ -171,6 +169,6 @@ defmodule Sanbase.ExternalServices.Etherscan.Scraper do
     |> String.split()
     |> Enum.find(fn x -> String.starts_with?(x, "Supply") end)
     |> (fn supply -> String.trim(supply, "Supply:") end).()
-    |> D.new()
+    |> Decimal.new()
   end
 end

--- a/lib/sanbase/external_services/etherscan/scraper.ex
+++ b/lib/sanbase/external_services/etherscan/scraper.ex
@@ -63,7 +63,7 @@ defmodule Sanbase.ExternalServices.Etherscan.Scraper do
   def parse_address_page!(html, project_info) do
     {:ok, html} = Floki.parse_document(html)
 
-    %ProjectInfo{project_info | creation_transaction: creation_transaction(html)}
+    %{project_info | creation_transaction: creation_transaction(html)}
   end
 
   def parse_token_page!(nil, project_info), do: project_info

--- a/lib/sanbase/external_services/project_info.ex
+++ b/lib/sanbase/external_services/project_info.ex
@@ -70,7 +70,7 @@ defmodule Sanbase.ExternalServices.ProjectInfo do
     missing_values? or !Project.has_contract_address?(project)
   end
 
-  def from_project(project) do
+  def from_project(%Project{} = project) do
     project_info =
       struct(__MODULE__, Map.to_list(project))
       |> struct(Map.to_list(find_or_create_initial_ico(project)))
@@ -140,7 +140,7 @@ defmodule Sanbase.ExternalServices.ProjectInfo do
   end
 
   defp maybe_add_contract_address(
-         project,
+         %Project{} = project,
          %{main_contract_address: contract_address} = project_info_map
        )
        when is_binary(contract_address) do
@@ -161,9 +161,9 @@ defmodule Sanbase.ExternalServices.ProjectInfo do
     Repo.preload(project, [:contract_addresses], force: true)
   end
 
-  defp maybe_add_contract_address(project, _project_info_map), do: project
+  defp maybe_add_contract_address(%Project{} = project, _project_info_map), do: project
 
-  defp insert_tag({:ok, project}, project_info) do
+  defp insert_tag({:ok, %Project{} = project}, %ProjectInfo{} = project_info) do
     do_insert_tag(project, project_info)
     {:ok, project}
   end
@@ -188,7 +188,7 @@ defmodule Sanbase.ExternalServices.ProjectInfo do
 
   defp do_insert_tag(_, _), do: :ok
 
-  defp find_or_create_initial_ico(project) do
+  defp find_or_create_initial_ico(%Project{} = project) do
     case Project.initial_ico(project) do
       nil -> %Ico{project_id: project.id}
       ico -> ico

--- a/lib/sanbase/external_services/project_info.ex
+++ b/lib/sanbase/external_services/project_info.ex
@@ -77,7 +77,7 @@ defmodule Sanbase.ExternalServices.ProjectInfo do
 
     case Project.coinmarketcap_id(project) do
       nil -> project_info
-      cmc_id -> %__MODULE__{project_info | coinmarketcap_id: cmc_id}
+      cmc_id -> %{project_info | coinmarketcap_id: cmc_id}
     end
   end
 
@@ -200,7 +200,7 @@ defmodule Sanbase.ExternalServices.ProjectInfo do
        )
        when is_binary(contract) do
     case Ethauth.total_supply(contract) do
-      {:ok, total_supply} -> %ProjectInfo{project_info | total_supply: total_supply}
+      {:ok, total_supply} -> %{project_info | total_supply: total_supply}
       _ -> project_info
     end
   end
@@ -212,7 +212,7 @@ defmodule Sanbase.ExternalServices.ProjectInfo do
        )
        when is_binary(contract) do
     case Ethauth.token_decimals(contract) do
-      {:ok, token_decimals} -> %ProjectInfo{project_info | token_decimals: token_decimals}
+      {:ok, token_decimals} -> %{project_info | token_decimals: token_decimals}
       _ -> project_info
     end
   end
@@ -230,13 +230,13 @@ defmodule Sanbase.ExternalServices.ProjectInfo do
 
     {block_number, ""} = Integer.parse(block_number_hex, 16)
 
-    %ProjectInfo{project_info | contract_block_number: block_number}
+    %{project_info | contract_block_number: block_number}
   end
 
   defp fetch_abi(%ProjectInfo{main_contract_address: main_contract_address} = project_info) do
     case Etherscan.Requests.get_abi(main_contract_address) do
       {:ok, abi} ->
-        %ProjectInfo{project_info | contract_abi: abi}
+        %{project_info | contract_abi: abi}
 
       {:error, error} ->
         Logger.warning(

--- a/lib/sanbase_web/controllers/report_controller.ex
+++ b/lib/sanbase_web/controllers/report_controller.ex
@@ -74,6 +74,6 @@ defmodule SanbaseWeb.ReportController do
   end
 
   defp stringify_tags(%Report{tags: tags} = report) do
-    %Report{report | tags: tags |> Enum.join(", ")}
+    %{report | tags: tags |> Enum.join(", ")}
   end
 end

--- a/lib/sanbase_web/graphql/middlewares/access_control/access_control.ex
+++ b/lib/sanbase_web/graphql/middlewares/access_control/access_control.ex
@@ -138,11 +138,11 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
 
   # The auth method is not `basic` and the slug is not one of the freely available slugs
   # all of the required checks are done
-  defp check_has_access(resolution, opts) do
+  defp check_has_access(%Resolution{} = resolution, opts) do
     full_check_has_access(resolution, opts)
   end
 
-  defp full_check_has_access(resolution, opts) do
+  defp full_check_has_access(%Resolution{} = resolution, opts) do
     resolution
     |> apply_if_not_resolved(&check_experimental_metric_access/1)
     |> apply_if_not_resolved(&check_plan_has_access/1)
@@ -161,7 +161,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
     resolution
   end
 
-  defp apply_if_not_resolved(resolution, fun) do
+  defp apply_if_not_resolved(%Resolution{} = resolution, fun) do
     fun.(resolution)
   end
 
@@ -183,7 +183,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
 
   defp check_experimental_metric_access(%Resolution{} = resolution), do: resolution
 
-  defp do_check_experimental_metric(current_user, metric, resolution) do
+  defp do_check_experimental_metric(current_user, metric, %Resolution{} = resolution) do
     if user_can_access_metric?(current_user, metric.status) do
       resolution
     else
@@ -223,7 +223,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
   #
   # The shared access token is checked first and if it gives access to the
   # request, the user plan access is bypassed
-  defp check_plan_has_access(resolution) do
+  defp check_plan_has_access(%Resolution{} = resolution) do
     case check_shared_access_token_has_access?(resolution) do
       true -> resolution
       false -> check_user_plan_has_access(resolution)
@@ -299,7 +299,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
 
   # If the query is marked as having free realtime and historical data
   # do not restrict anything
-  defp maybe_apply_restrictions(resolution, %{
+  defp maybe_apply_restrictions(%Resolution{} = resolution, %{
          allow_realtime_data: true,
          allow_historical_data: true
        }) do
@@ -322,11 +322,11 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
     end
   end
 
-  defp maybe_apply_restrictions(resolution, _) do
+  defp maybe_apply_restrictions(%Resolution{} = resolution, _) do
     resolution
   end
 
-  defp restricted_query(resolution, middleware_args, query_or_argument) do
+  defp restricted_query(%Resolution{} = resolution, middleware_args, query_or_argument) do
     args =
       case restricted_query_shared_access_token(
              resolution,
@@ -383,7 +383,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
     }
   end
 
-  defp restricted_query_shared_access_token(_, _, _), do: nil
+  defp restricted_query_shared_access_token(%Resolution{} = _, _, _), do: nil
 
   defp restricted_query_user_plan(
          %Resolution{arguments: %{from: from, to: to}, context: context},
@@ -440,7 +440,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
     end
   end
 
-  defp not_restricted_query(resolution, _middleware_args) do
+  defp not_restricted_query(%Resolution{} = resolution, _middleware_args) do
     resolution
   end
 

--- a/lib/sanbase_web/graphql/middlewares/access_control/access_control.ex
+++ b/lib/sanbase_web/graphql/middlewares/access_control/access_control.ex
@@ -87,7 +87,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
       |> Map.put(:__slug__, extracted_slug)
       |> Map.put(:__metric__, extracted_metric)
 
-    %Resolution{resolution | context: context}
+    %{resolution | context: context}
   end
 
   # Basic auth should have no restrictions. Check only the sanity of the `from`
@@ -555,7 +555,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
          from,
          to
        ) do
-    %Resolution{resolution | arguments: %{args | from: from, to: to}}
+    %{resolution | arguments: %{args | from: from, to: to}}
   end
 
   # metrics

--- a/lib/sanbase_web/graphql/middlewares/transform_resolution.ex
+++ b/lib/sanbase_web/graphql/middlewares/transform_resolution.ex
@@ -21,10 +21,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.TransformResolution do
     selectors = get_selectors(resolution)
     elem = {:get_metric, metric, selectors}
 
-    %Resolution{
-      resolution
-      | context: Map.update(context, :__get_query_name_arg__, [elem], &[elem | &1])
-    }
+    %{resolution | context: Map.update(context, :__get_query_name_arg__, [elem], &[elem | &1])}
   end
 
   defp do_call(:get_signal, %{context: context} = resolution) do
@@ -32,10 +29,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.TransformResolution do
     selectors = get_selectors(resolution)
     elem = {:get_signal, signal, selectors}
 
-    %Resolution{
-      resolution
-      | context: Map.update(context, :__get_query_name_arg__, [elem], &[elem | &1])
-    }
+    %{resolution | context: Map.update(context, :__get_query_name_arg__, [elem], &[elem | &1])}
   end
 
   defp do_call(_query_field, resolution) do

--- a/lib/sanbase_web/graphql/middlewares/transform_resolution.ex
+++ b/lib/sanbase_web/graphql/middlewares/transform_resolution.ex
@@ -16,7 +16,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.TransformResolution do
     |> do_call(resolution)
   end
 
-  defp do_call(:get_metric, %{context: context} = resolution) do
+  defp do_call(:get_metric, %Resolution{context: context} = resolution) do
     %{arguments: %{metric: metric}} = resolution
     selectors = get_selectors(resolution)
     elem = {:get_metric, metric, selectors}
@@ -24,7 +24,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.TransformResolution do
     %{resolution | context: Map.update(context, :__get_query_name_arg__, [elem], &[elem | &1])}
   end
 
-  defp do_call(:get_signal, %{context: context} = resolution) do
+  defp do_call(:get_signal, %Resolution{context: context} = resolution) do
     %{arguments: %{signal: signal}} = resolution
     selectors = get_selectors(resolution)
     elem = {:get_signal, signal, selectors}
@@ -32,12 +32,12 @@ defmodule SanbaseWeb.Graphql.Middlewares.TransformResolution do
     %{resolution | context: Map.update(context, :__get_query_name_arg__, [elem], &[elem | &1])}
   end
 
-  defp do_call(_query_field, resolution) do
+  defp do_call(_query_field, %Resolution{} = resolution) do
     resolution
   end
 
   @fields_with_selector ["timeseriesData", "timeseriesDataPerSlug", "aggregatedTimeseriesData"]
-  defp get_selectors(resolution) do
+  defp get_selectors(%Resolution{} = resolution) do
     resolution.definition.selections
     |> Enum.map(fn %{name: name} = field ->
       case Inflex.camelize(name, :lower) do


### PR DESCRIPTION
## Changes

- **Stop using %StructModule{struct | ...} update syntax**
- **Find and remove some more %StructModule{struct | ...} update syntax occurrences**
  - Use regex `%(\w+)\{[\r\n\s]*(?<struct>\w+)[\r\n\s]* \|` and replace with `%{$2 |`
- **Add pattern matching in function header**

Relevant Elixir Issue: https://github.com/elixir-lang/elixir/issues/13974

Instead of using `%Module{struct | ...}` prefer pattern matching `%Module{} = struct` in the function head/case clause/etc. This should work better with the type system.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
