### PR TITLE
Security improvements

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -172,7 +172,7 @@ config :sasl, sasl_error_logger: false
 # Configures Elixir's Logger
 config :logger, :console,
   format: {Sanbase.Utils.JsonLogger, :format},
-  metadata: [:request_id, :api_token, :user_id, :remote_ip, :complexity, :query, :san_balance],
+  metadata: [:request_id, :user_id, :remote_ip, :complexity, :query, :san_balance],
   handle_otp_reports: true,
   handle_sasl_reports: true
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -325,7 +325,9 @@ config :ex_audit,
   ],
   primitive_structs: [DateTime, NaiveDateTime, Date]
 
-config :sanbase, Sanbase.Metric.Registry.Sync, sync_secret: "secret_only_on_prod"
+config :sanbase, Sanbase.Metric.Registry.Sync,
+  sync_secret: "secret_only_on_prod",
+  export_secret: "export_secret_only_on_prod"
 
 # Import configs
 import_config "ueberauth_config.exs"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -28,6 +28,10 @@ config :sanbase, Sanbase.SimpleMailer,
 
 config :sanbase, SanbaseWeb.SESController, webhook_secret: System.get_env("SES_WEBHOOK_SECRET")
 
+if mailjet_webhook_secret = System.get_env("MAILJET_WEBHOOK_SECRET") do
+  config :sanbase, SanbaseWeb.MailjetController, webhook_secret: mailjet_webhook_secret
+end
+
 config :sanbase, Sanbase.SmartContracts.SanrNFT,
   alchemy_api_key: System.get_env("ALCHEMY_API_KEY")
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -170,5 +170,6 @@ if config_env() == :prod do
     ]
 
   config :sanbase, Sanbase.Metric.Registry.Sync,
-    sync_secret: System.get_env("METRIC_REGISTRY_SYNC_SECRET")
+    sync_secret: System.get_env("METRIC_REGISTRY_SYNC_SECRET"),
+    export_secret: System.get_env("METRIC_REGISTRY_EXPORT_SECRET")
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -142,6 +142,7 @@ config :waffle,
   storage_dir_prefix: "/"
 
 config :sanbase, SanbaseWeb.Plug.VerifyStripeWebhook, webhook_secret: "stripe_webhook_secret"
+config :sanbase, SanbaseWeb.MailjetController, webhook_secret: "test_mailjet_secret"
 
 config :sanbase, Sanbase.Alert, email_channel_enabled: {:system, "EMAIL_CHANNEL_ENABLED", "true"}
 

--- a/lib/sanbase/alerts/user_trigger.ex
+++ b/lib/sanbase/alerts/user_trigger.ex
@@ -91,7 +91,28 @@ defmodule Sanbase.Alert.UserTrigger do
 
   @impl Sanbase.Entity.Behaviour
   def get_visibility_data(id) do
-    Sanbase.Entity.Query.default_get_visibility_data(__MODULE__, :user_trigger, id)
+    # is_public is a virtual field computed from the embedded trigger,
+    # so we can't use default_get_visibility_data which tries to select it directly.
+    query =
+      from(ut in base_query(),
+        where: ut.id == ^id,
+        select: %{user_id: ut.user_id, is_hidden: ut.is_hidden}
+      )
+
+    case Repo.one(query) do
+      nil ->
+        {:error, "UserTrigger with id #{id} does not exist."}
+
+      %{user_id: user_id, is_hidden: is_hidden} = result ->
+        # Load the full record to check trigger.is_public
+        case by_id(id, []) do
+          {:ok, ut} ->
+            {:ok, %{user_id: user_id, is_hidden: is_hidden, is_public: ut.trigger.is_public}}
+
+          _ ->
+            {:ok, Map.put(result, :is_public, false)}
+        end
+    end
   end
 
   @impl Sanbase.Entity.Behaviour

--- a/lib/sanbase/alerts/user_trigger.ex
+++ b/lib/sanbase/alerts/user_trigger.ex
@@ -90,17 +90,27 @@ defmodule Sanbase.Alert.UserTrigger do
   end
 
   @impl Sanbase.Entity.Behaviour
-  def get_visibility_data(id) do
-    # is_public is virtual (computed from the embedded trigger), so the default
-    # helper that selects it directly doesn't work here.
-    case by_id(id, []) do
-      {:ok, ut} ->
-        {:ok, %{user_id: ut.user_id, is_hidden: ut.is_hidden, is_public: ut.trigger.is_public}}
+  # is_public is virtual (computed from the embedded trigger), so the default
+  # helper that selects it directly doesn't work here.
+  def get_visibility_data(id) when is_integer(id) do
+    query =
+      from(ut in base_query(),
+        where: ut.id == ^id,
+        select: %{
+          user_id: ut.user_id,
+          is_hidden: ut.is_hidden,
+          is_public: fragment("?.trigger->>'is_public' = 'true'", ut)
+        }
+      )
 
-      _ ->
-        {:error, "UserTrigger with id #{id} does not exist."}
+    case Repo.one(query) do
+      %{} = map -> {:ok, map}
+      nil -> {:error, "UserTrigger with id #{id} does not exist."}
     end
   end
+
+  def get_visibility_data(id),
+    do: {:error, "Invalid UserTrigger id: #{inspect(id)}. Expected an integer."}
 
   @impl Sanbase.Entity.Behaviour
   def by_id!(id, opts) when is_integer(id), do: by_id(id, opts) |> to_bang()

--- a/lib/sanbase/alerts/user_trigger.ex
+++ b/lib/sanbase/alerts/user_trigger.ex
@@ -91,27 +91,14 @@ defmodule Sanbase.Alert.UserTrigger do
 
   @impl Sanbase.Entity.Behaviour
   def get_visibility_data(id) do
-    # is_public is a virtual field computed from the embedded trigger,
-    # so we can't use default_get_visibility_data which tries to select it directly.
-    query =
-      from(ut in base_query(),
-        where: ut.id == ^id,
-        select: %{user_id: ut.user_id, is_hidden: ut.is_hidden}
-      )
+    # is_public is virtual (computed from the embedded trigger), so the default
+    # helper that selects it directly doesn't work here.
+    case by_id(id, []) do
+      {:ok, ut} ->
+        {:ok, %{user_id: ut.user_id, is_hidden: ut.is_hidden, is_public: ut.trigger.is_public}}
 
-    case Repo.one(query) do
-      nil ->
+      _ ->
         {:error, "UserTrigger with id #{id} does not exist."}
-
-      %{user_id: user_id, is_hidden: is_hidden} = result ->
-        # Load the full record to check trigger.is_public
-        case by_id(id, []) do
-          {:ok, ut} ->
-            {:ok, %{user_id: user_id, is_hidden: is_hidden, is_public: ut.trigger.is_public}}
-
-          _ ->
-            {:ok, Map.put(result, :is_public, false)}
-        end
     end
   end
 

--- a/lib/sanbase/entity/entity.ex
+++ b/lib/sanbase/entity/entity.ex
@@ -50,6 +50,7 @@ defmodule Sanbase.Entity do
           | :user_trigger
           | :dashboard
           | :query
+          | :timeline_event
 
   @type option ::
           {:page, non_neg_integer()}

--- a/lib/sanbase/entity/entity.ex
+++ b/lib/sanbase/entity/entity.ex
@@ -78,11 +78,29 @@ defmodule Sanbase.Entity do
   """
   @spec get_visibility_data(entity_type, entity_id) ::
           {:ok, Sanbase.Entity.Behaviour.visibility_map()} | {:error, String.t()}
-  def get_visibility_data(entity_type, entity_id) do
-    module = deduce_entity_module(entity_type)
+  # Timeline events are always public — they are derived surface of other
+  # entities (insights, watchlists, triggers) and have no visibility flag
+  # of their own. `user_id` is intentionally nil here: no caller currently
+  # needs ownership for timeline events (they are read-only from the API
+  # perspective). If a future caller needs ownership checks, fetch the
+  # event separately — do not rely on this map.
+  def get_visibility_data(:timeline_event, _entity_id),
+    do: {:ok, %{is_public: true, user_id: nil}}
 
-    module.get_visibility_data(entity_id)
+  def get_visibility_data(entity_type, entity_id) do
+    case Registry.fetch_entity_module(entity_type) do
+      {:ok, module} -> module.get_visibility_data(entity_id)
+      :error -> {:error, "Unknown entity type: #{inspect(entity_type)}"}
+    end
   end
+
+  @doc """
+  Maps the vote-API entity name to the Entity-API type.
+  The Vote schema uses `:post` (column `post_id`) while the Entity API
+  exposes the same entity as `:insight`. Other types are identical.
+  """
+  def vote_entity_to_entity_type(:post), do: :insight
+  def vote_entity_to_entity_type(other), do: other
 
   @doc ~s"""
   Return information about the number of created entities by a given user

--- a/lib/sanbase/entity/entity.ex
+++ b/lib/sanbase/entity/entity.ex
@@ -78,20 +78,46 @@ defmodule Sanbase.Entity do
   """
   @spec get_visibility_data(entity_type, entity_id) ::
           {:ok, Sanbase.Entity.Behaviour.visibility_map()} | {:error, String.t()}
-  # Timeline events are always public — they are derived surface of other
-  # entities (insights, watchlists, triggers) and have no visibility flag
-  # of their own. `user_id` is intentionally nil here: no caller currently
-  # needs ownership for timeline events (they are read-only from the API
-  # perspective). If a future caller needs ownership checks, fetch the
-  # event separately — do not rely on this map.
-  def get_visibility_data(:timeline_event, _entity_id),
-    do: {:ok, %{is_public: true, user_id: nil}}
+  # Timeline event visibility is derived from the backing entity.
+  # A private watchlist/trigger or unpublished insight must not become votable
+  # just because there is a timeline event pointing to it.
+  def get_visibility_data(:timeline_event, timeline_event_id)
+      when is_integer(timeline_event_id) do
+    case Sanbase.Timeline.TimelineEvent.by_id(timeline_event_id, []) do
+      {:ok, timeline_event} ->
+        timeline_event_visibility_data(timeline_event)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  def get_visibility_data(:timeline_event, timeline_event_id),
+    do: {:error, "Invalid timeline event id: #{inspect(timeline_event_id)}. Expected an integer."}
 
   def get_visibility_data(entity_type, entity_id) do
     case Registry.fetch_entity_module(entity_type) do
       {:ok, module} -> module.get_visibility_data(entity_id)
       :error -> {:error, "Unknown entity type: #{inspect(entity_type)}"}
     end
+  end
+
+  defp timeline_event_visibility_data(%{post_id: post_id}) when is_integer(post_id) do
+    Sanbase.Insight.Post.get_visibility_data(post_id)
+  end
+
+  defp timeline_event_visibility_data(%{user_list_id: user_list_id})
+       when is_integer(user_list_id) do
+    Sanbase.UserList.get_visibility_data(user_list_id)
+  end
+
+  defp timeline_event_visibility_data(%{user_trigger_id: user_trigger_id})
+       when is_integer(user_trigger_id) do
+    Sanbase.Alert.UserTrigger.get_visibility_data(user_trigger_id)
+  end
+
+  defp timeline_event_visibility_data(%{id: timeline_event_id}) do
+    {:error, "Timeline event with id #{timeline_event_id} does not reference a supported entity"}
   end
 
   @doc """

--- a/lib/sanbase/entity/entity_registry.ex
+++ b/lib/sanbase/entity/entity_registry.ex
@@ -122,6 +122,16 @@ defmodule Sanbase.Entity.Registry do
     end
   end
 
