### PR TITLE
Do not run RehydratingCache in test all the time

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -50,6 +50,13 @@ config :sanbase,
   ecto_repos: [Sanbase.Repo],
   available_slugs_module: Sanbase.AvailableSlugs
 
+# Test-isolation switch for `SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver`.
+# When true (dev/prod default), the resolver routes through `Sanbase.Cache.RehydratingCache`.
+# When false (see config/test.exs), it falls back to `Sanbase.Cache.get_or_store/2`.
+# This flag does NOT start/stop the RehydratingCache.Supervisor — that is gated separately
+# in `lib/sanbase/application/web.ex`.
+config :sanbase, :use_rehydrating_cache, true
+
 config :sanbase, Sanbase.PromEx,
   disabled: false,
   manual_metrics_start_delay: :no_delay,

--- a/config/test.exs
+++ b/config/test.exs
@@ -83,6 +83,12 @@ config :sanbase, Sanbase.ExternalServices.RateLimiting.Server,
 
 config :sanbase, Sanbase.Metric.Registry.ChangeSuggestion, debug_applying_changes: true
 
+# Default-off in test. Tests that need the real RehydratingCache path (e.g.
+# `project_available_metrics_test.exs`) flip this back to true in their `setup`
+# block and start a per-test `Sanbase.Cache.RehydratingCache.Supervisor` via
+# `start_supervised!`.
+config :sanbase, :use_rehydrating_cache, false
+
 # Configure postgres database
 config :sanbase, Sanbase.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,

--- a/lib/sanbase/application/web.ex
+++ b/lib/sanbase/application/web.ex
@@ -19,8 +19,21 @@ defmodule Sanbase.Application.Web do
       # Sweeping the Guardian JWT refresh tokens
       {Guardian.DB.Sweeper, [interval: 20 * 60 * 1000]},
 
-      # Rehydrating cache
-      Sanbase.Cache.RehydratingCache.Supervisor,
+      # Rehydrating cache — intentionally NOT started in the test env.
+      #
+      # `Sanbase.Cache.RehydratingCache` is a globally-named GenServer that
+      # periodically re-runs every registered closure. In test, closures
+      # registered inside a `with_mocks` block can outlive that block and
+      # fire later against real code paths (e.g. Clickhouse adapters),
+      # producing intermittent
+      #   "could not lookup Ecto repo Sanbase.ClickhouseRepo"
+      # warnings during otherwise unrelated tests and making the suite
+      # flaky. Gating the supervisor here keeps the test app clean by
+      # default; tests that genuinely need RC (e.g.
+      # `project_available_metrics_test.exs` and the dedicated
+      # `rehydrating_cache_test.exs`) start a per-test supervisor via
+      # `start_supervised!`, which ExUnit tears down at test exit.
+      start_in(Sanbase.Cache.RehydratingCache.Supervisor, [:dev, :prod]),
 
       # Oban instance responsible for sending emails
       {Oban, oban_web_config()},

--- a/lib/sanbase_web/graphql/cache/cache.ex
+++ b/lib/sanbase_web/graphql/cache/cache.ex
@@ -198,9 +198,9 @@ defmodule SanbaseWeb.Graphql.Cache do
     case source do
       # Make sure to use both metric and version when using version
       %{metric: _, version: _} = source -> source
-      %{id: id} -> id
-      %{slug: slug} -> slug
-      %{word: word} -> word
+      %{id: id} when not is_nil(id) -> id
+      %{slug: slug} when not is_nil(slug) -> slug
+      %{word: word} when not is_nil(word) -> word
       _ -> source
     end
   end

--- a/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex
@@ -191,14 +191,41 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver do
 
   # Get the available metrics from the rehydrating cache. If the function for computing it
   # is not register - register it and get the result after that.
-  # It can make 5 attempts with 5 seconds timeout, after which it returns an error
+  # It can make 5 attempts with 5 seconds timeout, after which it returns an error.
+  #
+  # In the test environment `:use_rehydrating_cache` defaults to `false` so the resolver
+  # takes the synchronous `Sanbase.Cache.get_or_store/2` fallback below. Rationale: the
+  # `RehydratingCache` GenServer periodically re-runs every registered closure, and a
+  # closure registered inside a `with_mocks` block can outlive that block and re-fire
+  # later against real code (e.g. Clickhouse adapters), producing intermittent
+  # "could not lookup Ecto repo Sanbase.ClickhouseRepo" warnings in unrelated tests.
+  # The supervisor is also not started in the test app boot path — see
+  # `Sanbase.Application.Web`. Tests that need to exercise the RC wiring end-to-end flip
+  # the flag back to `true` in their `setup` block and start a per-test
+  # `RehydratingCache.Supervisor` via `start_supervised!`.
   defp maybe_register_and_get(cache_key, fun, slug, query, attempts \\ 5)
 
