### PR TITLE
metric registry test button

### DIFF
--- a/lib/sanbase/available_metrics/available_metrics.ex
+++ b/lib/sanbase/available_metrics/available_metrics.ex
@@ -26,11 +26,18 @@ defmodule Sanbase.AvailableMetrics do
   def get_not_updated() do
     from(
       av in __MODULE__,
-      where: av.updated_at < ^DateTime.add(DateTime.utc_now(), -86400),
+      where: av.updated_at < ^DateTime.add(DateTime.utc_now(), -86_400),
       order_by: [asc: av.updated_at],
       select: av.metric
     )
     |> Sanbase.Repo.all()
+  end
+
+  def update_metric(metric) do
+    {:ok, slugs} = Sanbase.Metric.available_slugs(metric)
+    {:ok, _} = create_or_update(%{metric: metric, available_slugs: slugs})
+  rescue
+    _ -> {:error, "Failed to update available slugs for #{metric}"}
   end
 
   def update_all() do
@@ -121,7 +128,7 @@ defmodule Sanbase.AvailableMetrics do
 
   defp maybe_apply_filter(metrics, :only_intraday_metrics, %{"only_intraday_metrics" => "on"}) do
     metrics
-    |> Enum.filter(&(&1.frequency_seconds < 86400))
+    |> Enum.filter(&(&1.frequency_seconds < 86_400))
   end
 
   defp maybe_apply_filter(metrics, :match_metric_name, %{"match_metric_name" => query})

--- a/lib/sanbase_web/live/available_metrics/available_metrics_live.ex
+++ b/lib/sanbase_web/live/available_metrics/available_metrics_live.ex
@@ -18,6 +18,7 @@ defmodule SanbaseWeb.AvailableMetricsLive do
     {:ok,
      socket
      |> assign(
+       page_title: "Santiment | Available Metrics",
        visible_metrics: visible_metrics,
        metrics_map: metrics_map,
        filter: default_filter

--- a/test/sanbase_web/api_call_limit/api_call_limit_api_test.exs
+++ b/test/sanbase_web/api_call_limit/api_call_limit_api_test.exs
@@ -242,7 +242,7 @@ defmodule SanbaseWeb.ApiCallLimitTest do
         |> Timex.shift(days: -(days_in_old_month - 1))
 
       for i <- 0..(iterations - 1) do
-        dt = DateTime.add(now, 86400 * i, :second)
+        dt = DateTime.add(now, 86_400 * i, :second)
 
         Sanbase.Mock.prepare_mock2(&DateTime.utc_now/0, dt)
         |> Sanbase.Mock.run_with_mocks(fn ->
@@ -307,7 +307,7 @@ defmodule SanbaseWeb.ApiCallLimitTest do
         # This test might fail if executed 0-14 minutes before midnight
         # If we mock the dt to be a concrete date, then the KafkaExporter
         # send_after will fail
-        dt = DateTime.add(now, 86400 * i, :second)
+        dt = DateTime.add(now, 86_400 * i, :second)
 
         Sanbase.Mock.prepare_mock2(&DateTime.utc_now/0, dt)
         |> Sanbase.Mock.run_with_mocks(fn ->
@@ -374,7 +374,7 @@ defmodule SanbaseWeb.ApiCallLimitTest do
         # This test might fail if executed 0-14 minutes before midnight
         # If we mock the dt to be a concrete date, then the KafkaExporter
         # send_after will fail
-        dt = DateTime.add(now, 86400 * i, :second)
+        dt = DateTime.add(now, 86_400 * i, :second)
 
         Sanbase.Mock.prepare_mock2(&DateTime.utc_now/0, dt)
         |> Sanbase.Mock.run_with_mocks(fn ->


### PR DESCRIPTION
## Changes

- **Start computing available slugs when a new metric is created**
- **Add a button that builds a GraphQL query that runs a getMetric query for tests**
  - Use the precomputed available assets so we can pick a slug that is guaranteed to succeed.
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/1a3827cf-614f-4cd6-b877-fc47ba1483cd" />
<img width="1571" alt="image" src="https://github.com/user-attachments/assets/af0e636c-f4c5-45f2-9ddf-7908395d4aea" />

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