+  @doc """
+  Non-raising variant of `entity_module/1`.
+  """
+  def fetch_entity_module(type) do
+    case Map.fetch(@entities, type) do
+      {:ok, %{module: module}} -> {:ok, module}
+      :error -> :error
+    end
+  end
+
   @doc "Returns the vote table column for a given entity type."
   def entity_vote_field(type) do
     case Map.fetch(@entities, type) do

--- a/lib/sanbase/mcp/http_plugs.ex
+++ b/lib/sanbase/mcp/http_plugs.ex
@@ -71,6 +71,7 @@ defmodule Sanbase.MCP.AuthPlug do
     case header_value do
       "Bearer Apikey " <> apikey -> apikey
       "Apikey " <> apikey -> apikey
+      "Bearer " <> apikey -> apikey
       _ -> nil
     end
   end

--- a/lib/sanbase/mcp/http_plugs.ex
+++ b/lib/sanbase/mcp/http_plugs.ex
@@ -71,7 +71,6 @@ defmodule Sanbase.MCP.AuthPlug do
     case header_value do
       "Bearer Apikey " <> apikey -> apikey
       "Apikey " <> apikey -> apikey
-      "Bearer " <> apikey -> apikey
       _ -> nil
     end
   end

--- a/lib/sanbase_web/controllers/admin/invoice_download_controller.ex
+++ b/lib/sanbase_web/controllers/admin/invoice_download_controller.ex
@@ -3,7 +3,31 @@ defmodule SanbaseWeb.Admin.InvoiceDownloadController do
 
   alias Sanbase.Billing.Invoices.{InvoiceArchive, S3Storage}
 
+  # Finance data: restrict download to Admin Panel Owners. Viewer/Editor
+  # admins have no business-need for raw invoice archives.
+  @allowed_role_ids [Sanbase.Accounts.Role.admin_panel_owner_role_id()]
+
   def download(conn, %{"id" => id}) do
+    if authorized?(conn) do
+      serve_download(conn, id)
+    else
+      conn
+      |> put_status(403)
+      |> text("Forbidden: invoice download requires Admin Panel Owner role")
+    end
+  end
+
+  defp authorized?(conn) do
+    case conn.assigns[:current_user] do
+      %Sanbase.Accounts.User{} = user ->
+        Enum.any?(user.roles, fn ur -> ur.role.id in @allowed_role_ids end)
+
+      _ ->
+        false
+    end
+  end
+
+  defp serve_download(conn, id) do
     case Sanbase.Repo.get(InvoiceArchive, id) do
       %{status: "completed", s3_key: s3_key} = archive when not is_nil(s3_key) ->
         if S3Storage.local_storage?() do

--- a/lib/sanbase_web/controllers/admin/invoice_download_controller.ex
+++ b/lib/sanbase_web/controllers/admin/invoice_download_controller.ex
@@ -5,7 +5,10 @@ defmodule SanbaseWeb.Admin.InvoiceDownloadController do
 
   # Finance data: restrict download to Admin Panel Owners. Viewer/Editor
   # admins have no business-need for raw invoice archives.
-  @allowed_role_ids [Sanbase.Accounts.Role.admin_panel_owner_role_id()]
+  @allowed_role_ids [
+    Sanbase.Accounts.Role.admin_panel_editor_role_id(),
+    Sanbase.Accounts.Role.admin_panel_owner_role_id()
+  ]
 
   def download(conn, %{"id" => id}) do
     if authorized?(conn) do

--- a/lib/sanbase_web/controllers/auth_controller.ex
+++ b/lib/sanbase_web/controllers/auth_controller.ex
@@ -258,10 +258,30 @@ defmodule SanbaseWeb.AuthController do
       @valid_redirect_hosts ["localhost" | @valid_redirect_hosts]
   end
 
+  @max_redirect_url_length 2048
+
   @doc false
-  def validate_redirect_url(url) do
+  def validate_redirect_url(url) when is_binary(url) do
+    cond do
+      byte_size(url) > @max_redirect_url_length ->
+        Logger.warning("Rejecting oversized redirect URL (#{byte_size(url)} bytes)")
+        {:error, "Invalid redirect URL"}
+
+      contains_control_chars?(url) ->
+        Logger.warning("Rejecting redirect URL with control characters")
+        {:error, "Invalid redirect URL"}
+
+      true ->
+        do_validate_redirect_url(url)
+    end
+  end
+
+  def validate_redirect_url(_), do: {:error, "Invalid redirect URL"}
+
+  defp do_validate_redirect_url(url) do
     case URI.parse(url) do
-      %URI{scheme: "sanbase", userinfo: nil, host: host} ->
+      %URI{scheme: "sanbase", userinfo: nil, host: host, port: nil}
+      when is_binary(host) and host != "" ->
         if valid_sanbase_deeplink_host?(host) do
           true
         else
@@ -269,7 +289,8 @@ defmodule SanbaseWeb.AuthController do
           {:error, "Invalid redirect URL"}
         end
 
-      %URI{scheme: "https", host: host, userinfo: nil} when host in @valid_redirect_hosts ->
+      %URI{scheme: "https", userinfo: nil, host: host, port: port}
+      when host in @valid_redirect_hosts and port in [nil, 443] ->
         true
 
       _ ->
@@ -278,15 +299,19 @@ defmodule SanbaseWeb.AuthController do
     end
   end
 
+  # Reject CR/LF/NUL/tab and any other ASCII control byte. These have no
+  # business in a URL and are classic vectors for log-injection and HTTP
+  # response splitting.
+  defp contains_control_chars?(url) do
+    String.match?(url, ~r/[\x00-\x1F\x7F]/)
+  end
+
   # The sanbase:// deep-link scheme uses the host component as an "action"
   # (e.g., sanbase://home, sanbase://portfolio/btc). Reject anything that
   # looks like a real DNS host (contains a dot) or is otherwise non-empty
   # nonsense — that prevents attackers from smuggling their own domain
   # through the mobile app's deep-link handler.
-  defp valid_sanbase_deeplink_host?(nil), do: true
-  defp valid_sanbase_deeplink_host?(""), do: true
-
-  defp valid_sanbase_deeplink_host?(host) when is_binary(host) do
+  defp valid_sanbase_deeplink_host?(host) when is_binary(host) and host != "" do
     not String.contains?(host, ".") and String.match?(host, ~r/^[a-zA-Z0-9_-]+$/)
   end
 

--- a/lib/sanbase_web/controllers/auth_controller.ex
+++ b/lib/sanbase_web/controllers/auth_controller.ex
@@ -258,7 +258,9 @@ defmodule SanbaseWeb.AuthController do
       @valid_redirect_hosts ["localhost" | @valid_redirect_hosts]
   end
 
-  @max_redirect_url_length 2048
+  # Temporary headroom — real FE redirect URLs should fit in 2048, but until we
+  # audit every deep-link case we keep 4096 to avoid breaking login returns.
+  @max_redirect_url_length 4096
 
   @doc false
   def validate_redirect_url(url) when is_binary(url) do

--- a/lib/sanbase_web/controllers/auth_controller.ex
+++ b/lib/sanbase_web/controllers/auth_controller.ex
@@ -261,8 +261,13 @@ defmodule SanbaseWeb.AuthController do
   @doc false
   def validate_redirect_url(url) do
     case URI.parse(url) do
-      %URI{scheme: "sanbase"} ->
-        true
+      %URI{scheme: "sanbase", userinfo: nil, host: host} ->
+        if valid_sanbase_deeplink_host?(host) do
+          true
+        else
+          Logger.warning("Rejecting sanbase:// redirect with suspicious host: #{url}")
+          {:error, "Invalid redirect URL"}
+        end
 
       %URI{scheme: "https", host: host, userinfo: nil} when host in @valid_redirect_hosts ->
         true
@@ -272,4 +277,18 @@ defmodule SanbaseWeb.AuthController do
         {:error, "Invalid redirect URL"}
     end
   end
+
+  # The sanbase:// deep-link scheme uses the host component as an "action"
+  # (e.g., sanbase://home, sanbase://portfolio/btc). Reject anything that
+  # looks like a real DNS host (contains a dot) or is otherwise non-empty
+  # nonsense — that prevents attackers from smuggling their own domain
+  # through the mobile app's deep-link handler.
+  defp valid_sanbase_deeplink_host?(nil), do: true
+  defp valid_sanbase_deeplink_host?(""), do: true
+
+  defp valid_sanbase_deeplink_host?(host) when is_binary(host) do
+    not String.contains?(host, ".") and String.match?(host, ~r/^[a-zA-Z0-9_-]+$/)
+  end
+
+  defp valid_sanbase_deeplink_host?(_), do: false
 end

--- a/lib/sanbase_web/controllers/auth_controller.ex
+++ b/lib/sanbase_web/controllers/auth_controller.ex
@@ -264,7 +264,7 @@ defmodule SanbaseWeb.AuthController do
       %URI{scheme: "sanbase"} ->
         true
 
-      %URI{scheme: "https", host: host} when host in @valid_redirect_hosts ->
+      %URI{scheme: "https", host: host, userinfo: nil} when host in @valid_redirect_hosts ->
         true
 
       _ ->

--- a/lib/sanbase_web/controllers/auth_controller.ex
+++ b/lib/sanbase_web/controllers/auth_controller.ex
@@ -292,13 +292,33 @@ defmodule SanbaseWeb.AuthController do
         end
 
       %URI{scheme: "https", userinfo: nil, host: host, port: port}
-      when host in @valid_redirect_hosts and port in [nil, 443] ->
-        true
+      when is_binary(host) and port in [nil, 443] ->
+        if String.downcase(host) in @valid_redirect_hosts do
+          true
+        else
+          Logger.warning(
+            "Attempt to redirect to an unsupported endpoint after login: #{redact_url(url)}"
+          )
+
+          {:error, "Invalid redirect URL"}
+        end
 
       _ ->
-        Logger.warning("Attempt to redirect to an unsupported endpoint after login: #{url}")
+        Logger.warning(
+          "Attempt to redirect to an unsupported endpoint after login: #{redact_url(url)}"
+        )
+
         {:error, "Invalid redirect URL"}
     end
+  end
+
+  defp redact_url(url) do
+    url
+    |> URI.parse()
+    |> Map.merge(%{userinfo: nil, query: nil, fragment: nil})
+    |> URI.to_string()
+  rescue
+    _ -> "<unparseable>"
   end
 
   # Reject CR/LF/NUL/tab and any other ASCII control byte. These have no

--- a/lib/sanbase_web/controllers/bot_login_controller.ex
+++ b/lib/sanbase_web/controllers/bot_login_controller.ex
@@ -24,8 +24,8 @@ defmodule SanbaseWeb.BotLoginController do
     |> SanbaseWeb.Guardian.add_jwt_tokens_to_conn_session(jwt_tokens)
     |> put_resp_header("cache-control", "no-store")
     |> put_resp_header("pragma", "no-cache")
+    |> put_resp_content_type("text/plain")
     |> resp(200, jwt_tokens.access_token)
-    |> put_resp_content_type("application/json")
     |> send_resp()
   end
 end

--- a/lib/sanbase_web/controllers/bot_login_controller.ex
+++ b/lib/sanbase_web/controllers/bot_login_controller.ex
@@ -22,7 +22,10 @@ defmodule SanbaseWeb.BotLoginController do
 
     conn
     |> SanbaseWeb.Guardian.add_jwt_tokens_to_conn_session(jwt_tokens)
-    |> resp(200, jwt_tokens.access_token)
+    |> put_resp_header("cache-control", "no-store")
+    |> put_resp_header("pragma", "no-cache")
+    |> put_resp_content_type("application/json")
+    |> resp(200, Jason.encode!(%{access_token: jwt_tokens.access_token}))
     |> send_resp()
   end
 end

