### PR TITLE
Drain the connection pool before shutting down the app

### DIFF
--- a/lib/sanbase/application/application.ex
+++ b/lib/sanbase/application/application.ex
@@ -343,6 +343,12 @@ defmodule Sanbase.Application do
       # Start the endpoint when the application starts
       SanbaseWeb.Endpoint,
 
+      # Drain the running connections before closing. This will allow the
+      # currently executing API calls to finish. The drainer first makes
+      # the TCP acceptor to stop accepting new connections and then waits
+      # until there are no connections or 30 seconds pass.
+      {SanbaseWeb.ConnectionDrainer, shutdown: 30_000, ranch_ref: SanbaseWeb.Endpoint.HTTP},
+
       # Process that starts test-only deps
       start_in(Sanbase.TestSetupService, [:test]),
       Sanbase.EventBus.children()

--- a/lib/sanbase_web/connection_drainer.ex
+++ b/lib/sanbase_web/connection_drainer.ex
@@ -1,0 +1,56 @@
+defmodule SanbaseWeb.ConnectionDrainer do
+  @moduledoc ~s"""
+  Implement a graceful shutdown for the Phoenix server by draining connections.
+
+  In the Supervision tree, processes start in the order they are defined
+  and are stopped in the reverse order. This process should be put after the
+  Endpoint.
+  """
+  use GenServer
+
+  require Logger
+
+  def child_spec(options) when is_list(options) do
+    ranch_ref = Keyword.fetch!(options, :ranch_ref)
+    shutdown = Keyword.fetch!(options, :shutdown)
+
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [ranch_ref]},
+      shutdown: shutdown
+    }
+  end
+
+  def start_link(ranch_ref) do
+    GenServer.start_link(__MODULE__, ranch_ref, name: __MODULE__)
+  end
+
+  def init(ranch_ref) do
+    Process.flag(:trap_exit, true)
+    # Maybe not needed, but if this process is killed for some reason and restarted,
+    # we want to be able to resume accepting connections.
+    :ranch.resume_listener(ranch_ref)
+    {:ok, ranch_ref}
+  end
+
+  def terminate(reason, ranch_ref) do
+    # If we're in terminating state, the Logger does not work here for some reason
+    IO.puts("[#{DateTime.utc_now(:second)}][ConnectionDrainer] Terminating with reason #{reason}")
+    # Stop accepting new connections
+    :ok = :ranch.suspend_listener(ranch_ref)
+    running_connections = :ranch.procs(ranch_ref, :connections)
+
+    IO.puts(
+      "[#{DateTime.utc_now(:second)}][ConnectionDrainer] Stopped accepting new connections. Waiting for #{length(running_connections)} connections to finish."
+    )
+
+    # Wait until the connections are all finished.
+    # If it takes more time, the `:shutdown` timeout will kick in
+    # and kill this process. This way we have a balance between
+    # waiting for most connections to finish, but not waiting too long
+    # or getting stuck.
+    :ok = :ranch.wait_for_connections(ranch_ref, :==, 0)
+
+    IO.puts("[#{DateTime.utc_now(:second)}][ConnectionDrainer] Finished draining connections.")
+  end
+end


### PR DESCRIPTION
## Changes

Connection Draining is a feature that allows servers that are going to be updated (a new deployment is being rolled out) to gracefully handle running connections.

The draining happens in 2 phases:
- Stop accepting new TCP connections
- Wait until the number of connections drops to 0
  - Or a specified number of seconds pass, whatever happens first. A timeout guarantees that we won't get stuck.


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
