### PR TITLE
Translate SanAPI custom plans to their base plan for Sanbase requests

### DIFF
--- a/lib/sanbase_web/graphql/plugs/auth_plug.ex
+++ b/lib/sanbase_web/graphql/plugs/auth_plug.ex
@@ -198,7 +198,7 @@ defmodule SanbaseWeb.Graphql.AuthPlug do
             auth_method: :user_token,
             current_user: current_user,
             subscription: subscription,
-            plan: Subscription.plan_name(subscription)
+            plan: effective_plan_name(subscription, "SANBASE")
           },
           requested_product_id: @product_id_sanbase,
           requested_product: "SANBASE",
@@ -232,7 +232,7 @@ defmodule SanbaseWeb.Graphql.AuthPlug do
           auth_method: :user_token,
           current_user: current_user,
           subscription: subscription,
-          plan: Subscription.plan_name(subscription)
+          plan: effective_plan_name(subscription, requested_product)
         },
         requested_product_id: requested_product_id,
         requested_product: requested_product,
@@ -299,7 +299,7 @@ defmodule SanbaseWeb.Graphql.AuthPlug do
           current_user: current_user,
           token: token,
           subscription: subscription,
-          plan: Subscription.plan_name(subscription)
+          plan: effective_plan_name(subscription, Product.code_by_id(requested_product_id))
         },
         subscription_product_id: subscription_product_id,
         subscription_product: subscription_product,
@@ -317,6 +317,13 @@ defmodule SanbaseWeb.Graphql.AuthPlug do
   # Private functions
 
   defp find_best_subscription(requested_product, user_id) do
+    # Cross-product fallback in both directions so paying customers keep their
+    # benefits in the other product (e.g. Sanbase MAX gets API access, SanAPI
+    # BUSINESS_PRO gets Sanbase benefits). Plan name translation for the
+    # destination product happens in effective_plan_name/2 — in particular,
+    # SanAPI custom plans are mapped to their `restricted_access_as_plan`
+    # when used for Sanbase requests, so their API-specific metric whitelist
+    # doesn't leak into Sanbase access checks.
     api_sub = Subscription.current_subscription(user_id, @product_id_api)
     sanbase_sub = Subscription.current_subscription(user_id, @product_id_sanbase)
 
@@ -324,6 +331,25 @@ defmodule SanbaseWeb.Graphql.AuthPlug do
       "SANBASE" -> sanbase_sub || api_sub
       "SANAPI" -> api_sub || sanbase_sub
     end
+  end
+
+  # A SanAPI custom plan's raw name (e.g. "CUSTOM_FOO") encodes an
+  # API-specific metric whitelist that must not be applied to Sanbase calls.
+  # When a Sanbase request falls back to such a subscription, resolve the
+  # custom plan's `restricted_access_as_plan` (defaulting to FREE) so the
+  # Sanbase access checker treats the user as that standard tier.
+  defp effective_plan_name(subscription, "SANBASE") do
+    case subscription do
+      %Subscription{plan: %{has_custom_restrictions: true, name: name}} ->
+        Sanbase.Queries.Authorization.fetch_base_plan_for_custom(name)
+
+      _ ->
+        Subscription.plan_name(subscription)
+    end
+  end
+
+  defp effective_plan_name(subscription, _requested_product) do
+    Subscription.plan_name(subscription)
   end
 
   defp get_user_subscription(user_id, product) do
@@ -337,6 +363,9 @@ defmodule SanbaseWeb.Graphql.AuthPlug do
   end
 
   defp get_user_subscription_for_sanbase(user_id) do
+    # Falls back to a SanAPI subscription so paying SanAPI users keep their
+    # Sanbase benefits. Custom plans are translated separately via
+    # effective_plan_name/2.
     get_user_subscription(user_id, @product_id_sanbase) ||
       get_user_subscription(user_id, @product_id_api)
   end

--- a/test/sanbase/billing/custom_plan_test.exs
+++ b/test/sanbase/billing/custom_plan_test.exs
@@ -157,6 +157,44 @@ defmodule Sanbase.Billing.Plan.CustomPlanTest do
     end
   end
 
+  describe "effective plan name when a SanAPI custom plan is used cross-product" do
+    alias SanbaseWeb.Graphql.{AuthPlug, ContextPlug}
+
+    test "Sanbase request resolves to the custom plan's restricted_access_as_plan", context do
+      %{user: user} = context
+
+      conn =
+        build_conn()
+        |> get("/get_routed_conn")
+        |> setup_jwt_auth(user)
+        |> AuthPlug.call(%{})
+        |> ContextPlug.call(%{})
+
+      conn_context = conn.private.absinthe.context
+
+      assert conn_context.requested_product == "SANBASE"
+      assert conn_context.subscription_product == "SANAPI"
+      # The raw plan name is "CUSTOM_API_PLAN", but for SANBASE requests it
+      # must be translated to restricted_access_as_plan ("PRO") so the
+      # SanAPI custom metric whitelist isn't applied to Sanbase access checks.
+      assert conn_context.auth.plan == "PRO"
+    end
+
+    test "SanAPI request keeps the raw custom plan name", context do
+      %{conn: apikey_conn} = context
+
+      conn = apikey_conn |> get("/get_routed_conn") |> AuthPlug.call(%{}) |> ContextPlug.call(%{})
+
+      conn_context = conn.private.absinthe.context
+
+      assert conn_context.requested_product == "SANAPI"
+      assert conn_context.subscription_product == "SANAPI"
+      # SanAPI requests keep the raw "CUSTOM_*" name so CustomAccessChecker
+      # applies the plan's metric/query whitelist.
+      assert conn_context.auth.plan == "CUSTOM_API_PLAN"
+    end
+  end
+
   describe "validation" do
     test "rejects malformed regex in not_accessible_patterns", context do
       Sanbase.Repo.query!("ALTER SEQUENCE plans_id_seq RESTART WITH 9001")


### PR DESCRIPTION
## Changes

A user with only a SanAPI custom plan (CUSTOM_*) was getting their API-specific metric whitelist (e.g. social-only) applied to Sanbase calls, restricting Sanbase below what the custom plan grants. Now, when a Sanbase request falls back to a SanAPI custom subscription, the plan name is swapped for the custom plan's restricted_access_as_plan (e.g. PRO / BUSINESS_PRO / BUSINESS_MAX, defaulting to FREE if unset) so SanbaseAccessChecker treats the user as that standard tier. Standard cross-product fallbacks (e.g. SanAPI BUSINESS_PRO -> Sanbase) are unchanged.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
