### PR TITLE
Compress the GraphQL response in dev mode

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -13,6 +13,7 @@ port = String.to_integer(System.get_env("PORT") || "4000")
 
 config :sanbase, SanbaseWeb.Endpoint,
   http: [
+    compress: true,
     port: port,
     protocol_options: [
       # Bump up cowboy2's timeout to 100 seconds


### PR DESCRIPTION
## Changes

On prod the API servers are behind AWS ingress, which uses Brotli
compression before sending the response.


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
