### PR TITLE
Add script for automatic submit of registry change requests

### DIFF
--- a/scripts/submit_sentiment_ratio_aggregation_change.exs
+++ b/scripts/submit_sentiment_ratio_aggregation_change.exs
@@ -1,0 +1,58 @@
+# Script to submit change requests for sentiment ratio metrics
+# that are unverified and have default_aggregation = sum.
+# Changes default_aggregation from sum to avg.
+#
+# Run with: mix run scripts/submit_sentiment_ratio_aggregation_change.exs
+
+alias Sanbase.Metric.Registry
+alias Sanbase.Metric.Registry.ChangeSuggestion
+
+import Ecto.Query
+
+submitted_by = "ivan.i@santiment.net"
+notes = "Change default aggregation from sum to avg for sentiment ratio metrics"
+
+# Query metrics that are:
+# 1. Unverified (is_verified == false)
+# 2. Have both "sentiment" and "ratio" in their name
+# 3. Have default_aggregation == "sum"
+metrics =
+  from(m in Registry,
+    where:
+      m.is_verified == false and
+        like(m.metric, "%sentiment%") and
+        like(m.metric, "%ratio%") and
+        m.default_aggregation == "sum"
+  )
+  |> Sanbase.Repo.all()
+
+IO.puts("Found #{length(metrics)} metrics matching criteria:\n")
+
+for m <- metrics do
+  IO.puts("  - #{m.metric} (id: #{m.id}, aggregation: #{m.default_aggregation})")
+end
+
+IO.puts("")
+
+results =
+  Enum.map(metrics, fn metric ->
+    params = %{"default_aggregation" => "avg"}
+
+    case ChangeSuggestion.create_change_suggestion(metric, params, notes, submitted_by) do
+      {:ok, suggestion} ->
+        IO.puts(
+          "[OK] Change request created for #{metric.metric} (suggestion id: #{suggestion.id})"
+        )
+
+        {:ok, metric.metric}
+
+      {:error, error} ->
+        IO.puts("[ERROR] Failed to create change request for #{metric.metric}: #{inspect(error)}")
+        {:error, metric.metric, error}
+    end
+  end)
+
+successes = Enum.count(results, &match?({:ok, _}, &1))
+failures = Enum.count(results, &match?({:error, _, _}, &1))
+
+IO.puts("\nDone. #{successes} change requests created, #{failures} failures.")


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an administrative script to automate updates to unverified sentiment-ratio metric configurations, including discovery of affected metrics, batched submission of configuration change requests, per-item success/error logging, and a summary of total successes and failures. This streamlines maintenance of sentiment ratio metrics without any changes to public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->