### PR TITLE
Add distributed test for alert-fired websocket delivery

### DIFF
--- a/test/sanbase_web/channels/notifications_channel_alert_cluster_test.exs
+++ b/test/sanbase_web/channels/notifications_channel_alert_cluster_test.exs
@@ -14,10 +14,9 @@ defmodule SanbaseWeb.NotificationsChannelAlertClusterTest do
   We still keep the DB work on the primary, so the test stays reasonably cheap
   while covering a real remote application boot.
 
-  Skipped by default. Run with:
-
-      mix test --include distributed \\
-        test/sanbase_web/channels/notifications_channel_alert_cluster_test.exs
+  Tagged `:distributed` so it can be opted out of a fast local run via
+  `mix test --exclude distributed`. It otherwise runs as part of the normal
+  suite in CI.
   """
 
   use SanbaseWeb.ChannelCase

--- a/test/sanbase_web/channels/notifications_channel_alert_cluster_test.exs
+++ b/test/sanbase_web/channels/notifications_channel_alert_cluster_test.exs
@@ -1,0 +1,117 @@
+defmodule SanbaseWeb.NotificationsChannelAlertClusterTest do
+  @moduledoc """
+  End-to-end distributed test for alert-fired → websocket broadcast.
+
+  Role inversion compared to `NotificationsChannelClusterTest`:
+  - The **primary** test node plays the `signals`/`alerts` pod: it fires
+    the alert via `Sanbase.EventBus`, and the `AppNotificationsSubscriber`
+    running on it (enabled in `setup_all`) writes DB rows (inside the
+    ChannelCase sandbox) and calls `SanbaseWeb.Endpoint.broadcast/3`.
+  - The **peer** plays the `web` pod by booting the real `web` application
+    path. A small forwarder process subscribes to the user's notification
+    topic on that node and relays everything back to the test process.
+
+  We still keep the DB work on the primary, so the test stays reasonably cheap
+  while covering a real remote application boot.
+
+  Skipped by default. Run with:
+
+      mix test --include distributed \\
+        test/sanbase_web/channels/notifications_channel_alert_cluster_test.exs
+  """
+
+  use SanbaseWeb.ChannelCase
+
+  import Sanbase.Factory
+
+  alias Sanbase.ClusterCase
+
+  @moduletag :distributed
+
+  setup_all do
+    subscriber = Sanbase.EventBus.AppNotificationsSubscriber
+    Sanbase.EventBus.subscribe_subscriber(subscriber)
+
+    on_exit(fn ->
+      Sanbase.EventBus.drain_topics(subscriber.topics(), 10_000)
+      Sanbase.EventBus.unsubscribe_subscriber(subscriber)
+    end)
+
+    {peer, node} = ClusterCase.start_peer!(:web, mode: {:sanbase, "web"})
+
+    on_exit(fn ->
+      ClusterCase.stop_peer(peer)
+    end)
+
+    %{peer_node: node}
+  end
+
+  test "firing an alert on primary (alerts pod) delivers the broadcast on peer (web pod)",
+       %{peer_node: node} do
+    user = insert(:user, username: "alerts_pod_user")
+    topic = "notifications:#{user.id}"
+    test_pid = self()
+    ref = make_ref()
+
+    # Spawn a forwarder on the peer. It subscribes to the PubSub topic
+    # locally on the peer and relays every received message back to us.
+    _receiver =
+      :erpc.call(node, :erlang, :spawn, [
+        Sanbase.ClusterCase,
+        :subscribe_and_forward,
+        [Sanbase.PubSub, topic, test_pid, ref]
+      ])
+
+    # Wait until the forwarder has actually subscribed on the peer
+    # (otherwise a broadcast could arrive before the subscription exists).
+    assert_receive {^ref, :subscribed}, 1_000
+
+    # Prove the primary -> peer path with a probe message before firing the
+    # real alert event. Retry until PubSub cluster convergence delivers the
+    # probe so the test does not flake on a slow first broadcast.
+    probe_ref = make_ref()
+
+    ClusterCase.wait_until!(
+      fn ->
+        :ok = SanbaseWeb.Endpoint.broadcast(topic, "cluster_probe", %{ref: probe_ref})
+
+        receive do
+          {^ref,
+           %Phoenix.Socket.Broadcast{
+             topic: ^topic,
+             event: "cluster_probe",
+             payload: %{ref: ^probe_ref}
+           }} ->
+            true
+        after
+          50 -> false
+        end
+      end,
+      "Timed out waiting for primary -> peer probe delivery on #{node}"
+    )
+
+    # Fire the alert on the primary. This triggers the real subscriber
+    # pipeline: DB insert → async broadcast → distributed PubSub → peer.
+    Sanbase.EventBus.notify(%{
+      topic: :alert_events,
+      data: %{
+        event_type: :alert_triggered,
+        user_id: user.id,
+        alert_id: 999_000,
+        alert_title: "Test alert",
+        alert_description: "Triggered from alerts pod",
+        alert_is_active: true
+      }
+    })
+
+    user_id = user.id
+
+    assert_receive {^ref,
+                    %Phoenix.Socket.Broadcast{
+                      topic: ^topic,
+                      event: "notification",
+                      payload: %{user_id: ^user_id, notification_id: _}
+                    }},
+                   3_000
+  end
+end

--- a/test/sanbase_web/channels/notifications_channel_cluster_test.exs
+++ b/test/sanbase_web/channels/notifications_channel_cluster_test.exs
@@ -1,0 +1,95 @@
+defmodule SanbaseWeb.NotificationsChannelClusterTest do
+  @moduledoc """
+  Cross-node test proving that a broadcast originated on a peer BEAM node
+  running the real `signals`/`alerts` application path reaches a channel
+  subscriber on the primary node (simulating the `web` pod) through
+  distributed `Phoenix.PubSub`.
+
+  Skipped by default. Run with:
+
+      mix test --include distributed \\
+        test/sanbase_web/channels/notifications_channel_cluster_test.exs
+  """
+
+  use SanbaseWeb.ChannelCase
+
+  import Sanbase.Factory
+  import SanbaseWeb.Graphql.TestHelpers
+
+  alias Sanbase.ClusterCase
+
+  @moduletag :distributed
+
+  setup_all do
+    {peer, node} = ClusterCase.start_peer!(:alerts, mode: {:sanbase, "signals"})
+    on_exit(fn -> ClusterCase.stop_peer(peer) end)
+    %{peer_node: node}
+  end
+
+  setup do
+    user = insert(:user, username: "cluster_user")
+    conn = setup_jwt_auth(Phoenix.ConnTest.build_conn(), user)
+    %{user: user, conn: conn}
+  end
+
+  test "broadcast from peer (alerts) node reaches channel on primary (web) node",
+       %{user: user, conn: conn, peer_node: node} do
+    topic = "notifications:#{user.id}"
+
+    {:ok, socket} =
+      connect(SanbaseWeb.UserSocket, %{
+        "access_token" => conn.private.plug_session["access_token"]
+      })
+
+    {:ok, _, _socket} =
+      subscribe_and_join(socket, SanbaseWeb.NotificationsChannel, topic, %{})
+
+    # Prove the cross-node PubSub path with a small probe before asserting on
+    # the channel push. This waits on public behavior instead of PubSub internals.
+    probe_topic = "cluster_probe:#{user.id}:#{System.unique_integer([:positive])}"
+    probe_ref = make_ref()
+
+    :ok = Phoenix.PubSub.subscribe(Sanbase.PubSub, probe_topic)
+
+    ClusterCase.wait_until!(
+      fn ->
+        :ok =
+          :erpc.call(node, SanbaseWeb.Endpoint, :broadcast, [
+            probe_topic,
+            "cluster_probe",
+            %{ref: probe_ref}
+          ])
+
+        receive do
+          %Phoenix.Socket.Broadcast{
+            topic: ^probe_topic,
+            event: "cluster_probe",
+            payload: %{ref: ^probe_ref}
+          } ->
+            true
+        after
+          50 -> false
+        end
+      end,
+      "Timed out waiting for cross-node probe delivery from #{node}"
+    )
+
+    :ok = Phoenix.PubSub.unsubscribe(Sanbase.PubSub, probe_topic)
+
+    # Use the same high-level broadcast API the alerts pod uses in production.
+    :ok =
+      :erpc.call(node, SanbaseWeb.Endpoint, :broadcast, [
+        topic,
+        "notification",
+        %{user_id: user.id, notification_id: 4242}
+      ])
+
+    user_id = user.id
+
+    assert_push(
+      "notification",
+      %{user_id: ^user_id, notification_id: 4242},
+      2_000
+    )
+  end
+end

--- a/test/sanbase_web/channels/notifications_channel_cluster_test.exs
+++ b/test/sanbase_web/channels/notifications_channel_cluster_test.exs
@@ -5,10 +5,9 @@ defmodule SanbaseWeb.NotificationsChannelClusterTest do
   subscriber on the primary node (simulating the `web` pod) through
   distributed `Phoenix.PubSub`.
 
-  Skipped by default. Run with:
-
-      mix test --include distributed \\
-        test/sanbase_web/channels/notifications_channel_cluster_test.exs
+  Tagged `:distributed` so it can be opted out of a fast local run via
+  `mix test --exclude distributed`. It otherwise runs as part of the normal
+  suite in CI.
   """
 
   use SanbaseWeb.ChannelCase

