### PR TITLE
Add alternative rank_up_to to top_all_projects screener function

### DIFF
--- a/lib/sanbase/project/list/project_list.ex
+++ b/lib/sanbase/project/list/project_list.ex
@@ -701,7 +701,7 @@ defmodule Sanbase.Project.List do
       nil ->
         from(p in query,
           inner_join: latest_cmc in assoc(p, :latest_coinmarketcap_data),
-          order_by: latest_cmc.rank
+          order_by: [latest_cmc.rank, p.slug]
         )
 
       _ ->

--- a/test/sanbase_web/graphql/watchlist/project/project_dynamic_watchlist_test.exs
+++ b/test/sanbase_web/graphql/watchlist/project/project_dynamic_watchlist_test.exs
@@ -294,7 +294,10 @@ defmodule SanbaseWeb.Graphql.ProjectDynamicWatchlistTest do
 
   test "dynamic watchlist for top erc20 projects", %{conn: conn} do
     function = %{"name" => "top_erc20_projects", "args" => %{"size" => 2}}
-    result = do_execute_mutation(conn, create_watchlist_query(function: function))
+
+    result =
+      do_execute_mutation(conn, create_watchlist_query(function: function))
+
     user_list = result["data"]["createWatchlist"]
 
     assert user_list["listItems"] == [


### PR DESCRIPTION
## Changes

We have this `allProjectsByFunction` supported function: 
```graphql
{
  byRank: allProjectsByFunction(
    function: "{\"name\": \"top_all_projects\", \"args\": {\"size\": 20}}") {
    stats{
      projectsCount
    }
      projects {
        slug
        rank
        marketcapUsd
      }
  }
}
```

It returns the top 20 projects, ordered by rank.
<details>
<summary>Result</summary>

```json
{
  "data": {
    "byRank": {
      "projects": [
        {
          "marketcapUsd": 2300130225748.6514,
          "rank": 1,
          "slug": "bitcoin"
        },
        {
          "marketcapUsd": 518739527148.6799,
          "rank": 2,
          "slug": "ethereum"
        },
        {
          "marketcapUsd": 179521487836.08035,
          "rank": 3,
          "slug": "xrp"
        },
        {
          "marketcapUsd": 167112269428.0483,
          "rank": 4,
          "slug": "arb-tether"
        },
        {
          "marketcapUsd": 167112269428.0483,
          "rank": 4,
          "slug": "chain-key-usdt"
        },
        {
          "marketcapUsd": 167112269428.0483,
          "rank": 4,
          "slug": "tether"
        },
        {
          "marketcapUsd": 167112269428.0483,
          "rank": 4,
          "slug": "sol-tether"
        },
        {
          "marketcapUsd": 167112269428.0483,
          "rank": 4,
          "slug": "a-tether"
        },
        {
          "marketcapUsd": 167112269428.0483,
          "rank": 4,
          "slug": "bnb-tether"
        },
        {
          "marketcapUsd": 167112269428.0483,
          "rank": 4,
          "slug": "p-tether"
        },
        {
          "marketcapUsd": 167112269428.0483,
          "rank": 4,
          "slug": "o-tether"
        },
        {
          "marketcapUsd": 117709289556.503,
          "rank": 5,
          "slug": "binance-coin"
        },
        {
          "marketcapUsd": 98348524711.69632,
          "rank": 6,
          "slug": "solana"
        },
        {
          "marketcapUsd": 68395632849.14483,
          "rank": 7,
          "slug": "a-usd-coin"
        },
        {
          "marketcapUsd": 68395632849.14483,
          "rank": 7,
          "slug": "arb-usd-coin"
        },
        {
          "marketcapUsd": 68395632849.14483,
          "rank": 7,
          "slug": "p-usd-coin"
        },
        {
          "marketcapUsd": 68395632849.14483,
          "rank": 7,
          "slug": "usd-coin"
        },
        {
          "marketcapUsd": 68395632849.14483,
          "rank": 7,
          "slug": "o-usd-coin"
        },
        {
          "marketcapUsd": 68395632849.14483,
          "rank": 7,
          "slug": "bnb-usd-coin"
        },
        {
          "marketcapUsd": 68395632849.14483,
          "rank": 7,
          "slug": "chain-key-usdc"
        }
      ],
      "stats": {
        "projectsCount": 20
      }
    }
  }
}
```

</details>

But we have a problem with how we do multichain support -- we have multiple assets like `tether`, `a-tether`, `o-tether`, etc. with the same rank.
The above query returns 20 assets, but the last asset in the list is with rank 7 because many of these assets are multichain duplications.

To solve this, we introduce an alternative parameter to `size` called `rank_up_to`. It returns all assets with rank between 1 and `rank_up_to` (inclusive), ordered by rank.

It looks like this:
```graphql
{
  byRank: allProjectsByFunction(
    function: "{\"name\": \"top_all_projects\", \"args\": {\"rank_up_to\": 20}}") {
    stats{
      projectsCount
    }
      projects {
        slug
        rank
        marketcapUsd
      }
  }
}
```
and returns 34 assets in total, the last one being with rank 20.
<details>
  <summary>Result</summary>

```json
{
  "data": {
    "byRank": {
      "projects": [
        {
          "marketcapUsd": 2298023745035.865,
          "rank": 1,
          "slug": "bitcoin"
        },
        {
          "marketcapUsd": 516052688558.47815,
          "rank": 2,
          "slug": "ethereum"
        },
        {
          "marketcapUsd": 179346887970.65973,
          "rank": 3,
          "slug": "xrp"
        },
        {
          "marketcapUsd": 167115804151.73834,
          "rank": 4,
          "slug": "bnb-tether"
        },
        {
          "marketcapUsd": 167115804151.73834,
          "rank": 4,
          "slug": "tether"
        },
        {
          "marketcapUsd": 167115804151.73834,
          "rank": 4,
          "slug": "arb-tether"
        },
        {
          "marketcapUsd": 167115804151.73834,
          "rank": 4,
          "slug": "o-tether"
        },
        {
          "marketcapUsd": 167115804151.73834,
          "rank": 4,
          "slug": "sol-tether"
        },
        {
          "marketcapUsd": 167115804151.73834,
          "rank": 4,
          "slug": "p-tether"
        },
        {
          "marketcapUsd": 167115804151.73834,
          "rank": 4,
          "slug": "a-tether"
        },
        {
          "marketcapUsd": 167115804151.73834,
          "rank": 4,
          "slug": "chain-key-usdt"
        },
        {
          "marketcapUsd": 117522877866.87119,
          "rank": 5,
          "slug": "binance-coin"
        },
        {
          "marketcapUsd": 98196474628.71959,
          "rank": 6,
          "slug": "solana"
        },
        {
          "marketcapUsd": 68394585501.47395,
          "rank": 7,
          "slug": "arb-usd-coin"
        },
        {
          "marketcapUsd": 68394585501.47395,
          "rank": 7,
          "slug": "a-usd-coin"
        },
        {
          "marketcapUsd": 68394585501.47395,
          "rank": 7,
          "slug": "chain-key-usdc"
        },
        {
          "marketcapUsd": 68394585501.47395,
          "rank": 7,
          "slug": "p-usd-coin"
        },
        {
          "marketcapUsd": 68394585501.47395,
          "rank": 7,
          "slug": "o-usd-coin"
        },
        {
          "marketcapUsd": 68394585501.47395,
          "rank": 7,
          "slug": "bnb-usd-coin"
        },
        {
          "marketcapUsd": 68394585501.47395,
          "rank": 7,
          "slug": "usd-coin"
        }
      ],
      "stats": {
        "projectsCount": 20
      }
    }
  }
}
```

</details>
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
