### PR TITLE
Migrate entity types with public handling

### DIFF
--- a/lib/sanbase/chart/chart_configuration.ex
+++ b/lib/sanbase/chart/chart_configuration.ex
@@ -136,6 +136,31 @@ defmodule Sanbase.Chart.Configuration do
     |> where([config], config.user_id == ^user_id)
   end
 
+  def entity_ids_by_opts(opts) do
+    # Which of the provided by the API opts are passed to the entity modules.
+    @passed_opts [
+      :filter,
+      :cursor,
+      :user_ids,
+      :is_featured_data_only,
+      :is_moderator,
+      :min_title_length,
+      :min_description_length
+    ]
+
+    entity_opts = Keyword.take(opts, @passed_opts)
+
+    current_user_id = Keyword.get(opts, :current_user_id)
+    include_all_user_entities = Keyword.fetch!(opts, :include_all_user_entities)
+    include_public_entities = Keyword.fetch!(opts, :include_public_entities)
+
+    case {include_all_user_entities, include_public_entities} do
+      {false, true} -> public_entity_ids_query(entity_opts)
+      {true, false} -> user_entity_ids_query(current_user_id, entity_opts)
+      {true, true} -> public_and_user_entity_ids_query(current_user_id, entity_opts)
+    end
+  end
+
   def public?(%__MODULE__{is_public: is_public}), do: is_public
 
   def user_configurations(user_id, querying_user_id, project_id \\ nil) do

--- a/lib/sanbase/dashboards/dashboard/dashboard.ex
+++ b/lib/sanbase/dashboards/dashboard/dashboard.ex
@@ -284,6 +284,31 @@ defmodule Sanbase.Dashboards.Dashboard do
     |> where([ul], ul.user_id == ^user_id)
   end
 
+  def entity_ids_by_opts(opts) do
+    # Which of the provided by the API opts are passed to the entity modules.
+    @passed_opts [
+      :filter,
+      :cursor,
+      :user_ids,
+      :is_featured_data_only,
+      :is_moderator,
+      :min_title_length,
+      :min_description_length
+    ]
+
+    entity_opts = Keyword.take(opts, @passed_opts)
+
+    current_user_id = Keyword.get(opts, :current_user_id)
+    include_all_user_entities = Keyword.fetch!(opts, :include_all_user_entities)
+    include_public_entities = Keyword.fetch!(opts, :include_public_entities)
+
+    case {include_all_user_entities, include_public_entities} do
+      {false, true} -> public_entity_ids_query(entity_opts)
+      {true, false} -> user_entity_ids_query(current_user_id, entity_opts)
+      {true, true} -> public_and_user_entity_ids_query(current_user_id, entity_opts)
+    end
+  end
+
   def public?(dashboard), do: dashboard.is_public
 
   # Private functions

--- a/lib/sanbase/entity/entity.ex
+++ b/lib/sanbase/entity/entity.ex
@@ -812,122 +812,34 @@ defmodule Sanbase.Entity do
   end
 
   defp entity_ids_query(:user_trigger, opts) do
-    # `ordered?: false` is important otherwise the default order will be applied
-    # and this will conflict with the distinct(true) check
-    entity_opts =
-      Keyword.take(opts, @passed_opts) ++
-        [preload?: false, distinct?: true, ordered?: false]
-
-    current_user_id = Keyword.get(opts, :current_user_id)
-    include_all_user_entities = Keyword.fetch!(opts, :include_all_user_entities)
-    include_public_entities = Keyword.fetch!(opts, :include_public_entities)
-
-    case {include_all_user_entities, include_public_entities} do
-      {false, true} -> UserTrigger.public_entity_ids_query(entity_opts)
-      {true, false} -> UserTrigger.user_entity_ids_query(current_user_id, entity_opts)
-      {true, true} -> UserTrigger.public_and_user_entity_ids_query(current_user_id, entity_opts)
-    end
+    UserTrigger.entity_ids_by_opts(opts)
   end
 
   defp entity_ids_query(:screener, opts) do
-    entity_opts = Keyword.take(opts, @passed_opts) ++ [is_screener: true]
-
-    current_user_id = Keyword.get(opts, :current_user_id)
-    include_all_user_entities = Keyword.fetch!(opts, :include_all_user_entities)
-    include_public_entities = Keyword.fetch!(opts, :include_public_entities)
-
-    case {include_all_user_entities, include_public_entities} do
-      {false, true} -> UserList.public_entity_ids_query(entity_opts)
-      {true, false} -> UserList.user_entity_ids_query(current_user_id, entity_opts)
-      {true, true} -> UserList.public_and_user_entity_ids_query(current_user_id, entity_opts)
-    end
+    opts = Keyword.put(opts, :is_screener, true)
+    UserList.entity_ids_by_opts(opts)
   end
 
   defp entity_ids_query(:project_watchlist, opts) do
-    entity_opts = Keyword.take(opts, @passed_opts) ++ [is_screener: false, type: :project]
-
-    current_user_id = Keyword.get(opts, :current_user_id)
-    include_all_user_entities = Keyword.fetch!(opts, :include_all_user_entities)
-    include_public_entities = Keyword.fetch!(opts, :include_public_entities)
-
-    case {include_all_user_entities, include_public_entities} do
-      {false, true} -> UserList.public_entity_ids_query(entity_opts)
-      {true, false} -> UserList.user_entity_ids_query(current_user_id, entity_opts)
-      {true, true} -> UserList.public_and_user_entity_ids_query(current_user_id, entity_opts)
-    end
+    opts = opts |> Keyword.put(:is_screener, false) |> Keyword.put(:type, :project)
+    UserList.entity_ids_by_opts(opts)
   end
 
   defp entity_ids_query(:address_watchlist, opts) do
