### PR TITLE
Add more metrics to MCP. Allow fetching metrics for many assets. Add new fields

### DIFF
--- a/lib/sanbase/mcp/available_metrics.ex
+++ b/lib/sanbase/mcp/available_metrics.ex
@@ -1,0 +1,179 @@
+defmodule Sanbase.MCP.DataCatalog.AvailableMetrics do
+  def list() do
+    list =
+      financial_metrics() ++
+        development_activity_metrics() ++
+        social_metrics() ++
+        on_chain_metrics()
+
+    List.flatten(list)
+  end
+
+  def financial_metrics() do
+    [
+      %{
+        name: "price_usd",
+        description: "Price in USD for cryptocurrencies",
+        unit: "USD",
+        supports_many_slugs: true
+      },
+      %{
+        name: "marketcap_usd",
+        description: "Total market capitalization in USD",
+        unit: "USD",
+        supports_many_slugs: true
+      },
+      %{
+        name: "volume_usd",
+        description: "Trading volume in USD",
+        unit: "USD",
+        supports_many_slugs: true
+      },
+      %{
+        name: "price_btc",
+        description: "Asset price denominated in BTC",
+        unit: "BTC",
+        supports_many_slugs: true
+      },
+      %{
+        name: "price_volatility_1d",
+        description: "Realized price volatility over 1 day",
+        unit: "percent",
+        supports_many_slugs: true
+      },
+      %{
+        name: "fully_diluted_valuation_usd",
+        description: "Fully diluted valuation in USD",
+        unit: "USD",
+        supports_many_slugs: true
+      }
+    ]
+  end
+
+  def development_activity_metrics() do
+    [
+      %{
+        name: "dev_activity_1d",
+        description:
+          "Development activity events on tracked repositories (commits, PRs, issues, etc.)",
+        unit: "count",
+        supports_many_slugs: true
+      },
+      %{
+        name: "dev_activity_contributors_count_7d",
+        description: """
+        Number of unique developers contributing across tracked repositories of the asset,
+        computed at 7 day sliding windows. Data points are produced for each day and each
+        point is computed using the data from the previous 7 days.
+        """,
+        unit: "count",
+        supports_many_slugs: true
+      }
+    ]
+  end
+
+  def social_metrics() do
+    [
+      %{
+        name: "social_volume_total",
+        description: "Total social media mentions and discussions",
+        unit: "count"
+      },
+      %{
+        name: "social_dominance_total",
+        description: "Share of total crypto social mentions attributed to the asset",
+        unit: "percent"
+      },
+      %{
+        name: "sentiment_weighted_total",
+        description: "Overall weighted social sentiment score",
+        unit: "score"
+      },
+      for source <- [:twitter, :telegram, :reddit] do
+        [
+          %{
+            name: "sentiment_weighted_#{source}",
+            description:
+              "Weighted social sentiment score computed on the text messages in #{source}",
+            unit: "score"
+          },
+          %{
+            name: "social_volume_#{source}",
+            description: "Social media mentions in #{source}",
+            unit: "count"
+          },
+          %{
+            name: "social_dominance_#{source}",
+            description: "Share of crypto social mentions attributed to the asset in #{source}",
+            unit: "percent"
+          }
+        ]
+      end,
+      %{
+        name: "twitter_followers",
+        description: "Number of followers on the project's official Twitter/X account",
+        unit: "count"
+      }
+    ]
+    |> List.flatten()
+  end
+
+  def on_chain_metrics() do
+    [
+      %{
+        name: "daily_active_addresses",
+        description: "Daily active addresses",
+        unit: "count",
+        supports_many_slugs: true
+      },
+      %{
+        name: "transactions_count",
+        description: "Number of on-chain transactions",
+        unit: "count",
+        supports_many_slugs: true
+      },
+      %{
+        name: "transaction_volume",
+        description: "On-chain transaction volume in number of coins/tokens",
+        unit: "count",
+        supports_many_slugs: true
+      },
+      %{
+        name: "transaction_volume_usd",
+        description: "On-chain transaction volume in USD",
+        unit: "USD",
+        supports_many_slugs: true
+      },
+      %{
+        name: "network_growth",
+        description: "New addresses that made their first on-chain transaction",
+        unit: "count",
+        supports_many_slugs: true
+      },
+      %{
+        name: "mvrv_usd",
+        description: "Market Value to Realized Value ratio (USD terms)",
+        unit: "ratio",
+        supports_many_slugs: true
+      },
+      %{
+        name: "supply_on_exchanges",
+        description: "Amount of tokens held on exchange addresses",
+        unit: "tokens",
+        supports_many_slugs: true
+      },
+      %{
+        name: "exchange_inflow_usd",
+        description: "USD value of tokens deposited to exchange addresses",
+        unit: "USD",
+        supports_many_slugs: true
+      },
+      %{
+        name: "exchange_outflow_usd",
+        description: "USD value of tokens withdrawn from exchange addresses",
+        unit: "USD",
+        supports_many_slugs: true
+      }
+    ]
+  end
+end