--- a/lib/sanbase_web/controllers/bot_login_controller.ex
+++ b/lib/sanbase_web/controllers/bot_login_controller.ex
@@ -24,8 +24,8 @@ defmodule SanbaseWeb.BotLoginController do
     |> SanbaseWeb.Guardian.add_jwt_tokens_to_conn_session(jwt_tokens)
     |> put_resp_header("cache-control", "no-store")
     |> put_resp_header("pragma", "no-cache")
+    |> resp(200, jwt_tokens.access_token)
     |> put_resp_content_type("application/json")
-    |> resp(200, Jason.encode!(%{access_token: jwt_tokens.access_token}))
     |> send_resp()
   end
 end

--- a/lib/sanbase_web/controllers/data_controller.ex
+++ b/lib/sanbase_web/controllers/data_controller.ex
@@ -11,7 +11,9 @@ defmodule SanbaseWeb.DataController do
   This contains information about santiment team users, so it cannot be publicly freely available
   """
   def santiment_team_members(conn, %{"secret" => secret}) do
-    case santiment_team_members_secret() == secret do
+    expected = santiment_team_members_secret()
+
+    case is_binary(expected) and Plug.Crypto.secure_compare(secret, expected) do
       true ->
         {:ok, data} = get_santiment_team_members()
 
@@ -67,7 +69,9 @@ defmodule SanbaseWeb.DataController do
   end
 
   def monitored_twitter_handles(conn, %{"secret" => secret}) do
-    case santiment_team_members_secret() == secret do
+    expected = santiment_team_members_secret()
+
+    case is_binary(expected) and Plug.Crypto.secure_compare(secret, expected) do
       true ->
         cache_key = {__MODULE__, __ENV__.function} |> Sanbase.Cache.hash()
         {:ok, data} = Sanbase.Cache.get_or_store(cache_key, &get_monitored_twitter_handles_list/0)

--- a/lib/sanbase_web/controllers/data_controller.ex
+++ b/lib/sanbase_web/controllers/data_controller.ex
@@ -372,9 +372,8 @@ defmodule SanbaseWeb.DataController do
     end
   end
 
-  # On stage/prod the env var is set and is different from the default one.
+  # Fails closed: returns nil when the env var is missing so the
+  # is_binary(expected) guard at the call sites rejects all requests.
   defp santiment_team_members_secret(),
-    do:
-      System.get_env("SANTIMENT_TEAM_MEMBERS_ENDPOINT_SECRET") ||
-        "random_secret"
+    do: System.get_env("SANTIMENT_TEAM_MEMBERS_ENDPOINT_SECRET")
 end

--- a/lib/sanbase_web/controllers/mailjet_controller.ex
+++ b/lib/sanbase_web/controllers/mailjet_controller.ex
@@ -5,8 +5,28 @@ defmodule SanbaseWeb.MailjetController do
 
   alias Sanbase.Email.MailjetEventHandler
 
-  def webhook(conn, params) do
-    Logger.info("Received Mailjet webhook: #{inspect(params)}")
+  def webhook(conn, %{"secret" => secret} = params) do
+    expected_secret = webhook_secret()
+
+    if is_binary(expected_secret) and Plug.Crypto.secure_compare(secret, expected_secret) do
+      handle_webhook(conn, params)
+    else
+      Logger.warning("Invalid Mailjet webhook secret")
+
+      conn
+      |> send_resp(403, "Forbidden")
+      |> halt()
+    end
+  end
+
+  def webhook(conn, _params) do
+    conn
+    |> send_resp(403, "Forbidden")
+    |> halt()
+  end
+
+  defp handle_webhook(conn, params) do
+    Logger.info("Received Mailjet webhook event: #{Map.get(params, "event")}")
 
     with "unsub" <- Map.get(params, "event"),
          email when is_binary(email) <- Map.get(params, "email"),
@@ -30,5 +50,9 @@ defmodule SanbaseWeb.MailjetController do
 
     # Always respond with 200 to acknowledge receipt of webhook
     send_resp(conn, 200, "")
+  end
+
+  defp webhook_secret do
+    Application.get_env(:sanbase, __MODULE__)[:webhook_secret]
   end
 end

--- a/lib/sanbase_web/controllers/mailjet_controller.ex
+++ b/lib/sanbase_web/controllers/mailjet_controller.ex
@@ -9,7 +9,7 @@ defmodule SanbaseWeb.MailjetController do
     expected_secret = webhook_secret()
 
     if is_binary(expected_secret) and Plug.Crypto.secure_compare(secret, expected_secret) do
-      handle_webhook(conn, params)
+      handle_webhook(conn, Map.delete(params, "secret"))
     else
       Logger.warning("Invalid Mailjet webhook secret")
 
@@ -42,7 +42,9 @@ defmodule SanbaseWeb.MailjetController do
       end
     else
       nil ->
-        Logger.warning("Missing required parameters in Mailjet webhook: #{inspect(params)}")
+        Logger.warning(
+          "Missing required parameters in Mailjet webhook event: #{Map.get(params, "event")}"
+        )
 
       unexpected ->
         Logger.warning("Unexpected data in Mailjet webhook: #{inspect(unexpected)}")

--- a/lib/sanbase_web/controllers/metric_registry_controller.ex
+++ b/lib/sanbase_web/controllers/metric_registry_controller.ex
@@ -4,9 +4,7 @@ defmodule SanbaseWeb.MetricRegistryController do
   require Logger
 
   def sync(conn, %{"secret" => secret} = params) do
-    expected = get_sync_secret()
-
-    case is_binary(expected) and Plug.Crypto.secure_compare(secret, expected) do
+    case valid_secret?(secret, get_sync_secret()) do
       true ->
         try do
           case Sanbase.Metric.Registry.Sync.apply_sync(
@@ -53,9 +51,7 @@ defmodule SanbaseWeb.MetricRegistryController do
         "actual_changes" => actual_changes,
         "secret" => secret
       }) do
-    expected = get_sync_secret()
-
-    case is_binary(expected) and Plug.Crypto.secure_compare(secret, expected) do
+    case valid_secret?(secret, get_sync_secret()) do
       true ->
         # The code fetches the sync by the UUID and checks there if the sync is dry run or not
         case Sanbase.Metric.Registry.Sync.mark_sync_as_completed(sync_uuid, actual_changes) do
@@ -78,9 +74,7 @@ defmodule SanbaseWeb.MetricRegistryController do
   end
 
   def export_json(conn, %{"secret" => secret}) do
-    expected = get_export_secret()
-
-    case is_binary(expected) and Plug.Crypto.secure_compare(secret, expected) do
+    case valid_secret?(secret, get_export_secret()) do
       true ->
         conn
         |> put_resp_content_type("application/x-ndjson")
@@ -126,4 +120,10 @@ defmodule SanbaseWeb.MetricRegistryController do
   defp get_export_secret() do
     Sanbase.Utils.Config.module_get(Sanbase.Metric.Registry.Sync, :export_secret)
   end
+
+  defp valid_secret?(secret, expected) when is_binary(secret) and is_binary(expected) do
+    Plug.Crypto.secure_compare(secret, expected)
+  end
+
+  defp valid_secret?(_secret, _expected), do: false
 end

--- a/lib/sanbase_web/controllers/metric_registry_controller.ex
+++ b/lib/sanbase_web/controllers/metric_registry_controller.ex
@@ -77,9 +77,25 @@ defmodule SanbaseWeb.MetricRegistryController do
     end
   end
 
+  def export_json(conn, %{"secret" => secret}) do
+    expected = get_sync_secret()
+
+    case is_binary(expected) and Plug.Crypto.secure_compare(secret, expected) do
+      true ->
+        conn
+        |> resp(200, get_metric_registry_json())
+        |> send_resp()
+
+      false ->
+        conn
+        |> resp(403, "Unauthorized")
+        |> send_resp()
+    end
+  end
+
   def export_json(conn, _params) do
     conn
-    |> resp(200, get_metric_registry_json())
+    |> resp(403, "Unauthorized")
     |> send_resp()
   end
 

--- a/lib/sanbase_web/controllers/metric_registry_controller.ex
+++ b/lib/sanbase_web/controllers/metric_registry_controller.ex
@@ -78,11 +78,12 @@ defmodule SanbaseWeb.MetricRegistryController do
   end
 
   def export_json(conn, %{"secret" => secret}) do
-    expected = get_sync_secret()
+    expected = get_export_secret()
 
     case is_binary(expected) and Plug.Crypto.secure_compare(secret, expected) do
       true ->
         conn
+        |> put_resp_content_type("application/x-ndjson")
         |> resp(200, get_metric_registry_json())
         |> send_resp()
 
@@ -101,32 +102,28 @@ defmodule SanbaseWeb.MetricRegistryController do
 
   defp get_metric_registry_json() do
     Sanbase.Metric.Registry.all()
-    |> Enum.take(1)
     |> Enum.map(&transform/1)
-
-    # |> Enum.map(&Jason.encode!/1)
-    # |> Enum.intersperse("\n")
+    |> Enum.map(&Jason.encode!/1)
+    |> Enum.intersperse("\n")
   end
 
   defp transform(struct) when is_struct(struct) do
     struct
     |> Map.from_struct()
     |> Map.drop([:__meta__, :inserted_at, :updated_at, :change_suggestions])
-    |> Map.new(fn
-      {k, v} when is_list(v) ->
-        {k, Enum.map(v, &transform/1)}
-
-      {k, v} when is_map(v) ->
-        {k, transform(v)}
-
-      {k, v} ->
-        {k, v}
-    end)
+    |> Map.new(fn {k, v} -> {k, transform(v)} end)
   end
 
+  defp transform(list) when is_list(list), do: Enum.map(list, &transform/1)
+  defp transform(map) when is_map(map), do: Map.new(map, fn {k, v} -> {k, transform(v)} end)
+  defp transform(tuple) when is_tuple(tuple), do: tuple |> Tuple.to_list() |> transform()
   defp transform(data), do: data
 
   defp get_sync_secret() do
     Sanbase.Utils.Config.module_get(Sanbase.Metric.Registry.Sync, :sync_secret)
+  end
+
+  defp get_export_secret() do
+    Sanbase.Utils.Config.module_get(Sanbase.Metric.Registry.Sync, :export_secret)
   end
 end

--- a/lib/sanbase_web/controllers/metric_registry_controller.ex
+++ b/lib/sanbase_web/controllers/metric_registry_controller.ex
@@ -4,7 +4,9 @@ defmodule SanbaseWeb.MetricRegistryController do
   require Logger
 
   def sync(conn, %{"secret" => secret} = params) do
-    case secret == get_sync_secret() do
+    expected = get_sync_secret()
+
+    case is_binary(expected) and Plug.Crypto.secure_compare(secret, expected) do
       true ->
         try do
           case Sanbase.Metric.Registry.Sync.apply_sync(
@@ -51,7 +53,9 @@ defmodule SanbaseWeb.MetricRegistryController do
         "actual_changes" => actual_changes,
         "secret" => secret
       }) do
-    case secret == get_sync_secret() do
+    expected = get_sync_secret()
+
+    case is_binary(expected) and Plug.Crypto.secure_compare(secret, expected) do
       true ->
         # The code fetches the sync by the UUID and checks there if the sync is dry run or not
         case Sanbase.Metric.Registry.Sync.mark_sync_as_completed(sync_uuid, actual_changes) do

--- a/lib/sanbase_web/controllers/oauth_controller.ex
+++ b/lib/sanbase_web/controllers/oauth_controller.ex
@@ -96,6 +96,7 @@ defmodule SanbaseWeb.OAuthController do
   def authorize_consent(%Plug.Conn{} = conn, %{"decision" => "deny"} = params) do
     with redirect_uri when is_binary(redirect_uri) <- params["redirect_uri"],
          client_id when is_binary(client_id) <- params["client_id"],
+         true <- valid_uuid?(client_id),
          %Boruta.Ecto.Client{redirect_uris: uris} <-
            Sanbase.Repo.get(Boruta.Ecto.Client, client_id),
          true <- redirect_uri in uris do
@@ -439,4 +440,13 @@ defmodule SanbaseWeb.OAuthController do
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp valid_uuid?(value) when is_binary(value) do
+    case Ecto.UUID.cast(value) do
+      {:ok, _} -> true
+      :error -> false
+    end
+  end
+
+  defp valid_uuid?(_), do: false
 end

--- a/lib/sanbase_web/controllers/oauth_controller.ex
+++ b/lib/sanbase_web/controllers/oauth_controller.ex
@@ -54,7 +54,9 @@ defmodule SanbaseWeb.OAuthController do
   # --- Authorize (GET) - preauthorize then show consent ---
 
   def authorize(%Plug.Conn{} = conn, _params) do
-    Logger.info("[OAuth] authorize — all params: #{inspect(conn.params)}")
+    Logger.info(
+      "[OAuth] authorize — client_id: #{inspect(conn.params["client_id"])}, response_type: #{inspect(conn.params["response_type"])}, scope: #{inspect(conn.params["scope"])}"
+    )
 
     case current_user_from_session(conn) do
       {:ok, user, conn} ->

--- a/lib/sanbase_web/controllers/oauth_controller.ex
+++ b/lib/sanbase_web/controllers/oauth_controller.ex
@@ -441,11 +441,13 @@ defmodule SanbaseWeb.OAuthController do
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
-  defp valid_uuid?(value) when is_binary(value) do
-    case Ecto.UUID.cast(value) do
-      {:ok, _} -> true
-      :error -> false
-    end
+  # Only accept the canonical 8-4-4-4-12 UUID text form; Ecto.UUID.cast/1 also
+  # accepts raw 16-byte binaries, which are not valid request parameters.
+  defp valid_uuid?(
+         <<_::binary-size(8), "-", _::binary-size(4), "-", _::binary-size(4), "-",
+           _::binary-size(4), "-", _::binary-size(12)>> = value
+       ) do
+    match?({:ok, _}, Ecto.UUID.cast(value))
   end
 
   defp valid_uuid?(_), do: false

--- a/lib/sanbase_web/controllers/repo_reader_controller.ex
+++ b/lib/sanbase_web/controllers/repo_reader_controller.ex
@@ -45,14 +45,14 @@ defmodule SanbaseWeb.RepoReaderController do
   end
 
   def reader_webhook(conn, %{"secret" => secret} = params) do
-    Logger.info(
-      "[RepoReaderController] Received reader webhook with params: #{inspect(Map.delete(params, "secret"))}"
-    )
-
     expected = endpoint_secret()
 
     case is_binary(expected) and Plug.Crypto.secure_compare(secret, expected) do
       true ->
+        Logger.info(
+          "[RepoReaderController] Received reader webhook with params: #{inspect(Map.delete(params, "secret"))}"
+        )
+
         changed_files = Map.get(params, "changed_files", [])
 
         case Sanbase.RepoReader.update_projects(changed_files) do

--- a/lib/sanbase_web/controllers/repo_reader_controller.ex
+++ b/lib/sanbase_web/controllers/repo_reader_controller.ex
@@ -4,28 +4,44 @@ defmodule SanbaseWeb.RepoReaderController do
   require Logger
   alias Sanbase.Utils.Config
 
-  def validator_webhook(conn, params) do
-    Logger.info(
-      "[RepoReaderController] Received validator webhook with params: #{inspect(Map.delete(params, "secret"))}"
-    )
+  def validator_webhook(conn, %{"secret" => secret} = params) do
+    expected = endpoint_secret()
 
-    changed_files = Map.get(params, "changed_files", [])
-    branch = Map.fetch!(params, "branch")
-    fork_repo = Map.fetch!(params, "fork_repo")
+    case is_binary(expected) and Plug.Crypto.secure_compare(secret, expected) do
+      true ->
+        Logger.info(
+          "[RepoReaderController] Received validator webhook with params: #{inspect(Map.delete(params, "secret"))}"
+        )
 
-    case Sanbase.RepoReader.validate_changes(fork_repo, branch, changed_files) do
-      :ok ->
+        changed_files = Map.get(params, "changed_files", [])
+        branch = Map.fetch!(params, "branch")
+        fork_repo = Map.fetch!(params, "fork_repo")
+
+        case Sanbase.RepoReader.validate_changes(fork_repo, branch, changed_files) do
+          :ok ->
+            conn
+            |> put_resp_header("content-type", "application/json; charset=utf-8")
+            |> put_status(200)
+            |> json(%{result: "OK"})
+
+          {:error, error} ->
+            conn
+            |> put_resp_header("content-type", "application/json; charset=utf-8")
+            |> put_status(400)
+            |> json(%{error: error})
+        end
+
+      false ->
         conn
-        |> put_resp_header("content-type", "application/json; charset=utf-8")
-        |> put_status(200)
-        |> json(%{result: "OK"})
-
-      {:error, error} ->
-        conn
-        |> put_resp_header("content-type", "application/json; charset=utf-8")
-        |> put_status(400)
-        |> json(%{error: error})
+        |> send_resp(403, "Unauthorized")
+        |> halt()
     end
+  end
+
+  def validator_webhook(conn, _params) do
+    conn
+    |> send_resp(403, "Unauthorized")
+    |> halt()
   end
 
   def reader_webhook(conn, %{"secret" => secret} = params) do
@@ -33,7 +49,9 @@ defmodule SanbaseWeb.RepoReaderController do
       "[RepoReaderController] Received reader webhook with params: #{inspect(Map.delete(params, "secret"))}"
     )
 
-    case endpoint_secret() == secret do
+    expected = endpoint_secret()
+
+    case is_binary(expected) and Plug.Crypto.secure_compare(secret, expected) do
       true ->
         changed_files = Map.get(params, "changed_files", [])
 

--- a/lib/sanbase_web/controllers/ses_controller.ex
+++ b/lib/sanbase_web/controllers/ses_controller.ex
@@ -21,17 +21,21 @@ defmodule SanbaseWeb.SESController do
   end
 
   defp handle_sns_message(%{"Type" => "SubscriptionConfirmation", "SubscribeURL" => url}) do
-    Logger.info("Confirming SNS subscription")
+    if valid_sns_url?(url) do
+      Logger.info("Confirming SNS subscription")
 
-    case Req.get(url) do
-      {:ok, %{status: 200}} ->
-        Logger.info("SNS subscription confirmed")
+      case Req.get(url, redirect: false, receive_timeout: 5_000) do
+        {:ok, %{status: 200}} ->
+          Logger.info("SNS subscription confirmed")
 
-      {:ok, %{status: status}} ->
-        Logger.error("SNS subscription confirmation failed with status: #{status}")
+        {:ok, %{status: status}} ->
+          Logger.error("SNS subscription confirmation failed with status: #{status}")
 
-      {:error, reason} ->
-        Logger.error("Failed to confirm SNS subscription: #{inspect(reason)}")
+        {:error, reason} ->
+          Logger.error("Failed to confirm SNS subscription: #{inspect(reason)}")
+      end
+    else
+      Logger.warning("Rejected SNS SubscribeURL with non-AWS domain: #{url}")
     end
   end
 
@@ -165,4 +169,14 @@ defmodule SanbaseWeb.SESController do
   end
 
   defp parse_timestamp(_), do: DateTime.utc_now()
+
+  defp valid_sns_url?(url) do
+    case URI.parse(url) do
+      %URI{scheme: "https", host: host} when is_binary(host) ->
+        String.ends_with?(host, ".amazonaws.com")
+
+      _ ->
+        false
+    end
+  end
 end

--- a/lib/sanbase_web/controllers/ses_controller.ex
+++ b/lib/sanbase_web/controllers/ses_controller.ex
@@ -173,7 +173,7 @@ defmodule SanbaseWeb.SESController do
   defp valid_sns_url?(url) do
     case URI.parse(url) do
       %URI{scheme: "https", host: host} when is_binary(host) ->
-        String.ends_with?(host, ".amazonaws.com")
+        String.starts_with?(host, "sns.") and String.ends_with?(host, ".amazonaws.com")
 
       _ ->
         false

--- a/lib/sanbase_web/controllers/stripe_controller.ex
+++ b/lib/sanbase_web/controllers/stripe_controller.ex
@@ -7,7 +7,7 @@ defmodule SanbaseWeb.StripeController do
 
   def webhook(conn, _params) do
     stripe_event = conn.assigns[:stripe_event]
-    Logger.info("Stripe event received: #{inspect(stripe_event)}")
+    Logger.info("Stripe event received: type=#{stripe_event["type"]} id=#{stripe_event["id"]}")
 
     case StripeEvent.by_id(stripe_event["id"]) do
       nil ->

--- a/lib/sanbase_web/endpoint.ex
+++ b/lib/sanbase_web/endpoint.ex
@@ -22,18 +22,15 @@ defmodule SanbaseWeb.Endpoint do
     "//localhost"
   ]
 
-  socket("/socket", SanbaseWeb.UserSocket,
-    websocket: true,
-    check_origin: @websocket_allowed_origins
-  )
+  socket("/socket", SanbaseWeb.UserSocket, websocket: [check_origin: @websocket_allowed_origins])
 
   socket("/live", Phoenix.LiveView.Socket,
     websocket: [
       connect_info: [
         session: {SanbaseWeb.LiveViewUtils, :session_options, [@session_options]}
-      ]
-    ],
-    check_origin: @websocket_allowed_origins
+      ],
+      check_origin: @websocket_allowed_origins
+    ]
   )
 
   # Serve at "/" the static files from "priv/static" directory.

--- a/lib/sanbase_web/endpoint.ex
+++ b/lib/sanbase_web/endpoint.ex
@@ -15,7 +15,17 @@ defmodule SanbaseWeb.Endpoint do
     signing_salt: "grT-As16"
   ]
 
-  socket("/socket", SanbaseWeb.UserSocket, websocket: true, check_origin: false)
+  @websocket_allowed_origins [
+    "//*.santiment.net",
+    "//*.santiment.network",
+    "//*.sanr.app",
+    "//localhost"
+  ]
+
+  socket("/socket", SanbaseWeb.UserSocket,
+    websocket: true,
+    check_origin: @websocket_allowed_origins
+  )
 
   socket("/live", Phoenix.LiveView.Socket,
     websocket: [
@@ -23,7 +33,7 @@ defmodule SanbaseWeb.Endpoint do
         session: {SanbaseWeb.LiveViewUtils, :session_options, [@session_options]}
       ]
     ],
-    check_origin: false
+    check_origin: @websocket_allowed_origins
   )
 
   # Serve at "/" the static files from "priv/static" directory.

--- a/lib/sanbase_web/graphql/document/document_provider.ex
+++ b/lib/sanbase_web/graphql/document/document_provider.ex
@@ -29,7 +29,7 @@ defmodule SanbaseWeb.Graphql.DocumentProvider do
   def pipeline(%Absinthe.Plug.Request.Query{pipeline: pipeline}) do
     pipeline
     |> Absinthe.Pipeline.insert_before(
-      Absinthe.Phase.Document.Complexity.Analysis,
+      Absinthe.Phase.Document.Validation.Result,
       SanbaseWeb.Graphql.Phase.Document.Validation.MaxDepth
     )
     |> Absinthe.Pipeline.insert_before(
@@ -235,7 +235,7 @@ defmodule SanbaseWeb.Graphql.Phase.Document.Validation.MaxDepth do
         message: "Query exceeds maximum nesting depth of #{@max_depth}"
       }
 
-      {:error, Absinthe.Phase.put_error(bp_root, error)}
+      {:ok, Absinthe.Phase.put_error(bp_root, error)}
     else
       {:ok, bp_root}
     end

--- a/lib/sanbase_web/graphql/document/document_provider.ex
+++ b/lib/sanbase_web/graphql/document/document_provider.ex
@@ -30,6 +30,10 @@ defmodule SanbaseWeb.Graphql.DocumentProvider do
     pipeline
     |> Absinthe.Pipeline.insert_before(
       Absinthe.Phase.Document.Complexity.Analysis,
+      SanbaseWeb.Graphql.Phase.Document.Validation.MaxDepth
+    )
+    |> Absinthe.Pipeline.insert_before(
+      Absinthe.Phase.Document.Complexity.Analysis,
       SanbaseWeb.Graphql.Phase.Document.Complexity.Preprocess
     )
     |> Absinthe.Pipeline.insert_before(
@@ -201,6 +205,53 @@ defmodule SanbaseWeb.Graphql.Phase.Document.Execution.Idempotent do
   use Absinthe.Phase
   @spec run(Absinthe.Blueprint.t(), Keyword.t()) :: Absinthe.Phase.result_t()
   def run(bp_root, _), do: {:ok, bp_root}
+end
+
+defmodule SanbaseWeb.Graphql.Phase.Document.Validation.MaxDepth do
+  @moduledoc """
+  Rejects GraphQL documents whose selection nesting exceeds @max_depth.
+
+  The existing complexity analyzer bounds total cost but does not stop a
+  client from sending a deeply-nested query that hits a single expensive
+  resolver repeatedly or exploits cycles in the schema. An explicit depth
+  cap blocks introspection/DoS attempts that bypass complexity scoring.
+  """
+  use Absinthe.Phase
+
+  @max_depth 15
+
+  @spec run(Absinthe.Blueprint.t(), Keyword.t()) :: Absinthe.Phase.result_t()
+  def run(bp_root, _) do
+    max = bp_root.operations |> Enum.map(&operation_depth/1) |> Enum.max(fn -> 0 end)
+
+    if max > @max_depth do
+      error = %Absinthe.Phase.Error{
+        phase: __MODULE__,
+        message: "Query exceeds maximum nesting depth of #{@max_depth}"
+      }
+
+      {:error, Absinthe.Phase.put_error(bp_root, error)}
+    else
+      {:ok, bp_root}
+    end
+  end
+
+  defp operation_depth(%{selections: selections}), do: selections_depth(selections, 1)
+  defp operation_depth(_), do: 0
+
+  defp selections_depth([], depth), do: depth
+
+  defp selections_depth(selections, depth) do
+    selections
+    |> Enum.map(&node_depth(&1, depth))
+    |> Enum.max(fn -> depth end)
+  end
+
+  defp node_depth(%{selections: inner}, depth) when is_list(inner) and inner != [] do
+    selections_depth(inner, depth + 1)
+  end
+
+  defp node_depth(_, depth), do: depth
 end
 
 defmodule SanbaseWeb.Graphql.Phase.Document.Complexity.Preprocess do

--- a/lib/sanbase_web/graphql/document/document_provider.ex
+++ b/lib/sanbase_web/graphql/document/document_provider.ex
@@ -222,7 +222,12 @@ defmodule SanbaseWeb.Graphql.Phase.Document.Validation.MaxDepth do
 
   @spec run(Absinthe.Blueprint.t(), Keyword.t()) :: Absinthe.Phase.result_t()
   def run(bp_root, _) do
-    max = bp_root.operations |> Enum.map(&operation_depth/1) |> Enum.max(fn -> 0 end)
+    fragments = Map.new(bp_root.fragments || [], fn f -> {f.name, f} end)
+
+    max =
+      bp_root.operations
+      |> Enum.map(&operation_depth(&1, fragments))
+      |> Enum.max(fn -> 0 end)
 
     if max > @max_depth do
       error = %Absinthe.Phase.Error{
@@ -236,22 +241,47 @@ defmodule SanbaseWeb.Graphql.Phase.Document.Validation.MaxDepth do
     end
   end
 
-  defp operation_depth(%{selections: selections}), do: selections_depth(selections, 1)
-  defp operation_depth(_), do: 0
+  defp operation_depth(%{selections: selections}, fragments),
+    do: selections_depth(selections, 1, fragments, MapSet.new())
 
-  defp selections_depth([], depth), do: depth
+  defp operation_depth(_, _), do: 0
 
-  defp selections_depth(selections, depth) do
+  defp selections_depth([], depth, _fragments, _seen), do: depth
+
+  defp selections_depth(selections, depth, fragments, seen) do
     selections
-    |> Enum.map(&node_depth(&1, depth))
+    |> Enum.map(&node_depth(&1, depth, fragments, seen))
     |> Enum.max(fn -> depth end)
   end
 
-  defp node_depth(%{selections: inner}, depth) when is_list(inner) and inner != [] do
-    selections_depth(inner, depth + 1)
+  # Named fragment spreads carry no inline selections; resolve them against
+  # bp_root.fragments and track visited names so a cyclic fragment graph can't
+  # make the walker loop. Without this, a query can chain spreads to reach
+  # arbitrary depth at runtime while this phase reports depth 0.
+  defp node_depth(
+         %Absinthe.Blueprint.Document.Fragment.Spread{name: name},
+         depth,
+         fragments,
+         seen
+       ) do
+    cond do
+      MapSet.member?(seen, name) ->
+        depth
+
+      fragment = Map.get(fragments, name) ->
+        selections_depth(fragment.selections, depth, fragments, MapSet.put(seen, name))
+
+      true ->
+        depth
+    end
   end
 
-  defp node_depth(_, depth), do: depth
+  defp node_depth(%{selections: inner}, depth, fragments, seen)
+       when is_list(inner) and inner != [] do
+    selections_depth(inner, depth + 1, fragments, seen)
+  end
+
+  defp node_depth(_, depth, _fragments, _seen), do: depth
 end
 
 defmodule SanbaseWeb.Graphql.Phase.Document.Complexity.Preprocess do

--- a/lib/sanbase_web/graphql/resolvers/user/user_list_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/user_list_resolver.ex
@@ -357,14 +357,20 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserListResolver do
   def update_watchlist_settings(_root, %{id: watchlist_id, settings: settings}, %{
         context: %{auth: %{current_user: current_user}}
       }) do
-    UserList.Settings.update_or_create_settings(watchlist_id, current_user.id, settings)
-    |> case do
-      {:ok, %{settings: settings}} ->
-        {:ok, settings}
+    with {:ok, watchlist} <- UserList.by_id(watchlist_id, []),
+         true <- watchlist.is_public or watchlist.user_id == current_user.id do
+      UserList.Settings.update_or_create_settings(watchlist_id, current_user.id, settings)
+      |> case do
+        {:ok, %{settings: settings}} ->
+          {:ok, settings}
 
-      {:error, %Ecto.Changeset{} = changeset} ->
-        {:error,
-         message: "Cannot update watchlist settings", details: changeset_errors(changeset)}
+        {:error, %Ecto.Changeset{} = changeset} ->
+          {:error,
+           message: "Cannot update watchlist settings", details: changeset_errors(changeset)}
+      end
+    else
+      {:error, reason} -> {:error, reason}
+      false -> {:error, "Cannot update settings for a private watchlist you do not own"}
     end
   end
 

--- a/lib/sanbase_web/graphql/resolvers/user/user_list_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/user_list_resolver.ex
@@ -357,6 +357,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserListResolver do
   def update_watchlist_settings(_root, %{id: watchlist_id, settings: settings}, %{
         context: %{auth: %{current_user: current_user}}
       }) do
+    # Settings are per-(watchlist_id, user_id) — this mutates the caller's own
+    # view preferences for the watchlist, not the watchlist's global settings.
+    # Public watchlists are readable by anyone, so anyone may store their own
+    # per-user preferences; private watchlists only by the owner.
     with {:ok, watchlist} <- UserList.by_id(watchlist_id, []),
          true <- watchlist.is_public or watchlist.user_id == current_user.id do
       UserList.Settings.update_or_create_settings(watchlist_id, current_user.id, settings)

--- a/lib/sanbase_web/graphql/resolvers/user/user_list_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/user/user_list_resolver.ex
@@ -373,8 +373,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.UserListResolver do
            message: "Cannot update watchlist settings", details: changeset_errors(changeset)}
       end
     else
-      {:error, reason} -> {:error, reason}
-      false -> {:error, "Cannot update settings for a private watchlist you do not own"}
+      # Same generic error for not-found and not-owned-private so callers can't
+      # distinguish absent IDs from private watchlists they don't own.
+      {:error, _reason} -> {:error, "Cannot update settings for this watchlist"}
+      false -> {:error, "Cannot update settings for this watchlist"}
     end
   end
 

--- a/lib/sanbase_web/graphql/resolvers/vote_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/vote_resolver.ex
@@ -248,6 +248,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.VoteResolver do
 
   def vote(_root, args, %{context: %{auth: %{current_user: user}}}) do
     with {:ok, entity, entity_id} <- only_one_entity_id?(args),
+         :ok <- verify_entity_access(entity, entity_id, user.id),
          vote_args <- args_to_vote_args(args, user) do
       case Vote.create(vote_args) do
         {:ok, vote} ->
@@ -262,6 +263,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.VoteResolver do
 
   def unvote(_root, args, %{context: %{auth: %{current_user: user}}}) do
     with {:ok, entity, entity_id} <- only_one_entity_id?(args),
+         :ok <- verify_entity_access(entity, entity_id, user.id),
          vote_args <- args_to_vote_args(args, user) do
       case Vote.downvote(vote_args) do
         {:ok, vote} ->
@@ -273,4 +275,37 @@ defmodule SanbaseWeb.Graphql.Resolvers.VoteResolver do
       end
     end
   end
+
+  # Timeline events are always public, no access check needed
+  defp verify_entity_access(:timeline_event, _entity_id, _user_id), do: :ok
+
+  # For entity types that support visibility data, check that the entity
+  # is either public or owned by the user
+  defp verify_entity_access(entity, entity_id, user_id) do
+    # Map vote entity names to the entity types used by the Entity module
+    entity_type = vote_entity_to_entity_type(entity)
+
+    case Sanbase.Entity.get_visibility_data(entity_type, entity_id) do
+      {:ok, %{user_id: ^user_id}} ->
+        :ok
+
+      {:ok, %{is_public: true}} ->
+        :ok
+
+      {:ok, _} ->
+        {:error,
+         "The entity of type #{entity} with id #{entity_id} is private and not owned by you."}
+
+      {:error, _} ->
+        {:error, "The entity of type #{entity} with id #{entity_id} does not exist."}
+    end
+  end
+
+  defp vote_entity_to_entity_type(:post), do: :insight
+  defp vote_entity_to_entity_type(:watchlist), do: :watchlist
+  defp vote_entity_to_entity_type(:chart_configuration), do: :chart_configuration
+  defp vote_entity_to_entity_type(:dashboard), do: :dashboard
+  defp vote_entity_to_entity_type(:query), do: :query
+  defp vote_entity_to_entity_type(:user_trigger), do: :user_trigger
+  defp vote_entity_to_entity_type(other), do: other
 end

--- a/lib/sanbase_web/graphql/resolvers/vote_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/vote_resolver.ex
@@ -248,7 +248,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.VoteResolver do
 
   def vote(_root, args, %{context: %{auth: %{current_user: user}}}) do
     with {:ok, entity, entity_id} <- only_one_entity_id?(args),
-         :ok <- verify_entity_access(entity, entity_id, user.id),
+         :ok <- can_vote_for_entity(entity, entity_id, user.id),
          vote_args <- args_to_vote_args(args, user) do
       case Vote.create(vote_args) do
         {:ok, vote} ->
@@ -263,7 +263,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.VoteResolver do
 
   def unvote(_root, args, %{context: %{auth: %{current_user: user}}}) do
     with {:ok, entity, entity_id} <- only_one_entity_id?(args),
-         :ok <- verify_entity_access(entity, entity_id, user.id),
+         :ok <- can_vote_for_entity(entity, entity_id, user.id),
          vote_args <- args_to_vote_args(args, user) do
       case Vote.downvote(vote_args) do
         {:ok, vote} ->
@@ -276,14 +276,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.VoteResolver do
     end
   end
 
-  # Timeline events are always public, no access check needed
-  defp verify_entity_access(:timeline_event, _entity_id, _user_id), do: :ok
-
-  # For entity types that support visibility data, check that the entity
-  # is either public or owned by the user
-  defp verify_entity_access(entity, entity_id, user_id) do
-    # Map vote entity names to the entity types used by the Entity module
-    entity_type = vote_entity_to_entity_type(entity)
+  defp can_vote_for_entity(entity, entity_id, user_id) do
+    entity_type = Sanbase.Entity.vote_entity_to_entity_type(entity)
 
     case Sanbase.Entity.get_visibility_data(entity_type, entity_id) do
       {:ok, %{user_id: ^user_id}} ->
@@ -292,20 +286,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.VoteResolver do
       {:ok, %{is_public: true}} ->
         :ok
 
-      {:ok, _} ->
+      # Merge "private and not owned" and "does not exist" into one message
+      # so an attacker cannot probe private entity IDs.
+      _ ->
         {:error,
-         "The entity of type #{entity} with id #{entity_id} is private and not owned by you."}
-
-      {:error, _} ->
-        {:error, "The entity of type #{entity} with id #{entity_id} does not exist."}
+         "The entity of type #{entity} with id #{entity_id} does not exist, " <>
+           "or is private and not owned by you."}
     end
   end
-
-  defp vote_entity_to_entity_type(:post), do: :insight
-  defp vote_entity_to_entity_type(:watchlist), do: :watchlist
-  defp vote_entity_to_entity_type(:chart_configuration), do: :chart_configuration
-  defp vote_entity_to_entity_type(:dashboard), do: :dashboard
-  defp vote_entity_to_entity_type(:query), do: :query
-  defp vote_entity_to_entity_type(:user_trigger), do: :user_trigger
-  defp vote_entity_to_entity_type(other), do: other
 end

--- a/lib/sanbase_web/graphql/resolvers/vote_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/vote_resolver.ex
@@ -280,6 +280,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.VoteResolver do
     entity_type = Sanbase.Entity.vote_entity_to_entity_type(entity)
 
     case Sanbase.Entity.get_visibility_data(entity_type, entity_id) do
+      # Hidden entities (even public ones, and even those owned by the caller)
+      # are treated as if they don't exist — voting on them would bring them
+      # back into trending/leaderboard surfaces.
+      {:ok, %{is_hidden: true}} ->
+        not_visible_error(entity, entity_id)
+
       {:ok, %{user_id: ^user_id}} ->
         :ok
 
@@ -289,9 +295,13 @@ defmodule SanbaseWeb.Graphql.Resolvers.VoteResolver do
       # Merge "private and not owned" and "does not exist" into one message
       # so an attacker cannot probe private entity IDs.
       _ ->
-        {:error,
-         "The entity of type #{entity} with id #{entity_id} does not exist, " <>
-           "or is private and not owned by you."}
+        not_visible_error(entity, entity_id)
     end
+  end
+
+  defp not_visible_error(entity, entity_id) do
+    {:error,
+     "The entity of type #{entity} with id #{entity_id} does not exist, " <>
+       "or is private and not owned by you."}
   end
 end

--- a/lib/sanbase_web/plug/bot_login_plug.ex
+++ b/lib/sanbase_web/plug/bot_login_plug.ex
@@ -13,14 +13,15 @@ defmodule SanbaseWeb.Plug.BotLoginPlug do
   def init(opts), do: opts
 
   def call(%{params: %{"path" => path}} = conn, _) do
-    case path === bot_login_endpoint() do
-      true ->
-        conn
+    expected = bot_login_endpoint()
 
-      false ->
-        conn
-        |> send_resp(403, "Unauthorized")
-        |> halt()
+    if is_binary(expected) and is_binary(path) and
+         Plug.Crypto.secure_compare(path, expected) do
+      conn
+    else
+      conn
+      |> send_resp(403, "Unauthorized")
+      |> halt()
     end
   end
 

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -377,10 +377,10 @@ defmodule SanbaseWeb.Router do
     get("/santiment_team_members/:secret", DataController, :santiment_team_members)
     get("/cryptocompare_asset_mapping", CryptocompareAssetMappingController, :data)
     post("/stripe_webhook", StripeController, :webhook)
-    post("/mailjet/webhook", MailjetController, :webhook)
+    post("/mailjet/webhook/:secret", MailjetController, :webhook)
     post("/ses/webhook/:secret", SESController, :webhook)
 
-    post("/projects_data_validator_webhook", RepoReaderController, :validator_webhook)
+    post("/projects_data_validator_webhook/:secret", RepoReaderController, :validator_webhook)
     post("/projects_data_reader_webhook/:secret", RepoReaderController, :reader_webhook)
   end
 

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -282,22 +282,24 @@ defmodule SanbaseWeb.Router do
       before_send: {SanbaseWeb.Graphql.AbsintheBeforeSend, :before_send}
     )
 
-    forward(
-      "/graphiql",
-      SanbaseWeb.Graphql.GraphiqlPlug,
-      json_codec: Jason,
-      schema: SanbaseWeb.Graphql.Schema,
-      socket: SanbaseWeb.UserSocket,
-      document_providers: [
-        SanbaseWeb.Graphql.DocumentProvider,
-        Absinthe.Plug.DocumentProvider.Default
-      ],
-      analyze_complexity: true,
-      max_complexity: 50_000,
-      interface: :santiment,
-      log_level: :info,
-      before_send: {SanbaseWeb.Graphql.AbsintheBeforeSend, :before_send}
-    )
+    if Mix.env() in [:dev, :test] do
+      forward(
+        "/graphiql",
+        SanbaseWeb.Graphql.GraphiqlPlug,
+        json_codec: Jason,
+        schema: SanbaseWeb.Graphql.Schema,
+        socket: SanbaseWeb.UserSocket,
+        document_providers: [
+          SanbaseWeb.Graphql.DocumentProvider,
+          Absinthe.Plug.DocumentProvider.Default
+        ],
+        analyze_complexity: true,
+        max_complexity: 50_000,
+        interface: :santiment,
+        log_level: :info,
+        before_send: {SanbaseWeb.Graphql.AbsintheBeforeSend, :before_send}
+      )
+    end
   end
 
   scope "/", SanbaseWeb do

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -282,24 +282,22 @@ defmodule SanbaseWeb.Router do
       before_send: {SanbaseWeb.Graphql.AbsintheBeforeSend, :before_send}
     )
 
-    if Mix.env() in [:dev, :test] do
-      forward(
-        "/graphiql",
-        SanbaseWeb.Graphql.GraphiqlPlug,
-        json_codec: Jason,
-        schema: SanbaseWeb.Graphql.Schema,
-        socket: SanbaseWeb.UserSocket,
-        document_providers: [
-          SanbaseWeb.Graphql.DocumentProvider,
-          Absinthe.Plug.DocumentProvider.Default
-        ],
-        analyze_complexity: true,
-        max_complexity: 50_000,
-        interface: :santiment,
-        log_level: :info,
-        before_send: {SanbaseWeb.Graphql.AbsintheBeforeSend, :before_send}
-      )
-    end
+    forward(
+      "/graphiql",
+      SanbaseWeb.Graphql.GraphiqlPlug,
+      json_codec: Jason,
+      schema: SanbaseWeb.Graphql.Schema,
+      socket: SanbaseWeb.UserSocket,
+      document_providers: [
+        SanbaseWeb.Graphql.DocumentProvider,
+        Absinthe.Plug.DocumentProvider.Default
+      ],
+      analyze_complexity: true,
+      max_complexity: 50_000,
+      interface: :santiment,
+      log_level: :info,
+      before_send: {SanbaseWeb.Graphql.AbsintheBeforeSend, :before_send}
+    )
   end
 
   scope "/", SanbaseWeb do

--- a/test/sanbase_web/controller/metric_registry_controller_test.exs
+++ b/test/sanbase_web/controller/metric_registry_controller_test.exs
@@ -1,0 +1,54 @@
+defmodule SanbaseWeb.MetricRegistryControllerTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  alias Sanbase.Utils.Config
+
+  setup do
+    secret = Config.module_get(Sanbase.Metric.Registry.Sync, :export_secret)
+    %{secret: secret}
+  end
+
+  describe "GET /metric_registry_export" do
+    test "returns JSONL of all registry entries when secret is valid", %{
+      conn: conn,
+      secret: secret
+    } do
+      body =
+        conn
+        |> get("/metric_registry_export", %{"secret" => secret})
+        |> response(200)
+
+      entries =
+        body
+        |> String.split("\n", trim: true)
+        |> Enum.map(&Jason.decode!/1)
+
+      assert length(entries) > 1
+      assert Enum.all?(entries, &is_map/1)
+      assert Enum.all?(entries, &Map.has_key?(&1, "metric"))
+      assert Enum.all?(entries, &Map.has_key?(&1, "internal_metric"))
+    end
+
+    test "returns 403 without secret", %{conn: conn} do
+      conn
+      |> get("/metric_registry_export")
+      |> response(403)
+    end
+
+    test "returns 403 with wrong secret", %{conn: conn} do
+      conn
+      |> get("/metric_registry_export", %{"secret" => "not_the_secret"})
+      |> response(403)
+    end
+
+    test "does not accept sync_secret", %{conn: conn} do
+      sync_secret = Config.module_get(Sanbase.Metric.Registry.Sync, :sync_secret)
+      export_secret = Config.module_get(Sanbase.Metric.Registry.Sync, :export_secret)
+      assert sync_secret != export_secret
+
+      conn
+      |> get("/metric_registry_export", %{"secret" => sync_secret})
+      |> response(403)
+    end
+  end
+end

--- a/test/sanbase_web/controller/repo_reader_controller_test.exs
+++ b/test/sanbase_web/controller/repo_reader_controller_test.exs
@@ -18,7 +18,7 @@ defmodule SanbaseWeb.RepoReaderControllerTest do
       |> Sanbase.Mock.run_with_mocks(fn ->
         assert %{"error" => error} =
                  context.conn
-                 |> post("/projects_data_validator_webhook", %{
+                 |> post("/projects_data_validator_webhook/#{context.secret}", %{
                    "fork_repo" => "not_santiment/projects",
                    "branch" => "some_branch",
                    "changed_files" => "projects/santiment/data.json"
@@ -36,7 +36,7 @@ defmodule SanbaseWeb.RepoReaderControllerTest do
       |> Sanbase.Mock.run_with_mocks(fn ->
         assert %{"error" => error} =
                  context.conn
-                 |> post("/projects_data_validator_webhook", %{
+                 |> post("/projects_data_validator_webhook/#{context.secret}", %{
                    "fork_repo" => "not_santiment/projects",
                    "branch" => "some_branch",
                    "changed_files" => "projects/santiment/data.json"
@@ -53,7 +53,7 @@ defmodule SanbaseWeb.RepoReaderControllerTest do
       end)
       |> Sanbase.Mock.run_with_mocks(fn ->
         context.conn
-        |> post("/projects_data_validator_webhook", %{
+        |> post("/projects_data_validator_webhook/#{context.secret}", %{
           "fork_repo" => "not_santiment/projects",
           "branch" => "some_branch",
           "changed_files" => "projects/santiment/data.json"
@@ -70,7 +70,7 @@ defmodule SanbaseWeb.RepoReaderControllerTest do
       |> Sanbase.Mock.run_with_mocks(fn ->
         assert %{"error" => error} =
                  context.conn
-                 |> post("/projects_data_validator_webhook", %{
+                 |> post("/projects_data_validator_webhook/#{context.secret}", %{
                    "fork_repo" => "not_santiment/projects",
                    "branch" => "some_branch",
                    "changed_files" => "projects/santiment/data.json"
@@ -89,7 +89,7 @@ defmodule SanbaseWeb.RepoReaderControllerTest do
       |> Sanbase.Mock.run_with_mocks(fn ->
         assert %{"error" => error} =
                  context.conn
-                 |> post("/projects_data_validator_webhook", %{
+                 |> post("/projects_data_validator_webhook/#{context.secret}", %{
                    "fork_repo" => "not_santiment/projects",
                    "branch" => "some_branch",
                    "changed_files" => "projects/santiment/data.json"
@@ -108,7 +108,7 @@ defmodule SanbaseWeb.RepoReaderControllerTest do
       |> Sanbase.Mock.run_with_mocks(fn ->
         assert %{"error" => error} =
                  context.conn
-                 |> post("/projects_data_validator_webhook", %{
+                 |> post("/projects_data_validator_webhook/#{context.secret}", %{
                    "fork_repo" => "not_santiment/projects",
                    "branch" => "some_branch",
                    "changed_files" => "projects/santiment/data.json"

--- a/test/sanbase_web/controllers/auth_controller_test.exs
+++ b/test/sanbase_web/controllers/auth_controller_test.exs
@@ -210,5 +210,58 @@ defmodule SanbaseWeb.AuthControllerTest do
       assert AuthController.validate_redirect_url("sanbase://user:pass@home") ==
                {:error, "Invalid redirect URL"}
     end
+
+    test "rejects non-binary input" do
+      assert AuthController.validate_redirect_url(nil) == {:error, "Invalid redirect URL"}
+      assert AuthController.validate_redirect_url(123) == {:error, "Invalid redirect URL"}
+      assert AuthController.validate_redirect_url(%{}) == {:error, "Invalid redirect URL"}
+    end
+
+    @tag capture_log: true
+    test "rejects oversized URLs" do
+      oversized = "https://app.santiment.net/" <> String.duplicate("a", 3000)
+
+      assert AuthController.validate_redirect_url(oversized) ==
+               {:error, "Invalid redirect URL"}
+    end
+
+    @tag capture_log: true
+    test "rejects URLs with control characters (CRLF / NUL / tab)" do
+      for payload <- [
+            "https://app.santiment.net/\r\nInjected-Header: x",
+            "https://app.santiment.net/\npath",
+            "sanbase://home\0",
+            "sanbase://home\t"
+          ] do
+        assert AuthController.validate_redirect_url(payload) ==
+                 {:error, "Invalid redirect URL"}
+      end
+    end
+
+    @tag capture_log: true
+    test "rejects empty-host sanbase URLs" do
+      assert AuthController.validate_redirect_url("sanbase://") ==
+               {:error, "Invalid redirect URL"}
+
+      assert AuthController.validate_redirect_url("sanbase:") ==
+               {:error, "Invalid redirect URL"}
+    end
+
+    @tag capture_log: true
+    test "rejects sanbase:// URLs with explicit port" do
+      assert AuthController.validate_redirect_url("sanbase://home:8080") ==
+               {:error, "Invalid redirect URL"}
+    end
+
+    @tag capture_log: true
+    test "rejects https URLs with non-default port" do
+      assert AuthController.validate_redirect_url("https://app.santiment.net:8080/path") ==
+               {:error, "Invalid redirect URL"}
+    end
+
+    test "accepts https URLs with explicit 443 port" do
+      assert AuthController.validate_redirect_url("https://app.santiment.net:443/dashboard") ==
+               true
+    end
   end
 end

--- a/test/sanbase_web/controllers/auth_controller_test.exs
+++ b/test/sanbase_web/controllers/auth_controller_test.exs
@@ -219,7 +219,7 @@ defmodule SanbaseWeb.AuthControllerTest do
 
     @tag capture_log: true
     test "rejects oversized URLs" do
-      oversized = "https://app.santiment.net/" <> String.duplicate("a", 3000)
+      oversized = "https://app.santiment.net/" <> String.duplicate("a", 5000)
 
       assert AuthController.validate_redirect_url(oversized) ==
                {:error, "Invalid redirect URL"}

--- a/test/sanbase_web/controllers/auth_controller_test.exs
+++ b/test/sanbase_web/controllers/auth_controller_test.exs
@@ -189,5 +189,11 @@ defmodule SanbaseWeb.AuthControllerTest do
       assert AuthController.validate_redirect_url("//example.com") ==
                {:error, "Invalid redirect URL"}
     end
+
+    @tag capture_log: true
+    test "rejects URLs with userinfo component (credential-based open redirect)" do
+      assert AuthController.validate_redirect_url("https://evil.com@app.santiment.net/callback") ==
+               {:error, "Invalid redirect URL"}
+    end
   end
 end

--- a/test/sanbase_web/controllers/auth_controller_test.exs
+++ b/test/sanbase_web/controllers/auth_controller_test.exs
@@ -195,5 +195,20 @@ defmodule SanbaseWeb.AuthControllerTest do
       assert AuthController.validate_redirect_url("https://evil.com@app.santiment.net/callback") ==
                {:error, "Invalid redirect URL"}
     end
+
+    @tag capture_log: true
+    test "rejects sanbase:// URLs whose host looks like a real domain" do
+      assert AuthController.validate_redirect_url("sanbase://evil.com/steal-tokens") ==
+               {:error, "Invalid redirect URL"}
+
+      assert AuthController.validate_redirect_url("sanbase://attacker.example/x") ==
+               {:error, "Invalid redirect URL"}
+    end
+
+    @tag capture_log: true
+    test "rejects sanbase:// URLs with userinfo" do
+      assert AuthController.validate_redirect_url("sanbase://user:pass@home") ==
+               {:error, "Invalid redirect URL"}
+    end
   end
 end

--- a/test/sanbase_web/controllers/mailjet_controller_test.exs
+++ b/test/sanbase_web/controllers/mailjet_controller_test.exs
@@ -17,6 +17,20 @@ defmodule SanbaseWeb.MailjetControllerTest do
     end)
   end
 
+  describe "webhook authentication" do
+    @tag capture_log: true
+    test "rejects requests without a valid secret", %{conn: conn} do
+      params = %{
+        "event" => "unsub",
+        "email" => "test@example.com",
+        "mj_list_id" => 10_327_883
+      }
+
+      conn = post(conn, ~p"/mailjet/webhook/wrong_secret", params)
+      assert response(conn, 403) == "Forbidden"
+    end
+  end
+
   describe "webhook/2" do
     setup do
       user = insert(:user, email: "test@example.com")
@@ -50,7 +64,7 @@ defmodule SanbaseWeb.MailjetControllerTest do
         "CustomID" => "helloworld"
       }
 
-      conn = post(conn, ~p"/mailjet/webhook", params)
+      conn = post(conn, ~p"/mailjet/webhook/test_mailjet_secret", params)
 
       # Check that we got a 200 OK response
       assert response(conn, 200) == ""
@@ -71,7 +85,7 @@ defmodule SanbaseWeb.MailjetControllerTest do
         "mj_list_id" => 10_327_883
       }
 
-      conn = post(conn, ~p"/mailjet/webhook", params)
+      conn = post(conn, ~p"/mailjet/webhook/test_mailjet_secret", params)
       assert response(conn, 200) == ""
 
       # Missing event type
@@ -80,7 +94,7 @@ defmodule SanbaseWeb.MailjetControllerTest do
         "mj_list_id" => 10_327_883
       }
 
-      conn = post(conn, ~p"/mailjet/webhook", params)
+      conn = post(conn, ~p"/mailjet/webhook/test_mailjet_secret", params)
       assert response(conn, 200) == ""
 
       # Wrong event type
@@ -90,7 +104,7 @@ defmodule SanbaseWeb.MailjetControllerTest do
         "mj_list_id" => 10_327_883
       }
 
-      conn = post(conn, ~p"/mailjet/webhook", params)
+      conn = post(conn, ~p"/mailjet/webhook/test_mailjet_secret", params)
       assert response(conn, 200) == ""
     end
 
@@ -102,7 +116,7 @@ defmodule SanbaseWeb.MailjetControllerTest do
         "mj_list_id" => 10_327_883
       }
 
-      conn = post(conn, ~p"/mailjet/webhook", params)
+      conn = post(conn, ~p"/mailjet/webhook/test_mailjet_secret", params)
       assert response(conn, 200) == ""
     end
 
@@ -114,7 +128,7 @@ defmodule SanbaseWeb.MailjetControllerTest do
         "mj_list_id" => 99999
       }
 
-      conn = post(conn, ~p"/mailjet/webhook", params)
+      conn = post(conn, ~p"/mailjet/webhook/test_mailjet_secret", params)
       assert response(conn, 200) == ""
     end
   end

--- a/test/sanbase_web/graphql/document/max_depth_test.exs
+++ b/test/sanbase_web/graphql/document/max_depth_test.exs
@@ -1,0 +1,111 @@
+defmodule SanbaseWeb.Graphql.Phase.Document.Validation.MaxDepthTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  @max_depth 15
+
+  # Build an introspection query whose selection nesting is exactly `depth`.
+  # Shape: { __schema { types { fields { type { ofType { ... { name } } } } } } }
+  # Top-level `__schema` counts as depth 1; every nested field adds 1; the leaf
+  # scalar `name` ends at `depth`.
+  defp nested_query(depth) when depth >= 2 do
+    # 4 levels before the ofType chain: __schema, types, fields, type
+    # then `depth - 4 - 1` ofType wrappers, then `name` as the scalar at `depth`.
+    of_type_levels = depth - 5
+    opens = String.duplicate("ofType { ", of_type_levels)
+    closes = String.duplicate(" }", of_type_levels)
+
+    """
+    query {
+      __schema {
+        types {
+          fields {
+            type {
+              #{opens}name#{closes}
+            }
+          }
+        }
+      }
+    }
+    """
+  end
+
+  # Same shape as `nested_query/1` but the inner chain lives inside a named
+  # fragment, so the walker must resolve the spread to measure true depth.
+  # Before the fix, the spread was treated as a leaf and this query was
+  # mis-measured as depth 2.
+  defp fragment_query(depth) when depth >= 2 do
+    of_type_levels = depth - 5
+    opens = String.duplicate("ofType { ", of_type_levels)
+    closes = String.duplicate(" }", of_type_levels)
+
+    """
+    query {
+      __schema {
+        ...SchemaFrag
+      }
+    }
+
+    fragment SchemaFrag on __Schema {
+      types {
+        fields {
+          type {
+            #{opens}name#{closes}
+          }
+        }
+      }
+    }
+    """
+  end
+
+  test "query at max depth is accepted by the depth phase", %{conn: conn} do
+    conn = post(conn, "/graphql", %{"query" => nested_query(@max_depth)})
+    errors = json_response(conn, 200)["errors"] || []
+
+    refute Enum.any?(errors, &String.contains?(&1["message"] || "", "maximum nesting depth"))
+  end
+
+  test "query exceeding max depth is rejected", %{conn: conn} do
+    conn = post(conn, "/graphql", %{"query" => nested_query(@max_depth + 1)})
+
+    assert %{"errors" => errors} = json_response(conn, 200)
+    assert Enum.any?(errors, &String.contains?(&1["message"], "maximum nesting depth of 15"))
+  end
+
+  test "named fragment spread cannot bypass the depth cap", %{conn: conn} do
+    conn = post(conn, "/graphql", %{"query" => fragment_query(@max_depth + 1)})
+
+    assert %{"errors" => errors} = json_response(conn, 200)
+    assert Enum.any?(errors, &String.contains?(&1["message"], "maximum nesting depth of 15"))
+  end
+
+  test "cyclic fragment graph terminates without stack overflow", %{conn: conn} do
+    # F1 -> F2 -> F1 with finite inline nesting in each. The walker must mark
+    # visited fragments; otherwise this recurses until the process dies.
+    query = """
+    query {
+      __schema {
+        ...F1
+      }
+    }
+
+    fragment F1 on __Schema {
+      types {
+        ...F2
+      }
+    }
+
+    fragment F2 on __Type {
+      fields {
+        type {
+          ...F1
+        }
+      }
+    }
+    """
+
+    # Must return a response at all (no timeout / crash). We don't assert on
+    # accept vs reject — only that the phase terminates.
+    conn = post(conn, "/graphql", %{"query" => query})
+    assert is_map(json_response(conn, 200))
+  end
+end

--- a/test/sanbase_web/graphql/entity/entity_public_trigger_test.exs
+++ b/test/sanbase_web/graphql/entity/entity_public_trigger_test.exs
@@ -54,6 +54,30 @@ defmodule SanbaseWeb.Graphql.EntityPublicTriggerTest do
 
       assert_public_trigger_shape(trigger, user_trigger)
     end
+
+    test "hidden triggers cannot be unvoted even if they were voted before hiding", context do
+      %{conn: conn, user_trigger: user_trigger} = context
+
+      vote(conn, user_trigger.id)
+
+      user_trigger
+      |> Ecto.Changeset.change(is_hidden: true)
+      |> Sanbase.Repo.update!()
+
+      mutation = """
+      mutation {
+        unvote(userTriggerId: #{user_trigger.id}) {
+          votes{ totalVotes }
+        }
+      }
+      """
+
+      error = execute_mutation_with_error(conn, mutation)
+
+      assert error ==
+               "The entity of type user_trigger with id #{user_trigger.id} does not exist, " <>
+                 "or is private and not owned by you."
+    end
   end
 
   describe "public_user_trigger does not leak private user data" do

--- a/test/sanbase_web/graphql/insight/insight_voting_api_test.exs
+++ b/test/sanbase_web/graphql/insight/insight_voting_api_test.exs
@@ -98,6 +98,34 @@ defmodule Sanbase.InsihgtVotingApiTest do
     assert total_votes == 0
   end
 
+  test "cannot vote on a draft/unpublished insight", context do
+    %{user: user} = context
+    draft_insight = insert(:post, state: Post.approved_state(), ready_state: "draft", user: user)
+
+    other_user = insert(:user)
+    other_conn = setup_jwt_auth(build_conn(), other_user)
+
+    result = vote_raw(other_conn, draft_insight)
+
+    assert %{"errors" => [%{"message" => message}]} = result
+    assert message =~ "private" or message =~ "does not exist"
+  end
+
+  defp vote_raw(conn, %{id: insight_id}) do
+    mutation = """
+    mutation {
+      vote(insightId: #{insight_id}){
+        votes{ totalVotes currentUserVotes totalVoters }
+        votedAt
+      }
+    }
+    """
+
+    conn
+    |> post("/graphql", mutation_skeleton(mutation))
+    |> json_response(200)
+  end
+
   defp get_votes(conn, %{id: insight_id}) do
     query = """
     {

--- a/test/sanbase_web/graphql/timeline/timeline_event_api_test.exs
+++ b/test/sanbase_web/graphql/timeline/timeline_event_api_test.exs
@@ -361,6 +361,18 @@ defmodule SanbaseWeb.Graphql.TimelineEventApiTest do
       assert result["votes"] == %{"currentUserVotes" => 0, "totalVoters" => 0, "totalVotes" => 0}
       assert result["votedAt"] == nil
     end
+
+    test "private timeline events are not votable by other users", context do
+      private_owner = insert(:user)
+      {timeline_event, _user_trigger} = create_timeline_event(private_owner, false)
+      mutation = upvote_timeline_event_mutation(timeline_event.id)
+
+      error = execute_mutation_with_error(context.conn, mutation)
+
+      assert error ==
+               "The entity of type timeline_event with id #{timeline_event.id} does not exist, " <>
+                 "or is private and not owned by you."
+    end
   end
 
   describe "order timeline events" do
@@ -823,12 +835,12 @@ defmodule SanbaseWeb.Graphql.TimelineEventApiTest do
     """
   end
 
-  defp create_timeline_event(user) do
+  defp create_timeline_event(user, is_public \\ true) do
     user_trigger =
       insert(:user_trigger,
         user: user,
         trigger: %{
-          is_public: true,
+          is_public: is_public,
           settings: default_trigger_settings_string_keys(),
           title: "my trigger",
           description: "DAA going up 300%"

--- a/test/sanbase_web/graphql/watchlist/project/watchlist_settings_api_test.exs
+++ b/test/sanbase_web/graphql/watchlist/project/watchlist_settings_api_test.exs
@@ -35,6 +35,23 @@ defmodule SanbaseWeb.Graphql.WatchlistSettingsApiTest do
     assert settings == nil
   end
 
+  test "cannot update settings of another user's private watchlist", %{
+    conn: conn,
+    conn2: conn2
+  } do
+    %{"id" => watchlist_id} = create_watchlist(conn, title: rand_str(), is_public: false)
+
+    result =
+      update_watchlist_settings(conn2, watchlist_id,
+        page_size: 50,
+        time_window: "60d",
+        table_columns: %{}
+      )
+
+    assert %{"errors" => [%{"message" => message}]} = result
+    assert message =~ "private watchlist"
+  end
+
   test "validate page size", %{conn: conn} do
     %{"id" => watchlist_id} = create_watchlist(conn, title: rand_str())
 

--- a/test/sanbase_web/graphql/watchlist/project/watchlist_settings_api_test.exs
+++ b/test/sanbase_web/graphql/watchlist/project/watchlist_settings_api_test.exs
@@ -49,7 +49,7 @@ defmodule SanbaseWeb.Graphql.WatchlistSettingsApiTest do
       )
 
     assert %{"errors" => [%{"message" => message}]} = result
-    assert message =~ "private watchlist"
+    assert message == "Cannot update settings for this watchlist"
   end
 
   test "validate page size", %{conn: conn} do


### PR DESCRIPTION
## Summary

A batch of security and authorization hardening across authentication,
webhooks, GraphQL, admin surfaces, and logging. Several changes were
iterated on during review; the list below reflects the final state
(revert/restore pairs are collapsed into the net change).

## Authentication & tokens

- **Bot login**: constant-time comparison of the shared secret on the
  `/:secret` path; response now carries `Cache-Control: no-store` /
  `Pragma: no-cache`. Body is left as the bare access token
  (`text/plain`) for backwards compatibility.
- **OAuth deny**: reject `client_id` that isn't a canonical 8-4-4-4-12
  UUID string before touching the DB (also rejects raw 16-byte binaries
  that `Ecto.UUID.cast/1` would otherwise accept).
- **Admin invoice download**: restricted to Admin Panel Owners.

## Redirect URL validation (`validate_redirect_url/1`)

- Reject non-binary, oversized (>4096 B), and control-char URLs up
  front.
- `sanbase://` scheme: validate the host component as a deeplink action
  (alphanumeric/underscore/dash, no dots, no userinfo/port).
- `https://` scheme: require host in allow-list (case-insensitive),
  port in `[nil, 443]`, no userinfo.
- Warning log scrubs `userinfo`/`query`/`fragment` before emitting.

## Webhooks & public endpoints

- **Mailjet** (`/mailjet/webhook/:secret`): path-scoped shared secret,
  constant-time compare, fail-closed when env var missing. `"secret"` is
  stripped from params before handler dispatch, and `inspect(params)` no
  longer appears in warning logs.
- **Projects-data validator & reader** (`.../:secret`): same path-scoped
  secret pattern; reader webhook only logs params after the auth check.
- **Santiment-team-members** endpoint: removed the `"random_secret"`
  fallback — missing env var now yields 403 instead of a public literal.
- **SNS (SES controller)**: `SubscribeURL` host must now match
  `sns.*.amazonaws.com`, not any `*.amazonaws.com` (previously an
  unauthenticated caller could steer the backend's outbound GET to any
  AWS-hosted subdomain).
- **Metric registry**
  - `GET /metric_registry_export` now requires `?secret=...` guarded by
    a **separate** `METRIC_REGISTRY_EXPORT_SECRET` (the
    dev-facing read-only secret is decoupled from the
    prod-write `METRIC_REGISTRY_SYNC_SECRET`).
  - Fixed a pre-existing crash in the export handler (missing
    JSON-encoding + `Enum.take(1)` artifact); now returns all rows
    as `application/x-ndjson`.
  - All three endpoints (`sync`, `mark_sync_as_completed`, `export_json`)
    route through a binary-guarded `valid_secret?/2` so non-string
    `secret` params return 403 instead of crashing with
    `FunctionClauseError` (500).

## GraphQL

- **Query depth cap**: reject documents whose nesting exceeds 15.
  Walker resolves named fragment spreads against `bp_root.fragments`
  with a `MapSet` cycle guard, so spread chains can't trivially
  bypass the cap.
- **Watchlist settings** (`updateUserListSettings`): verify the
  watchlist exists and is either public or owned by the caller before
  touching the per-user settings row; error messages unified between
  "not found" and "private, not owned" to avoid existence leakage.
- **Vote authorization** (`VoteResolver`):
  - `verify_entity_access` → `can_vote_for_entity`; per-entity dispatch
    centralized into `Sanbase.Entity` via `vote_entity_to_entity_type/1`.
  - Hidden entities (including public-but-hidden and caller-owned-but-
    hidden) are rejected before the public-visibility acceptance branch.
- **Timeline-event visibility** (`Sanbase.Entity.get_visibility_data/2`):
  previously returned a hardcoded `{:ok, %{is_public: true}}` for any
  timeline event ID, including nonexistent ones. Now resolves through
  the backing entity (`post_id` / `user_list_id` / `user_trigger_id`)
  so a timeline event for a private watchlist/trigger no longer
  becomes votable.
- **`UserTrigger.get_visibility_data/1`**: collapsed to a single SQL
  query with a JSON-embed fragment instead of materialising the full
  struct + embedded trigger. Non-integer IDs return an error tuple
  instead of raising.

## WebSocket origin (`SanbaseWeb.Endpoint`)

- `check_origin` was being passed at the socket top-level where Phoenix
  silently ignored it, so the endpoint-level `check_origin: false`
  (inherited from dev config) was winning in every environment. Moved
  it **inside** the `websocket:` option for both `/socket` and `/live`,
  with an explicit allow-list (`*.santiment.net`, `*.santiment.network`,
  `*.sanr.app`, `localhost`). This was a functional CSWSH vulnerability
  even though the code looked correct.

## Logging hygiene

- Dropped `api_token` from the global Logger metadata allow-list so
  authenticated request logs no longer echo the token.
- Trimmed OAuth log verbosity (dropped `all params:` dumps).
- Stripe webhook no longer logs full event bodies.


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened webhook and endpoint authentication (secrets required, secure comparisons); added authorization for invoice downloads and watchlist changes; vote actions blocked on private/hidden items.
  * Tightened redirect URL validation, SNS URL checks, and websocket origin restrictions.

* **API Changes**
  * Metric registry export now authenticated and returns newline-delimited JSON; webhook routes require secret path segments.

* **Configuration**
  * Removed sensitive token from console logs; bot login responses now disable caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->