### PR TITLE
Fix lastSanbaseActivity in case of no refresh tokens

### DIFF
--- a/lib/sanbase_web/guardian/guardian_token.ex
+++ b/lib/sanbase_web/guardian/guardian_token.ex
@@ -25,7 +25,15 @@ defmodule SanbaseWeb.Guardian.Token do
 
     case Sanbase.Repo.all(query) do
       [] ->
-        {:error, "User has not exchanged any refresh tokens"}
+        case Sanbase.Accounts.get_user(user_id) do
+          # Alternatively, we can also check if the registration_state is finished
+          # and report with a different error message if it's not
+          {:ok, %{updated_at: updated_at}} ->
+            {:ok, DateTime.from_naive!(updated_at, "Etc/UTC")}
+
+          _ ->
+            {:error, "User with id #{user_id} does not exist"}
+        end
 
       list ->
         last_activity =


### PR DESCRIPTION
The refresh token could have been deleted for one reason or another

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
