### PR TITLE
Add feature_access_level user flag

### DIFF
--- a/lib/sanbase/accounts/user.ex
+++ b/lib/sanbase/accounts/user.ex
@@ -31,7 +31,7 @@ defmodule Sanbase.Accounts.User do
 
   # User with free subscription that is used for external integration testing
   @sanbase_bot_email "sanbase.bot@santiment.net"
-  @allowed_metric_access_levels ["alpha", "beta", "released"]
+  @allowed_access_levels ["alpha", "beta", "released"]
 
   @preloads [:roles, [roles: :role], :eth_accounts, :user_settings]
   def preloads(), do: @preloads
@@ -96,6 +96,7 @@ defmodule Sanbase.Accounts.User do
     field(:marketing_accepted, :boolean, default: false)
 
     field(:metric_access_level, :string, default: "released")
+    field(:feature_access_level, :string, default: "released")
 
     has_one(:user_settings, UserSettings, on_delete: :delete_all)
 
@@ -180,6 +181,7 @@ defmodule Sanbase.Accounts.User do
       :username,
       :name,
       :metric_access_level,
+      :feature_access_level,
       :registration_state,
       :description,
       :website_url,
@@ -198,7 +200,8 @@ defmodule Sanbase.Accounts.User do
     |> unique_constraint(:username)
     |> unique_constraint(:stripe_customer_id)
     |> unique_constraint(:twitter_id)
-    |> validate_inclusion(:metric_access_level, @allowed_metric_access_levels)
+    |> validate_inclusion(:metric_access_level, @allowed_access_levels)
+    |> validate_inclusion(:feature_access_level, @allowed_access_levels)
   end
 
   def san_balance(user), do: __MODULE__.SanBalance.san_balance(user)

--- a/lib/sanbase_web/graphql/schema/types/user_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_types.ex
@@ -185,6 +185,9 @@ defmodule SanbaseWeb.Graphql.UserTypes do
       resolve(&UserResolver.permissions/3)
     end
 
+    field(:metric_access_level, :string)
+    field(:feature_access_level, :string)
+
     field :san_balance, :float do
       cache_resolve(&UserResolver.san_balance/3)
     end

--- a/priv/repo/migrations/20250507135031_add_feature_access_level_user_field.exs
+++ b/priv/repo/migrations/20250507135031_add_feature_access_level_user_field.exs
@@ -1,0 +1,9 @@
+defmodule Sanbase.Repo.Migrations.AddFeatureAccessLevelUserField do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add(:feature_access_level, :string)
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 15.1 (Homebrew)
--- Dumped by pg_dump version 15.1 (Homebrew)
+-- Dumped from database version 15.10 (Homebrew)
+-- Dumped by pg_dump version 15.10 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -2114,9 +2114,9 @@ CREATE TABLE public.metric_registry (
     deprecation_note text,
     inserted_at timestamp with time zone NOT NULL,
     updated_at timestamp with time zone NOT NULL,
-    status character varying(255) DEFAULT 'released'::character varying NOT NULL,
     is_verified boolean DEFAULT true NOT NULL,
     sync_status character varying(255) DEFAULT 'synced'::character varying NOT NULL,
+    status character varying(255) DEFAULT 'released'::character varying NOT NULL,
     last_sync_datetime timestamp(0) without time zone
 );
 
@@ -4633,7 +4633,8 @@ CREATE TABLE public.users (
     metric_access_level character varying(255) DEFAULT 'released'::character varying NOT NULL,
     description text,
     website_url character varying(255),
-    twitter_handle character varying(255)
+    twitter_handle character varying(255),
+    feature_access_level character varying(255)
 );
 
 
@@ -10049,19 +10050,20 @@ INSERT INTO public."schema_migrations" (version) VALUES (20241029080754);
 INSERT INTO public."schema_migrations" (version) VALUES (20241029082533);
 INSERT INTO public."schema_migrations" (version) VALUES (20241029151959);
 INSERT INTO public."schema_migrations" (version) VALUES (20241030141825);
-INSERT INTO public."schema_migrations" (version) VALUES (20241104061632);
 INSERT INTO public."schema_migrations" (version) VALUES (20241104115340);
 INSERT INTO public."schema_migrations" (version) VALUES (20241108112754);
 INSERT INTO public."schema_migrations" (version) VALUES (20241112094924);
 INSERT INTO public."schema_migrations" (version) VALUES (20241114140339);
 INSERT INTO public."schema_migrations" (version) VALUES (20241114141110);
 INSERT INTO public."schema_migrations" (version) VALUES (20241116104556);
+INSERT INTO public."schema_migrations" (version) VALUES (20241121133719);
 INSERT INTO public."schema_migrations" (version) VALUES (20241128113958);
 INSERT INTO public."schema_migrations" (version) VALUES (20241128161315);
 INSERT INTO public."schema_migrations" (version) VALUES (20241202104812);
 INSERT INTO public."schema_migrations" (version) VALUES (20241212054904);
 INSERT INTO public."schema_migrations" (version) VALUES (20250110083203);
 INSERT INTO public."schema_migrations" (version) VALUES (20250121155544);
+INSERT INTO public."schema_migrations" (version) VALUES (20250124152414);
 INSERT INTO public."schema_migrations" (version) VALUES (20250203104426);
 INSERT INTO public."schema_migrations" (version) VALUES (20250207100755);
 INSERT INTO public."schema_migrations" (version) VALUES (20250207134446);
@@ -10077,7 +10079,9 @@ INSERT INTO public."schema_migrations" (version) VALUES (20250318100856);
 INSERT INTO public."schema_migrations" (version) VALUES (20250324103930);
 INSERT INTO public."schema_migrations" (version) VALUES (20250326110304);
 INSERT INTO public."schema_migrations" (version) VALUES (20250327120623);
+INSERT INTO public."schema_migrations" (version) VALUES (20250411143236);
 INSERT INTO public."schema_migrations" (version) VALUES (20250413084531);
 INSERT INTO public."schema_migrations" (version) VALUES (20250414115309);
 INSERT INTO public."schema_migrations" (version) VALUES (20250414122835);
 INSERT INTO public."schema_migrations" (version) VALUES (20250416132314);
+INSERT INTO public."schema_migrations" (version) VALUES (20250507135031);


### PR DESCRIPTION
## Changes
Add `featureAccessLevel` flag to the user GraphQL type.

```graphql
{
  currentUser{
    featureAccessLevel
  }
}
```

This new flag is to be used by the FE to decide what feature should be shown to the user.

This PR also exposes to the API the already existing `metricAccessLevel` flag.
The values of these flags can only be changed through the admin panel.


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