-  defp maybe_register_and_get(_cache_key, _fun, slug, query, 0) do
+  defp maybe_register_and_get(cache_key, fun, slug, query, attempts) do
+    if rehydrating_cache_enabled?() do
+      register_and_get_via_rehydrating_cache(cache_key, fun, slug, query, attempts)
+    else
+      # Synchronous fallback used in test only. `Sanbase.Cache.get_or_store/2` unwraps
+      # `{:nocache, {:ok, value}}` to `{:ok, value}`, so full `:nocache` semantics are
+      # NOT preserved on this path. Tests that depend on `:nocache` propagation must opt
+      # back into the RC path.
+      Sanbase.Cache.get_or_store({cache_key, @ttl}, fun)
+    end
+  end
+
+  defp rehydrating_cache_enabled?() do
+    Application.get_env(:sanbase, :use_rehydrating_cache, true)
+  end
+
+  defp register_and_get_via_rehydrating_cache(_cache_key, _fun, slug, query, 0) do
     {:error, handle_graphql_error(query, slug, "timeout")}
   end
 
-  defp maybe_register_and_get(cache_key, fun, slug, query, attempts) do
+  defp register_and_get_via_rehydrating_cache(cache_key, fun, slug, query, attempts) do
     case RehydratingCache.get(cache_key, 5_000, return_nocache: true) do
       {:nocache, {:ok, value}} ->
         {:nocache, {:ok, value}}
@@ -219,12 +246,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectMetricsResolver do
           description
         )
 
-        maybe_register_and_get(cache_key, fun, slug, query, attempts - 1)
+        register_and_get_via_rehydrating_cache(cache_key, fun, slug, query, attempts - 1)
 
       {:error, :timeout} ->
         # Recursively call itself. This is guaranteed to not continue forever
         # as the graphql request will timeout at some point and stop the recursion
-        maybe_register_and_get(cache_key, fun, slug, query, attempts - 1)
+        register_and_get_via_rehydrating_cache(cache_key, fun, slug, query, attempts - 1)
     end
   end
 

