### PR TITLE
Properly handle restrictions in aggregated_timeseries_data

### DIFF
--- a/lib/sanbase_web/graphql/middlewares/access_control/access_control.ex
+++ b/lib/sanbase_web/graphql/middlewares/access_control/access_control.ex
@@ -570,6 +570,7 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
 
   # metrics
   @get_metric_fields [
+    :aggregated_timeseries_data,
     :timeseries_data,
     :timeseries_data_json,
     :timeseries_data_per_slug,


### PR DESCRIPTION
## Changes
The timerange restrictions were not properly applied to `aggregatedTimeseriesData` -- in case of free metrics it was wrongly applying restrictions for anon/no subscription users.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
