### PR TITLE
Do not downcase insight s3 image urls

### DIFF
--- a/lib/sanbase/insight/image_url.ex
+++ b/lib/sanbase/insight/image_url.ex
@@ -22,13 +22,13 @@ defmodule Sanbase.Insight.ImageUrl do
   end
 
   @doc """
-  Extract Sanbase-hosted image URLs from text. Returns downcased URLs.
+  Extract Sanbase-hosted image URLs from text.
   """
   def extract_from_text(nil), do: []
   def extract_from_text(""), do: []
 
   def extract_from_text(text) do
-    Regex.scan(regex(), text)
-    |> Enum.map(fn [url] -> String.downcase(url) end)
+    Regex.scan(regex(), text, capture: :first)
+    |> List.flatten()
   end
 end

--- a/lib/sanbase/insight/post_image.ex
+++ b/lib/sanbase/insight/post_image.ex
@@ -34,7 +34,6 @@ defmodule Sanbase.Insight.PostImage do
     post_image
     |> cast(attrs, @cast_fields)
     |> validate_required([:image_url, :content_hash, :hash_algorithm])
-    |> update_change(:image_url, &String.downcase/1)
     |> unique_constraint(:image_url, name: :image_url_index)
   end
 


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image URLs are no longer automatically converted to lowercase during extraction and storage, preserving their original casing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->