--- a/lib/sanbase/mcp/data_catalog.ex
+++ b/lib/sanbase/mcp/data_catalog.ex
@@ -1,124 +1,7 @@
 defmodule Sanbase.MCP.DataCatalog do
   @moduledoc "Centralized catalog of available metrics and slugs for MCP tools"
 
-  @available_metrics [
-    %{
-      name: "price_usd",
-      description: "Price in USD for cryptocurrencies",
-      unit: "USD"
-    },
-    %{
-      name: "marketcap_usd",
-      description: "Total market capitalization in USD",
-      unit: "USD"
-    },
-    %{
-      name: "volume_usd",
-      description: "Trading volume in USD",
-      unit: "USD"
-    },
-    %{
-      name: "price_btc",
-      description: "Asset price denominated in BTC",
-      unit: "BTC"
-    },
-    %{
-      name: "price_volatility_1d",
-      description: "Realized price volatility over 1 day",
-      unit: "percent"
-    },
-    %{
-      name: "fully_diluted_valuation_usd",
-      description: "Fully diluted valuation in USD",
-      unit: "USD"
-    },
-    %{
-      name: "dev_activity",
-      description:
-        "Development activity events on tracked repositories (commits, PRs, issues, etc.)",
-      unit: "count"
-    },
-    %{
-      name: "dev_activity_contributors_count",
-      description: "Number of unique developers contributing across tracked repositories",
-      unit: "count"
-    },
-    %{
-      name: "github_activity",
-      description: "GitHub activity events for the project",
-      unit: "count"
-    },
-    %{
-      name: "github_activity_contributors_count",
-      description: "Unique GitHub contributors count",
-      unit: "count"
-    },
-    %{
-      name: "social_volume_total",
-      description: "Total social media mentions and discussions",
-      unit: "count"
-    },
-    %{
-      name: "social_dominance_total",
-      description: "Share of total crypto social mentions attributed to the asset",
-      unit: "percent"
-    },
-    %{
-      name: "sentiment_weighted_total",
-      description: "Overall weighted social sentiment score",
-      unit: "score"
-    },
-    %{
-      name: "twitter_followers",
-      description: "Number of followers on the project's official Twitter/X account",
-      unit: "count"
-    },
-    %{
-      name: "daily_active_addresses",
-      description: "Daily active addresses",
-      unit: "count"
-    },
-    %{
-      name: "transactions_count",
-      description: "Number of on-chain transactions",
-      unit: "count"
-    },
-    %{
-      name: "transaction_volume",
-      description: "On-chain transaction volume in number of coins/tokens",
-      unit: "count"
-    },
-    %{
-      name: "transaction_volume_usd",
-      description: "On-chain transaction volume in USD",
-      unit: "USD"
-    },
-    %{
-      name: "network_growth",
-      description: "New addresses that made their first on-chain transaction",
-      unit: "count"
-    },
-    %{
-      name: "mvrv_usd",
-      description: "Market Value to Realized Value ratio (USD terms)",
-      unit: "ratio"
-    },
-    %{
-      name: "supply_on_exchanges",
-      description: "Amount of tokens held on exchange addresses",
-      unit: "tokens"
-    },
-    %{
-      name: "exchange_inflow_usd",
-      description: "USD value of tokens deposited to exchange addresses",
-      unit: "USD"
-    },
-    %{
-      name: "exchange_outflow_usd",
-      description: "USD value of tokens withdrawn from exchange addresses",
-      unit: "USD"
-    }
-  ]
+  @available_metrics Sanbase.MCP.DataCatalog.AvailableMetrics.list()
 
   @spec get_all_projects() :: list(map())
   def get_all_projects() do
