### PR TITLE
Disable async storage of api call usage

### DIFF
--- a/lib/sanbase_web/graphql/absinthe_before_send.ex
+++ b/lib/sanbase_web/graphql/absinthe_before_send.ex
@@ -63,16 +63,25 @@ defmodule SanbaseWeb.Graphql.AbsintheBeforeSend do
     result_sizes = result_sizes(blueprint)
     do_not_cache? = Process.get(:do_not_cache_query) == true
 
-    maybe_async(fn -> export_api_call_data(queries, conn, blueprint, result_sizes) end)
+    # Temporarily disable
+    # maybe_async(fn -> export_api_call_data(queries, conn, blueprint, result_sizes) end)
+    #
+    # maybe_async(fn ->
+    #   maybe_update_api_call_limit_usage(
+    #     conn,
+    #     blueprint.execution.context,
+    #     Enum.count(queries),
+    #     result_sizes
+    #   )
+    # end)
+    export_api_call_data(queries, conn, blueprint, result_sizes)
 
-    maybe_async(fn ->
-      maybe_update_api_call_limit_usage(
-        conn,
-        blueprint.execution.context,
-        Enum.count(queries),
-        result_sizes
-      )
-    end)
+    maybe_update_api_call_limit_usage(
+      conn,
+      blueprint.execution.context,
+      Enum.count(queries),
+      result_sizes
+    )
 
     case do_not_cache? or has_graphql_errors?(blueprint) do
       true -> :ok


### PR DESCRIPTION
## Changes

Seems like there is some data copying between processes when the API usage and api call export are started in new processes.
Disable the async mechanism until https://github.com/santiment/sanbase2/pull/4714 is finished and reduces the data shared.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
