### PR TITLE
Rework hyperliquidBboPrices API

### DIFF
--- a/lib/sanbase_web/graphql/middlewares/access_control/access_control.ex
+++ b/lib/sanbase_web/graphql/middlewares/access_control/access_control.ex
@@ -635,6 +635,10 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
   defp get_query_or_argument(:timeseries_data, %{signal: signal}, _args),
     do: {:signal, signal}
 
+  # hyperliquid BBO prices — nested under `hyperliquidBboPrices`
+  defp get_query_or_argument(:timeseries_data, %{__source__: :hyperliquid_bbo_prices}, _args),
+    do: {:query, :hyperliquid_bbo_prices}
+
   defp get_query_or_argument(:aggregated_timeseries_data, %{signal: signal}, _args),
     do: {:signal, signal}
 

--- a/lib/sanbase_web/graphql/resolvers/hyperliquid_bbo_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/hyperliquid_bbo_resolver.ex
@@ -1,16 +1,35 @@
 defmodule SanbaseWeb.Graphql.Resolvers.HyperliquidBboResolver do
   alias Sanbase.Hyperliquid.Bbo.BboPrices
+  alias Sanbase.Project
+
+  @source "hyperliquid"
 
   @doc ~s"""
-  Resolver for `hyperliquidBboPrices`. Delegates to
+  Resolver for `hyperliquidBboPrices.timeseriesData`. Delegates to
   `Sanbase.Hyperliquid.Bbo.BboPrices.timeseries_data/4` and rewraps any error
   with a slug-tagged message.
   """
-  @spec bbo_prices(any(), map(), Absinthe.Resolution.t()) ::
+  @spec timeseries_data(any(), map(), Absinthe.Resolution.t()) ::
           {:ok, [BboPrices.point()]} | {:error, String.t()}
-  def bbo_prices(_root, %{slug: slug, from: from, to: to, interval: interval}, _resolution) do
+  def timeseries_data(_root, %{slug: slug, from: from, to: to, interval: interval}, _resolution) do
     with {:error, error} <- BboPrices.timeseries_data(slug, from, to, interval) do
       {:error, "Cannot fetch hyperliquid BBO prices for #{slug}. Reason: #{inspect(error)}"}
     end
+  end
+
+  @doc ~s"""
+  Resolver for `hyperliquidBboPrices.availableProjects`. Returns projects that
+  have a `hyperliquid` source slug mapping.
+  """
+  @spec available_projects(any(), map(), Absinthe.Resolution.t()) :: {:ok, [%Project{}]}
+  def available_projects(_root, _args, _resolution) do
+    slugs =
+      @source
+      |> Project.SourceSlugMapping.get_source_slug_mappings()
+      |> Enum.map(fn {_source_slug, project_slug} -> project_slug end)
+      |> Enum.uniq()
+      |> Enum.sort(:asc)
+
+    {:ok, Project.List.by_slugs(slugs)}
   end
 end

--- a/lib/sanbase_web/graphql/schema/queries/hyperliquid_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/hyperliquid_queries.ex
@@ -1,32 +1,18 @@
 defmodule SanbaseWeb.Graphql.Schema.HyperliquidQueries do
   use Absinthe.Schema.Notation
 
-  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 2]
-
-  alias SanbaseWeb.Graphql.Resolvers.HyperliquidBboResolver
-  alias SanbaseWeb.Graphql.Complexity
-  alias SanbaseWeb.Graphql.Middlewares.AccessControl
-
   object :hyperliquid_queries do
     @desc ~s"""
-    Fetch Hyperliquid BBO (best bid / best offer) timeseries for a given slug.
+    Entry point for Hyperliquid BBO (best bid / best offer) data.
 
-    Each output row represents one interval bucket; within a bucket, bid and
-    ask values are taken from the row with the largest `dt`, so every row
-    reflects a single source snapshot.
+    Returns an object with sub-fields:
+      * `timeseriesData` — bucketed BBO timeseries for a given slug.
+      * `availableProjects` — projects that have a `hyperliquid` source mapping.
     """
-    field :hyperliquid_bbo_prices, list_of(:hyperliquid_bbo_point) do
+    field :hyperliquid_bbo_prices, :hyperliquid_bbo_data do
       meta(access: :free)
 
-      arg(:slug, non_null(:string))
-      arg(:from, non_null(:datetime))
-      arg(:to, non_null(:datetime))
-      arg(:interval, non_null(:interval))
-      arg(:caching_params, :caching_params_input_object)
-
-      complexity(&Complexity.from_to_interval/3)
-      middleware(AccessControl)
-      cache_resolve(&HyperliquidBboResolver.bbo_prices/3, ttl: 60, max_ttl_offset: 30)
+      resolve(fn _root, _args, _resolution -> {:ok, %{__source__: :hyperliquid_bbo_prices}} end)
     end
   end
 end

