### PR TITLE
Fix alert webhook without proper URL error

### DIFF
--- a/lib/sanbase/accounts/user/alert.ex
+++ b/lib/sanbase/accounts/user/alert.ex
@@ -26,10 +26,19 @@ defmodule Sanbase.Accounts.User.Alert do
     user = Sanbase.Repo.preload(user, :user_settings)
     settings = UserSettings.settings_for(user)
 
-    valid_webhook_url? = match?(:ok, Sanbase.Utils.Validation.valid_url?(webhook_url))
+    valid_webhook_url? = match?(:ok, Sanbase.Utils.Validation.valid_public_url?(webhook_url))
     alert_limit_reached? = daily_limit_reached?(settings, "webhook")
 
     valid_webhook_url? and not alert_limit_reached?
+  end
+
+  def can_receive_telegram_channel_alert?(user, chat_id) do
+    user = Sanbase.Repo.preload(user, :user_settings)
+    settings = UserSettings.settings_for(user)
+
+    alert_limit_reached? = daily_limit_reached?(settings, "telegram_channel")
+
+    is_binary(chat_id) and chat_id != "" and not alert_limit_reached?
   end
 
   defp daily_limit_reached?(%{} = settings, channel) when is_binary(channel) do

--- a/lib/sanbase/alerts/alert.ex
+++ b/lib/sanbase/alerts/alert.ex
@@ -49,6 +49,32 @@ defimpl Sanbase.Alert, for: Any do
 
   defp send_to_channel("web_push", _user_trigger, _max_alerts_to_send), do: {"web_push", []}
 
