### PR TITLE
Add timeseries data JSON result queries

### DIFF
--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -579,6 +579,41 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       cache_resolve(&MetricResolver.timeseries_data/3)
     end
 
+    field :timeseries_data_json, :json do
+      arg(:slug, :string)
+      arg(:selector, :metric_target_selector_input_object)
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+      arg(:interval, :interval, default_value: "1d")
+      arg(:aggregation, :aggregation, default_value: nil)
+      arg(:transform, :timeseries_metric_transform_input_object)
+      arg(:include_incomplete_data, :boolean, default_value: false)
+      arg(:only_finalized_data, :boolean, default_value: false)
+      arg(:caching_params, :caching_params_input_object)
+
+      complexity(&Complexity.from_to_interval/3)
+      middleware(AccessControl)
+
+      cache_resolve(&MetricResolver.timeseries_data/3)
+    end
+
+    field :timeseries_data_per_slug_json, :json do
+      arg(:selector, :metric_target_selector_input_object)
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+      arg(:interval, :interval, default_value: "1d")
+      arg(:aggregation, :aggregation, default_value: nil)
+      arg(:transform, :timeseries_metric_transform_input_object)
+      arg(:include_incomplete_data, :boolean, default_value: false)
+      arg(:only_finalized_data, :boolean, default_value: false)
+      arg(:caching_params, :caching_params_input_object)
+
+      complexity(&Complexity.from_to_interval/3)
+      middleware(AccessControl)
+
+      cache_resolve(&MetricResolver.timeseries_data_per_slug/3)
+    end
+
     field :timeseries_data_per_slug, list_of(:metric_data_per_slug) do
       arg(:selector, :metric_target_selector_input_object)
       arg(:from, non_null(:datetime))


### PR DESCRIPTION
## Changes

Returning list of objects results in excessive type checking and boxing
done by Absinthe. In the end, it can happen that a response that is less
than 1Mb in JSON format requires more than 50Mb of RAM memory to process
because it creates an in-memory struct for each value in the result.

Introduce *Json queries which do exactly the same thing as the original
ones, but only change the result type to JSON. This makes it impossible
to specify which fields you want to select, but it requires much less
RAM memory when running. A quick test showed that in the original
queries when the size of the response goes over a few megabytes, it can
consume hundreds megabytes of RAM just to process. In the new JSON
queries we can easily return results that are 25Mb in JSON.


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