--- a/lib/sanbase_web/graphql/schema/types/hyperliquid_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/hyperliquid_types.ex
@@ -1,6 +1,12 @@
 defmodule SanbaseWeb.Graphql.HyperliquidTypes do
   use Absinthe.Schema.Notation
 
+  import SanbaseWeb.Graphql.Cache, only: [cache_resolve: 2]
+
+  alias SanbaseWeb.Graphql.Resolvers.HyperliquidBboResolver
+  alias SanbaseWeb.Graphql.Complexity
+  alias SanbaseWeb.Graphql.Middlewares.AccessControl
+
   @desc ~s"""
   A bucketed BBO (best bid / best offer) snapshot for a Hyperliquid asset.
 
@@ -25,5 +31,41 @@ defmodule SanbaseWeb.Graphql.HyperliquidTypes do
     (bid_price * ask_volume + ask_price * bid_volume) / (bid_volume + ask_volume).
     """
     field(:weighted_mid_price, :float)
+  end
+
+  @desc ~s"""
+  Entry point for Hyperliquid BBO (best bid / best offer) data.
+
+  Use `timeseriesData` to fetch a bucketed BBO timeseries for a given slug
+  and `availableProjects` to list projects backed by a Hyperliquid source
+  mapping.
+  """
+  object :hyperliquid_bbo_data do
+    @desc ~s"""
+    Fetch Hyperliquid BBO timeseries for a given slug.
+
+    Each output row represents one interval bucket; within a bucket, bid and
+    ask values are taken from the row with the largest `dt`, so every row
+    reflects a single source snapshot.
+    """
+    field :timeseries_data, list_of(:hyperliquid_bbo_point) do
+      arg(:slug, non_null(:string))
+      arg(:from, non_null(:datetime))
+      arg(:to, non_null(:datetime))
+      arg(:interval, non_null(:interval))
+      arg(:caching_params, :caching_params_input_object)
+
+      complexity(&Complexity.from_to_interval/3)
+      middleware(AccessControl)
+      cache_resolve(&HyperliquidBboResolver.timeseries_data/3, ttl: 60, max_ttl_offset: 30)
+    end
+
+    @desc ~s"""
+    List of projects that have a `hyperliquid` source slug mapping and can be
+    queried via `timeseriesData`.
+    """
+    field :available_projects, list_of(:project) do
+      cache_resolve(&HyperliquidBboResolver.available_projects/3, ttl: 300)
+    end
   end
 end

--- a/test/sanbase_web/graphql/hyperliquid_bbo_api_test.exs
+++ b/test/sanbase_web/graphql/hyperliquid_bbo_api_test.exs
@@ -1,6 +1,7 @@
 defmodule SanbaseWeb.Graphql.HyperliquidBboApiTest do
   use SanbaseWeb.ConnCase, async: false
 
+  import Sanbase.Factory
   import SanbaseWeb.Graphql.TestHelpers
 
   alias Sanbase.Hyperliquid.Bbo.BboPrices
@@ -15,125 +16,194 @@ defmodule SanbaseWeb.Graphql.HyperliquidBboApiTest do
     }
   end
 
-  test "returns BBO points with computed mid and weighted_mid", ctx do
-    %{conn: conn, slug: slug, from: from, to: to, t1: t1, t2: t2} = ctx
+  describe "timeseriesData" do
+    test "returns BBO points with computed mid and weighted_mid", ctx do
+      %{conn: conn, slug: slug, from: from, to: to, t1: t1, t2: t2} = ctx
 