@@ -166,7 +49,11 @@ defmodule Sanbase.MCP.DataCatalog do
       {:ok, metadata} = Sanbase.Metric.metadata(m.name)
       # metatata.docs is a list of structs and structs cannot be serialized to JSON
       docs = metadata.docs |> Enum.map(fn d -> %{url: d.link} end)
-      Map.put(m, :documentation_urls, docs)
+
+      m
+      |> Map.put(:documentation_urls, docs)
+      |> Map.put(:min_interval, metadata.min_interval)
+      |> Map.put(:default_aggregation, metadata.default_aggregation)
     end)
   end
 
@@ -186,7 +73,8 @@ defmodule Sanbase.MCP.DataCatalog do
   def get_available_metrics_for_slug(slug) do
     if valid_slug?(slug) do
       metrics_intersection = fn all_metrics_for_slug ->
-        all_metrics_for_slug_mapset = MapSet.new(all_metrics_for_slug)
+        all_metrics_for_slug_mapset =
+          MapSet.new(all_metrics_for_slug)
 
         Enum.reduce(available_metrics(), [], fn %{name: name} = metric, acc ->
           if MapSet.member?(all_metrics_for_slug_mapset, name) do

--- a/lib/sanbase/mcp/metrics_and_assets_discovery_tool.ex
+++ b/lib/sanbase/mcp/metrics_and_assets_discovery_tool.ex
@@ -18,14 +18,18 @@ defmodule Sanbase.MCP.MetricsAndAssetsDiscoveryTool do
 
   ### Usage Guidance
 
-  - **`slug`**: The unique, lowercase, hyphen-separated identifier for a crypto asset
-    (e.g., `"bitcoin"`). Use this to focus results on a single asset.
-  - **`metric`**: The unique, lowercase, snake_case identifier for a metric
-    (e.g., `"price_usd"`). Use this to focus results on a single metric.
+  - **slug**: The unique, lowercase, hyphen-separated identifier for a crypto asset
+    (e.g., "bitcoin"). Use this to focus results on a single asset.
+  - **metric**: The unique, lowercase, snake_case identifier for a metric
+    (e.g., "price_usd"). Use this to focus results on a single metric.
+  - **interval**: The datetime interval between two data points in the result.
+    (e.g. 5m means 5 minutes, 1h means 1 hour, 2d means 2 days, etc.). Default is 1d.
+  - **time_period**: How far back in time to fetch data. Examples: "7d" (7 days),
+    "30d" (30 days), etc. Default is 30d.
 
   ### Example Parameters
 
-  - **Li st all metrics and assets:**
+  - **List all metrics and assets:**
     ```
     {}
     ```

--- a/test/sanbase/mcp/mcp_fetch_metric_test.exs
+++ b/test/sanbase/mcp/mcp_fetch_metric_test.exs
@@ -55,7 +55,9 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
       result =
         try_few_times(
           fn ->
-            Sanbase.MCP.Client.call_tool("metrics_and_assets_discovery_tool", %{slug: "bitcoin"})
+            Sanbase.MCP.Client.call_tool("metrics_and_assets_discovery_tool", %{
+              slug: "bitcoin"
+            })
           end,
           attempts: 3,
           sleep: 250
@@ -77,30 +79,35 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                 is_error: false
               }} = result
 
