### PR TITLE
Add cancel_at_period_end: true to PromoTrial

### DIFF
--- a/lib/sanbase/billing/subscription/promo_trial.ex
+++ b/lib/sanbase/billing/subscription/promo_trial.ex
@@ -179,7 +179,7 @@ defmodule Sanbase.Billing.Subscription.PromoTrial do
       customer: user.stripe_customer_id,
       items: [%{plan: plan.stripe_id}],
       trial_end: trial_end_unix,
-      cancel_at: trial_end_unix
+      cancel_at: trial_end_unix - 60
     }
   end
 

--- a/lib/sanbase/billing/subscription/promo_trial.ex
+++ b/lib/sanbase/billing/subscription/promo_trial.ex
@@ -173,10 +173,13 @@ defmodule Sanbase.Billing.Subscription.PromoTrial do
   end
 
   defp promotional_subsciption_data(user, plan, trial_days) do
+    trial_end_unix = Timex.shift(Timex.now(), days: trial_days) |> DateTime.to_unix()
+
     %{
       customer: user.stripe_customer_id,
       items: [%{plan: plan.stripe_id}],
-      trial_end: Timex.shift(Timex.now(), days: trial_days) |> DateTime.to_unix()
+      trial_end: trial_end_unix,
+      cancel_at: trial_end_unix
     }
   end
 

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,14 +2,15 @@
 -- PostgreSQL database dump
 --
 
-\restrict MGqEcjjv5Bj7d9SzGKGTG4BBRyNg3SXGmrFDjjmmw9rcn4eIZji2lT9SEQ1a9fy
+\restrict rg49JhdfuYvzkmMwjbtFtgpts4TBllmDGQKCJMBxkwdDmdxkoEEefAh524URkUs
 
--- Dumped from database version 15.15 (Homebrew)
--- Dumped by pg_dump version 15.15 (Homebrew)
+-- Dumped from database version 17.9 (Homebrew)
+-- Dumped by pg_dump version 17.9 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
+SET transaction_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
@@ -11614,7 +11615,7 @@ ALTER TABLE ONLY public.webinar_registrations
 -- PostgreSQL database dump complete
 --
 
-\unrestrict MGqEcjjv5Bj7d9SzGKGTG4BBRyNg3SXGmrFDjjmmw9rcn4eIZji2lT9SEQ1a9fy
+\unrestrict rg49JhdfuYvzkmMwjbtFtgpts4TBllmDGQKCJMBxkwdDmdxkoEEefAh524URkUs
 
 INSERT INTO public."schema_migrations" (version) VALUES (20171008200815);
 INSERT INTO public."schema_migrations" (version) VALUES (20171008203355);