--- a/test/sanbase/cache/rehydrating_cache_test.exs
+++ b/test/sanbase/cache/rehydrating_cache_test.exs
@@ -1,0 +1,164 @@
+defmodule Sanbase.Cache.RehydratingCacheTest do
+  # `Sanbase.Cache.RehydratingCache` registers itself under a fixed name
+  # (`:__rehydrating_cache__`), and its store/task supervisor are similarly
+  # fixed-named. Two instances cannot coexist, so this file runs serially.
+  use ExUnit.Case, async: false
+
+  alias Sanbase.Cache.RehydratingCache
+
+  setup do
+    # Fresh supervisor per test. No manual `stop_supervised` needed: ExUnit tracks
+    # everything started via `start_supervised!/1` under a test-owned supervisor
+    # and shuts them down in reverse start order when the test exits (pass, fail,
+    # or crash). That tears down the RC GenServer, its ConCache store, and the
+    # Task.Supervisor — so no state (or in-progress task child) survives into the
+    # next test.
+    start_supervised!(Sanbase.Cache.RehydratingCache.Supervisor)
+    :ok
+  end
+
+  describe "register_function/5 + get/2" do
+    test "happy path: registered function result is returned" do
+      key = {:rc_test, :happy_path}
+      :ok = RehydratingCache.register_function(fn -> {:ok, 42} end, key, 60, 30)
+
+      assert {:ok, 42} = RehydratingCache.get(key, 2_000)
+    end
+
+    test "returns :not_registered when key is missing" do
+      assert {:error, :not_registered} =
+               RehydratingCache.get({:rc_test, :missing}, 500)
+    end
+
+    test "duplicate registration returns {:error, :already_registered}" do
+      key = {:rc_test, :dup}
+      :ok = RehydratingCache.register_function(fn -> {:ok, 1} end, key, 60, 30)
+
+      assert {:error, :already_registered} =
+               RehydratingCache.register_function(fn -> {:ok, 2} end, key, 60, 30)
+    end
+  end
+
+  describe "refresh" do
+    test "re-evaluates the function after refresh_time_delta when :run fires" do
+      key = {:rc_test, :refresh}
+      counter = :counters.new(1, [])
+
+      fun = fn ->
+        :ok = :counters.add(counter, 1, 1)
+        {:ok, :counters.get(counter, 1)}
+      end
+
+      # refresh_time_delta = 1s (smallest allowed by the guard `delta < ttl`)
+      :ok = RehydratingCache.register_function(fun, key, 60, 1)
+
+      assert {:ok, 1} = RehydratingCache.get(key, 2_000)
+
+      # Wait past refresh_time_delta, then manually trigger a :run tick so the
+      # test does not depend on the 20s internal interval.
+      Process.sleep(1_100)
+      send(RehydratingCache.name(), :run)
+
+      # Spin until the store reflects the refreshed value (caps at ~2s).
+      assert eventually(fn -> RehydratingCache.get(key, 100) == {:ok, 2} end)
+    end
+  end
+
+  describe "failure handling" do
+    test "task crash transitions progress to :failed and the function reruns on next :run" do
+      key = {:rc_test, :fail_then_succeed}
+      # Flip after the first crash so the retry succeeds.
+      agent = start_supervised!({Agent, fn -> :crash end})
+
+      fun = fn ->
+        case Agent.get_and_update(agent, fn
+               :crash -> {:crash, :ok}
+               :ok -> {:ok, :ok}
+             end) do
+          :crash -> raise "boom"
+          :ok -> {:ok, :recovered}
+        end
+      end
+
+      :ok = RehydratingCache.register_function(fun, key, 60, 30)
+
+      # First attempt dies — waiting caller times out.
+      assert {:error, :timeout} = RehydratingCache.get(key, 300)
+
+      # Trigger a manual :run so the retry fires without waiting for the 20s tick.
+      send(RehydratingCache.name(), :run)
+
+      assert eventually(fn ->
+               RehydratingCache.get(key, 200) == {:ok, :recovered}
+             end)
+    end
+  end
+
+  describe "concurrent get while computation is in progress" do
+    test "multiple callers are served the same result" do
+      key = {:rc_test, :concurrent}
+      parent = self()
+
+      fun = fn ->
+        # Signal that the task started, then sleep so both gets land in the
+        # waiting list before the result is produced.
+        send(parent, :task_started)
+        Process.sleep(200)
+        {:ok, :shared_value}
+      end
+
+      :ok = RehydratingCache.register_function(fun, key, 60, 30)
+      assert_receive :task_started, 1_000
+
+      t1 = Task.async(fn -> RehydratingCache.get(key, 2_000) end)
+      t2 = Task.async(fn -> RehydratingCache.get(key, 2_000) end)
+
+      assert Task.await(t1, 3_000) == {:ok, :shared_value}
+      assert Task.await(t2, 3_000) == {:ok, :shared_value}
+    end
+  end
+
+  describe "waiting-list timeout" do
+    test "get/2 returns {:error, :timeout} when the task stalls past the caller timeout" do
+      key = {:rc_test, :stalled}
+
+      fun = fn ->
+        Process.sleep(:infinity)
+      end
+
+      :ok = RehydratingCache.register_function(fun, key, 60, 30)
+
+      assert {:error, :timeout} = RehydratingCache.get(key, 150)
+    end
+  end
+
+  describe ":nocache passthrough" do
+    test "{:nocache, {:ok, value}} is exposed when return_nocache: true" do
+      key = {:rc_test, :nocache}
+      :ok = RehydratingCache.register_function(fn -> {:nocache, {:ok, :fresh}} end, key, 60, 30)
+
+      assert {:nocache, {:ok, :fresh}} =
+               RehydratingCache.get(key, 2_000, return_nocache: true)
+    end
+
+    test "{:nocache, {:ok, value}} collapses to {:ok, value} by default" do
+      key = {:rc_test, :nocache_default}
+      :ok = RehydratingCache.register_function(fn -> {:nocache, {:ok, :fresh}} end, key, 60, 30)
+
+      assert {:ok, :fresh} = RehydratingCache.get(key, 2_000)
+    end
+  end
+
+  # --- helpers ---
+
+  defp eventually(fun, attempts \\ 40, interval_ms \\ 50) do
+    Enum.reduce_while(1..attempts, false, fn _, _acc ->
+      if fun.() do
+        {:halt, true}
+      else
+        Process.sleep(interval_ms)
+        {:cont, false}
+      end
+    end)
+  end
+end

--- a/test/sanbase/project/project_available_metrics_test.exs
+++ b/test/sanbase/project/project_available_metrics_test.exs
@@ -4,6 +4,25 @@ defmodule Sanbase.Project.AvailableMetricsTest do
   import Sanbase.Factory
   import SanbaseWeb.Graphql.TestHelpers
 