-      assert Jason.decode!(json_text) ==
-               %{
-                 "description" => "All metrics available for bitcoin",
-                 "metrics" => [
-                   %{
-                     "description" => "Daily active addresses",
-                     "documentation_urls" => [
-                       %{"url" => "https://academy.santiment.net/metrics/daily-active-addresses"}
-                     ],
-                     "name" => "daily_active_addresses",
-                     "unit" => "count"
-                   },
-                   %{
-                     "description" => "Price in USD for cryptocurrencies",
-                     "documentation_urls" => [
-                       %{"url" => "https://academy.santiment.net/metrics/price"}
-                     ],
-                     "name" => "price_usd",
-                     "unit" => "USD"
-                   }
-                 ],
-                 "metrics_count" => 2,
-                 "slug" => "bitcoin"
-               }
+      assert Jason.decode!(json_text) == %{
+               "description" => "All metrics available for bitcoin",
+               "metrics" => [
+                 %{
+                   "description" => "Daily active addresses",
+                   "documentation_urls" => [
+                     %{"url" => "https://academy.santiment.net/metrics/daily-active-addresses"}
+                   ],
+                   "name" => "daily_active_addresses",
+                   "unit" => "count",
+                   "default_aggregation" => "avg",
+                   "min_interval" => "1d",
+                   "supports_many_slugs" => true
+                 },
+                 %{
+                   "description" => "Price in USD for cryptocurrencies",
+                   "documentation_urls" => [
+                     %{"url" => "https://academy.santiment.net/metrics/price"}
+                   ],
+                   "name" => "price_usd",
+                   "unit" => "USD",
+                   "default_aggregation" => "last",
+                   "min_interval" => "1s",
+                   "supports_many_slugs" => true
+                 }
+               ],
+               "metrics_count" => 2,
+               "slug" => "bitcoin"
+             }
     end)
   end
 
@@ -209,7 +216,10 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                    %{"url" => "https://academy.santiment.net/metrics/price"}
                  ],
                  "name" => "price_usd",
-                 "unit" => "USD"
+                 "unit" => "USD",
+                 "default_aggregation" => "last",
+                 "min_interval" => "1s",
+                 "supports_many_slugs" => true
                },
                %{
                  "description" => "Total market capitalization in USD",
@@ -217,7 +227,10 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                    %{"url" => "https://academy.santiment.net/metrics/marketcap"}
                  ],
                  "name" => "marketcap_usd",
-                 "unit" => "USD"
+                 "unit" => "USD",
+                 "default_aggregation" => "last",
+                 "min_interval" => "1s",
+                 "supports_many_slugs" => true
                },
                %{
                  "description" => "Trading volume in USD",
@@ -225,7 +238,10 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                    %{"url" => "https://academy.santiment.net/metrics/trading-volume"}
                  ],
                  "name" => "volume_usd",
-                 "unit" => "USD"
+                 "unit" => "USD",
+                 "default_aggregation" => "last",
+                 "min_interval" => "1s",
+                 "supports_many_slugs" => true
                },
                %{
                  "description" => "Asset price denominated in BTC",
@@ -233,7 +249,10 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                    %{"url" => "https://academy.santiment.net/metrics/price"}
                  ],
                  "name" => "price_btc",
-                 "unit" => "BTC"
+                 "unit" => "BTC",
+                 "default_aggregation" => "last",
+                 "min_interval" => "1s",
+                 "supports_many_slugs" => true
                },
                %{
                  "description" => "Realized price volatility over 1 day",
@@ -241,17 +260,21 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                    %{"url" => "https://academy.santiment.net/metrics/price-volatility"}
                  ],
                  "name" => "price_volatility_1d",
-                 "unit" => "percent"
+                 "unit" => "percent",
+                 "default_aggregation" => "avg",
+                 "min_interval" => "5m",
+                 "supports_many_slugs" => true
                },
                %{
                  "description" => "Fully diluted valuation in USD",
                  "documentation_urls" => [
-                   %{
-                     "url" => "https://academy.santiment.net/metrics/fully-diluted-valuation"
-                   }
+                   %{"url" => "https://academy.santiment.net/metrics/fully-diluted-valuation"}
                  ],
                  "name" => "fully_diluted_valuation_usd",
-                 "unit" => "USD"
+                 "unit" => "USD",
+                 "default_aggregation" => "last",
+                 "min_interval" => "1d",
+                 "supports_many_slugs" => true
                },
                %{
                  "description" =>
@@ -262,42 +285,26 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                        "https://academy.santiment.net/metrics/development-activity/development-activity"
                    }
                  ],
