### PR TITLE
Review pull request

### DIFF
--- a/lib/sanbase/mcp/data_catalog.ex
+++ b/lib/sanbase/mcp/data_catalog.ex
@@ -45,7 +45,6 @@ defmodule Sanbase.MCP.DataCatalog do
   def available_metrics() do
     @available_metrics
     |> Enum.map(fn m ->
-      nil
       {:ok, metadata} = Sanbase.Metric.metadata(m.name)
       # metatata.docs is a list of structs and structs cannot be serialized to JSON
       docs = metadata.docs |> Enum.map(fn d -> %{url: d.link} end)

--- a/lib/sanbase/mcp/fetch_metric_data_tool.ex
+++ b/lib/sanbase/mcp/fetch_metric_data_tool.ex
@@ -10,6 +10,7 @@ defmodule Sanbase.MCP.FetchMetricDataTool do
   alias Anubis.Server.Response
   alias Sanbase.MCP.DataCatalog
 
+  @slugs_per_call_limit 10
   schema do
     field(:metric, :string,
       required: true,
@@ -21,7 +22,7 @@ defmodule Sanbase.MCP.FetchMetricDataTool do
       description: """
       List of slug identifiers (e.g., ["bitcoin"], ["bitcoin", "ethereum"], etc.).
 
-      Accepts at most 10 slugs at a time.
+      Accepts at most #{@slugs_per_call_limit} slugs at a time.
 
       Only metrics that are listed as `supports_many_slugs: true` can accept a list of more than
       one slug at a time.
@@ -107,10 +108,6 @@ defmodule Sanbase.MCP.FetchMetricDataTool do
     end
   end
 
-  defp validate_many_slugs_supported(_metric, []) do
-    {:error, "The list of slugs provided is empty."}
-  end
-
   defp validate_many_slugs_supported(_metric, [_single_slug]), do: :ok
 
   defp validate_many_slugs_supported(metric, slugs) when is_list(slugs) do
@@ -125,11 +122,12 @@ defmodule Sanbase.MCP.FetchMetricDataTool do
   end
 
   defp validate_slugs([]) do
-    {:error, "The list of slugs provided is empty."}
+    {:error,
+     "The provided list of slugs is empty. Provide between 1 and #{@slugs_per_call_limit} slugs."}
   end
 
-  defp validate_slugs(slugs) when is_list(slugs) and length(slugs) > 10 do
-    {:error, "The list of slugs can contain at most 10 slugs"}
+  defp validate_slugs(slugs) when is_list(slugs) and length(slugs) > @slugs_per_call_limit do
+    {:error, "The list of slugs can contain at most #{@slugs_per_call_limit} slugs"}
   end
 
   defp validate_slugs(slugs) when is_list(slugs) do

--- a/test/sanbase/mcp/mcp_fetch_metric_test.exs
+++ b/test/sanbase/mcp/mcp_fetch_metric_test.exs
@@ -549,6 +549,37 @@ defmodule SanbaseWeb.Graphql.MCPFetchMetricTest do
     result
   end
 
+  test "fetch metric with empty slugs list" do
+    result =
+      try_few_times(
+        fn ->
+          Sanbase.MCP.Client.call_tool("fetch_metric_data_tool", %{
+            slugs: [],
+            metric: "price_usd"
+          })
+        end,
+        attempts: 3,
+        sleep: 250
+      )
+
+    assert {:ok,
+            %Anubis.MCP.Response{
+              id: _,
+              is_error: true,
+              method: "tools/call",
+              result: %{
+                "content" => [
+                  %{
+                    "text" =>
+                      "The provided list of slugs is empty. Provide between 1 and 10 slugs.",
+                    "type" => "text"
+                  }
+                ],
+                "isError" => true
+              }
+            }} = result
+  end
+
   test "fetch metric with wrong asset name" do
     result =
       try_few_times(


### PR DESCRIPTION
## Changes

This PR centralizes the metric catalog in `Sanbase.MCP.DataCatalog.AvailableMetrics` and significantly enhances `Sanbase.MCP.FetchMetricDataTool`. The tool now supports fetching data for multiple slugs, with optional `interval` and `time_period` parameters. Responses are structured to provide per-slug data. The catalog also exposes richer metric metadata, including `documentation_urls`, `min_interval`, and `default_aggregation`.

Key improvements include:
*   **Multi-slug support**: `FetchMetricDataTool` now accepts a list of `slugs`.
*   **Enhanced parameters**: Added `interval` and `time_period` for more flexible data fetching.
*   **Richer metadata**: `DataCatalog` now provides more detailed metric information.
*   **Validation**: Enforces `supports_many_slugs` for multi-slug queries.
*   **Data Consistency**: Ensures multi-slug datetime values are ISO8601 formatted and chronologically sorted.
*   **Documentation**: Updated module documentation and fixed a typo.

**Breaking Change**: The `slug` parameter has been replaced by `slugs`. Clients using the old `slug` parameter will need to update.

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

---
<a href="https://cursor.com/background-agent?bcId=bc-644ee6f5-be04-4fc8-b1cf-ea6504681785">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-644ee6f5-be04-4fc8-b1cf-ea6504681785">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

