### PR TITLE
Add lookback_days option to get_available_metrics_for_selector

### DIFF
--- a/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
@@ -86,9 +86,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
 
   def get_available_metrics_for_selector(_root, args, resolution) do
     user_metric_access_level = resolution_to_metric_access_level(resolution)
+    lookback_days = resolution_to_available_metrics_lookback_days(resolution)
 
     case Metric.available_metrics_for_selector(args.selector,
-           user_metric_access_level: user_metric_access_level
+           user_metric_access_level: user_metric_access_level,
+           lookback_days: lookback_days
          ) do
       {:ok, metrics} ->
         metrics = maybe_apply_regex_filter(metrics, args[:name_regex_filter])
@@ -665,6 +667,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   defp resolution_to_metric_access_level(resolution) do
     get_in(resolution.context, [:auth, :current_user, Access.key(:metric_access_level)]) ||
       "released"
+  end
+
+  defp resolution_to_available_metrics_lookback_days(resolution) do
+    get_in(resolution.context, [
+      :auth,
+      :current_user,
+      Access.key(:available_metrics_lookback_days)
+    ])
   end
 
   defp user_can_access_version?(version, resolution) do

--- a/lib/sanbase_web/graphql/schema/queries/metric_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/metric_queries.ex
@@ -49,7 +49,10 @@ defmodule SanbaseWeb.Graphql.Schema.MetricQueries do
       """
       arg(:name_regex_filter, :string, default_value: nil)
 
-      cache_resolve(&MetricResolver.get_available_metrics_for_selector/3, ttl: 300)
+      cache_resolve(&MetricResolver.get_available_metrics_for_selector/3,
+        ttl: 300,
+        include_user_details_in_key: true
+      )
     end
   end
 end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Available metrics are now personalized based on user-specific lookback periods, ensuring relevant metric suggestions tailored to individual users.

* **Performance**
  * Improved caching for metric availability queries to deliver faster, user-specific results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->