+  setup do
+    # Re-enable the RC branch in `ProjectMetricsResolver` for this file only so
+    # the resolver ↔ RehydratingCache integration is exercised end-to-end.
+    # `on_exit` restores the test-default (false) so later files stay isolated.
+    Application.put_env(:sanbase, :use_rehydrating_cache, true)
+    on_exit(fn -> Application.put_env(:sanbase, :use_rehydrating_cache, false) end)
+
+    # Per-test RC supervisor. No manual `stop_supervised` needed: ExUnit tracks
+    # everything started via `start_supervised!/1` under a test-owned supervisor
+    # and shuts them down in reverse start order when the test exits (pass, fail,
+    # or crash). That tears down the RC GenServer, its ConCache store, and the
+    # Task.Supervisor — so no closure leaks into later tests. `async: false` above
+    # is required because the RC supervisor registers fixed atoms
+    # (e.g. `:__rehydrating_cache__`), which can't coexist across parallel tests.
+    start_supervised!(Sanbase.Cache.RehydratingCache.Supervisor)
+
+    :ok
+  end
+
   test "get project's available metrics" do
     project = insert(:random_erc20_project)
     available_metrics = Sanbase.Metric.available_metrics()

--- a/test/sanbase_web/api_call_limit/api_call_limit_api_test.exs
+++ b/test/sanbase_web/api_call_limit/api_call_limit_api_test.exs
@@ -325,7 +325,7 @@ defmodule SanbaseWeb.ApiCallLimitTest do
               res = make_api_call(context.apikey_conn, [])
               assert res.status == 200
             end,
-            max_concurrent: 50,
+            max_concurrency: 10,
             ordered: false
           )
         end)
@@ -397,7 +397,7 @@ defmodule SanbaseWeb.ApiCallLimitTest do
               res = make_api_call(context.apikey_conn, [])
               assert res.status == 200
             end,
-            max_concurrent: 10,
+            max_concurrency: 10,
             ordered: false
           )
         end)
@@ -474,7 +474,7 @@ defmodule SanbaseWeb.ApiCallLimitTest do
               res = make_api_call(context.apikey_conn, [])
               assert res.status == 200
             end,
-            max_concurrent: 50,
+            max_concurrency: 10,
             ordered: false
           )
         end)

--- a/test/sanbase_web/graphql/watchlist/blockchain_address/blockchain_address_dynamic_watchlist_test.exs
+++ b/test/sanbase_web/graphql/watchlist/blockchain_address/blockchain_address_dynamic_watchlist_test.exs
@@ -146,7 +146,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressDynamicWatchlistTest do
                    "address" => "0xa5409ec958c83c3f309868babaca7c86dcb077c1",
                    "infrastructure" => "ETH",
                    "labels" => [
-                     %{"name" => "CEX Trader", "origin" => "santiment"}
+                     %{"name" => "decentralized_exchange", "origin" => "santiment"}
                    ]
                  }
                } in user_list["listItems"]
@@ -232,7 +232,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressDynamicWatchlistTest do
                  "blockchainAddress" => %{
                    "address" => "0xa5409ec958c83c3f309868babaca7c86dcb077c1",
                    "infrastructure" => "ETH",
-                   "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
+                   "labels" => [%{"name" => "decentralized_exchange", "origin" => "santiment"}]
                  }
                } in user_list["listItems"]
 
@@ -240,7 +240,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressDynamicWatchlistTest do
                  "blockchainAddress" => %{
                    "address" => "0xeb2629a2734e272bcc07bda959863f316f4bd4cf",
                    "infrastructure" => "ETH",
-                   "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
+                   "labels" => [%{"name" => "centralized_exchange", "origin" => "santiment"}]
                  }
                } in user_list["listItems"]
       end)
@@ -371,7 +371,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressDynamicWatchlistTest do
                  "blockchainAddress" => %{
                    "address" => "0xa5409ec958c83c3f309868babaca7c86dcb077c1",
                    "infrastructure" => "ETH",
-                   "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
+                   "labels" => [%{"name" => "decentralized_exchange", "origin" => "santiment"}]
                  }
                } in user_list["listItems"]
 
@@ -379,7 +379,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressDynamicWatchlistTest do
                  "blockchainAddress" => %{
                    "address" => "0xeb2629a2734e272bcc07bda959863f316f4bd4cf",
                    "infrastructure" => "ETH",
-                   "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
+                   "labels" => [%{"name" => "centralized_exchange", "origin" => "santiment"}]
                  }
                } in user_list["listItems"]
       end)
@@ -436,7 +436,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressDynamicWatchlistTest do
                  "blockchainAddress" => %{
                    "address" => "0xeb2629a2734e272bcc07bda959863f316f4bd4cf",
                    "infrastructure" => "ETH",
-                   "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
+                   "labels" => [%{"name" => "centralized_exchange", "origin" => "santiment"}]
                  }
                } in user_list["listItems"]
       end)
