### PR TITLE
Make Oban start optional. Make it wait for Repo to compile first

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,8 @@
 ##############
 # Print interpolated SQL query when executing CH, so it's ready for copy-paste
 # PRINT_INTERPOLATED_CLICKHOUSE_SQL=true
+
+# Start Oban locally. Off by default in dev to avoid Oban.Sonar crashing
+# during background recompiles (Sanbase.Repo briefly purged). Enable when
+# working on Oban-driven flows (cron, scrapers, email queue, etc).
+# OBAN_ENABLED=true

--- a/lib/sanbase/application/admin.ex
+++ b/lib/sanbase/application/admin.ex
@@ -22,7 +22,13 @@ defmodule Sanbase.Application.Admin do
       Sanbase.AI.DescriptionJob,
       # Persistent GenServer for invoice archive generation jobs
       Sanbase.Billing.Invoices.GenerationJob,
-      {Oban, oban_admin_config()},
+      # Oban admin instance.
+      # Wrapped in a dedicated supervisor with a relaxed restart policy so
+      # transient `Oban.Sonar` crashes during dev recompiles don't cascade.
+      start_if(
+        fn -> {Sanbase.Application.ObanSupervisor, config: oban_admin_config()} end,
+        &Sanbase.Application.ObanSupervisor.enabled?/0
+      ),
 
       # Start the libcluster in admin, so we can send messages to the web pods when some
       # important tables changes.

--- a/lib/sanbase/application/oban_supervisor.ex
+++ b/lib/sanbase/application/oban_supervisor.ex
@@ -1,0 +1,62 @@
+defmodule Sanbase.Application.ObanSupervisor do
+  @moduledoc """
+  Wraps an Oban instance so the host application supervisor is shielded from
+  transient `Oban.Sonar` crashes.
+
+  In dev, Mix recompiles run in the background while the app is already up.
+  Loading a freshly compiled `.beam` briefly purges the previous version of
+  the module. If `Oban.Sonar` ticks during that window, `Sanbase.Repo.query/3`
+  is reported as undefined and Sonar crashes. Under the host supervisor's
+  tight `max_restarts: 5, max_seconds: 1` policy, that single crash can
+  cascade and shut down the whole app. This dedicated supervisor isolates
+  those restarts behind a more forgiving policy and pre-loads `Sanbase.Repo`
+  to narrow the window.
+  """
+  use Supervisor
+
+  alias Sanbase.Utils.Config
+
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    config = Keyword.fetch!(opts, :config)
+    oban_name = Keyword.fetch!(config, :name)
+
+    %{
+      id: {__MODULE__, oban_name},
+      start: {__MODULE__, :start_link, [opts]},
+      type: :supervisor
+    }
+  end
+
+  def start_link(opts) do
+    config = Keyword.fetch!(opts, :config)
+    oban_name = Keyword.fetch!(config, :name)
+    sup_name = Module.concat(__MODULE__, oban_name)
+
+    Supervisor.start_link(__MODULE__, config, name: sup_name)
+  end
+
+  @impl true
+  def init(config) do
+    Code.ensure_loaded!(Sanbase.Repo)
+
+    children = [{Oban, config}]
+
+    Supervisor.init(children, strategy: :one_for_one, max_restarts: 10, max_seconds: 60)
+  end
+
+  @doc """
+  Whether Oban should be started in the current environment.
+
+  In `:dev`, Oban is opt-in via `OBAN_ENABLED=true` so the dev recompile
+  race is avoided entirely unless the developer is actively working on
+  Oban-driven flows. In all other envs Oban always starts.
+  """
+  @spec enabled?() :: boolean()
+  def enabled?() do
+    case Config.module_get(Sanbase, :env) do
+      :dev -> System.get_env("OBAN_ENABLED", "false") == "true"
+      _ -> true
+    end
+  end
+end

--- a/lib/sanbase/application/scrapers.ex
+++ b/lib/sanbase/application/scrapers.ex
@@ -64,8 +64,13 @@ defmodule Sanbase.Application.Scrapers do
       # Realtime coinmarketcap price fetcher
       Sanbase.ExternalServices.Coinmarketcap.TickerFetcher,
 
-      # Oban for scraper jobs
-      {Oban, oban_scrapers_config()},
+      # Oban for scraper jobs.
+      # Wrapped in a dedicated supervisor with a relaxed restart policy so
+      # transient `Oban.Sonar` crashes during dev recompiles don't cascade.
+      start_if(
+        fn -> {Sanbase.Application.ObanSupervisor, config: oban_scrapers_config()} end,
+        &Sanbase.Application.ObanSupervisor.enabled?/0
+      ),
 
       # Scrape and export Cryptocompare realtime and historical prices.
       # Historical prices work is scheduled by Oban

--- a/lib/sanbase/application/web.ex
+++ b/lib/sanbase/application/web.ex
@@ -35,8 +35,13 @@ defmodule Sanbase.Application.Web do
       # `start_supervised!`, which ExUnit tears down at test exit.
       start_in(Sanbase.Cache.RehydratingCache.Supervisor, [:dev, :prod]),
 
-      # Oban instance responsible for sending emails
-      {Oban, oban_web_config()},
+      # Oban instance responsible for sending emails.
+      # Wrapped in a dedicated supervisor with a relaxed restart policy so
+      # transient `Oban.Sonar` crashes during dev recompiles don't cascade.
+      start_if(
+        fn -> {Sanbase.Application.ObanSupervisor, config: oban_web_config()} end,
+        &Sanbase.Application.ObanSupervisor.enabled?/0
+      ),
 
       # Start libcluster
       start_in(


### PR DESCRIPTION
## Changes

Oban startup in dev was fragile. Background mix recompiles briefly purge
Sanbase.Repo, and if Oban.Sonar ticks during that window it crashes with
UndefinedFunctionError. The host supervisor's tight max_restarts: 5 /
max_seconds: 1 budget then escalates a single Sonar crash into a full
application shutdown — even though the DB is healthy.

This PR isolates Oban behind a dedicated supervisor and makes it opt-in
locally.

### What changed

- New Sanbase.Application.ObanSupervisor wraps each Oban instance. It calls Code.ensure_loaded!(Sanbase.Repo) before start (narrowing the race window) and runs with a relaxed
max_restarts: 10 / max_seconds: 60 so transient Sonar crashes are absorbed locally instead of cascading.
- Web, Scrapers, and Admin Oban instances now start through the wrapper.
- enabled?/0 gate: in :dev, Oban only starts when OBAN_ENABLED=true. All other environments unchanged — Oban always starts in prod, and testing: :manual still applies in test.
- .env.example documents the new flag.

### Behavior

- Dev default: Oban skipped, no Sonar, no crash race. Boot is clean.
- Dev with OBAN_ENABLED=true: Oban runs wrapped; a Sonar tick during a recompile no longer kills the app.
- Test / Prod: behavior unchanged.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made Oban background job processing configurable in development via the `OBAN_ENABLED` environment variable (defaults to disabled to prevent crashes during development recompiles).
  * Implemented a dedicated supervisor wrapper with improved crash handling to prevent Oban-related failures from cascading during development work.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santiment/sanbase2/pull/5159)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->