--- a/test/sanbase/billing/promo_trial_test.exs
+++ b/test/sanbase/billing/promo_trial_test.exs
@@ -1,0 +1,93 @@
+defmodule Sanbase.Billing.PromoTrialTest do
+  use Sanbase.DataCase
+
+  import Sanbase.Factory
+  import Mock
+
+  alias Sanbase.Billing.Subscription.PromoTrial
+  alias Sanbase.StripeApi
+  alias Sanbase.StripeApiTestResponse
+
+  setup context do
+    user = insert(:user, stripe_customer_id: "cus_test_promo")
+    Map.put(context, :user, user)
+  end
+
+  describe "create_promo_trial/1 cancels at trial end" do
+    setup_with_mocks(
+      [
+        {StripeApi, [:passthrough],
+         [
+           create_subscription: fn args ->
+             send(self(), {:stripe_create_subscription, args})
+             StripeApiTestResponse.create_subscription_resp(status: "trialing")
+           end
+         ]}
+      ],
+      context
+    ) do
+      {:ok, context}
+    end
+
+    test "passes cancel_at == trial_end to Stripe for list-of-plans variant", context do
+      plan = context.plans.plan_pro_sanbase
+
+      assert {:ok, [_subscription]} =
+               PromoTrial.create_promo_trial(%{
+                 user_id: context.user.id,
+                 plans: [plan.id],
+                 trial_days: 14
+               })
+
+      assert_receive {:stripe_create_subscription, args}
+      assert is_integer(args.trial_end)
+      assert args.cancel_at == args.trial_end
+      assert args.customer == "cus_test_promo"
+    end
+
+    test "passes cancel_at == trial_end to Stripe for single plan_id variant", context do
+      plan = context.plans.plan_pro_sanbase
+
+      assert {:ok, _subscription} =
+               PromoTrial.create_promo_trial(%{
+                 user_id: context.user.id,
+                 plan_id: plan.id,
+                 trial_days: 7
+               })
+
+      assert_receive {:stripe_create_subscription, args}
+      assert args.cancel_at == args.trial_end
+    end
+
+    test "string-keyed params variant also sets cancel_at == trial_end", context do
+      plan = context.plans.plan_pro_sanbase
+
+      assert {:ok, [_subscription]} =
+               PromoTrial.create_promo_trial(%{
+                 "user_id" => context.user.id,
+                 "plans" => [plan.id],
+                 "trial_days" => 30
+               })
+
+      assert_receive {:stripe_create_subscription, args}
+      assert args.cancel_at == args.trial_end
+    end
+
+    test "trial_end timestamp roughly matches requested trial_days", context do
+      plan = context.plans.plan_pro_sanbase
+      trial_days = 14
+
+      {:ok, [_subscription]} =
+        PromoTrial.create_promo_trial(%{
+          user_id: context.user.id,
+          plans: [plan.id],
+          trial_days: trial_days
+        })
+
+      assert_receive {:stripe_create_subscription, args}
+      expected = DateTime.utc_now() |> DateTime.add(trial_days * 24 * 3600, :second)
+      delta = abs(args.trial_end - DateTime.to_unix(expected))
+      assert delta < 60
+    end
+  end
+end

--- a/test/sanbase/billing/promo_trial_test.exs
+++ b/test/sanbase/billing/promo_trial_test.exs
@@ -29,7 +29,7 @@ defmodule Sanbase.Billing.PromoTrialTest do
       {:ok, context}
     end
 
-    test "passes cancel_at == trial_end to Stripe for list-of-plans variant", context do
+    test "passes cancel_at 60s before trial_end for list-of-plans variant", context do
       plan = context.plans.plan_pro_sanbase
 
       assert {:ok, [_subscription]} =
@@ -41,11 +41,11 @@ defmodule Sanbase.Billing.PromoTrialTest do
 
       assert_receive {:stripe_create_subscription, args}
       assert is_integer(args.trial_end)
-      assert args.cancel_at == args.trial_end
+      assert args.cancel_at == args.trial_end - 60
       assert args.customer == "cus_test_promo"
     end
 
-    test "passes cancel_at == trial_end to Stripe for single plan_id variant", context do
+    test "passes cancel_at 60s before trial_end for single plan_id variant", context do
       plan = context.plans.plan_pro_sanbase
 
       assert {:ok, _subscription} =
@@ -56,10 +56,10 @@ defmodule Sanbase.Billing.PromoTrialTest do
                })
 
       assert_receive {:stripe_create_subscription, args}
-      assert args.cancel_at == args.trial_end
+      assert args.cancel_at == args.trial_end - 60
     end
 
-    test "string-keyed params variant also sets cancel_at == trial_end", context do
+    test "string-keyed params variant also sets cancel_at 60s before trial_end", context do
       plan = context.plans.plan_pro_sanbase
 
       assert {:ok, [_subscription]} =
@@ -70,7 +70,7 @@ defmodule Sanbase.Billing.PromoTrialTest do
                })
 
       assert_receive {:stripe_create_subscription, args}
-      assert args.cancel_at == args.trial_end
+      assert args.cancel_at == args.trial_end - 60
     end
 
     test "trial_end timestamp roughly matches requested trial_days", context do


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Promotional trial subscriptions now schedule automatic cancellation at the end of the trial period when synced with Stripe.

* **Chores**
  * Regenerated database dump metadata and adjusted session timeout settings for compatibility with newer PostgreSQL tooling.

* **Tests**
  * Added tests covering promotional trial creation and verifying correct trial end and cancellation timing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santiment/sanbase2/pull/5153)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->