-    data = [
-      %{
-        datetime: t1,
-        bid_price: 100.0,
-        bid_volume: 2.0,
-        ask_price: 102.0,
-        ask_volume: 4.0,
-        mid_price: 101.0,
-        weighted_mid_price: 604.0 / 6.0
-      },
-      %{
-        datetime: t2,
-        bid_price: nil,
-        bid_volume: nil,
-        ask_price: 200.0,
-        ask_volume: 1.0,
-        mid_price: nil,
-        weighted_mid_price: nil
+      data = [
+        %{
+          datetime: t1,
+          bid_price: 100.0,
+          bid_volume: 2.0,
+          ask_price: 102.0,
+          ask_volume: 4.0,
+          mid_price: 101.0,
+          weighted_mid_price: 604.0 / 6.0
+        },
+        %{
+          datetime: t2,
+          bid_price: nil,
+          bid_volume: nil,
+          ask_price: 200.0,
+          ask_volume: 1.0,
+          mid_price: nil,
+          weighted_mid_price: nil
+        }
+      ]
+
+      Sanbase.Mock.prepare_mock2(&BboPrices.timeseries_data/4, {:ok, data})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result =
+          run_timeseries_query(conn, slug, from, to, "1m")
+          |> get_in(["data", "hyperliquidBboPrices", "timeseriesData"])
+
+        assert result == [
+                 %{
+                   "datetime" => DateTime.to_iso8601(t1),
+                   "bidPrice" => 100.0,
+                   "bidVolume" => 2.0,
+                   "askPrice" => 102.0,
+                   "askVolume" => 4.0,
+                   "midPrice" => 101.0,
+                   "weightedMidPrice" => 604.0 / 6.0
+                 },
+                 %{
+                   "datetime" => DateTime.to_iso8601(t2),
+                   "bidPrice" => nil,
+                   "bidVolume" => nil,
+                   "askPrice" => 200.0,
+                   "askVolume" => 1.0,
+                   "midPrice" => nil,
+                   "weightedMidPrice" => nil
+                 }
+               ]
+      end)
+    end
+
+    test "accepts cachingParams to disable caching", ctx do
+      %{conn: conn, slug: slug, from: from, to: to, t1: t1} = ctx
+
+      data = [
+        %{
+          datetime: t1,
+          bid_price: 100.0,
+          bid_volume: 1.0,
+          ask_price: 101.0,
+          ask_volume: 1.0,
+          mid_price: 100.5,
+          weighted_mid_price: 100.5
+        }
+      ]
+
+      Sanbase.Mock.prepare_mock2(&BboPrices.timeseries_data/4, {:ok, data})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        caching = "cachingParams: { baseTtl: 1, maxTtlOffset: 1 }"
+        result = run_timeseries_query(conn, slug, from, to, "1m", caching)
+
+        assert result["errors"] == nil
+        assert length(result["data"]["hyperliquidBboPrices"]["timeseriesData"]) == 1
+      end)
+    end
+
+    test "access control middleware runs on nested field (rejects to < from)", ctx do
+      %{conn: conn, slug: slug, t1: t1} = ctx
+
+      data = [
+        %{
+          datetime: t1,
+          bid_price: 100.0,
+          bid_volume: 1.0,
+          ask_price: 101.0,
+          ask_volume: 1.0,
+          mid_price: 100.5,
+          weighted_mid_price: 100.5
+        }
+      ]
+
+      Sanbase.Mock.prepare_mock2(&BboPrices.timeseries_data/4, {:ok, data})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result =
+          run_timeseries_query(
+            conn,
+            slug,
+            ~U[2026-05-07 00:05:00Z],
+            ~U[2026-05-07 00:00:00Z],
+            "1m"
+          )
+
+        assert [%{"message" => message} | _] = result["errors"]
+        assert message =~ "`to` datetime parameter must be after the `from` datetime parameter"
+        assert result["data"]["hyperliquidBboPrices"]["timeseriesData"] == nil
+      end)
+    end
+
+    test "interval is required", ctx do
+      %{conn: conn, slug: slug, from: from, to: to} = ctx
+
+      query = """
+      {
+        hyperliquidBboPrices {
+          timeseriesData(
+            slug: "#{slug}"
+            from: "#{from}"
+            to: "#{to}"
+          ) {
+            datetime
+          }
+        }
       }
-    ]
+      """
 
