### PR TITLE
Make Quantum jobs run only on the local node

### DIFF
--- a/config/scheduler_config.exs
+++ b/config/scheduler_config.exs
@@ -6,6 +6,10 @@ config :sanbase, Sanbase.Alerts.Scheduler,
   scheduler_enabled: {:system, "QUANTUM_SCHEDULER_ENABLED", false},
   timeout: 30_000,
   overlap: false,
+  # Run every job on the local node only. Without this, Quantum's default
+  # strategy distributes jobs randomly across all connected cluster nodes
+  # (web/admin pods), which do not have the scheduler modules available.
+  run_strategy: {Quantum.RunStrategy.Local, []},
   jobs: [
     monitor_excessive_sanbase_usage: [
       schedule: "0 * * * *",
@@ -65,6 +69,7 @@ config :sanbase, Sanbase.Scrapers.Scheduler,
   scheduler_enabled: {:system, "QUANTUM_SCHEDULER_ENABLED", false},
   timeout: 30_000,
   overlap: false,
+  run_strategy: {Quantum.RunStrategy.Local, []},
   jobs: [
     update_api_call_limit_plans: [
       schedule: "@daily",


### PR DESCRIPTION
## Changes

Commit 460b59faa (Jan 19) started libcluster in alerts pod. Signals pod now joins sanbase-web + sanbase-admin pods via postgres topology.
Quantum 3.5.3 default `run_strategy =  {Random, :cluster}` which picks random node from cluster each tick. When Quantum picks sanbase-web or sanbase-admin pod (which may be rotating / not have the module / unreachable in that instant), jobs can fail
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