-                 "name" => "dev_activity",
-                 "unit" => "count"
+                 "name" => "dev_activity_1d",
+                 "unit" => "count",
+                 "default_aggregation" => "sum",
+                 "min_interval" => "1d",
+                 "supports_many_slugs" => true
                },
                %{
                  "description" =>
-                   "Number of unique developers contributing across tracked repositories",
+                   "Number of unique developers contributing across tracked repositories of the asset,\ncomputed at 7 day sliding windows. Data points are produced for each day and each\npoint is computed using the data from the previous 7 days.\n",
                  "documentation_urls" => [
                    %{
                      "url" =>
                        "https://academy.santiment.net/metrics/development-activity/development-activity-contributors-count"
                    }
                  ],
-                 "name" => "dev_activity_contributors_count",
-                 "unit" => "count"
-               },
-               %{
-                 "description" => "GitHub activity events for the project",
-                 "documentation_urls" => [
-                   %{
-                     "url" =>
-                       "https://academy.santiment.net/metrics/development-activity/github-activity"
-                   }
-                 ],
-                 "name" => "github_activity",
-                 "unit" => "count"
-               },
-               %{
-                 "description" => "Unique GitHub contributors count",
-                 "documentation_urls" => [
-                   %{
-                     "url" =>
-                       "https://academy.santiment.net/metrics/development-activity/github-activity-contributors-count"
-                   }
-                 ],
-                 "name" => "github_activity_contributors_count",
-                 "unit" => "count"
+                 "name" => "dev_activity_contributors_count_7d",
+                 "unit" => "count",
+                 "default_aggregation" => "last",
+                 "min_interval" => "1d",
+                 "supports_many_slugs" => true
                },
                %{
                  "description" => "Total social media mentions and discussions",
@@ -305,7 +312,9 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                    %{"url" => "https://academy.santiment.net/metrics/social-volume"}
                  ],
                  "name" => "social_volume_total",
-                 "unit" => "count"
+                 "unit" => "count",
+                 "default_aggregation" => "sum",
+                 "min_interval" => "5m"
                },
                %{
                  "description" => "Share of total crypto social mentions attributed to the asset",
@@ -313,7 +322,9 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                    %{"url" => "https://academy.santiment.net/metrics/social-dominance"}
                  ],
                  "name" => "social_dominance_total",
-                 "unit" => "percent"
+                 "unit" => "percent",
+                 "default_aggregation" => "avg",
+                 "min_interval" => "5m"
                },
                %{
                  "description" => "Overall weighted social sentiment score",
@@ -324,24 +335,121 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                    }
                  ],
                  "name" => "sentiment_weighted_total",
