### PR TITLE
Add last_sanbase_activity and joined_at fields for public user

### DIFF
--- a/lib/sanbase/accounts/user.ex
+++ b/lib/sanbase/accounts/user.ex
@@ -131,16 +131,6 @@ defmodule Sanbase.Accounts.User do
     user.email || user.username || user.twitter_id || "id_#{user.id}"
   end
 
-  def get_signup_dt(%__MODULE__{registration_state: registration_state}) do
-    case registration_state do
-      %{"datetime" => datetime, "state" => "finished"} when is_binary(datetime) ->
-        Sanbase.DateTimeUtils.from_iso8601!(datetime)
-
-      _ ->
-        nil
-    end
-  end
-
   def describe(%__MODULE__{} = user) do
     cond do
       user.username != nil -> "User with username #{user.username}"

--- a/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/user_resolver.ex
@@ -103,6 +103,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserResolver do
   end
 
   def joined_at(%User{} = user, _args, _resolution) do
+    do_get_joined_at(user)
+  end
+
+  def joined_at(_root, _args, %{context: %{auth: %{current_user: user}}}) do
+    do_get_joined_at(user)
+  end
+
+  defp do_get_joined_at(%User{} = user) do
     case user do
       %{registration_state: %{"state" => "finished", "datetime" => datetime_iso8601}} ->
         {:ok, Sanbase.DateTimeUtils.from_iso8601!(datetime_iso8601)}
@@ -393,14 +401,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserResolver do
 
   def user_promo_codes(_, _, _) do
     {:ok, []}
-  end
-
-  def signup_datetime(_root, _args, %{context: %{auth: %{current_user: user}}}) do
-    {:ok, User.get_signup_dt(user)}
-  end
-
-  def signup_datetime(%User{} = user, _args, _resolution) do
-    {:ok, User.get_signup_dt(user)}
   end
 
   def user_no_preloads(%{user_id: user_id}, _args, %{context: %{loader: loader}}) do

--- a/lib/sanbase_web/graphql/schema/types/user_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_types.ex
@@ -72,6 +72,20 @@ defmodule SanbaseWeb.Graphql.UserTypes do
     field(:website_url, :string)
     field(:twitter_handle, :string)
 
+    @desc ~s"""
+    String representation of when the user was last active on sanbase.
+    The returned result is in the form 'Last 5 mintes', 'Last 24 hours', etc.
+
+    API activity authenticated with apikeys is not considered here.
+    """
+    field :last_sanbase_activity, :string do
+      resolve(&UserResolver.last_sanbase_activity/3)
+    end
+
+    field :joined_at, :datetime do
+      resolve(&UserResolver.joined_at/3)
+    end
+
     field :is_moderator, :boolean do
       resolve(&UserResolver.moderator?/3)
     end

--- a/lib/sanbase_web/graphql/schema/types/user_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_types.ex
@@ -361,8 +361,8 @@ defmodule SanbaseWeb.Graphql.UserTypes do
       resolve(&UserAffiliateDetailsResolver.are_user_affiliate_datails_submitted/3)
     end
 
-    field :signup_datetime, :datetime do
-      resolve(&UserResolver.signup_datetime/3)
+    field :joined_at, :datetime do
+      resolve(&UserResolver.joined_at/3)
     end
   end
 

--- a/test/sanbase_web/graphql/user/current_user_api_test.exs
+++ b/test/sanbase_web/graphql/user/current_user_api_test.exs
@@ -72,7 +72,7 @@ defmodule SanbaseWeb.Graphql.CurrentUserApiTest do
     end
   end
 
-  describe "signupDatetime" do
+  describe "joinedAt" do
     test "when user is registered returns the signup datetime", _context do
       registration_dt = DateTime.utc_now(:second)
 
@@ -81,14 +81,15 @@ defmodule SanbaseWeb.Graphql.CurrentUserApiTest do
 
       conn = setup_jwt_auth(build_conn(), user)
       result = get_user(conn) |> get_in(["data", "currentUser"])
-      assert result["signupDatetime"] == DateTime.to_iso8601(registration_dt)
+      assert result["joinedAt"] == DateTime.to_iso8601(registration_dt)
     end
 
-    test "when user has no registration_state - returns nil", _context do
-      user = insert(:user)
+    test "when user has no registration_state - returns insertedAt", _context do
+      inserted_at = ~U[2020-01-01 12:00:00Z]
+      user = insert(:user_registration_not_finished, inserted_at: inserted_at)
       conn = setup_jwt_auth(build_conn(), user)
       result = get_user(conn) |> get_in(["data", "currentUser"])
-      assert result["signupDatetime"] == nil
+      assert result["joinedAt"] == DateTime.to_iso8601(inserted_at)
     end
   end
 
@@ -107,7 +108,7 @@ defmodule SanbaseWeb.Graphql.CurrentUserApiTest do
         followers{ count users { id } }
         following{ count users { id } }
         isEligibleForSanbaseTrial
-        signupDatetime
+        joinedAt
       }
     }
     """

--- a/test/support/factory/factory.ex
+++ b/test/support/factory/factory.ex
@@ -39,7 +39,11 @@ defmodule Sanbase.Factory do
       email: (:crypto.strong_rand_bytes(16) |> Base.encode16()) <> "@santiment.net",
       salt: User.generate_salt(),
       privacy_policy_accepted: true,
-      registration_state: %{"state" => "finished"},
+      registration_state: %{
+        "state" => "finished",
+        "datetime" => "#{DateTime.utc_now()}",
+        "data" => %{"origin_url" => "http://localhost"}
+      },
       san_balance: Decimal.new(0),
       san_balance_updated_at: Timex.now()
     }


### PR DESCRIPTION
## Changes
```graphql
{
  getUser(selector: {id: 32}) {
    joinedAt
    lastSanbaseActivity
  }
}
```
```json
{
  "data": {
    "getUser": {
      "joinedAt": "2018-05-29T10:24:14Z",
      "lastSanbaseActivity": "Last 24 hours"
    }
  }
}
```

The `lastSanbaseActivity` can be one of:
`Last 5 minutes`, `Last hour`, `Last 24 hours`, `Last 3 days`, `More than 3 days ago`
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
