### PR TITLE
Improve Metric.Registry UI regarding missing docs

### DIFF
--- a/lib/sanbase/accounts/user/role.ex
+++ b/lib/sanbase/accounts/user/role.ex
@@ -7,14 +7,15 @@ defmodule Sanbase.Accounts.Role do
   @san_team_role_id 1
   @san_family_role_id 2
   @san_moderator_role_id 3
-  @registry_viewer_role_id 4
-  @registry_change_suggester_id 5
-  @registry_change_approver_role_id 6
-  @registry_deployer_role_id 7
-  @registry_owner_id 8
-  @admin_panel_viewer_id 9
-  @admin_panel_editor_id 10
-  @admin_panel_owner_id 11
+  # Comment them out
+  # @registry_viewer_role_id 4
+  # @registry_change_suggester_id 5
+  # @registry_change_approver_role_id 6
+  # @registry_deployer_role_id 7
+  # @registry_owner_id 8
+  # @admin_panel_viewer_id 9
+  # @admin_panel_editor_id 10
+  # @admin_panel_owner_id 11
 
   schema "roles" do
     field(:name, :string)

--- a/lib/sanbase_web/live/metric_registry/metric_registry_change_suggestions_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_change_suggestions_live.ex
@@ -64,7 +64,9 @@ defmodule SanbaseWeb.MetricRegistryChangeSuggestionsLive do
               NEW METRIC
             </span>
           </:col>
-          <:col :let={row} label="Changes"><.formatted_changes changes={row.changes} /></:col>
+          <:col :let={row} label="Changes">
+            <.formatted_changes is_new_metric={!row.metric_registry_id} changes={row.changes} />
+          </:col>
           <:col :let={row} label="Date">
             <.request_dates inserted_at={row.inserted_at} updated_at={row.updated_at} />
           </:col>
@@ -203,8 +205,19 @@ defmodule SanbaseWeb.MetricRegistryChangeSuggestionsLive do
 
   defp formatted_changes(assigns) do
     ~H"""
-    {Sanbase.ExAudit.Patch.format_patch(%{patch: @changes})}
+    <div>
+      <div :if={@is_new_metric and no_docs?(@changes)} class="text-2xl font-bold text-red-700 mb-2">
+        MISSING DOCUMENTATION
+      </div>
+      <div>
+        {Sanbase.ExAudit.Patch.format_patch(%{patch: @changes})}
+      </div>
+    </div>
     """
+  end
+
+  defp no_docs?(changes) do
+    not Map.has_key?(changes, :docs)
   end
 
   defp request_dates(assigns) do

--- a/lib/sanbase_web/live/metric_registry/metric_registry_index_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_index_live.ex
@@ -91,6 +91,7 @@ defmodule SanbaseWeb.MetricRegistryIndexLive do
             status={row.status}
           />
         </:col>
+        <:col :let={row} label="Docs"><.docs docs={row.docs} /></:col>
         <:col
           :let={row}
           label="Table"
@@ -162,6 +163,7 @@ defmodule SanbaseWeb.MetricRegistryIndexLive do
       |> maybe_apply_filter(:match_metric, params)
       |> maybe_apply_filter(:unverified_only, params)
       |> maybe_apply_filter(:not_synced_only, params)
+      |> maybe_apply_filter(:no_docs_only, params)
       |> maybe_apply_filter(:sort_by, params)
       |> Enum.map(& &1.id)
 
@@ -290,6 +292,24 @@ defmodule SanbaseWeb.MetricRegistryIndexLive do
           @updated_at
         )} ago
       </div>
+    </div>
+    """
+  end
+
+  defp docs(assigns) do
+    ~H"""
+    <div>
+      <span :if={@docs == []} class="text-gray-400 text-sm font-semibold">Missing</span>
+      <span :if={@docs != []} class="text-gray-900 text-sm font-semibold">
+        <.link
+          :for={%{link: link} <- @docs}
+          class="underline text-blue-600 hover:text-blue-800 hover:cursor-pointer"
+          href={link}
+          target="_blank"
+        >
+          Link
+        </.link>
+      </span>
     </div>
     """
   end
@@ -503,6 +523,7 @@ defmodule SanbaseWeb.MetricRegistryIndexLive do
           <div class="flex flex-row mt-4 space-x-2 ">
             <.filter_unverified />
             <.filter_not_synced />
+            <.filter_without_docs />
           </div>
         </div>
         <div>
@@ -569,6 +590,24 @@ defmodule SanbaseWeb.MetricRegistryIndexLive do
           type="checkbox"
           class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded "
         /> Show Only Not Synced
+      </label>
+    </div>
+    """
+  end
+
+  defp filter_without_docs(assigns) do
+    ~H"""
+    <div class="flex items-center mb-4 ">
+      <label
+        for="no-docs-only"
+        class="cursor-pointer ms-2 text-sm font-medium text-gray-900 dark:text-gray-300"
+      >
+        <input
+          id="no-docs-only"
+          name="no_docs_only"
+          type="checkbox"
+          class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded "
+        /> Show Only Without Docs
       </label>
     </div>
     """
@@ -682,6 +721,13 @@ defmodule SanbaseWeb.MetricRegistryIndexLive do
     metrics
     |> Enum.filter(fn m ->
       m.sync_status != "synced"
+    end)
+  end
+
+  defp maybe_apply_filter(metrics, :no_docs_only, %{"no_docs_only" => "on"}) do
+    metrics
+    |> Enum.filter(fn m ->
+      m.docs == []
     end)
   end
 


### PR DESCRIPTION
## Changes

#### Add warning to `New Metric` change requests when the change request is created without documentation: 
<img width="1508" alt="image" src="https://github.com/user-attachments/assets/5293e655-e731-4a76-9310-d47938562eed" />

---

#### Add filter on the index page to list only the metrics without docs:
<img width="1293" alt="image" src="https://github.com/user-attachments/assets/bc8c4218-53f8-45e4-a74d-9ee45d6ba7ec" />

---

#### Add column with docs links 
<img width="1344" alt="image" src="https://github.com/user-attachments/assets/bf0dcb35-43aa-4e1a-afb9-6c909b40164e" />

<img width="1450" alt="image" src="https://github.com/user-attachments/assets/08e83f97-9e72-4dee-8eb0-f8710dab576a" />

---

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