+                 "unit" => "score",
+                 "default_aggregation" => "avg",
+                 "min_interval" => "5m"
+               },
+               %{
+                 "default_aggregation" => "avg",
+                 "description" =>
+                   "Weighted social sentiment score computed on the text messages in twitter",
+                 "documentation_urls" => [
+                   %{"url" => "https://academy.santiment.net/metrics/deprecated-metrics"}
+                 ],
+                 "min_interval" => "5m",
+                 "name" => "sentiment_weighted_twitter",
                  "unit" => "score"
+               },
+               %{
+                 "default_aggregation" => "sum",
+                 "description" => "Social media mentions in twitter",
+                 "documentation_urls" => [
+                   %{"url" => "https://academy.santiment.net/metrics/social-volume"}
+                 ],
+                 "min_interval" => "5m",
+                 "name" => "social_volume_twitter",
+                 "unit" => "count"
+               },
+               %{
+                 "default_aggregation" => "avg",
+                 "description" =>
+                   "Share of crypto social mentions attributed to the asset in twitter",
+                 "documentation_urls" => [
+                   %{"url" => "https://academy.santiment.net/metrics/deprecated-metrics"}
+                 ],
+                 "min_interval" => "5m",
+                 "name" => "social_dominance_twitter",
+                 "unit" => "percent"
+               },
+               %{
+                 "default_aggregation" => "avg",
+                 "description" =>
+                   "Weighted social sentiment score computed on the text messages in telegram",
+                 "documentation_urls" => [],
+                 "min_interval" => "5m",
+                 "name" => "sentiment_weighted_telegram",
+                 "unit" => "score"
+               },
+               %{
+                 "default_aggregation" => "sum",
+                 "description" => "Social media mentions in telegram",
+                 "documentation_urls" => [
+                   %{"url" => "https://academy.santiment.net/metrics/social-volume"}
+                 ],
+                 "min_interval" => "5m",
+                 "name" => "social_volume_telegram",
+                 "unit" => "count"
+               },
+               %{
+                 "default_aggregation" => "avg",
+                 "description" =>
+                   "Share of crypto social mentions attributed to the asset in telegram",
+                 "documentation_urls" => [
+                   %{"url" => "https://academy.santiment.net/metrics/social-dominance"}
+                 ],
+                 "min_interval" => "5m",
+                 "name" => "social_dominance_telegram",
+                 "unit" => "percent"
+               },
+               %{
+                 "default_aggregation" => "avg",
+                 "description" =>
+                   "Weighted social sentiment score computed on the text messages in reddit",
+                 "documentation_urls" => [],
+                 "min_interval" => "5m",
+                 "name" => "sentiment_weighted_reddit",
+                 "unit" => "score"
+               },
+               %{
+                 "default_aggregation" => "sum",
+                 "description" => "Social media mentions in reddit",
+                 "documentation_urls" => [
+                   %{"url" => "https://academy.santiment.net/metrics/social-volume"}
+                 ],
+                 "min_interval" => "5m",
+                 "name" => "social_volume_reddit",
+                 "unit" => "count"
+               },
+               %{
+                 "default_aggregation" => "avg",
+                 "description" =>
+                   "Share of crypto social mentions attributed to the asset in reddit",
+                 "documentation_urls" => [
+                   %{"url" => "https://academy.santiment.net/metrics/social-dominance"}
+                 ],
+                 "min_interval" => "5m",
+                 "name" => "social_dominance_reddit",
+                 "unit" => "percent"
                },
                %{
                  "description" =>
                    "Number of followers on the project's official Twitter/X account",
                  "documentation_urls" => [],
                  "name" => "twitter_followers",
-                 "unit" => "count"
+                 "unit" => "count",
+                 "default_aggregation" => "last",
+                 "min_interval" => "6h"
                },
                %{
                  "description" => "Daily active addresses",
                  "documentation_urls" => [
-                   %{
-                     "url" => "https://academy.santiment.net/metrics/daily-active-addresses"
-                   }
+                   %{"url" => "https://academy.santiment.net/metrics/daily-active-addresses"}
                  ],
                  "name" => "daily_active_addresses",
-                 "unit" => "count"
+                 "unit" => "count",
+                 "default_aggregation" => "avg",
+                 "min_interval" => "1d",
+                 "supports_many_slugs" => true
                },
                %{
                  "description" => "Number of on-chain transactions",
@@ -349,7 +457,10 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                    %{"url" => "https://academy.santiment.net/metrics/transaction-count"}
                  ],
                  "name" => "transactions_count",
-                 "unit" => "count"
+                 "unit" => "count",
+                 "default_aggregation" => "sum",
+                 "min_interval" => "1d",
+                 "supports_many_slugs" => true
                },
                %{
                  "description" => "On-chain transaction volume in number of coins/tokens",
@@ -357,7 +468,10 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                    %{"url" => "https://academy.santiment.net/metrics/transaction-volume"}
                  ],
                  "name" => "transaction_volume",
-                 "unit" => "count"
+                 "unit" => "count",
+                 "default_aggregation" => "sum",
+                 "min_interval" => "5m",
+                 "supports_many_slugs" => true
                },
                %{
                  "description" => "On-chain transaction volume in USD",
@@ -365,7 +479,10 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                    %{"url" => "https://academy.santiment.net/metrics/transaction-volume"}
                  ],
                  "name" => "transaction_volume_usd",
