### PR TITLE
Add user_id to Logger's metadata

### DIFF
--- a/lib/sanbase_web/graphql/plugs/auth_plug.ex
+++ b/lib/sanbase_web/graphql/plugs/auth_plug.ex
@@ -83,6 +83,11 @@ defmodule SanbaseWeb.Graphql.AuthPlug do
       {:ok, %AuthStruct{} = auth_struct} ->
         auth_struct = augment_auth(auth_struct, conn)
 
+        case auth_struct do
+          %{auth: %{current_user: %{id: user_id}}} -> Logger.metadata(user_id: user_id)
+          _ -> Logger.metadata(user_id: "anonymous")
+        end
+
         conn
         |> maybe_put_new_access_token(auth_struct)
         |> put_private(:san_authentication, Map.from_struct(auth_struct))


### PR DESCRIPTION
## Changes
Add `user_id` to the JSON log.
Anon users:
<img width="1512" height="58" alt="image" src="https://github.com/user-attachments/assets/30d9b322-1e10-4567-b6c9-f859da83f0b6" />
Logged users:
<img width="1512" height="99" alt="image" src="https://github.com/user-attachments/assets/1fee620a-b2a1-4566-8f93-2cb4f851d642" />


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
