### PR TITLE
Reduce the caching of metrics from max of 420 seconds to max of 90 seconds

### DIFF
--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -653,7 +653,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       complexity(&Complexity.from_to_interval/3)
       middleware(AccessControl, resolve_slugs_list: true)
 
-      cache_resolve(&MetricResolver.timeseries_data/3)
+      cache_resolve(&MetricResolver.timeseries_data/3, ttl: 60, max_ttl_offset: 30)
     end
 
     field :timeseries_data_per_slug_json, :json do
@@ -671,7 +671,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       complexity(&Complexity.from_to_interval_selector_weight/3)
       middleware(AccessControl, resolve_slugs_list: true)
 
-      cache_resolve(&MetricResolver.timeseries_data_per_slug/3)
+      cache_resolve(&MetricResolver.timeseries_data_per_slug/3, ttl: 60, max_ttl_offset: 30)
     end
 
     field :timeseries_data_per_slug, list_of(:metric_data_per_slug) do


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