-                 "unit" => "USD"
+                 "unit" => "USD",
+                 "default_aggregation" => "sum",
+                 "min_interval" => "1d",
+                 "supports_many_slugs" => true
                },
                %{
                  "description" => "New addresses that made their first on-chain transaction",
@@ -373,7 +490,10 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                    %{"url" => "https://academy.santiment.net/metrics/network-growth"}
                  ],
                  "name" => "network_growth",
-                 "unit" => "count"
+                 "unit" => "count",
+                 "default_aggregation" => "sum",
+                 "min_interval" => "1d",
+                 "supports_many_slugs" => true
                },
                %{
                  "description" => "Market Value to Realized Value ratio (USD terms)",
@@ -381,7 +501,10 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                    %{"url" => "https://academy.santiment.net/metrics/mvrv"}
                  ],
                  "name" => "mvrv_usd",
-                 "unit" => "ratio"
+                 "unit" => "ratio",
+                 "default_aggregation" => "last",
+                 "min_interval" => "1d",
+                 "supports_many_slugs" => true
                },
                %{
                  "description" => "Amount of tokens held on exchange addresses",
@@ -392,7 +515,10 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                    }
                  ],
                  "name" => "supply_on_exchanges",
-                 "unit" => "tokens"
+                 "unit" => "tokens",
+                 "default_aggregation" => "avg",
+                 "min_interval" => "1d",
+                 "supports_many_slugs" => true
                },
                %{
                  "description" => "USD value of tokens deposited to exchange addresses",
@@ -400,7 +526,10 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                    %{"url" => "https://academy.santiment.net/metrics/exchange-funds-flow"}
                  ],
                  "name" => "exchange_inflow_usd",
-                 "unit" => "USD"
+                 "unit" => "USD",
+                 "default_aggregation" => "sum",
+                 "min_interval" => "5m",
+                 "supports_many_slugs" => true
                },
                %{
                  "description" => "USD value of tokens withdrawn from exchange addresses",
@@ -408,12 +537,14 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
                    %{"url" => "https://academy.santiment.net/metrics/exchange-funds-flow"}
                  ],
                  "name" => "exchange_outflow_usd",
-                 "unit" => "USD"
+                 "unit" => "USD",
+                 "default_aggregation" => "sum",
+                 "min_interval" => "5m",
+                 "supports_many_slugs" => true
                }
              ],
-             "metrics_count" => 23
-           } =
-             result
+             "metrics_count" => 30
+           } = result
 
     result
   end
