### PR TITLE
Fix getMost* currentUserDataOnly. Add insertedAt for more entities

### DIFF
--- a/lib/sanbase/entity/entity.ex
+++ b/lib/sanbase/entity/entity.ex
@@ -908,8 +908,14 @@ defmodule Sanbase.Entity do
 
         _ ->
           if is_integer(Keyword.get(opts, :current_user_data_only)) do
+            # For backwards compatibility, when current_user_data_only is set
+            # previously we returned all public and private entities of the user.
+            # Now, if the `public_status` is not explicitly set, we do the same.
             Keyword.put(opts, :public_status, :all)
           else
+            # If current_user_data_only is provided then we can only fetch public
+            # entities. If the public_status is something else and current_user_data_only
+            # is not set, the resolver will reject the query and return a descriptive error
             Keyword.put(opts, :public_status, :public)
           end
       end

--- a/lib/sanbase/entity/entity.ex
+++ b/lib/sanbase/entity/entity.ex
@@ -899,10 +899,19 @@ defmodule Sanbase.Entity do
       end
 
     opts =
-      case Keyword.get(opts, :public_status) do
-        value when value in [:all, :public, :private] -> opts
-        nil -> Keyword.put(opts, :public_status, :public)
-        value -> raise ArgumentError, "Invalid value for :public_status option: #{inspect(value)}"
+      case Keyword.get(opts, :filter) do
+        %{public_status: value} when value in [:all, :public, :private] ->
+          Keyword.put(opts, :public_status, value)
+
+        %{public_status: value} ->
+          raise ArgumentError, "Invalid value for :public_status option: #{inspect(value)}"
+
+        _ ->
+          if is_integer(Keyword.get(opts, :current_user_data_only)) do
+            Keyword.put(opts, :public_status, :all)
+          else
+            Keyword.put(opts, :public_status, :public)
+          end
       end
 
     opts =

--- a/lib/sanbase_web/graphql/helpers/utils.ex
+++ b/lib/sanbase_web/graphql/helpers/utils.ex
@@ -77,6 +77,8 @@ defmodule SanbaseWeb.Graphql.Helpers.Utils do
           |> Map.put(:id, ut.id)
           |> Map.put(:is_hidden, ut.is_hidden)
           |> Map.put(:is_featured, ut.is_featured)
+          |> Map.put(:inserted_at, ut.inserted_at)
+          |> Map.put(:updated_at, ut.updated_at)
     }
   end
 

--- a/lib/sanbase_web/graphql/schema/types/insight_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/insight_types.ex
@@ -82,6 +82,8 @@ defmodule SanbaseWeb.Graphql.InsightTypes do
       end)
     end
 
+    field(:inserted_at, non_null(:datetime))
+
     field :created_at, non_null(:datetime) do
       resolve(fn %{inserted_at: inserted_at}, _, _ ->
         {:ok, inserted_at}

--- a/lib/sanbase_web/graphql/schema/types/user_trigger_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_trigger_types.ex
@@ -48,6 +48,9 @@ defmodule SanbaseWeb.Graphql.UserTriggerTypes do
     field(:is_repeating, non_null(:boolean))
     field(:is_frozen, non_null(:boolean))
     field(:is_featured, :boolean)
+
+    field(:inserted_at, :datetime)
+    field(:updated_at, :datetime)
   end
 
   object :alerts_stats do

--- a/test/sanbase_web/graphql/entity/get_most_recent_api_test.exs
+++ b/test/sanbase_web/graphql/entity/get_most_recent_api_test.exs
@@ -17,6 +17,50 @@ defmodule SanbaseWeb.Graphql.GetMostRecentApiTest do
     Timex.shift(DateTime.utc_now(), seconds: -seconds)
   end
 
+  test "get most recent insights for current user properly orders drafts and published",
+       context do
+    %{conn: conn, user: user} = context
+
+    i1 =
+      insert(:published_post,
+        inserted_at: seconds_ago(45),
+        published_at: seconds_ago(45),
+        title: "Title 1",
+        user: user
+      )
+
+    i2 =
+      insert(:post,
+        ready_state: "draft",
+        inserted_at: seconds_ago(40),
+        title: "Title 2",
+        user: user
+      )
+
+    i3 =
+      insert(:published_post,
+        inserted_at: seconds_ago(25),
+        published_at: seconds_ago(25),
+        title: "Title 1",
+        user: user
+      )
+
+    result =
+      get_most_recent(conn, [:insight],
+        current_user_data_only: true,
+        filter: %{map_as_input_object: true, public_status: :all}
+      )
+
+    data = result["data"]
+    stats = result["stats"]
+
+    assert stats["totalEntitiesCount"] == 3
+    assert length(data) == 3
+    assert Enum.at(data, 0)["insight"]["id"] == i3.id
+    assert Enum.at(data, 1)["insight"]["id"] == i2.id
+    assert Enum.at(data, 2)["insight"]["id"] == i1.id
+  end
+
   test "get most recent insight with paywall and tags filter", %{conn: conn} do
     _ =
       insert(:published_post,
@@ -833,27 +877,30 @@ defmodule SanbaseWeb.Graphql.GetMostRecentApiTest do
         map -> map
       end
 
-    query = """
-    {
-      getMostRecent(#{map_to_args(args)}){
-        stats { currentPage currentPageSize totalPagesCount totalEntitiesCount }
-        data {
-          addressWatchlist{ id }
-          chartConfiguration{ id }
-          dashboard{ id }
-          query{ id }
-          insight{ id }
-          projectWatchlist{ id }
-          screener{ id views }
-          userTrigger{ trigger{ id } }
+    query =
+      """
+      {
+        getMostRecent(#{map_to_args(args)}){
+          stats { currentPage currentPageSize totalPagesCount totalEntitiesCount }
+          data {
+            addressWatchlist{ id insertedAt }
+            chartConfiguration{ id insertedAt }
+            dashboard{ id insertedAt }
+            query{ id insertedAt }
+            insight{ id insertedAt publishedAt }
+            projectWatchlist{ id insertedAt }
+            screener{ id views insertedAt }
+            userTrigger{ trigger{ id insertedAt } }
+          }
         }
       }
-    }
-    """
+      """
+      |> dbg()
 
     conn
     |> post("/graphql", query_skeleton(query))
     |> json_response(200)
+    |> IO.inspect()
     |> get_in(["data", "getMostRecent"])
   end
 end

--- a/test/sanbase_web/graphql/entity/get_most_recent_api_test.exs
+++ b/test/sanbase_web/graphql/entity/get_most_recent_api_test.exs
@@ -48,7 +48,7 @@ defmodule SanbaseWeb.Graphql.GetMostRecentApiTest do
     result =
       get_most_recent(conn, [:insight],
         current_user_data_only: true,
-        filter: %{map_as_input_object: true, public_status: :all}
+        filter: %{map_as_input_object: true}
       )
 
     data = result["data"]
@@ -895,12 +895,10 @@ defmodule SanbaseWeb.Graphql.GetMostRecentApiTest do
         }
       }
       """
-      |> dbg()
 
     conn
     |> post("/graphql", query_skeleton(query))
     |> json_response(200)
-    |> IO.inspect()
     |> get_in(["data", "getMostRecent"])
   end
 end


### PR DESCRIPTION
## Changes

- Add `insertedAt` for triggers and insights, so all entities have the same param name.
- Fix regression: Fix how `public_status` is fetched from the arguments. Apply different defaults -- `ALL` if `currentUserDataOnly: true` and `PUBLIC` otherwise. This way it's backwards compatible. If `public_status` is explicitly provided -- just use it.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
