### PR TITLE
Reduce the Oban Pruner uniqueness interval from 60 do 7 days

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -292,6 +292,9 @@ config :sanbase, Oban.Web,
     notifications_queue: 1,
     reminder_notifications_queue: 1
   ],
+  plugins: [
+    {Oban.Plugins.Pruner, max_age: 7 * 86_400}
+  ],
   name: :oban_web
 
 config :sanbase, Oban.Admin,

--- a/config/scrapers_config.exs
+++ b/config/scrapers_config.exs
@@ -34,10 +34,11 @@ config :sanbase, Oban.Scrapers,
     twitter_followers_migration_queue: [limit: 25, paused: true]
   ],
   plugins: [
-    # Prune completed/discarded jobs after 60 days. This keeps completed jobs
-    # available for the unique period (60 days) used by historical workers,
-    # replacing the old finished_oban_jobs archival mechanism.
-    {Oban.Plugins.Pruner, max_age: 60 * 86_400},
+    # Prune completed/discarded jobs after 7 days. The unique period on
+    # historical workers is set to match. Keeping completed jobs for longer
+    # causes the oban_jobs table (and its GIN indexes) to bloat, leading to
+    # progressively higher Postgres CPU usage.
+    {Oban.Plugins.Pruner, max_age: 7 * 86_400},
     {Oban.Plugins.Cron,
      crontab: [
        {"0 3 * * *", Sanbase.Cryptocompare.AddHistoricalJobsWorker,

--- a/lib/sanbase/cryptocompare/funding_rate/funding_rate_historical_worker.ex
+++ b/lib/sanbase/cryptocompare/funding_rate/funding_rate_historical_worker.ex
@@ -18,7 +18,7 @@ defmodule Sanbase.Cryptocompare.FundingRate.HistoricalWorker do
   use Oban.Worker,
     queue: @queue,
     max_attempts: 20,
-    unique: [period: 60 * 86_400]
+    unique: [period: 7 * 86_400]
 
   alias Sanbase.Utils.Config
   alias Sanbase.Cryptocompare.FundingRatePoint

--- a/lib/sanbase/cryptocompare/open_interest/open_interest_historical_worker.ex
+++ b/lib/sanbase/cryptocompare/open_interest/open_interest_historical_worker.ex
@@ -18,7 +18,7 @@ defmodule Sanbase.Cryptocompare.OpenInterest.HistoricalWorker do
   use Oban.Worker,
     queue: @queue,
     max_attempts: 20,
-    unique: [period: 60 * 86_400]
+    unique: [period: 7 * 86_400]
 
   alias Sanbase.Utils.Config
   alias Sanbase.Cryptocompare.OpenInterestPoint

--- a/lib/sanbase/cryptocompare/price/price_historical_worker.ex
+++ b/lib/sanbase/cryptocompare/price/price_historical_worker.ex
@@ -17,7 +17,7 @@ defmodule Sanbase.Cryptocompare.Price.HistoricalWorker do
   use Oban.Worker,
     queue: :cryptocompare_historical_jobs_queue,
     max_attempts: 20,
-    unique: [period: 60 * 86_400]
+    unique: [period: 7 * 86_400]
 
   alias Sanbase.Cryptocompare.HTTPHeaderUtils
 


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automatic pruning of completed/discarded background jobs after 7 days to reduce database bloat and improve performance.
  * Added pruning to the web job scheduler configuration and updated related explanatory comments.
  * Reduced job deduplication window from 60 days to 7 days across multiple background workers to align retention and cleanup policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->