### PR TITLE
Downcasing s3 images can break them

### DIFF
--- a/lib/sanbase/insight/image_url.ex
+++ b/lib/sanbase/insight/image_url.ex
@@ -22,12 +22,14 @@ defmodule Sanbase.Insight.ImageUrl do
   end
 
   @doc """
-  Extract Sanbase-hosted image URLs from text. Returns downcased URLs.
+  Extract Sanbase-hosted image URLs from text.
   """
   def extract_from_text(nil), do: []
   def extract_from_text(""), do: []
 
   def extract_from_text(text) do
-    Regex.scan(regex(), text)
+    regex()
+    |> Regex.scan(text)
+    |> List.flatten()
   end
 end

--- a/lib/sanbase/insight/image_url.ex
+++ b/lib/sanbase/insight/image_url.ex
@@ -29,6 +29,5 @@ defmodule Sanbase.Insight.ImageUrl do
 
   def extract_from_text(text) do
     Regex.scan(regex(), text)
-    |> Enum.map(fn [url] -> String.downcase(url) end)
   end
 end

--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -986,7 +986,12 @@ defmodule Sanbase.Insight.Post do
   defp do_images_cast(changeset, []), do: changeset
 
   defp do_images_cast(changeset, image_urls) do
-    images = PostImage |> where([i], i.image_url in ^image_urls) |> Repo.all()
+    # Match both original-case and downcased URLs to handle old records
+    # that were stored with downcased URLs before the downcase was removed.
+    downcased_urls = Enum.map(image_urls, &String.downcase/1)
+    all_candidate_urls = Enum.uniq(image_urls ++ downcased_urls)
+
+    images = PostImage |> where([i], i.image_url in ^all_candidate_urls) |> Repo.all()
     current_post_id = changeset.data.id
 
     reused? =

--- a/lib/sanbase/insight/post_image.ex
+++ b/lib/sanbase/insight/post_image.ex
@@ -34,7 +34,6 @@ defmodule Sanbase.Insight.PostImage do
     post_image
     |> cast(attrs, @cast_fields)
     |> validate_required([:image_url, :content_hash, :hash_algorithm])
-    |> update_change(:image_url, &String.downcase/1)
     |> unique_constraint(:image_url, name: :image_url_index)
   end
 

--- a/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
@@ -239,13 +239,32 @@ defmodule SanbaseWeb.Graphql.Resolvers.InsightResolver do
           []
       end
 
+    # Build a case-insensitive lookup from DB images to get variant URLs
+    db_image_by_url =
+      Map.new(db_images, fn img -> {String.downcase(img.image_url), img} end)
+
+    # Regex images are in text-appearance order — use them as the primary source
     regex_images =
       ImageUrl.extract_from_text(text)
-      |> Enum.map(fn url -> %{image_url: url} end)
+      |> Enum.map(fn url ->
+        case Map.get(db_image_by_url, String.downcase(url)) do
+          nil -> %{image_url: url}
+          db_img -> %{db_img | image_url: url}
+        end
+      end)
+
+    # Append any DB-only images not found in the text
+    text_urls =
+      MapSet.new(regex_images, fn %{image_url: url} -> String.downcase(url) end)
+
+    orphan_db_images =
+      Enum.reject(db_images, fn %{image_url: url} ->
+        MapSet.member?(text_urls, String.downcase(url))
+      end)
 
     all_images =
-      (db_images ++ regex_images)
-      |> Enum.uniq_by(fn %{image_url: url} -> url end)
+      (regex_images ++ orphan_db_images)
+      |> Enum.uniq_by(fn %{image_url: url} -> String.downcase(url) end)
 
     {:ok, all_images}
   end

--- a/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/insight_resolver.ex
@@ -245,7 +245,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.InsightResolver do
 
     all_images =
       (db_images ++ regex_images)
-      |> Enum.uniq_by(fn %{image_url: url} -> String.downcase(url) end)
+      |> Enum.uniq_by(fn %{image_url: url} -> url end)
 
     {:ok, all_images}
   end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extracted image URLs now preserve their original casing.
  * Image matching and deduplication improved: case-insensitive detection prevents duplicates across casing, while images found in content are returned first and database-only images are appended.
  * Stored image records no longer force lowercased URLs, preserving submitted casing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->