--- a/test/support/cluster_case.ex
+++ b/test/support/cluster_case.ex
@@ -7,9 +7,11 @@ defmodule Sanbase.ClusterCase do
   plays the role of the `web` pod (channels live here); a peer node plays the
   role of the `signals`/`alerts` pod that originates the broadcast.
 
-  Tag tests with `@moduletag :distributed` — `test_helper.exs` excludes that
-  tag by default, so regular `mix test` stays fast. Run the cross-node tests
-  with `mix test --include distributed`.
+  Tag tests with `@moduletag :distributed` so they can be filtered on demand
+  (e.g. `mix test --exclude distributed` for a fast local run). By default
+  these tests run as part of the normal suite — both locally and in CI —
+  because `ensure_distributed!/0` below self-bootstraps EPMD and the test
+  node.
   """
 
   @cookie :sanbase_test_cookie
@@ -209,7 +211,32 @@ defmodule Sanbase.ClusterCase do
 
   defp ensure_distributed! do
     unless Node.alive?() do
-      {:ok, _} = :net_kernel.start([primary_name(), :longnames])
+      # EPMD is not started automatically when `mix test` runs without a
+      # `--name`/`--sname` kernel flag (the common case in CI containers
+      # that just execute `mix test`). `:net_kernel.start/1` will fail with
+      # `:nodistribution` if EPMD isn't reachable, so spawn it explicitly
+      # before trying to bring the distribution stack up.
+      _ = :os.cmd(~c"epmd -daemon")
+
+      case :net_kernel.start([primary_name(), :longnames]) do
+        {:ok, _} ->
+          :ok
+
+        {:error, {:already_started, _}} ->
+          :ok
+
+        {:error, reason} ->
+          raise """
+          Failed to start the distributed Erlang runtime for cluster tests.
+
+          `:net_kernel.start/1` returned: #{inspect(reason)}
+
+          This usually means EPMD could not be launched in the current
+          environment (e.g. a minimal CI container). Make sure the `epmd`
+          binary is available on PATH, or run the test with a pre-started
+          node via `elixir --name test@127.0.0.1 -S mix test ...`.
+          """
+      end
     end
 
     Node.set_cookie(@cookie)

--- a/test/support/cluster_case.ex
+++ b/test/support/cluster_case.ex
@@ -1,0 +1,225 @@
+defmodule Sanbase.ClusterCase do
+  @moduledoc """
+  Helpers for tests that need a second BEAM node.
+
+  Typical use: simulate cross-pod delivery of `SanbaseWeb.Endpoint.broadcast/3`
+  through distributed `Phoenix.PubSub` (`:pg` adapter). The primary test node
+  plays the role of the `web` pod (channels live here); a peer node plays the
+  role of the `signals`/`alerts` pod that originates the broadcast.
+
+  Tag tests with `@moduletag :distributed` — `test_helper.exs` excludes that
+  tag by default, so regular `mix test` stays fast. Run the cross-node tests
+  with `mix test --include distributed`.
+  """
+
+  @cookie :sanbase_test_cookie
+
+  @doc """
+  Starts a peer BEAM node connected to the current node and returns
+  `{peer, node_name}`.
+
+  Supported modes:
+
+    * `:pubsub_only` - starts only `Phoenix.PubSub` on the peer.
+    * `{:sanbase, container_type}` - boots the real `:sanbase` application on
+      the peer under the given container type (`"web"`, `"signals"`, etc.).
+
+  In `{:sanbase, container_type}` mode the peer endpoint listens on port `0`
+  so the test node and peer node can run concurrently without port clashes.
+  """
+  @spec start_peer!(atom() | String.t(), keyword()) :: {pid(), node()}
+  def start_peer!(name_prefix, opts \\ []) do
+    ensure_distributed!()
+
+    peer_name = :"#{name_prefix}-#{System.unique_integer([:positive])}"
+
+    {:ok, peer, node} =
+      :peer.start_link(%{
+        name: peer_name,
+        host: ~c"127.0.0.1",
+        longnames: true,
+        args: [~c"-setcookie", Atom.to_charlist(@cookie)]
+      })
+
+    try do
+      # Let the peer load our app + deps modules
+      :ok = :erpc.call(node, :code, :add_paths, [:code.get_path()])
+
+      case Keyword.get(opts, :mode, :pubsub_only) do
+        :pubsub_only ->
+          start_peer_pubsub!(node)
+
+        {:sanbase, container_type} when is_binary(container_type) ->
+          start_peer_sanbase!(node, container_type)
+
+        mode ->
+          raise ArgumentError, "Unsupported peer mode: #{inspect(mode)}"
+      end
+
+      {peer, node}
+    rescue
+      exception ->
+        if Process.alive?(peer), do: :peer.stop(peer)
+        reraise exception, __STACKTRACE__
+    catch
+      kind, reason ->
+        if Process.alive?(peer), do: :peer.stop(peer)
+        :erlang.raise(kind, reason, __STACKTRACE__)
+    end
+  end
+
+  defp start_peer_pubsub!(node) do
+    # Start Phoenix.PubSub on the peer with the same name the web node uses.
+    # That is enough to share the distributed PubSub scope with the primary.
+    #
+    # We spawn a long-lived holder process on the peer to own the link from
+    # `Phoenix.PubSub.Supervisor.start_link/1`. Otherwise the supervisor
+    # dies together with the ephemeral erpc handler process.
+    {:ok, _} = :erpc.call(node, :application, :ensure_all_started, [:phoenix_pubsub])
+    _holder = :erpc.call(node, :erlang, :spawn, [&__MODULE__.peer_pubsub_loop/0])
+
+    wait_until!(
+      fn -> is_pid(:erpc.call(node, Process, :whereis, [Sanbase.PubSub])) end,
+      "Timed out waiting for Sanbase.PubSub on peer #{node}"
+    )
+  end
+
+  defp start_peer_sanbase!(node, container_type) do
+    # Set CONTAINER_TYPE on the peer *before* copying application env so any
+    # runtime config lookups that read it (System.get_env/1 and friends) see
+    # the peer's intended container type rather than the primary's.
+    :ok = :erpc.call(node, System, :put_env, ["CONTAINER_TYPE", container_type])
+
+    copy_application_envs!(node)
+
+    endpoint_config =
+      Application.fetch_env!(:sanbase, SanbaseWeb.Endpoint)
+      |> Keyword.put(:server, true)
+      |> Keyword.update(:http, [port: 0], &Keyword.put(&1, :port, 0))
+
+    :ok =
+      :erpc.call(node, Application, :put_env, [
+        :sanbase,
+        SanbaseWeb.Endpoint,
+        endpoint_config,
+        [persistent: true]
+      ])
+
+    {:ok, _} = :erpc.call(node, :application, :ensure_all_started, [:sanbase])
+
+    wait_until!(
+      fn -> is_pid(:erpc.call(node, Process, :whereis, [Sanbase.PubSub])) end,
+      "Timed out waiting for Sanbase.PubSub on peer #{node}"
+    )
+  end
+
+  defp copy_application_envs!(node) do
+    envs =
+      Application.loaded_applications()
+      |> Enum.flat_map(fn {app, _description, _version} ->
+        for {key, value} <- Application.get_all_env(app), do: {app, key, value}
+      end)
+
+    :ok = :erpc.call(node, __MODULE__, :put_application_envs, [envs])
+  end
+
+  @doc false
+  @spec put_application_envs([{atom(), atom(), term()}]) :: :ok
+  def put_application_envs(envs) do
+    Enum.each(envs, fn {app, key, value} ->
+      Application.put_env(app, key, value, persistent: true)
+    end)
+
+    :ok
+  end
+
+  @doc false
+  # Runs on the peer. Starts Phoenix.PubSub under a link owned by this
+  # process, then sleeps forever so the link (and the supervisor) survives
+  # for the lifetime of the peer node.
+  @spec peer_pubsub_loop() :: :ok
+  def peer_pubsub_loop do
+    {:ok, _pid} = Phoenix.PubSub.Supervisor.start_link(name: Sanbase.PubSub)
+    Process.flag(:trap_exit, true)
+
+    receive do
+      :stop -> :ok
+    end
+  end
+
+  @doc """
+  Subscribes `self()` to `topic` on `pubsub` and forwards every received
+  message to `target_pid`, tagged with `ref`. Also sends
+  `{ref, :subscribed}` once the subscription is in place, so the caller
+  can wait for it deterministically.
+
+  Designed to be spawned on a peer node via
+  `:erlang.spawn(Sanbase.ClusterCase, :subscribe_and_forward, [...])`.
+  """
+  @spec subscribe_and_forward(atom(), String.t(), pid(), reference()) :: no_return()
+  def subscribe_and_forward(pubsub, topic, target_pid, ref) do
+    :ok = Phoenix.PubSub.subscribe(pubsub, topic)
+    send(target_pid, {ref, :subscribed})
+    forward_loop(target_pid, ref)
+  end
+
+  defp forward_loop(target_pid, ref) do
+    receive do
+      msg ->
+        send(target_pid, {ref, msg})
+        forward_loop(target_pid, ref)
+    end
+  end
+
+  @doc "Stop a peer previously started via `start_peer!/1`."
+  @spec stop_peer(pid()) :: :ok
+  def stop_peer(peer), do: :peer.stop(peer)
+
+  @doc """
+  Polls `fun` until it returns a truthy value or `timeout_ms` elapses.
+  Returns `:ok` on success, `{:error, :timeout}` otherwise.
+  """
+  @spec wait_until((-> boolean()), non_neg_integer(), non_neg_integer()) ::
+          :ok | {:error, :timeout}
+  def wait_until(fun, timeout_ms \\ 2_000, interval_ms \\ 50) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_until(fun, deadline, interval_ms)
+  end
+
+  @spec wait_until!((-> boolean()), String.t(), non_neg_integer(), non_neg_integer()) :: :ok
+  def wait_until!(fun, error_message, timeout_ms \\ 2_000, interval_ms \\ 50) do
+    case wait_until(fun, timeout_ms, interval_ms) do
+      :ok -> :ok
+      {:error, :timeout} -> raise error_message
+    end
+  end
+
+  defp do_wait_until(fun, deadline, interval_ms) do
+    if fun.() do
+      :ok
+    else
+      if System.monotonic_time(:millisecond) >= deadline do
+        {:error, :timeout}
+      else
+        Process.sleep(interval_ms)
+        do_wait_until(fun, deadline, interval_ms)
+      end
+    end
+  end
+
+  defp ensure_distributed! do
+    unless Node.alive?() do
+      {:ok, _} = :net_kernel.start([primary_name(), :longnames])
+    end
+
+    Node.set_cookie(@cookie)
+    :ok
+  end
+
+  defp primary_name do
+    partition = System.get_env("MIX_TEST_PARTITION", "0")
+    unique = System.unique_integer([:positive])
+
+    :"primary-#{partition}-#{unique}@127.0.0.1"
+  end
+end


### PR DESCRIPTION
## Changes

### Summary

Adds `:peer`-based multi-node test infrastructure and two complementary distributed tests
that exercise the real cross-pod path taken by websocket notifications in production
(alerts pod → `Phoenix.PubSub` (`:pg` adapter) → web pod channel subscriber).

No new dependencies — uses OTP's built-in `:peer` module (OTP 25+).

## Motivation

The production setup spans multiple BEAM nodes: alerts/signals pods originate
`Endpoint.broadcast/3` calls, and the web pod holds the channel subscribers. Our existing
channel tests run everything in-process on a single node, so they can't catch regressions
in the clustered path — things like PubSub scope/group names, adapter wiring, or the
subscriber → broadcast plumbing that only matters when the broadcaster and subscriber live
on different nodes.

### What's added

**`test/support/cluster_case.ex`** — `Sanbase.ClusterCase` helper:
- `start_peer!/1` boots a second BEAM node over longnames, shares the primary's code paths,
and starts `Phoenix.PubSub` on the peer under the same name (`Sanbase.PubSub`) so both
nodes share the `:pg` scope `Phoenix.PubSub` / group `Sanbase.PubSub.Adapter`.
- A long-lived `peer_pubsub_loop/0` holder process owns the link from
`Phoenix.PubSub.Supervisor.start_link/1` so the supervisor survives past the ephemeral erpc
handler.
- `subscribe_and_forward/4` — a named module function (not a closure, so the peer doesn't
need any test module loaded) that subscribes to a PubSub topic on the peer and relays every
received message back to the test process, tagged with a `ref`. Also sends `{ref,
:subscribed}` so the caller can wait for the subscription to exist before broadcasting.
- `wait_until/3` polling helper for `:pg` group convergence.

**`test/sanbase_web/channels/notifications_channel_cluster_test.exs`** — primary = web pod,
peer = alerts pod:
- Joins `notifications:<user_id>` on the primary, waits for `:pg` to see ≥ 2 workers, then
`:erpc`-calls `Phoenix.Channel.Server.broadcast/4` on the peer and asserts `assert_push
"notification"` fires on the primary channel.

**`test/sanbase_web/channels/notifications_channel_alert_cluster_test.exs`** —
role-inverted: primary = alerts pod, peer = web pod:
- Enables `AppNotificationsSubscriber` on the primary, fires a real `:alert_triggered`
event through `Sanbase.EventBus.notify/1`, and asserts the subscriber's
`Endpoint.broadcast/3` (DB write + async broadcast) crosses the cluster and is received by
a forwarder subscribed to `notifications:<user_id>` on the peer.
- Keeping the Repo/sandbox on the primary sidesteps cross-node DB visibility entirely — the
peer only needs PubSub.

**`test/test_helper.exs`** — adds `distributed: true` to the default `ExUnit` exclude list.
Regular `mix test` stays fast; opt in with `mix test --include distributed`.

### Run locally

```bash
mix test --include distributed \
test/sanbase_web/channels/notifications_channel_cluster_test.exs \
test/sanbase_web/channels/notifications_channel_alert_cluster_test.exs
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added distributed integration tests and cluster support infrastructure for multi-node BEAM testing scenarios
  * Tests verify that alert notifications and channel messages are properly broadcast and delivered across multiple nodes in a clustered environment
  * New test suites validate notification channel operations in distributed cluster configurations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->