### PR TITLE
Stop using custom complexity weight for some metrics

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/metric/metric_adapter.ex
@@ -104,6 +104,15 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
     end)
   end
 
+  def timeseries_data_per_slug(metric, selector, _from, _to, _interval, _opts) do
+    {:error,
+     """
+     Error fetching timeseries data per slug for #{metric}. The selector is not supported.
+     The selector is not a slug or list of slugs and cannot be resolved to a list of slugs.
+     Got: #{inspect(selector)}
+     """}
+  end
+
   @impl Sanbase.Metric.Behaviour
   defdelegate histogram_data(metric, slug, from, to, interval, limit), to: HistogramMetric
 

--- a/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
@@ -266,8 +266,8 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesDataTest do
       %{"data" => %{"getMetric" => %{"timeseriesDataJson" => timeseries_data_json}}} = result
 
       assert timeseries_data_json == [
-               %{"v" => 100.0, "d" => "2019-01-01T00:00:00Z"},
-               %{"v" => 200.0, "d" => "2019-01-02T00:00:00Z"}
+               %{"v" => 100.0, "datetime" => "2019-01-01T00:00:00Z"},
+               %{"v" => 200.0, "datetime" => "2019-01-02T00:00:00Z"}
              ]
     end)
   end
@@ -457,46 +457,6 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesDataTest do
            end) =~ "Can't fetch #{metric} for an empty selector"
   end
 
-  test "complexity for clickhouse metrics is smaller", context do
-    slug = "ethereum"
-    to = ~U[2020-05-01 00:00:00Z]
-    from = ~U[2009-01-01 00:00:00Z]
-    interval = "1h"
-
-    ch_metric_error =
-      get_timeseries_metric(
-        context.conn,
-        "mvrv_usd",
-        %{slug: slug},
-        from,
-        to,
-        interval,
-        :last
-      )
-      |> get_in(["errors"])
-      |> List.first()
-      |> get_in(["message"])
-
-    social_metric_error =
-      get_timeseries_metric(
-        context.conn,
-        "twitter_followers",
-        %{slug: slug},
-        from,
-        to,
-        interval,
-        :last
-      )
-      |> get_in(["errors"])
-      |> List.first()
-      |> get_in(["message"])
-
-    ch_metric_complexity = error_to_complexity(ch_metric_error)
-    social_metric_complexity = error_to_complexity(social_metric_error)
-
-    assert ch_metric_complexity + 1 < social_metric_complexity
-  end
-
   # Private functions
 
   defp error_to_complexity(error_msg) do
@@ -600,6 +560,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesDataTest do
       }
     }
     """
+    |> dbg()
   end
 
   defp get_timeseries_data_query_without_selector(


### PR DESCRIPTION
## Changes

Improve the consistency of complexity computation.
The complexity weight was not working properly as well, as the metric
could not be extracted, so it was always 1 either way.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