@@ -423,7 +554,7 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
       try_few_times(
         fn ->
           Sanbase.MCP.Client.call_tool("fetch_metric_data_tool", %{
-            slug: "not_supported_slug",
+            slugs: ["not_supported_slug"],
             metric: "price_usd"
           })
         end,
@@ -455,7 +586,7 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
       try_few_times(
         fn ->
           Sanbase.MCP.Client.call_tool("fetch_metric_data_tool", %{
-            slug: context.p1.slug,
+            slugs: [context.p1.slug],
             metric: "not_supported_metric"
           })
         end,
@@ -482,7 +613,7 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
            } = result
   end
 
-  test "fetch metric - success", context do
+  test "fetch metric with single slug - success", _context do
     Sanbase.Mock.prepare_mock2(
       &Sanbase.Metric.timeseries_data/5,
       {:ok,
@@ -498,7 +629,7 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
         try_few_times(
           fn ->
             Sanbase.MCP.Client.call_tool("fetch_metric_data_tool", %{
-              slug: context.p1.slug,
+              slugs: ["bitcoin"],
               metric: "daily_active_addresses"
             })
           end,
@@ -523,18 +654,101 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
               }} = result
 
       assert %{
-               "data" => [
-                 %{"datetime" => "2020-01-01T00:00:00Z", "value" => 1.5},
-                 %{"datetime" => "2020-01-02T00:00:00Z", "value" => 2.2},
-                 %{"datetime" => "2020-01-03T00:00:00Z", "value" => 2.8},
-                 %{"datetime" => "2020-01-04T00:00:00Z", "value" => 5.8}
-               ],
-               "data_points" => 4,
+               "data" => %{
+                 "bitcoin" => [
+                   %{"datetime" => "2020-01-01T00:00:00Z", "value" => 1.5},
+                   %{"datetime" => "2020-01-02T00:00:00Z", "value" => 2.2},
+                   %{"datetime" => "2020-01-03T00:00:00Z", "value" => 2.8},
+                   %{"datetime" => "2020-01-04T00:00:00Z", "value" => 5.8}
+                 ]
+               },
                "interval" => "1d",
                "metric" => "daily_active_addresses",
-               "period" => "last_30_days",
-               "slug" => "bitcoin"
-             } == Jason.decode!(json_text)
+               "period" => "Since " <> iso8601_datetime,
+               "slugs" => ["bitcoin"]
+             } = Jason.decode!(json_text)
+
+      assert {:ok, %DateTime{}, _} = DateTime.from_iso8601(iso8601_datetime)
+    end)
+  end
+
+  test "fetch metric with multiple slugs - success", _context do
+    Sanbase.Mock.prepare_mock2(
+      &Sanbase.Metric.timeseries_data_per_slug/5,
+      {:ok,
+       [
+         %{
+           datetime: ~U[2020-01-01 00:00:00Z],
+           data: [
+             %{slug: "bitcoin", value: 1.5},
+             %{slug: "ethereum", value: 10.5}
+           ]
+         },
+         %{
+           datetime: ~U[2020-01-02 00:00:00Z],
+           data: [
+             %{slug: "bitcoin", value: 2.5},
+             %{slug: "ethereum", value: 12.5}
+           ]
+         },
+         %{
+           datetime: ~U[2020-01-03 00:00:00Z],
+           data: [
+             %{slug: "bitcoin", value: 3.5},
+             %{slug: "ethereum", value: 15.5}
+           ]
+         }
+       ]}
+    )
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      result =
+        try_few_times(
+          fn ->
+            Sanbase.MCP.Client.call_tool("fetch_metric_data_tool", %{
+              slugs: ["bitcoin", "ethereum"],
+              metric: "daily_active_addresses"
+            })
+          end,
+          attempts: 3,
+          sleep: 250
+        )
+
+      assert {:ok,
+              %Anubis.MCP.Response{
+                id: _,
+                is_error: false,
+                method: "tools/call",
+                result: %{
+                  "content" => [
+                    %{
+                      "text" => json_text,
+                      "type" => "text"
+                    }
+                  ],
+                  "isError" => false
+                }
+              }} = result
+
+      assert %{
+               "data" => %{
+                 "bitcoin" => [
+                   %{"datetime" => "2020-01-01T00:00:00Z", "value" => 1.5},
+                   %{"datetime" => "2020-01-02T00:00:00Z", "value" => 2.5},
+                   %{"datetime" => "2020-01-03T00:00:00Z", "value" => 3.5}
+                 ],
+                 "ethereum" => [
+                   %{"datetime" => "2020-01-01T00:00:00Z", "value" => 10.5},
+                   %{"datetime" => "2020-01-02T00:00:00Z", "value" => 12.5},
+                   %{"datetime" => "2020-01-03T00:00:00Z", "value" => 15.5}
+                 ]
+               },
+               "interval" => "1d",
+               "metric" => "daily_active_addresses",
+               "period" => "Since " <> iso8601_datetime,
+               "slugs" => ["bitcoin", "ethereum"]
+             } = Jason.decode!(json_text)
+
+      assert {:ok, %DateTime{}, _} = DateTime.from_iso8601(iso8601_datetime)
     end)
   end
 end


### PR DESCRIPTION
## Changes
- Return link to academy docs for each metric
- Rework the fetch metric to use `slugs` instead of `slug` so it can fetch data for many assets at once.
  - Change the shape of the returned data so the same structure is used both for single-slug and many-slugs calls.
  - The format is a JSON map where the keys are the slugs and the values are the list of timeseries data for this slug. This is different compared to our API.
- Add `time_period` and `interval` as params to the tool call. Also expose min_interval in the metrics description.
- Other small stuff

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
