### PR TITLE
Remove product_id check when fetching cutom plan data

### DIFF
--- a/lib/sanbase/billing/plan/custom_plan/custom_plan_loader.ex
+++ b/lib/sanbase/billing/plan/custom_plan/custom_plan_loader.ex
@@ -63,7 +63,7 @@ defmodule Sanbase.Billing.Plan.CustomPlan.Loader do
     plan =
       from(p in Plan,
         where:
-          p.name == ^plan_name and p.product_id == ^product_id and
+          p.name == ^plan_name and
             p.has_custom_restrictions == true,
         # There are montly and yearly plans, both should have the same plan
         limit: 1


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
Fix for: 
https://santimentag.sentry.io/issues/6733224932/?project=4508058683375616&query=is%3Aunresolved&referrer=issue-stream

The custom plan is uniquely identified by plan name. The check for product is not needed.

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