-    entity_opts =
-      Keyword.take(opts, @passed_opts) ++
-        [is_screener: false, type: :blockchain_address]
-
-    current_user_id = Keyword.get(opts, :current_user_id)
-    include_all_user_entities = Keyword.fetch!(opts, :include_all_user_entities)
-    include_public_entities = Keyword.fetch!(opts, :include_public_entities)
-
-    case {include_all_user_entities, include_public_entities} do
-      {false, true} -> UserList.public_entity_ids_query(entity_opts)
-      {true, false} -> UserList.user_entity_ids_query(current_user_id, entity_opts)
-      {true, true} -> UserList.public_and_user_entity_ids_query(current_user_id, entity_opts)
-    end
+    opts = opts |> Keyword.put(:is_screener, false) |> Keyword.put(:type, :blockchain_address)
+    UserList.entity_ids_by_opts(opts)
   end
 
   defp entity_ids_query(:chart_configuration, opts) do
-    entity_opts = Keyword.take(opts, @passed_opts)
-
-    current_user_id = Keyword.get(opts, :current_user_id)
-    include_all_user_entities = Keyword.fetch!(opts, :include_all_user_entities)
-    include_public_entities = Keyword.fetch!(opts, :include_public_entities)
-
-    case {include_all_user_entities, include_public_entities} do
-      {false, true} ->
-        Chart.Configuration.public_entity_ids_query(entity_opts)
-
-      {true, false} ->
-        Chart.Configuration.user_entity_ids_query(current_user_id, entity_opts)
-
-      {true, true} ->
-        Chart.Configuration.public_and_user_entity_ids_query(current_user_id, entity_opts)
-    end
+    Chart.Configuration.entity_ids_by_opts(opts)
   end
 
   defp entity_ids_query(:dashboard, opts) do
-    entity_opts = Keyword.take(opts, @passed_opts)
-
-    current_user_id = Keyword.get(opts, :current_user_id)
-    include_all_user_entities = Keyword.fetch!(opts, :include_all_user_entities)
-    include_public_entities = Keyword.fetch!(opts, :include_public_entities)
-
-    case {include_all_user_entities, include_public_entities} do
-      {false, true} ->
-        Dashboard.public_entity_ids_query(entity_opts)
-
-      {true, false} ->
-        Dashboard.user_entity_ids_query(current_user_id, entity_opts)
-
-      {true, true} ->
-        Dashboard.public_and_user_entity_ids_query(current_user_id, entity_opts)
-    end
+    Dashboard.entity_ids_by_opts(opts)
   end
 
   defp entity_ids_query(:query, opts) do
-    entity_opts = Keyword.take(opts, @passed_opts)
-
-    current_user_id = Keyword.get(opts, :current_user_id)
-    include_all_user_entities = Keyword.fetch!(opts, :include_all_user_entities)
-    include_public_entities = Keyword.fetch!(opts, :include_public_entities)
-
-    case {include_all_user_entities, include_public_entities} do
-      {false, true} ->
-        Query.public_entity_ids_query(entity_opts)
-
-      {true, false} ->
-        Query.user_entity_ids_query(current_user_id, entity_opts)
-
-      {true, true} ->
-        Query.public_and_user_entity_ids_query(current_user_id, entity_opts)
-    end
+    Query.entity_ids_by_opts(opts)
   end
 
   defp deduce_entity_creation_time_field(:insight), do: {:published_at, :inserted_at}

--- a/lib/sanbase/queries/query/query.ex
+++ b/lib/sanbase/queries/query/query.ex
@@ -268,6 +268,31 @@ defmodule Sanbase.Queries.Query do
     |> where([ul], ul.user_id == ^user_id)
   end
 
+  def entity_ids_by_opts(opts) do
+    # Which of the provided by the API opts are passed to the entity modules.
+    @passed_opts [
+      :filter,
+      :cursor,
+      :user_ids,
+      :is_featured_data_only,
+      :is_moderator,
+      :min_title_length,
+      :min_description_length
+    ]
+
+    entity_opts = Keyword.take(opts, @passed_opts)
+
+    current_user_id = Keyword.get(opts, :current_user_id)
+    include_all_user_entities = Keyword.fetch!(opts, :include_all_user_entities)
+    include_public_entities = Keyword.fetch!(opts, :include_public_entities)
+
+    case {include_all_user_entities, include_public_entities} do
+      {false, true} -> public_entity_ids_query(entity_opts)
+      {true, false} -> user_entity_ids_query(current_user_id, entity_opts)
+      {true, true} -> public_and_user_entity_ids_query(current_user_id, entity_opts)
+    end
+  end
+
   # Private functions
 
   defp base_query() do


### PR DESCRIPTION
## Changes

Migrated entity ID retrieval logic for `UserTrigger`, `UserList` (screener, project/address watchlists), `Chart.Configuration`, `Dashboard`, and `Query` to follow the pattern established by `Post.entity_ids_by_opts/1`.

This refactoring centralizes the responsibility for determining entity IDs within each respective module, reducing duplication in `Sanbase.Entity` and improving maintainability. Each module now encapsulates its specific logic for handling public/private entities and other options.

## Ticket

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

---
<a href="https://cursor.com/background-agent?bcId=bc-38532289-7c9a-43ce-82fe-2e842ba4d5c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-38532289-7c9a-43ce-82fe-2e842ba4d5c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

