### PR TITLE
Filter out stories that are not ready yet

### DIFF
--- a/lib/sanbase/social_data/trending_stories.ex
+++ b/lib/sanbase/social_data/trending_stories.ex
@@ -74,7 +74,8 @@ defmodule Sanbase.SocialData.TrendingStories do
       WHERE
         dt >= toDateTime({{from}}) AND
         dt < toDateTime({{to}}) AND
-        source = {{source}}
+        source = {{source}} AND
+        is_story = true
     )
     WHERE dt = last_dt_in_group
     ORDER BY t, score DESC


### PR DESCRIPTION
## Changes

Trending stories are computed in 2 phases. After the initial insertion
in the DB, some of the fields are empty. They are filled (if there is
story found) on a later step. This causes the API to not work properly
for a few minutes after round hours -- the fields are just empty.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
