### PR TITLE
Metric registry sync diff improvement

### DIFF
--- a/lib/sanbase/metric/registry/changelog.ex
+++ b/lib/sanbase/metric/registry/changelog.ex
@@ -19,6 +19,16 @@ defmodule Sanbase.Metric.Registry.Changelog do
     timestamps()
   end
 
+  def metric_registry_ids_with_changes() do
+    query =
+      __MODULE__
+      |> select([changelog], changelog.metric_registry_id)
+      |> distinct(true)
+
+    result = Sanbase.Repo.all(query) |> MapSet.new()
+    {:ok, result}
+  end
+
   def changeset(%__MODULE__{} = changelog, attrs) do
     changelog
     |> cast(attrs, [:old, :new, :metric_registry_id, :change_trigger])


### PR DESCRIPTION
## Changes

Previously we always showed `click to see diff` when a metric is not synced, ignoring the case of new metrics where there's no previous version. In this case it used to give an error when you open the modal.

<img width="748" height="415" alt="image" src="https://github.com/user-attachments/assets/1a8921a4-ace3-4d62-8e78-fc0b8eaf9c96" />

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
