### PR TITLE
Add is_market_metric graphql API

### DIFF
--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -85,10 +85,13 @@ defmodule Sanbase.SocialData.MetricAdapter do
            when is_map(s) and (is_map_key(s, :text) or is_map_key(s, :contract_address))
 
   @impl Sanbase.Metric.Behaviour
-  def timeseries_data("nft_social_volume", selector, from, to, interval, _opts)
+  def timeseries_data("nft_social_volume", selector, from, to, interval, opts)
       when is_supported_nft_sv_selector(selector) do
+    is_market_metric = Keyword.get(opts, :is_market_metric, false)
+
     Sanbase.SocialData.social_volume(selector, from, to, interval, "total",
-      metric: "nft_social_volume"
+      metric: "nft_social_volume",
+      is_market_metric: is_market_metric
     )
     |> transform_to_value_pairs(:mentions_count)
   end
@@ -109,21 +112,27 @@ defmodule Sanbase.SocialData.MetricAdapter do
         from,
         to,
         interval,
-        _opts
+        opts
       )
       when is_binary(contract) do
+    is_market_metric = Keyword.get(opts, :is_market_metric, false)
+
     Sanbase.SocialData.social_volume(selector, from, to, interval, "total",
-      metric: "nft_social_volume"
+      metric: "nft_social_volume",
+      is_market_metric: is_market_metric
     )
     |> transform_to_value_pairs(:mentions_count)
   end
 
   @impl Sanbase.Metric.Behaviour
-  def timeseries_data(metric, selector, from, to, interval, _opts)
+  def timeseries_data(metric, selector, from, to, interval, opts)
       when metric in @social_volume_timeseries_metrics do
     "social_volume_" <> source = metric
+    is_market_metric = Keyword.get(opts, :is_market_metric, false)
 
-    Sanbase.SocialData.social_volume(selector, from, to, interval, source)
+    Sanbase.SocialData.social_volume(selector, from, to, interval, source,
+      is_market_metric: is_market_metric
+    )
     |> transform_to_value_pairs(:mentions_count)
   end
 

--- a/lib/sanbase/social_data/social_volume.ex
+++ b/lib/sanbase/social_data/social_volume.ex
@@ -176,6 +176,7 @@ defmodule Sanbase.SocialData.SocialVolume do
       }
       |> maybe_add_and_rename_field(selector, :only_project_channels, "project")
       |> maybe_add_and_rename_field(selector, :only_project_channels_spec, "project_spec")
+      |> maybe_add_is_market_metric_field(opts)
       |> Jason.encode_to_iodata!()
 
     options = [recv_timeout: @recv_timeout]
@@ -202,6 +203,7 @@ defmodule Sanbase.SocialData.SocialVolume do
             ]
             |> maybe_add_and_rename_field(selector, :only_project_channels, "project")
             |> maybe_add_and_rename_field(selector, :only_project_channels_spec, "project_spec")
+            |> maybe_add_is_market_metric_param(opts)
         ]
 
       http_client().get(url, [], options)
@@ -227,6 +229,20 @@ defmodule Sanbase.SocialData.SocialVolume do
 
   defp metrics_hub_url() do
     Config.module_get(Sanbase.SocialData, :metricshub_url)
+  end
+
+  defp maybe_add_is_market_metric_field(body, opts) do
+    case Keyword.get(opts, :is_market_metric) do
+      true -> Map.put(body, "is_market_metric", "true")
+      _ -> body
+    end
+  end
+
+  defp maybe_add_is_market_metric_param(params, opts) do
+    case Keyword.get(opts, :is_market_metric) do
+      true -> params ++ [{"is_market_metric", "true"}]
+      _ -> params
+    end
   end
 
   defp wrap_ok(result), do: {:ok, result}

--- a/lib/sanbase_web/graphql/resolvers/social_data_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/social_data_resolver.ex
@@ -198,9 +198,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.SocialDataResolver do
         _resolution
       ) do
     treat_as_lucene = Map.get(args, :treat_word_as_lucene_query, false)
+    is_market_metric = Map.get(args, :is_market_metric, false)
 
     SocialData.social_volume(selector, from, to, interval, :total,
-      treat_word_as_lucene_query: treat_as_lucene
+      treat_word_as_lucene_query: treat_as_lucene,
+      is_market_metric: is_market_metric
     )
   end
 

--- a/lib/sanbase_web/graphql/schema/queries/social_data_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/social_data_queries.ex
@@ -215,6 +215,11 @@ defmodule SanbaseWeb.Graphql.Schema.SocialDataQueries do
       """
       arg(:treat_word_as_lucene_query, :boolean, default_value: false)
 
+      @desc ~s"""
+      If true, the metric will be marked as a market metric in the metrics hub request. Default is false.
+      """
+      arg(:is_market_metric, :boolean, default_value: false)
+
       complexity(&Complexity.from_to_interval/3)
       middleware(AccessControl, %{allow_realtime_data: true})
       cache_resolve(&SocialDataResolver.words_social_volume/3, ttl: 600, max_ttl_offset: 240)


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

```graphql
query {
  wordsSocialVolume(
    selector: {
      words: ["bitcoin", "ethereum"]
    }
    from: "utc_now-30d"
    to: "utc_now"
    interval: "1d"
    isMarketMetric: true
  ) {
    word
    timeseriesData {
      datetime
      mentionsCount
    }
  }
}
```

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
