### PR TITLE
Extend the list of multichain prefixes in san-cryptocompare mapping

### DIFF
--- a/lib/sanbase_web/controllers/cryptocompare_asset_mapping_controller.ex
+++ b/lib/sanbase_web/controllers/cryptocompare_asset_mapping_controller.ex
@@ -28,12 +28,12 @@ defmodule SanbaseWeb.CryptocompareAssetMappingController do
 
   # xrp before ripple
   # Ethereum asset before assets on other chains (with prefixes)
-  def sort_assets(list) do
+  defp sort_assets(list) do
     list
     |> Enum.sort_by(fn {_, value} ->
       case String.split(value, "-", parts: 2) do
         ["xrp" | _] -> {-1, value}
-        [prefix, _] when prefix in ["a", "p", "o", "bnb", "arb"] -> {1, value}
+        [prefix, _] when prefix in ["a", "p", "o", "bnb", "arb", "sol", "aave"] -> {1, value}
         _ -> {0, value}
       end
     end)


### PR DESCRIPTION
## Changes

Missing the mappings cause the Clickhouse dictionaries to link not to
the original asset like 'tether' but one of its multichain assets like
'a-tether'


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