+  defp send_to_channel(channel, user_trigger, _max_alerts_to_send) do
+    %{
+      id: trigger_id,
+      user: %User{id: user_id},
+      trigger: %{settings: %{payload: payload_map}}
+    } = user_trigger
+
+    Logger.error(
+      "Unsupported alert notification channel #{inspect(channel)} for user_trigger_id=#{trigger_id} user_id=#{user_id}"
+    )
+
+    error_list =
+      Enum.map(payload_map, fn {identifier, _payload} ->
+        {identifier,
+         {:error,
+          %{
+            reason: :unsupported_notification_channel,
+            channel: channel,
+            user_id: user_id,
+            trigger_id: trigger_id
+          }}}
+      end)
+
+    {"unknown", error_list}
+  end
+
   defp send_webhook(
          trigger,
          webhook_url,
@@ -57,7 +83,7 @@ defimpl Sanbase.Alert, for: Any do
     %{id: user_trigger_id} = trigger
 
     fun = fn identifier, payload ->
-      case Sanbase.Utils.Validation.valid_url?(webhook_url) do
+      case Sanbase.Utils.Validation.valid_public_url?(webhook_url) do
         :ok ->
           payload = transform_payload(payload, trigger.id, :webhook)
           do_send_webhook(webhook_url, identifier, payload, user_trigger_id)

--- a/lib/sanbase/alerts/evaluator/scheduler.ex
+++ b/lib/sanbase/alerts/evaluator/scheduler.ex
@@ -233,29 +233,11 @@ defmodule Sanbase.Alert.Scheduler do
     %{type: type, run_uuid: run_uuid} = info_map
 
     filtered =
-      Enum.filter(user_triggers, fn %{trigger: trigger, user: user} ->
+      Enum.filter(user_triggers, fn %{trigger: trigger, user: user} = ut ->
         channels = List.wrap(trigger.settings.channel)
 
         channels != [] and
-          Enum.any?(channels, fn
-            "email" ->
-              User.Alert.can_receive_email_alert?(user)
-
-            "telegram" ->
-              User.Alert.can_receive_telegram_alert?(user)
-
-            %{"webhook" => webhook_url} ->
-              User.Alert.can_receive_webhook_alert?(user, webhook_url)
-
-            "web_push" ->
-              # web push cannot be received currently. So if the other channels
-              # like telegram and email are not receivable, then the presence of
-              # web push should not cause scheduling of the alert
-              false
-
-            _ ->
-              true
-          end)
+          Enum.any?(channels, &channel_receivable?(&1, user, ut))
       end)
 
     total_count = length(user_triggers)
@@ -271,6 +253,38 @@ defmodule Sanbase.Alert.Scheduler do
     end
 
     filtered
+  end
+
+  # web push cannot be received currently, so its presence alone is not enough
+  # to schedule the alert.
+  defp channel_receivable?("email", user, _ut), do: User.Alert.can_receive_email_alert?(user)
+
+  defp channel_receivable?("telegram", user, _ut),
+    do: User.Alert.can_receive_telegram_alert?(user)
+
+  defp channel_receivable?("web_push", _user, _ut), do: false
+
+  defp channel_receivable?(%{"webhook" => url}, user, _ut),
+    do: User.Alert.can_receive_webhook_alert?(user, url)
+
+  defp channel_receivable?(%{webhook: url}, user, _ut),
+    do: User.Alert.can_receive_webhook_alert?(user, url)
+
+  defp channel_receivable?(%{"telegram_channel" => chat_id}, user, _ut),
+    do: User.Alert.can_receive_telegram_channel_alert?(user, chat_id)
+
+  defp channel_receivable?(%{telegram_channel: chat_id}, user, _ut),
+    do: User.Alert.can_receive_telegram_channel_alert?(user, chat_id)
+
+  # Bare "webhook" / "telegram_channel" strings or any other unknown channel
+  # cannot deliver — no URL / chat id to send to. Skip evaluation entirely so
+  # the alert does not waste resources or crash later in send_to_channel/3.
+  defp channel_receivable?(channel, _user, ut) do
+    Logger.warning(
+      "Skipping alert evaluation: unsupported notification channel #{inspect(channel)} for user_trigger_id=#{ut.id}"
+    )
+
+    false
   end
 
   defp deactivate_non_repeating(triggers) do

--- a/lib/sanbase/alerts/trigger/validation/notification_channel_validation.ex
+++ b/lib/sanbase/alerts/trigger/validation/notification_channel_validation.ex
@@ -1,14 +1,15 @@
 defmodule Sanbase.Alert.Validation.NotificationChannel do
   @notification_channels ["telegram_channel", "telegram", "email", "web_push", "webhook"]
+  @bare_string_channels ["telegram", "email", "web_push"]
 
   def valid_notification_channels(), do: @notification_channels
 
   # TODO: Check if the key => value checks are needed
   def valid_notification_channel?(%{"webhook" => webhook_url}) when is_binary(webhook_url),
-    do: :ok
+    do: Sanbase.Utils.Validation.valid_public_url?(webhook_url)
 
   def valid_notification_channel?(%{webhook: webhook_url}) when is_binary(webhook_url),
-    do: :ok
+    do: Sanbase.Utils.Validation.valid_public_url?(webhook_url)
 
   def valid_notification_channel?(%{"telegram_channel" => telegram_channel})
       when is_binary(telegram_channel),
@@ -18,20 +19,23 @@ defmodule Sanbase.Alert.Validation.NotificationChannel do
       when is_binary(telegram_channel),
       do: :ok
 
-  def valid_notification_channel?(channel) when channel in @notification_channels, do: :ok
+  # "webhook" and "telegram_channel" require a URL / chat id and must be passed
+  # as a map (e.g. %{"webhook" => url}). Bare strings carry no destination so
+  # they are rejected — they previously slipped through and caused
+  # FunctionClauseError in Sanbase.Alert.Any.send_to_channel/3.
+  def valid_notification_channel?(channel) when channel in @bare_string_channels, do: :ok
 
   def valid_notification_channel?(channels) when is_list(channels) do
-    channels
-    |> Enum.all?(&valid_notification_channel?(&1))
-    |> case do
-      true ->
-        :ok
-
-      false ->
-        {:error,
-         """
-         #{inspect(channels)} is not a valid list of notification channels. The available notification channels are [#{@notification_channels |> Enum.join(", ")}]
-         """}
+    # NOTE: each element returns either :ok or {:error, _}. Both are truthy,
+    # so `Enum.all?` without an explicit `== :ok` check would always be true
+    # and let bad channels slip through.
+    if Enum.all?(channels, &(valid_notification_channel?(&1) == :ok)) do
+      :ok
+    else
+      {:error,
+       """
+       #{inspect(channels)} is not a valid list of notification channels. The available notification channels are [#{@notification_channels |> Enum.join(", ")}]
+       """}
     end
   end
 

--- a/lib/sanbase/utils/ip_utils.ex
+++ b/lib/sanbase/utils/ip_utils.ex
@@ -2,6 +2,8 @@ defmodule Sanbase.Utils.IP do
   @range100mask10 CIDR.parse("100.64.0.0/10")
   @range10mask8 CIDR.parse("10.0.0.0/8")
 
+  @blocked_hostnames ~w(localhost)
+
   def san_cluster_ip?("::ffff:" <> rest), do: san_cluster_ip?(rest)
 
   def san_cluster_ip?(remote_ip) do
@@ -21,4 +23,61 @@ defmodule Sanbase.Utils.IP do
   def localhost?(_), do: false
 
   def ip_tuple_to_string(ip), do: ip |> :inet_parse.ntoa() |> to_string()
+
+  @doc ~s"""
+  Returns `true` when the host is private, reserved, loopback, link-local,
+  multicast, broadcast, or a known cloud-metadata endpoint. Use this when
+  validating user-supplied URLs to prevent SSRF (e.g. webhook destinations
+  pointing at `http://169.254.169.254/`).
+
+  Accepts a hostname string, an IP literal string, or an `:inet.ip_address/0`
+  tuple.
+  """
+  def blocked_host?(host) when is_binary(host) do
+    h = String.downcase(host)
+
+    cond do
+      h in @blocked_hostnames ->
+        true
+
+      String.ends_with?(h, ".localhost") ->
+        true
+
+      true ->
+        case :inet.parse_address(to_charlist(h)) do
+          {:ok, addr} -> private_or_reserved?(addr)
+          {:error, _} -> false
+        end
+    end
+  end
+
+  def blocked_host?(addr) when is_tuple(addr), do: private_or_reserved?(addr)
+
+  @doc ~s"""
+  Returns `true` for IPv4 / IPv6 addresses in private, reserved, loopback,
+  link-local, multicast or broadcast ranges (including IPv4-mapped IPv6
+  forms of those ranges).
+  """
+  # IPv4
+  def private_or_reserved?({0, _, _, _}), do: true
+  def private_or_reserved?({10, _, _, _}), do: true
+  def private_or_reserved?({127, _, _, _}), do: true
+  def private_or_reserved?({169, 254, _, _}), do: true
+  def private_or_reserved?({172, b, _, _}) when b in 16..31, do: true
+  def private_or_reserved?({192, 0, 0, _}), do: true
+  def private_or_reserved?({192, 168, _, _}), do: true
+  def private_or_reserved?({100, b, _, _}) when b in 64..127, do: true
+  def private_or_reserved?({a, _, _, _}) when a >= 224, do: true
+
+  # IPv6 unspecified, loopback, link-local (fe80::/10), unique-local (fc00::/7)
+  def private_or_reserved?({0, 0, 0, 0, 0, 0, 0, 0}), do: true
+  def private_or_reserved?({0, 0, 0, 0, 0, 0, 0, 1}), do: true
+  def private_or_reserved?({a, _, _, _, _, _, _, _}) when a >= 0xFE80 and a <= 0xFEBF, do: true
+  def private_or_reserved?({a, _, _, _, _, _, _, _}) when a >= 0xFC00 and a <= 0xFDFF, do: true
+
+  # IPv4-mapped IPv6: ::ffff:a.b.c.d
+  def private_or_reserved?({0, 0, 0, 0, 0, 0xFFFF, ab, cd}),
+    do: private_or_reserved?({div(ab, 256), rem(ab, 256), div(cd, 256), rem(cd, 256)})
+
+  def private_or_reserved?(_), do: false
 end

--- a/lib/sanbase/utils/validation.ex
+++ b/lib/sanbase/utils/validation.ex
@@ -130,6 +130,21 @@ defmodule Sanbase.Utils.Validation do
     uri.scheme != nil and uri.host != nil
   end
 
+  @doc ~s"""
+  Like `valid_url?/2` but also rejects URLs that point to private, loopback,
+  link-local or cloud-metadata destinations to prevent SSRF (e.g. user-supplied
+  webhook URLs reaching `http://169.254.169.254/` AWS instance metadata).
+  """
+  def valid_public_url?(url, opts \\ []) do
+    with :ok <- valid_url?(url, opts) do
+      host = URI.parse(url).host
+
+      if Sanbase.Utils.IP.blocked_host?(host),
+        do: {:error, "URL host '#{host}' is a private, reserved or otherwise blocked address"},
+        else: :ok
+    end
+  end
+
   # Private functions
 
   defp time_window_format_check(time_window) do

--- a/test/sanbase/alerts/notification_channel_validation_test.exs
+++ b/test/sanbase/alerts/notification_channel_validation_test.exs
@@ -1,0 +1,111 @@
+defmodule Sanbase.Alert.Validation.NotificationChannelTest do
+  use ExUnit.Case, async: true
+
+  alias Sanbase.Alert.Validation.NotificationChannel
+
+  describe "valid_notification_channel?/1 with bare strings" do
+    test "telegram is valid" do
+      assert NotificationChannel.valid_notification_channel?("telegram") == :ok
+    end
+
+    test "email is valid" do
+      assert NotificationChannel.valid_notification_channel?("email") == :ok
+    end
+
+    test "web_push is valid" do
+      assert NotificationChannel.valid_notification_channel?("web_push") == :ok
+    end
+
+    test "bare \"webhook\" is rejected (carries no URL)" do
+      assert {:error, msg} = NotificationChannel.valid_notification_channel?("webhook")
+      assert msg =~ "is not a valid notification channel"
+    end
+
+    test "bare \"telegram_channel\" is rejected (carries no chat id)" do
+      assert {:error, msg} = NotificationChannel.valid_notification_channel?("telegram_channel")
+      assert msg =~ "is not a valid notification channel"
+    end
+  end
+
+  describe "valid_notification_channel?/1 with map form" do
+    test "atom-key webhook with binary URL is valid" do
+      assert NotificationChannel.valid_notification_channel?(%{webhook: "https://example.com/x"}) ==
+               :ok
+    end
+
+    test "string-key webhook with binary URL is valid" do
+      assert NotificationChannel.valid_notification_channel?(%{
+               "webhook" => "https://example.com/x"
+             }) == :ok
+    end
+
+    test "atom-key telegram_channel with binary id is valid" do
+      assert NotificationChannel.valid_notification_channel?(%{telegram_channel: "@my_channel"}) ==
+               :ok
+    end
+
+    test "string-key telegram_channel with binary id is valid" do
+      assert NotificationChannel.valid_notification_channel?(%{
+               "telegram_channel" => "@my_channel"
+             }) == :ok
+    end
+
+    test "webhook map with non-binary URL is rejected" do
+      assert {:error, _} = NotificationChannel.valid_notification_channel?(%{webhook: nil})
+      assert {:error, _} = NotificationChannel.valid_notification_channel?(%{webhook: 123})
+    end
+
+    test "telegram_channel map with non-binary id is rejected" do
+      assert {:error, _} =
+               NotificationChannel.valid_notification_channel?(%{telegram_channel: nil})
+    end
+  end
+
+  describe "valid_notification_channel?/1 with lists" do
+    test "list of valid channels is valid" do
+      channels = [
+        "telegram",
+        "email",
+        %{"webhook" => "https://example.com/hook"}
+      ]
+
+      assert NotificationChannel.valid_notification_channel?(channels) == :ok
+    end
+
+    test "list containing bare \"webhook\" is rejected" do
+      channels = ["telegram", "webhook"]
+      assert {:error, msg} = NotificationChannel.valid_notification_channel?(channels)
+      assert msg =~ "is not a valid list of notification channels"
+    end
+
+    test "list containing bare \"telegram_channel\" is rejected" do
+      channels = ["email", "telegram_channel"]
+      assert {:error, _} = NotificationChannel.valid_notification_channel?(channels)
+    end
+  end
+
+  describe "valid_notification_channel?/1 with garbage" do
+    test "unknown string is rejected" do
+      assert {:error, _} = NotificationChannel.valid_notification_channel?("discord")
+    end
+
+    test "nil is rejected" do
+      assert {:error, _} = NotificationChannel.valid_notification_channel?(nil)
+    end
+
+    test "integer is rejected" do
+      assert {:error, _} = NotificationChannel.valid_notification_channel?(42)
+    end
+  end
+
+  describe "valid_notification_channels/0" do
+    test "advertises the full list of channel names" do
+      channels = NotificationChannel.valid_notification_channels()
+      assert "telegram" in channels
+      assert "email" in channels
+      assert "web_push" in channels
+      assert "webhook" in channels
+      assert "telegram_channel" in channels
+    end
+  end
+end

--- a/test/sanbase/alerts/trigger_sending_test.exs
+++ b/test/sanbase/alerts/trigger_sending_test.exs
@@ -2,6 +2,7 @@ defmodule Sanbase.Alert.TriggerSendingTest do
   use Sanbase.DataCase, async: false
 
   import Sanbase.Factory
+  import ExUnit.CaptureLog
 
   alias Sanbase.Alert.{UserTrigger, Scheduler}
   alias Sanbase.Alert.Trigger.MetricTriggerSettings
@@ -57,6 +58,134 @@ defmodule Sanbase.Alert.TriggerSendingTest do
 
       assert Sanbase.TestUtils.datetime_close_to(Timex.now(), last_triggered_dt, 60, :seconds)
     end)
+  end
+
+  describe "unsupported notification channel" do
+    test "Sanbase.Alert.send/1 does not raise on a bare \"webhook\" channel and logs the trigger",
+         context do
+      %{user: user} = context
+
+      user_trigger = %{
+        id: 4242,
+        user_id: user.id,
+        user: user,
+        trigger: %{
+          id: 4242,
+          settings: %{
+            channel: "webhook",
+            payload: %{"santiment" => "some payload"}
+          }
+        }
+      }
+
+      log =
+        capture_log(fn ->
+          assert [{"santiment", {:error, error}}] = Sanbase.Alert.Any.send(user_trigger)
+
+          assert error == %{
+                   reason: :unsupported_notification_channel,
+                   channel: "webhook",
+                   user_id: user.id,
+                   trigger_id: 4242
+                 }
+        end)
+
+      assert log =~ "Unsupported alert notification channel"
+      assert log =~ "user_trigger_id=4242"
+    end
+
+    test "Sanbase.Alert.send/1 does not raise when channel list contains an unsupported value",
+         context do
+      %{user: user} = context
+
+      user_trigger = %{
+        id: 99,
+        user_id: user.id,
+        user: user,
+        trigger: %{
+          id: 99,
+          settings: %{
+            channel: ["email", "telegram_channel"],
+            payload: %{"santiment" => "p1", "ethereum" => "p2"}
+          }
+        }
+      }
+
+      capture_log(fn ->
+        results = Sanbase.Alert.Any.send(user_trigger)
+
+        # email branch returns either :ok per identifier (when user has email +
+        # opt-in) or per-identifier error tuples; the catch-all for
+        # "telegram_channel" must contribute one error tuple per payload
+        # identifier with our unsupported reason.
+        unsupported =
+          Enum.filter(results, fn
+            {_, {:error, %{reason: :unsupported_notification_channel}}} -> true
+            _ -> false
+          end)
+
+        assert length(unsupported) == 2
+      end)
+    end
+  end
+
+  describe "channel validation at create time" do
+    test "rejects bare \"webhook\" string", context do
+      %{user: user, project: project} = context
+
+      assert {:error, _} =
+               UserTrigger.create_user_trigger(user, %{
+                 title: "x",
+                 is_public: false,
+                 cooldown: "1h",
+                 settings: %{
+                   type: "metric_signal",
+                   metric: "active_addresses_24h",
+                   target: %{slug: project.slug},
+                   channel: "webhook",
+                   time_window: "1d",
+                   operation: %{above_or_equal: 5}
+                 }
+               })
+    end
+
+    test "rejects bare \"telegram_channel\" string", context do
+      %{user: user, project: project} = context
+
+      assert {:error, _} =
+               UserTrigger.create_user_trigger(user, %{
+                 title: "x",
+                 is_public: false,
+                 cooldown: "1h",
+                 settings: %{
+                   type: "metric_signal",
+                   metric: "active_addresses_24h",
+                   target: %{slug: project.slug},
+                   channel: "telegram_channel",
+                   time_window: "1d",
+                   operation: %{above_or_equal: 5}
+                 }
+               })
+    end
+
+    test "accepts webhook in map form", context do
+      %{user: user, project: project} = context
+
+      assert {:ok, _} =
+               UserTrigger.create_user_trigger(user, %{
+                 title: "x",
+                 is_public: false,
+                 cooldown: "1h",
+                 settings: %{
+                   type: "metric_signal",
+                   metric: "active_addresses_24h",
+                   target: %{slug: project.slug},
+                   channel: %{"webhook" => "https://example.com/hook"},
+                   time_window: "1d",
+                   operation: %{above_or_equal: 5}
+                 }
+               })
+    end
   end
 
   defp create_trigger(user, slug, opts) do

--- a/test/sanbase/utils/ip_utils_test.exs
+++ b/test/sanbase/utils/ip_utils_test.exs
@@ -1,0 +1,103 @@
+defmodule Sanbase.Utils.IPTest do
+  use ExUnit.Case, async: true
+
+  alias Sanbase.Utils.IP
+
+  describe "private_or_reserved?/1 with IPv4 tuples" do
+    test "rejects loopback 127.0.0.0/8" do
+      assert IP.private_or_reserved?({127, 0, 0, 1})
+      assert IP.private_or_reserved?({127, 200, 0, 1})
+    end
+
+    test "rejects 0.0.0.0/8" do
+      assert IP.private_or_reserved?({0, 0, 0, 0})
+      assert IP.private_or_reserved?({0, 1, 2, 3})
+    end
+
+    test "rejects RFC1918 private ranges" do
+      assert IP.private_or_reserved?({10, 0, 0, 1})
+      assert IP.private_or_reserved?({172, 16, 0, 1})
+      assert IP.private_or_reserved?({172, 31, 255, 255})
+      assert IP.private_or_reserved?({192, 168, 1, 1})
+    end
+
+    test "accepts public 172.x outside 16..31" do
+      refute IP.private_or_reserved?({172, 15, 0, 1})
+      refute IP.private_or_reserved?({172, 32, 0, 1})
+    end
+
+    test "rejects link-local 169.254.0.0/16 (AWS metadata)" do
+      assert IP.private_or_reserved?({169, 254, 169, 254})
+    end
+
+    test "rejects carrier-grade NAT 100.64.0.0/10" do
+      assert IP.private_or_reserved?({100, 64, 0, 1})
+      assert IP.private_or_reserved?({100, 127, 255, 255})
+    end
+
+    test "rejects multicast and reserved upper ranges (>= 224)" do
+      assert IP.private_or_reserved?({224, 0, 0, 1})
+      assert IP.private_or_reserved?({255, 255, 255, 255})
+    end
+
+    test "accepts public IPv4 addresses" do
+      refute IP.private_or_reserved?({8, 8, 8, 8})
+      refute IP.private_or_reserved?({1, 1, 1, 1})
+      refute IP.private_or_reserved?({93, 184, 216, 34})
+    end
+  end
+
+  describe "private_or_reserved?/1 with IPv6 tuples" do
+    test "rejects unspecified and loopback" do
+      assert IP.private_or_reserved?({0, 0, 0, 0, 0, 0, 0, 0})
+      assert IP.private_or_reserved?({0, 0, 0, 0, 0, 0, 0, 1})
+    end
+
+    test "rejects link-local fe80::/10" do
+      assert IP.private_or_reserved?({0xFE80, 0, 0, 0, 0, 0, 0, 1})
+      assert IP.private_or_reserved?({0xFEBF, 0, 0, 0, 0, 0, 0, 1})
+    end
+
+    test "rejects unique-local fc00::/7" do
+      assert IP.private_or_reserved?({0xFC00, 0, 0, 0, 0, 0, 0, 1})
+      assert IP.private_or_reserved?({0xFDFF, 0, 0, 0, 0, 0, 0, 1})
+    end
+
+    test "rejects IPv4-mapped IPv6 to private ranges" do
+      # ::ffff:127.0.0.1
+      assert IP.private_or_reserved?({0, 0, 0, 0, 0, 0xFFFF, 0x7F00, 0x0001})
+      # ::ffff:169.254.169.254
+      assert IP.private_or_reserved?({0, 0, 0, 0, 0, 0xFFFF, 0xA9FE, 0xA9FE})
+    end
+
+    test "accepts public IPv6 addresses" do
+      refute IP.private_or_reserved?({0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8888})
+    end
+  end
+
+  describe "blocked_host?/1 with strings" do
+    test "rejects literal private/loopback IPv4" do
+      assert IP.blocked_host?("127.0.0.1")
+      assert IP.blocked_host?("169.254.169.254")
+      assert IP.blocked_host?("10.0.0.1")
+      assert IP.blocked_host?("192.168.1.1")
+    end
+
+    test "rejects literal IPv6 loopback" do
+      assert IP.blocked_host?("::1")
+    end
+
+    test "rejects localhost hostname (case-insensitive)" do
+      assert IP.blocked_host?("localhost")
+      assert IP.blocked_host?("LOCALHOST")
+      assert IP.blocked_host?("api.localhost")
+    end
+
+    test "accepts public hostnames and IPs" do
+      refute IP.blocked_host?("example.com")
+      refute IP.blocked_host?("hooks.slack.com")
+      refute IP.blocked_host?("8.8.8.8")
+      refute IP.blocked_host?("metadata.google.internal")
+    end
+  end
+end

--- a/test/sanbase/utils/validation_test.exs
+++ b/test/sanbase/utils/validation_test.exs
@@ -142,4 +142,59 @@ defmodule Sanbase.Utils.ValidationTest do
       assert Validation.valid_url_simple?("example.com") == false
     end
   end
+
+  describe "valid_public_url?/1" do
+    test "accepts public URLs" do
+      assert Validation.valid_public_url?("https://example.com/hook") == :ok
+      assert Validation.valid_public_url?("https://hooks.slack.com/services/x") == :ok
+    end
+
+    test "rejects AWS EC2 metadata IP (link-local 169.254.169.254)" do
+      assert {:error, _} =
+               Validation.valid_public_url?("http://169.254.169.254/latest/meta-data/")
+    end
+
+    test "rejects loopback IPv4" do
+      assert {:error, _} = Validation.valid_public_url?("http://127.0.0.1/admin")
+      assert {:error, _} = Validation.valid_public_url?("http://127.1.2.3/x")
+    end
+
+    test "rejects RFC1918 private IPv4 ranges" do
+      assert {:error, _} = Validation.valid_public_url?("http://10.0.0.1/x")
+      assert {:error, _} = Validation.valid_public_url?("http://172.16.0.1/x")
+      assert {:error, _} = Validation.valid_public_url?("http://172.31.255.255/x")
+      assert {:error, _} = Validation.valid_public_url?("http://192.168.1.1/x")
+    end
+
+    test "rejects 0.0.0.0 / x range" do
+      assert {:error, _} = Validation.valid_public_url?("http://0.0.0.0/x")
+    end
+
+    test "rejects multicast / reserved upper ranges" do
+      assert {:error, _} = Validation.valid_public_url?("http://224.0.0.1/x")
+      assert {:error, _} = Validation.valid_public_url?("http://255.255.255.255/x")
+    end
+
+    test "rejects localhost hostname" do
+      assert {:error, _} = Validation.valid_public_url?("http://localhost/x")
+      assert {:error, _} = Validation.valid_public_url?("http://LOCALHOST/x")
+      assert {:error, _} = Validation.valid_public_url?("http://service.localhost/x")
+    end
+
+    test "rejects IPv6 loopback and link-local" do
+      assert {:error, _} = Validation.valid_public_url?("http://[::1]/x")
+      assert {:error, _} = Validation.valid_public_url?("http://[fe80::1]/x")
+      assert {:error, _} = Validation.valid_public_url?("http://[fc00::1]/x")
+    end
+
+    test "rejects IPv4-mapped IPv6 to private ranges" do
+      assert {:error, _} = Validation.valid_public_url?("http://[::ffff:127.0.0.1]/x")
+      assert {:error, _} = Validation.valid_public_url?("http://[::ffff:169.254.169.254]/x")
+    end
+
+    test "still rejects empty / scheme-less URLs" do
+      assert {:error, _} = Validation.valid_public_url?("")
+      assert {:error, _} = Validation.valid_public_url?("not-a-url")
+    end
+  end
 end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Telegram Channel alerts.

* **Bug Fixes**
  * Webhook URL validation now rejects private and internal URLs to prevent misuse.
  * Enhanced security to block requests to private IP addresses and reserved ranges.
  * Improved error handling for unsupported alert notification channels.

* **Tests**
  * Added comprehensive test coverage for notification channel validation.
  * Added security tests for webhook URL validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->