@@ -499,7 +499,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressDynamicWatchlistTest do
                  "blockchainAddress" => %{
                    "address" => "0xa5409ec958c83c3f309868babaca7c86dcb077c1",
                    "infrastructure" => "ETH",
-                   "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
+                   "labels" => [%{"name" => "decentralized_exchange", "origin" => "santiment"}]
                  }
                } in user_list["listItems"]
 
@@ -507,7 +507,7 @@ defmodule SanbaseWeb.Graphql.BlockchainAddressDynamicWatchlistTest do
                  "blockchainAddress" => %{
                    "address" => "0xeb2629a2734e272bcc07bda959863f316f4bd4cf",
                    "infrastructure" => "ETH",
-                   "labels" => [%{"name" => "CEX Trader", "origin" => "santiment"}]
+                   "labels" => [%{"name" => "centralized_exchange", "origin" => "santiment"}]
                  }
                } in user_list["listItems"]
       end)


### PR DESCRIPTION
## Changes
### Summary

- Disable `Sanbase.Cache.RehydratingCache` in the default test boot path so leaked closures can no longer re-fire against unmocked ClickHouse adapters between tests.
- Give `ProjectMetricsResolver.maybe_register_and_get/5` a runtime-gated sync fallback (`Sanbase.Cache.get_or_store/2`) for test, while `project_available_metrics_test.exs` opts back into a per-test RC supervisor so the real resolver ↔
RC integration stays covered.
- Add the previously-missing `test/sanbase/cache/rehydrating_cache_test.exs` with 9 cases covering the public contract end-to-end.

### Background

`RehydratingCache` is a globally-named GenServer (`:__rehydrating_cache__`) with:

- a `:run` tick every 20s
- a 5-minute `@function_runtime_timeout`
- closures registered under caller-supplied `refresh_time_delta` (seconds)

Only one caller in prod (`ProjectMetricsResolver`) and one test (`project_available_metrics_test.exs`) ever register closures. But because the GenServer is long-lived and has no `clear_all`, a closure registered inside `run_with_mocks`
could outlive that block and fire later against real code paths, producing intermittent `"could not lookup Ecto repo Sanbase.ClickhouseRepo"` warnings during unrelated tests. There was also no dedicated test file for `RehydratingCache`
itself.

### What changed

1. **Config flag** (`config/config.exs`, `config/test.exs`)
 - `:use_rehydrating_cache` — `true` in dev/prod, `false` in test. Read at runtime via `Application.get_env/3`. Documented as a test-isolation switch, not a feature toggle.

2. **App boot** (`lib/sanbase/application/web.ex`)
 - `Sanbase.Cache.RehydratingCache.Supervisor` wrapped in `start_in(..., [:dev, :prod])`. The supervisor simply does not exist in the test app.

3. **Resolver branch** (`lib/sanbase_web/graphql/resolvers/project/project_metrics_resolver.ex`)
 - `maybe_register_and_get/5` now branches on the flag. The original body is renamed `register_and_get_via_rehydrating_cache/5` (no logic change).
 - Test fallback: `Sanbase.Cache.get_or_store({cache_key, @ttl}, fun)`. Note this collapses `{:nocache, {:ok, v}}` to `{:ok, v}` — documented in the plan and irrelevant to tests that don't opt back into RC.

4. **Opt-in for the integration test** (`test/sanbase/project/project_available_metrics_test.exs`)
 - `setup` flips the flag `true`, `start_supervised!`s a per-test RC supervisor, and `on_exit` restores the default. ExUnit tears down the supervisor and its task children at test exit, so no closure leaks.

5. **New `test/sanbase/cache/rehydrating_cache_test.exs`** (9 tests, `async: false`)
 - `register_function/5` + `get/2` happy path
 - `:not_registered` on missing key
 - `:already_registered` on duplicate
 - Refresh after `refresh_time_delta` via manual `send(name, :run)`
 - Task crash → progress `:failed` → retry on next `:run`
 - Concurrent `get/2` while in-progress — both callers served the same value
 - Waiting-list timeout against a stalled function
 - `{:nocache, {:ok, _}}` passthrough with `return_nocache: true`
 - `{:nocache, ...}` default collapse to `{:ok, _}`

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a configurable runtime switch to select the caching strategy and adjusted when the rehydrating cache is started across environments.
* **Tests**
  * Added comprehensive tests for the rehydrating cache (registration, refresh, timeouts, concurrent access) and updated test setups and expectations to exercise the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->