### PR TITLE
entity public status improvement

### DIFF
--- a/lib/sanbase/alerts/trigger/trigger_query.ex
+++ b/lib/sanbase/alerts/trigger/trigger_query.ex
@@ -45,6 +45,14 @@ defmodule Sanbase.Alert.TriggerQuery do
     end
   end
 
+  defmacro private_trigger?() do
+    quote do
+      fragment("""
+      trigger->>'is_public' != 'true'
+      """)
+    end
+  end
+
   defmacro slug_trigger_target?(slugs) do
     quote do
       fragment(

--- a/lib/sanbase/alerts/user_trigger.ex
+++ b/lib/sanbase/alerts/user_trigger.ex
@@ -126,6 +126,10 @@ defmodule Sanbase.Alert.UserTrigger do
     {:ok, result}
   end
 
+  def entity_ids_by_opts(opts) do
+    base_entity_ids_query(opts)
+  end
+
   # The base of all the entity queries
   defp base_entity_ids_query(opts) do
     base_query()
@@ -134,6 +138,7 @@ defmodule Sanbase.Alert.UserTrigger do
     |> Sanbase.Entity.Query.maybe_filter_is_featured_query(opts, :user_trigger_id)
     |> Sanbase.Entity.Query.maybe_filter_by_users(opts)
     |> Sanbase.Entity.Query.maybe_filter_by_cursor(:inserted_at, opts)
+    |> Sanbase.Entity.Query.maybe_apply_public_status_and_private_access(opts)
     |> select([ul], ul.id)
   end
 

--- a/lib/sanbase/chart/chart_configuration.ex
+++ b/lib/sanbase/chart/chart_configuration.ex
@@ -105,6 +105,10 @@ defmodule Sanbase.Chart.Configuration do
     {:ok, result}
   end
 
+  def entity_ids_by_opts(opts) do
+    base_entity_ids_query(opts)
+  end
+
   # The base of all the entity queries
   defp base_entity_ids_query(opts) do
     base_query()
@@ -115,6 +119,7 @@ defmodule Sanbase.Chart.Configuration do
     |> Sanbase.Entity.Query.maybe_filter_is_featured_query(opts, :chart_configuration_id)
     |> Sanbase.Entity.Query.maybe_filter_by_users(opts)
     |> Sanbase.Entity.Query.maybe_filter_by_cursor(:inserted_at, opts)
+    |> Sanbase.Entity.Query.maybe_apply_public_status_and_private_access(opts)
     |> select([config], config.id)
   end
 

--- a/lib/sanbase/dashboards/dashboard/dashboard.ex
+++ b/lib/sanbase/dashboards/dashboard/dashboard.ex
@@ -286,6 +286,10 @@ defmodule Sanbase.Dashboards.Dashboard do
 
   def public?(dashboard), do: dashboard.is_public
 
+  def entity_ids_by_opts(opts) do
+    base_entity_ids_query(opts)
+  end
+
   # Private functions
 
   defp base_query() do
@@ -300,10 +304,8 @@ defmodule Sanbase.Dashboards.Dashboard do
     |> Sanbase.Entity.Query.maybe_filter_by_users(opts)
     |> Sanbase.Entity.Query.maybe_filter_by_cursor(:inserted_at, opts)
     |> Sanbase.Entity.Query.maybe_filter_min_title_length(opts, :name)
-    |> Sanbase.Entity.Query.maybe_filter_min_description_length(
-      opts,
-      :description
-    )
+    |> Sanbase.Entity.Query.maybe_filter_min_description_length(opts, :description)
+    |> Sanbase.Entity.Query.maybe_apply_public_status_and_private_access(opts)
     |> select([ul], ul.id)
   end
 

--- a/lib/sanbase/entity/entity.ex
+++ b/lib/sanbase/entity/entity.ex
@@ -556,14 +556,18 @@ defmodule Sanbase.Entity do
   end
 
   defp most_used_base_query(entities, opts) when is_list(entities) and entities != [] do
+    user_id = Keyword.fetch!(opts, :current_user_id)
+
+    # Craft the opts so it fetches all public entities and
+    # all private entities of the user
     opts =
       opts
-      |> Keyword.put(:include_public_entities, true)
-      |> Keyword.put(:include_all_user_entities, true)
+      |> Keyword.put(:user_ids_and_all_other_public, [user_id])
+      |> Keyword.put(:can_access_user_private_entities, true)
+      |> Keyword.put(:public_status, :all)
 
     query =
-      Keyword.fetch!(opts, :current_user_id)
-      |> Sanbase.Accounts.Interaction.get_user_most_used_query(entities, opts)
+      Sanbase.Accounts.Interaction.get_user_most_used_query(user_id, entities, opts)
 
     where_clause_query =
       Enum.reduce(entities, nil, fn type, query_acc ->
@@ -769,6 +773,7 @@ defmodule Sanbase.Entity do
   @passed_opts [
     :filter,
     :cursor,
+    :user_ids_and_all_other_public,
     :user_ids,
     :public_status,
     :can_access_user_private_entities,

--- a/lib/sanbase/entity/entity.ex
+++ b/lib/sanbase/entity/entity.ex
@@ -532,9 +532,8 @@ defmodule Sanbase.Entity do
       Enum.reduce(entities, nil, fn type, query_acc ->
         entity_ids_query =
           entity_ids_query(type,
-            include_all_user_entities: true,
-            current_user_id: user_id,
-            include_public_entities: false
+            user_ids: [user_id],
+            can_access_user_private_entities: true
           )
 
         entity_query =
@@ -772,6 +771,7 @@ defmodule Sanbase.Entity do
     :cursor,
     :user_ids,
     :public_status,
+    :can_access_user_private_entities,
     :is_featured_data_only,
     :is_moderator,
     :min_title_length,
@@ -807,43 +807,18 @@ defmodule Sanbase.Entity do
       Keyword.take(opts, @passed_opts) ++
         [preload?: false, distinct?: true, ordered?: false]
 
-    current_user_id = Keyword.get(opts, :current_user_id)
-    include_all_user_entities = Keyword.fetch!(opts, :include_all_user_entities)
-    include_public_entities = Keyword.fetch!(opts, :include_public_entities)
-
-    case {include_all_user_entities, include_public_entities} do
-      {false, true} -> UserTrigger.public_entity_ids_query(entity_opts)
-      {true, false} -> UserTrigger.user_entity_ids_query(current_user_id, entity_opts)
-      {true, true} -> UserTrigger.public_and_user_entity_ids_query(current_user_id, entity_opts)
-    end
+    UserTrigger.entity_ids_by_opts(entity_opts)
   end
 
   defp entity_ids_query(:screener, opts) do
     entity_opts = Keyword.take(opts, @passed_opts) ++ [is_screener: true]
 
-    current_user_id = Keyword.get(opts, :current_user_id)
-    include_all_user_entities = Keyword.fetch!(opts, :include_all_user_entities)
-    include_public_entities = Keyword.fetch!(opts, :include_public_entities)
-
-    case {include_all_user_entities, include_public_entities} do
-      {false, true} -> UserList.public_entity_ids_query(entity_opts)
-      {true, false} -> UserList.user_entity_ids_query(current_user_id, entity_opts)
-      {true, true} -> UserList.public_and_user_entity_ids_query(current_user_id, entity_opts)
-    end
+    UserList.entity_ids_by_opts(entity_opts)
   end
 
   defp entity_ids_query(:project_watchlist, opts) do
     entity_opts = Keyword.take(opts, @passed_opts) ++ [is_screener: false, type: :project]
-
-    current_user_id = Keyword.get(opts, :current_user_id)
-    include_all_user_entities = Keyword.fetch!(opts, :include_all_user_entities)
-    include_public_entities = Keyword.fetch!(opts, :include_public_entities)
-
-    case {include_all_user_entities, include_public_entities} do
-      {false, true} -> UserList.public_entity_ids_query(entity_opts)
-      {true, false} -> UserList.user_entity_ids_query(current_user_id, entity_opts)
-      {true, true} -> UserList.public_and_user_entity_ids_query(current_user_id, entity_opts)
-    end
+    UserList.entity_ids_by_opts(entity_opts)
   end
 
   defp entity_ids_query(:address_watchlist, opts) do
@@ -851,72 +826,25 @@ defmodule Sanbase.Entity do
       Keyword.take(opts, @passed_opts) ++
         [is_screener: false, type: :blockchain_address]
 
-    current_user_id = Keyword.get(opts, :current_user_id)
-    include_all_user_entities = Keyword.fetch!(opts, :include_all_user_entities)
-    include_public_entities = Keyword.fetch!(opts, :include_public_entities)
-
-    case {include_all_user_entities, include_public_entities} do
-      {false, true} -> UserList.public_entity_ids_query(entity_opts)
-      {true, false} -> UserList.user_entity_ids_query(current_user_id, entity_opts)
-      {true, true} -> UserList.public_and_user_entity_ids_query(current_user_id, entity_opts)
-    end
+    UserList.entity_ids_by_opts(entity_opts)
   end
 
   defp entity_ids_query(:chart_configuration, opts) do
     entity_opts = Keyword.take(opts, @passed_opts)
 
-    current_user_id = Keyword.get(opts, :current_user_id)
-    include_all_user_entities = Keyword.fetch!(opts, :include_all_user_entities)
-    include_public_entities = Keyword.fetch!(opts, :include_public_entities)
-
-    case {include_all_user_entities, include_public_entities} do
-      {false, true} ->
-        Chart.Configuration.public_entity_ids_query(entity_opts)
-
-      {true, false} ->
-        Chart.Configuration.user_entity_ids_query(current_user_id, entity_opts)
-
-      {true, true} ->
-        Chart.Configuration.public_and_user_entity_ids_query(current_user_id, entity_opts)
-    end
+    Chart.Configuration.entity_ids_by_opts(entity_opts)
   end
 
   defp entity_ids_query(:dashboard, opts) do
     entity_opts = Keyword.take(opts, @passed_opts)
 
-    current_user_id = Keyword.get(opts, :current_user_id)
-    include_all_user_entities = Keyword.fetch!(opts, :include_all_user_entities)
-    include_public_entities = Keyword.fetch!(opts, :include_public_entities)
-
-    case {include_all_user_entities, include_public_entities} do
-      {false, true} ->
-        Dashboard.public_entity_ids_query(entity_opts)
-
-      {true, false} ->
-        Dashboard.user_entity_ids_query(current_user_id, entity_opts)
-
-      {true, true} ->
-        Dashboard.public_and_user_entity_ids_query(current_user_id, entity_opts)
-    end
+    Dashboard.entity_ids_by_opts(entity_opts)
   end
 
   defp entity_ids_query(:query, opts) do
     entity_opts = Keyword.take(opts, @passed_opts)
 
-    current_user_id = Keyword.get(opts, :current_user_id)
-    include_all_user_entities = Keyword.fetch!(opts, :include_all_user_entities)
-    include_public_entities = Keyword.fetch!(opts, :include_public_entities)
-
-    case {include_all_user_entities, include_public_entities} do
-      {false, true} ->
-        Query.public_entity_ids_query(entity_opts)
-
-      {true, false} ->
-        Query.user_entity_ids_query(current_user_id, entity_opts)
-
-      {true, true} ->
-        Query.public_and_user_entity_ids_query(current_user_id, entity_opts)
-    end
+    Query.entity_ids_by_opts(entity_opts)
   end
 
   defp deduce_entity_creation_time_field(:insight), do: {:published_at, :inserted_at}
@@ -1019,8 +947,10 @@ defmodule Sanbase.Entity do
           opts
       end
 
-    # Inlcude the status as-is.
-    opts = Keyword.put(opts, :public_status, public_status)
+    Enum.each([:public_status, :can_access_user_private_entities], fn key ->
+      if not Keyword.has_key?(opts, key),
+        do: raise(ArgumentError, "Key #{key} missing in the Entity opts")
+    end)
 
     opts
   end

--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -111,13 +111,29 @@ defmodule Sanbase.Insight.Post do
 
   # The base of all the entity queries
   defp base_entity_ids_query(opts) do
-    base_insights_query(opts)
-    |> maybe_apply_projects_filter_query(opts)
-    |> Sanbase.Entity.Query.maybe_filter_is_hidden(opts)
-    |> Sanbase.Entity.Query.maybe_filter_is_featured_query(opts, :post_id)
-    |> Sanbase.Entity.Query.maybe_filter_by_users(opts)
-    |> Sanbase.Entity.Query.maybe_filter_by_cursor(:published_at, opts)
-    |> select([p], p.id)
+    public_status = Keyword.fetch!(opts, :public_status)
+    can_access_drafts = Keyword.fetch!(opts, :can_fetch_user_private_entities)
+
+    query =
+      base_insights_query(opts)
+      |> maybe_apply_projects_filter_query(opts)
+      |> Sanbase.Entity.Query.maybe_filter_is_hidden(opts)
+      |> Sanbase.Entity.Query.maybe_filter_is_featured_query(opts, :post_id)
+      |> Sanbase.Entity.Query.maybe_filter_by_users(opts)
+      |> Sanbase.Entity.Query.maybe_filter_by_cursor(:published_at, opts)
+      |> select([p], p.id)
+
+    query =
+      case public_status do
+        :all when can_access_drafts ->
+          query
+
+        :private when can_access_drafts ->
+          query |> where([p], p.ready_state == ^@draft)
+
+        :public ->
+          query |> where([p], p.ready_state == ^@published)
+      end
   end
 
   @impl Sanbase.Entity.Behaviour
@@ -178,6 +194,10 @@ defmodule Sanbase.Insight.Post do
       [p],
       (p.ready_state == ^@published and p.state == ^@approved) or p.user_id == ^user_id
     )
+  end
+
+  def entity_ids_by_opts(opts) do
+    base_entity_ids_query(opts)
   end
 
   @impl Sanbase.Entity.Behaviour

--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -117,6 +117,7 @@ defmodule Sanbase.Insight.Post do
     |> Sanbase.Entity.Query.maybe_filter_is_featured_query(opts, :post_id)
     |> Sanbase.Entity.Query.maybe_filter_by_users(opts)
     |> Sanbase.Entity.Query.maybe_filter_by_cursor(:published_at, opts)
+    |> Sanbase.Entity.Query.maybe_apply_public_status_and_private_access(opts)
     |> select([p], p.id)
   end
 

--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -111,29 +111,13 @@ defmodule Sanbase.Insight.Post do
 
   # The base of all the entity queries
   defp base_entity_ids_query(opts) do
-    public_status = Keyword.fetch!(opts, :public_status)
-    can_access_drafts = Keyword.fetch!(opts, :can_fetch_user_private_entities)
-
-    query =
-      base_insights_query(opts)
-      |> maybe_apply_projects_filter_query(opts)
-      |> Sanbase.Entity.Query.maybe_filter_is_hidden(opts)
-      |> Sanbase.Entity.Query.maybe_filter_is_featured_query(opts, :post_id)
-      |> Sanbase.Entity.Query.maybe_filter_by_users(opts)
-      |> Sanbase.Entity.Query.maybe_filter_by_cursor(:published_at, opts)
-      |> select([p], p.id)
-
-    query =
-      case public_status do
-        :all when can_access_drafts ->
-          query
-
-        :private when can_access_drafts ->
-          query |> where([p], p.ready_state == ^@draft)
-
-        :public ->
-          query |> where([p], p.ready_state == ^@published)
-      end
+    base_insights_query(opts)
+    |> maybe_apply_projects_filter_query(opts)
+    |> Sanbase.Entity.Query.maybe_filter_is_hidden(opts)
+    |> Sanbase.Entity.Query.maybe_filter_is_featured_query(opts, :post_id)
+    |> Sanbase.Entity.Query.maybe_filter_by_users(opts)
+    |> Sanbase.Entity.Query.maybe_filter_by_cursor(:published_at, opts)
+    |> select([p], p.id)
   end
 
   @impl Sanbase.Entity.Behaviour

--- a/lib/sanbase/mcp/combined_trends_tool.ex
+++ b/lib/sanbase/mcp/combined_trends_tool.ex
@@ -302,7 +302,7 @@ defmodule Sanbase.MCP.CombinedTrendsTool do
     Logger.info("📊 Collected documents for #{length(all_words_with_docs)} words")
 
     # Step 2: Batch summarize all words and documents in one OpenAI call
-    word_summaries = batch_summarize_documents_with_ai(all_words_with_docs) |> dbg()
+    word_summaries = batch_summarize_documents_with_ai(all_words_with_docs)
 
     # Step 3: Apply summaries back to the word data structure
     enriched_words =

--- a/lib/sanbase/queries/query/query.ex
+++ b/lib/sanbase/queries/query/query.ex
@@ -199,6 +199,10 @@ defmodule Sanbase.Queries.Query do
     |> maybe_preload(opts)
   end
 
+  def entity_ids_by_opts(opts) do
+    base_entity_ids_query(opts)
+  end
+
   # Entity-based queries
 
   @impl Sanbase.Entity.Behaviour
@@ -239,11 +243,12 @@ defmodule Sanbase.Queries.Query do
   defp base_entity_ids_query(opts) do
     base_query()
     |> Sanbase.Entity.Query.maybe_filter_is_hidden(opts)
-    # |> Sanbase.Entity.Query.maybe_filter_is_featured_query(opts, :user_trigger_id)
+    |> Sanbase.Entity.Query.maybe_filter_is_featured_query(opts, :query_id)
     |> Sanbase.Entity.Query.maybe_filter_by_users(opts)
     |> Sanbase.Entity.Query.maybe_filter_by_cursor(:inserted_at, opts)
     |> Sanbase.Entity.Query.maybe_filter_min_title_length(opts, :name)
     |> Sanbase.Entity.Query.maybe_filter_min_description_length(opts, :description)
+    |> Sanbase.Entity.Query.maybe_apply_public_status_and_private_access(opts)
     |> select([ul], ul.id)
   end
 

--- a/lib/sanbase/user_lists/user_list.ex
+++ b/lib/sanbase/user_lists/user_list.ex
@@ -132,6 +132,10 @@ defmodule Sanbase.UserList do
     {:ok, result}
   end
 
+  def entity_ids_by_opts(opts) do
+    base_entity_ids_query(opts)
+  end
+
   # The base of all the entity queries
   defp base_entity_ids_query(opts) do
     base_query()
@@ -146,6 +150,7 @@ defmodule Sanbase.UserList do
     |> Sanbase.Entity.Query.maybe_filter_by_cursor(:inserted_at, opts)
     |> Sanbase.Entity.Query.maybe_filter_min_title_length(opts, :name)
     |> Sanbase.Entity.Query.maybe_filter_min_description_length(opts, :description)
+    |> Sanbase.Entity.Query.maybe_apply_public_status_and_private_access(opts)
     |> select([ul], ul.id)
   end
 

--- a/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
@@ -314,7 +314,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EntityResolver do
 
       # If not provided it's nil. Check it like this as checking for not presence or presence
       # of false is less readable
-      %{filter: %{public_status: :private}} and current_user_data_only != true ->
+      %{filter: %{public_status: :private}} when current_user_data_only != true ->
         {:error,
          "Cannot set both filter: { publicStatus: PRIVATE } and not set currentUserDataOnly: true"}
 

--- a/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
@@ -309,7 +309,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.EntityResolver do
       %{filter: %{public_status: :private}, user_id_data_only: id} when is_integer(id) ->
         {:error, "Cannot set both filter: { publicStatus: PRIVATE } and userIdDataOnly: <id>"}
 
-      %{filter: %{public_status: :private}, user_id_data_only: id} when is_integer(id) ->
+      %{filter: %{public_status: :all}, user_id_data_only: id} when is_integer(id) ->
         {:error, "Cannot set both filter: { publicStatus: ALL } and userIdDataOnly: <id>"}
 
       # If not provided it's nil. Check it like this as checking for not presence or presence

--- a/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
@@ -309,6 +309,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.EntityResolver do
       %{filter: %{public_status: :private}, user_id_data_only: id} when is_integer(id) ->
         {:error, "Cannot set both filter: { publicStatus: PRIVATE } and userIdDataOnly: <id>"}
 
+      %{filter: %{public_status: :private}, user_id_data_only: id} when is_integer(id) ->
+        {:error, "Cannot set both filter: { publicStatus: ALL } and userIdDataOnly: <id>"}
+
       # If not provided it's nil. Check it like this as checking for not presence or presence
       # of false is less readable
       %{filter: %{public_status: :private}} and current_user_data_only != true ->

--- a/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/entity_resolver.ex
@@ -14,49 +14,54 @@ defmodule SanbaseWeb.Graphql.Resolvers.EntityResolver do
   # Start Most Voted
 
   def get_most_voted(_root, args, _resolution) do
-    maybe_do_not_cache(args)
+    with :ok <- validate_arguments(args) do
+      maybe_do_not_cache(args)
 
-    {:ok, %{query: :get_most_voted, args: args}}
-  end
-
-  def get_most_voted_data(_root, _args, resolution) do
-    %{source: %{args: args}} = resolution
-    types = get_types(args)
-    opts = get_opts(args, resolution)
-
-    case early_return_empty?(opts) do
-      true ->
-        {:ok, []}
-
-      false ->
-        Sanbase.Entity.get_most_voted(types, opts)
-        |> maybe_extend_with_views_count(opts)
-        |> maybe_apply_function(&handle_result/1)
+      {:ok, %{query: :get_most_voted, args: args}}
     end
   end
 
-  def get_most_voted_stats(_root, _args, resolution) do
-    %{source: %{args: args}} = resolution
-    maybe_do_not_cache(args)
+  def get_most_voted_data(_root, _args, %{source: %{args: args}} = resolution) do
+    with :ok <- validate_arguments(args) do
+      types = get_types(args)
+      opts = get_opts(args, resolution)
 
-    types = get_types(args)
-    opts = get_opts(args, resolution)
+      case early_return_empty?(opts) do
+        true ->
+          {:ok, []}
 
-    case early_return_empty?(opts) do
-      true ->
-        {:ok, empty_stats()}
+        false ->
+          Sanbase.Entity.get_most_voted(types, opts)
+          |> maybe_extend_with_views_count(opts)
+          |> maybe_apply_function(&handle_result/1)
+      end
+    end
+  end
 
-      false ->
-        {:ok, total_entities_count} = Sanbase.Entity.get_most_voted_total_count(types, opts)
+  def get_most_voted_stats(_root, _args, %{source: %{args: args}} = resolution) do
+    with :ok <- validate_arguments(args) do
+      maybe_do_not_cache(args)
 
-        stats = %{
-          current_page: opts[:page],
-          current_page_size: opts[:page_size],
-          total_pages_count: (total_entities_count / opts[:page_size]) |> Float.ceil() |> trunc(),
-          total_entities_count: total_entities_count
-        }
+      types = get_types(args)
+      opts = get_opts(args, resolution)
 
-        {:ok, stats}
+      case early_return_empty?(opts) do
+        true ->
+          {:ok, empty_stats()}
+
+        false ->
+          {:ok, total_entities_count} = Sanbase.Entity.get_most_voted_total_count(types, opts)
+
+          stats = %{
+            current_page: opts[:page],
+            current_page_size: opts[:page_size],
+            total_pages_count:
+              (total_entities_count / opts[:page_size]) |> Float.ceil() |> trunc(),
+            total_entities_count: total_entities_count
+          }
+
+          {:ok, stats}
+      end
     end
   end
 
@@ -65,48 +70,55 @@ defmodule SanbaseWeb.Graphql.Resolvers.EntityResolver do
   # Start Most Recent
 
   def get_most_recent_data(_root, _args, %{source: %{args: args}} = resolution) do
-    maybe_do_not_cache(args)
-    types = get_types(args)
-    opts = get_opts(args, resolution)
+    with :ok <- validate_arguments(args) do
+      maybe_do_not_cache(args)
+      types = get_types(args)
+      opts = get_opts(args, resolution)
 
-    case early_return_empty?(opts) do
-      true ->
-        {:ok, []}
+      case early_return_empty?(opts) do
+        true ->
+          {:ok, []}
 
-      false ->
-        Sanbase.Entity.get_most_recent(types, opts)
-        |> maybe_extend_with_views_count(opts)
-        |> maybe_apply_function(&handle_result/1)
+        false ->
+          Sanbase.Entity.get_most_recent(types, opts)
+          |> maybe_extend_with_views_count(opts)
+          |> maybe_apply_function(&handle_result/1)
+      end
     end
   end
 
   def get_most_recent_stats(_root, _args, %{source: %{args: args}} = resolution) do
-    maybe_do_not_cache(args)
+    with :ok <- validate_arguments(args) do
+      maybe_do_not_cache(args)
 
-    types = get_types(args)
-    opts = get_opts(args, resolution)
+      types = get_types(args)
+      opts = get_opts(args, resolution)
 
-    case early_return_empty?(opts) do
-      true ->
-        {:ok, empty_stats()}
+      case early_return_empty?(opts) do
+        true ->
+          {:ok, empty_stats()}
 
-      false ->
-        {:ok, total_entities_count} = Sanbase.Entity.get_most_recent_total_count(types, opts)
+        false ->
+          {:ok, total_entities_count} = Sanbase.Entity.get_most_recent_total_count(types, opts)
 
-        stats = %{
-          current_page: opts[:page],
-          current_page_size: opts[:page_size],
-          total_pages_count: (total_entities_count / opts[:page_size]) |> Float.ceil() |> trunc(),
-          total_entities_count: total_entities_count
-        }
+          stats = %{
+            current_page: opts[:page],
+            current_page_size: opts[:page_size],
+            total_pages_count:
+              (total_entities_count / opts[:page_size]) |> Float.ceil() |> trunc(),
+            total_entities_count: total_entities_count
+          }
 
-        {:ok, stats}
+          {:ok, stats}
+      end
     end
   end
 
   def get_most_recent(_root, args, _resolution) do
-    maybe_do_not_cache(args)
-    {:ok, %{query: :get_most_recent, args: args}}
+    with :ok <- validate_arguments(args) do
+      maybe_do_not_cache(args)
+      {:ok, %{query: :get_most_recent, args: args}}
+    end
   end
 
   # End Most Recent
@@ -114,48 +126,54 @@ defmodule SanbaseWeb.Graphql.Resolvers.EntityResolver do
   # Start Most Used
 
   def get_most_used(_root, args, _resolution) do
-    maybe_do_not_cache(args)
-    {:ok, %{query: :get_most_used, args: args}}
-  end
-
-  def get_most_used_data(_root, _args, %{source: %{args: args}} = resolution) do
-    maybe_do_not_cache(args)
-    types = get_types(args)
-    opts = get_opts(args, resolution)
-
-    case early_return_empty?(opts) do
-      true ->
-        {:ok, []}
-
-      false ->
-        Sanbase.Entity.get_most_used(types, opts)
-        |> maybe_extend_with_views_count(opts)
-        |> maybe_apply_function(&handle_result/1)
+    with :ok <- validate_arguments(args) do
+      maybe_do_not_cache(args)
+      {:ok, %{query: :get_most_used, args: args}}
     end
   end
 
-  def get_most_used_stats(_root, _args, resolution) do
-    %{source: %{args: args}} = resolution
-    maybe_do_not_cache(args)
+  def get_most_used_data(_root, _args, %{source: %{args: args}} = resolution) do
+    with :ok <- validate_arguments(args) do
+      maybe_do_not_cache(args)
+      types = get_types(args)
+      opts = get_opts(args, resolution)
 
-    types = get_types(args)
-    opts = get_opts(args, resolution)
+      case early_return_empty?(opts) do
+        true ->
+          {:ok, []}
 
-    case early_return_empty?(opts) do
-      true ->
-        {:ok, empty_stats()}
+        false ->
+          Sanbase.Entity.get_most_used(types, opts)
+          |> maybe_extend_with_views_count(opts)
+          |> maybe_apply_function(&handle_result/1)
+      end
+    end
+  end
 
-      false ->
-        {:ok, total_entities_count} = Sanbase.Entity.get_most_used_total_count(types, opts)
+  def get_most_used_stats(_root, _args, %{source: %{args: args}} = resolution) do
+    with :ok <- validate_arguments(args) do
+      maybe_do_not_cache(args)
 
-        stats = %{
-          current_page: opts[:page],
-          current_page_size: opts[:page_size],
-          total_pages_count: (total_entities_count / opts[:page_size]) |> Float.ceil() |> trunc(),
-          total_entities_count: total_entities_count
-        }
+      types = get_types(args)
+      opts = get_opts(args, resolution)
 
-        {:ok, stats}
+      case early_return_empty?(opts) do
+        true ->
+          {:ok, empty_stats()}
+
+        false ->
+          {:ok, total_entities_count} = Sanbase.Entity.get_most_used_total_count(types, opts)
+
+          stats = %{
+            current_page: opts[:page],
+            current_page_size: opts[:page_size],
+            total_pages_count:
+              (total_entities_count / opts[:page_size]) |> Float.ceil() |> trunc(),
+            total_entities_count: total_entities_count
+          }
+
+          {:ok, stats}
+      end
     end
   end
 
@@ -273,5 +291,32 @@ defmodule SanbaseWeb.Graphql.Resolvers.EntityResolver do
       total_pages_count: 0,
       total_entities_count: 0
     }
+  end
+
+  defp validate_arguments(args) do
+    current_user_data_only = Map.get(args, :current_user_data_only)
+
+    case args do
+      %{current_user_data_only: true, user_id_data_only: id} when is_integer(id) ->
+        {:error, "Cannot set both currentUserDataOnly: true and userIdDataOnly: <id>"}
+
+      %{current_user_data_only: true, user_role_data_only: role} when is_atom(role) ->
+        {:error, "Cannot set both currentUserDataOnly: true and userRoleDataOnly: <role>"}
+
+      %{user_id_data_only: id, user_role_data_only: role} when is_integer(id) and is_atom(role) ->
+        {:error, "Cannot set both userIdDataOnly: <id> and userRoleDataOnly: <role>"}
+
+      %{filter: %{public_status: :private}, user_id_data_only: id} when is_integer(id) ->
+        {:error, "Cannot set both filter: { publicStatus: PRIVATE } and userIdDataOnly: <id>"}
+
+      # If not provided it's nil. Check it like this as checking for not presence or presence
+      # of false is less readable
+      %{filter: %{public_status: :private}} and current_user_data_only != true ->
+        {:error,
+         "Cannot set both filter: { publicStatus: PRIVATE } and not set currentUserDataOnly: true"}
+
+      _ ->
+        :ok
+    end
   end
 end


### PR DESCRIPTION
## Changes
Introduce more flexible internals for getMost* APIs

Previously we had to match on the cartesian product of two variables
({true, false}, {false, true} and {true, true}) to know whether to fetch
all public entities, user private entities or public + user entities.

Now that we needed to extend the behavior a bit, introducing a new
variable would have required to exponentially increase the number of
matches, becoming unmaintainable.

Rework the internals so now everything depends on the opts and one SQL
query which is dynamically built based on those opts.
The main rework is to change the set of params used and move to some better/more 
flexible ones.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
