### PR TITLE
Use persistent term backend for Absinthe

### DIFF
--- a/lib/sanbase/application/application.ex
+++ b/lib/sanbase/application/application.ex
@@ -168,6 +168,11 @@ defmodule Sanbase.Application do
   """
   def prepended_children(container_type) do
     [
+      # To enable the persistent term backend
+      # https://hexdocs.pm/absinthe/overview.html
+      {Absinthe.Schema, SanbaseWeb.Graphql.Schema},
+
+      # Start (optionally) the Kafka Brod Supervisor
       start_in_and_if(
         fn ->
           %{

--- a/lib/sanbase/billing/plan/standard_access_checker/standard_access_checker.ex
+++ b/lib/sanbase/billing/plan/standard_access_checker/standard_access_checker.ex
@@ -44,20 +44,22 @@ defmodule Sanbase.Billing.Plan.StandardAccessChecker do
 
   @doc documentation_ref: "# DOCS access-plans/index.md"
 
-  case ApiInfo.get_queries_without_access_level() do
-    [] ->
-      :ok
+  def run_check() do
+    case ApiInfo.get_queries_without_access_level() do
+      [] ->
+        :ok
 
-    queries ->
-      require Sanbase.Break, as: Break
+      queries ->
+        require Sanbase.Break, as: Break
 
-      Break.break("""
-      There are GraphQL queries defined without specifying their access level.
-      The access level could be either `free` or `restricted`.
-      To define an access level, put `meta(access: <level>)` in the field definition.
+        Break.break("""
+        There are GraphQL queries defined without specifying their access level.
+        The access level could be either `free` or `restricted`.
+        To define an access level, put `meta(access: <level>)` in the field definition.
 
-      Queries without access level: #{inspect(queries)}
-      """)
+        Queries without access level: #{inspect(queries)}
+        """)
+    end
   end
 
   @doc ~s"""

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -16,6 +16,7 @@ defmodule SanbaseWeb.Graphql.Schema do
   # Disable too many dependencies errors
   # credo:disable-for-this-file
   use Absinthe.Schema
+  @schema_provider Absinthe.Schema.PersistentTerm
 
   alias SanbaseWeb.Graphql
   alias SanbaseWeb.Graphql.{SanbaseRepo, SanbaseDataloader}


### PR DESCRIPTION
## Changes

The change is aimed to reduce the memory usage of Absinthe.
In order to use it, noone of the Absinthe functions should be called at compile-time.
Most of the compile-time invocations were removed by migrating to the Metric Registry.
In this PR some more functions are migrated to not invoke functions at compile time, but 
once at runtime and store it in persistent_term.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
