### PR TITLE
Increase the queue_interval value for ClickhouseRepo

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -99,7 +99,8 @@ config :sanbase, Sanbase.ExternalServices.RateLimiting.Server,
 config :sanbase, Sanbase.ClickhouseRepo,
   adapter: Ecto.Adapters.Postgres,
   queue_target: 10_000,
-  queue_interval: 2000,
+  queue_interval: 30_000,
+  timeout: 100_000,
   max_overflow: 3,
   scheme: :http
 
@@ -107,6 +108,7 @@ clickhouse_read_only_opts = [
   adapter: Ecto.Adapters.Postgres,
   queue_target: 60_000,
   queue_interval: 60_000,
+  timeout: 100_000,
   max_overflow: 3,
   scheme: :http
 ]
@@ -124,7 +126,7 @@ config :sanbase, Sanbase.Repo,
   pool_size: {:system, "SANBASE_POOL_SIZE", "20"},
   max_overflow: 5,
   queue_target: 5000,
-  queue_interval: 1000,
+  queue_interval: 10_000,
   timeout: 30_000,
   migration_timestamps: [type: :naive_datetime_usec]
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -10,9 +10,8 @@ config :sanbase, Sanbase.ClickhouseRepo,
   database: "not_secret_default",
   username: "not_secret_default",
   password: "",
-  timeout: 100_000,
   pool_size: {:system, "CLICKHOUSE_POOL_SIZE", "25"},
-  pool_overflow: 5
+  max_overflow: 5
 
 clickhouse_read_only_opts = [
   adapter: ClickhouseEcto,
@@ -22,9 +21,7 @@ clickhouse_read_only_opts = [
   database: "not_secret_default",
   username: "not_secret_default",
   password: "",
-  timeout: 100_000,
   pool_size: {:system, "CLICKHOUSE_READONLY_POOL_SIZE", "0"},
-  pool_overflow: 3,
   max_overflow: 5
 ]
 


### PR DESCRIPTION
## Changes

https://hexdocs.pm/db_connection/DBConnection.html#start_link/2-queue-config
queue_interval must be larger than queue_target.


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