-    Sanbase.Mock.prepare_mock2(&BboPrices.timeseries_data/4, {:ok, data})
-    |> Sanbase.Mock.run_with_mocks(fn ->
       result =
-        run_query(conn, slug, from, to, "1m")
-        |> get_in(["data", "hyperliquidBboPrices"])
+        conn
+        |> post("/graphql", query_skeleton(query, "hyperliquidBboPrices"))
+        |> json_response(200)
 
-      assert result == [
-               %{
-                 "datetime" => DateTime.to_iso8601(t1),
-                 "bidPrice" => 100.0,
-                 "bidVolume" => 2.0,
-                 "askPrice" => 102.0,
-                 "askVolume" => 4.0,
-                 "midPrice" => 101.0,
-                 "weightedMidPrice" => 604.0 / 6.0
-               },
-               %{
-                 "datetime" => DateTime.to_iso8601(t2),
-                 "bidPrice" => nil,
-                 "bidVolume" => nil,
-                 "askPrice" => 200.0,
-                 "askVolume" => 1.0,
-                 "midPrice" => nil,
-                 "weightedMidPrice" => nil
-               }
+      assert result["errors"] != nil
+    end
+  end
+
+  describe "availableProjects" do
+    test "returns projects with hyperliquid source slug mapping", %{conn: conn} do
+      p1 = insert(:random_project, slug: "btc-project")
+      p2 = insert(:random_project, slug: "eth-project")
+      _p3 = insert(:random_project, slug: "no-mapping-project")
+
+      insert(:source_slug_mapping, source: "hyperliquid", slug: "BTC", project: p1)
+      insert(:source_slug_mapping, source: "hyperliquid", slug: "ETH", project: p2)
+      insert(:source_slug_mapping, source: "cryptocompare", slug: "OTHER", project: p2)
+
+      query = """
+      {
+        hyperliquidBboPrices {
+          availableProjects { slug }
+        }
+      }
+      """
+
+      result =
+        conn
+        |> post("/graphql", query_skeleton(query, "hyperliquidBboPrices"))
+        |> json_response(200)
+        |> get_in(["data", "hyperliquidBboPrices", "availableProjects"])
+
+      assert Enum.sort_by(result, & &1["slug"]) == [
+               %{"slug" => "btc-project"},
+               %{"slug" => "eth-project"}
              ]
-    end)
+    end
   end
 
-  test "accepts cachingParams to disable caching", ctx do
-    %{conn: conn, slug: slug, from: from, to: to, t1: t1} = ctx
-
-    data = [
-      %{
-        datetime: t1,
-        bid_price: 100.0,
-        bid_volume: 1.0,
-        ask_price: 101.0,
-        ask_volume: 1.0,
-        mid_price: 100.5,
-        weighted_mid_price: 100.5
-      }
-    ]
-
-    Sanbase.Mock.prepare_mock2(&BboPrices.timeseries_data/4, {:ok, data})
-    |> Sanbase.Mock.run_with_mocks(fn ->
-      caching = "cachingParams: { baseTtl: 1, maxTtlOffset: 1 }"
-      result = run_query(conn, slug, from, to, "1m", caching)
-
-      assert result["errors"] == nil
-      assert length(result["data"]["hyperliquidBboPrices"]) == 1
-    end)
-  end
-
-  test "interval is required", ctx do
-    %{conn: conn, slug: slug, from: from, to: to} = ctx
+  defp run_timeseries_query(conn, slug, from, to, interval, extra_args \\ "") do
+    extra = if extra_args == "", do: "", else: "\n        #{extra_args}"
 
     query = """
     {
-      hyperliquidBboPrices(
-        slug: "#{slug}"
-        from: "#{from}"
-        to: "#{to}"
-      ) {
-        datetime
-      }
-    }
-    """
-
-    result =
-      conn
-      |> post("/graphql", query_skeleton(query, "hyperliquidBboPrices"))
-      |> json_response(200)
-
-    assert result["errors"] != nil
-  end
-
-  defp run_query(conn, slug, from, to, interval, extra_args \\ "") do
-    extra = if extra_args == "", do: "", else: "\n      #{extra_args}"
-
-    query = """
-    {
-      hyperliquidBboPrices(
-        slug: "#{slug}"
-        from: "#{from}"
-        to: "#{to}"
-        interval: "#{interval}"#{extra}
-      ) {
-        datetime
-        bidPrice
-        bidVolume
-        askPrice
-        askVolume
-        midPrice
-        weightedMidPrice
+      hyperliquidBboPrices {
+        timeseriesData(
+          slug: "#{slug}"
+          from: "#{from}"
+          to: "#{to}"
+          interval: "#{interval}"#{extra}
+        ) {
+          datetime
+          bidPrice
+          bidVolume
+          askPrice
+          askVolume
+          midPrice
+          weightedMidPrice
+        }
       }
     }
     """


### PR DESCRIPTION
## Changes

The API now has sub-fields that must be selected - timeseriesData and availableProjects.
Before that the top-level API acted as timeseriesData itself.

```graphql
{
  hyperliquidBboPrices {
    availableProjects{ slug }
    timeseriesData(
      slug: "bitcoin"
      from: "utc_now-10s"
      to: "utc_now"
      interval: "1s"
    ) {
      datetime
      bidPrice
      bidVolume
      askPrice
      askVolume
      midPrice
      weightedMidPrice
    }
  }
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `availableProjects` field to retrieve available Hyperliquid projects.

* **Changes**
  * Restructured Hyperliquid BBO endpoint; `timeseriesData` and `availableProjects` are now nested fields within a unified data container.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santiment/sanbase2/pull/5145)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->