### PR TITLE
Do not check for metric > 0 in Price SQL

### DIFF
--- a/lib/sanbase/prices/price_sql_query.ex
+++ b/lib/sanbase/prices/price_sql_query.ex
@@ -50,7 +50,7 @@ defmodule Sanbase.Price.SqlQuery do
     FROM #{@table}
     PREWHERE
       #{slug_filter(slug_or_slugs, argument_name: "slug")} AND
-      NOT isNaN(#{metric}) AND isNotNull(#{metric}) AND #{metric} > 0 AND
+      NOT isNaN(#{metric}) AND isNotNull(#{metric})  AND
       source = cast({{source}}, 'LowCardinality(String)') AND
       dt >= toDateTime({{from}}) AND
       dt < toDateTime({{to}})
@@ -272,7 +272,7 @@ defmodule Sanbase.Price.SqlQuery do
         #{aggregation(aggregation, "#{metric}", "dt")} AS value
       FROM #{@table}
       PREWHERE
-        isNotNull(#{metric}) AND NOT isNaN(#{metric}) AND #{metric} > 0 AND
+        isNotNull(#{metric}) AND NOT isNaN(#{metric}) AND
         dt >= toDateTime({{from}}) AND
         dt < toDateTime({{to}}) AND
         source = cast({{source}}, 'LowCardinality(String)')


### PR DESCRIPTION
## Changes

This check is inconsistent across the SQL queries and adapters.
It was causing an issue with the screener where the filter is used when
fetching the data but not when computing the order of assets

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
