### PR TITLE
Adjust MCP tool calls rate limits

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -192,15 +192,19 @@ config :sanbase, Sanbase.Insight.Post,
   creation_limit_day: 1000,
   creation_limit_minute: 1000
 
-# Increase the limits in test env so they are not hit unless
-# the limit is intentionally lowered by using Application.put_env
-config :sanbase, Sanbase.MCP.ToolInvocation,
-  global_rate_limit_minute: 10000,
-  global_rate_limit_hour: 10000,
-  global_rate_limit_day: 10000,
-  combined_trends_rate_limit_minute: 10000,
-  combined_trends_rate_limit_hour: 10000,
-  combined_trends_rate_limit_day: 10000
+# Increase the limits in test env so they are not hit unless a test
+# intentionally lowers them via Application.put_env on Sanbase.MCP.Restrictions.
+config :sanbase, Sanbase.MCP.Restrictions,
+  global: %{
+    free: %{minute: 10_000, hour: 10_000, day: 10_000, month: 10_000},
+    pro: %{minute: 10_000, hour: 10_000, day: 10_000, month: 10_000},
+    max: %{minute: 10_000, hour: 10_000, day: 10_000, month: 10_000}
+  },
+  combined_trends: %{
+    free: %{minute: 10_000, hour: 10_000, day: 10_000, month: 10_000},
+    pro: %{minute: 10_000, hour: 10_000, day: 10_000, month: 10_000},
+    max: %{minute: 10_000, hour: 10_000, day: 10_000, month: 10_000}
+  }
 
 # Configure test environment for OpenAI client mocking
 config :sanbase, :openai_client, Sanbase.AI.MockOpenAIClient

--- a/lib/sanbase/mcp/restrictions.ex
+++ b/lib/sanbase/mcp/restrictions.ex
@@ -1,0 +1,161 @@
+defmodule Sanbase.MCP.Restrictions do
+  @moduledoc """
+  Plan-aware rate limits for the Santiment MCP server.
+
+  Three tiers gate every authenticated user's MCP usage:
+
+    * `:free` — Sanbase FREE (no subscription) and SanAPI FREE
+    * `:pro`  — Sanbase PRO
+    * `:max`  — Sanbase MAX (incl. legacy PRO_PLUS / BUSINESS_* / CUSTOM*)
+                and every paid SanAPI plan (PRO, BUSINESS_PRO, BUSINESS_MAX,
+                CUSTOM, CUSTOM_*).
+
+  When a user has subscriptions across both products, the highest tier wins.
+
+  Windows are rolling: `minute` = last 60s, `hour` = last 3600s, `day` =
+  last 86_400s, `month` = last 30 days. The month bucket is rolling so it
+  does not reset on calendar month boundaries — same shape across all four
+  windows.
+
+  ## Limits
+
+  Global (all MCP tools combined):
+
+      +-------+--------+------+-------+--------+
+      | Tier  | Minute | Hour | Day   | Month  |
+      +-------+--------+------+-------+--------+
+      | free  |     15 |   30 |    50 |     50 |
+      | pro   |     30 |  250 |   600 |  2,000 |
+      | max   |     60 |  600 | 2,000 | 10,000 |
+      +-------+--------+------+-------+--------+
+
+  Per-tool sub-cap for `combined_trends_tool` (the only LLM-using tool —
+  costlier to serve, so it has a tighter envelope inside the global budget):
+
+      +-------+--------+------+-----+-------+
+      | Tier  | Minute | Hour | Day | Month |
+      +-------+--------+------+-----+-------+
+      | free  |      2 |    5 |  10 |    10 |
+      | pro   |      5 |   40 | 150 |   300 |
+      | max   |     10 |   80 | 400 |   800 |
+      +-------+--------+------+-----+-------+
+
+  ## Tier mapping
+
+      +---------+------------------------------------+-------+
+      | Product | Plan name                          | Tier  |
+      +---------+------------------------------------+-------+
+      | SANBASE | FREE                               | free  |
+      | SANBASE | PRO                                | pro   |
+      | SANBASE | PRO_PLUS, MAX, BUSINESS_PRO,       | max   |
+      |         | BUSINESS_MAX, CUSTOM, CUSTOM_*,    |       |
+      |         | PREMIUM                            |       |
+      | SANAPI  | FREE                               | free  |
+      | SANAPI  | BASIC, PRO, BUSINESS_PRO,          | max   |
+      |         | BUSINESS_MAX, CUSTOM, CUSTOM_*,    |       |
+      |         | PREMIUM                            |       |
+      +---------+------------------------------------+-------+
+
+  Unauthenticated users are blocked at the server layer before reaching
+  this module. Team members (`@santiment.net` + configured `team_emails`)
+  bypass rate-limit checks entirely.
+
+  ## Overriding in tests
+
+  Application env deep-merges into the defaults — set only what you need:
+
+      Application.put_env(:sanbase, Sanbase.MCP.Restrictions,
+        global: %{free: %{minute: 3}}
+      )
+  """
+
+  alias Sanbase.Accounts.User
+  alias Sanbase.Billing.{Plan, Product, Subscription}
+
+  @global %{
+    free: %{minute: 15, hour: 30, day: 50, month: 50},
+    pro: %{minute: 30, hour: 250, day: 600, month: 2_000},
+    max: %{minute: 60, hour: 600, day: 2_000, month: 10_000}
+  }
+
+  @combined_trends %{
+    free: %{minute: 2, hour: 5, day: 10, month: 10},
+    pro: %{minute: 5, hour: 40, day: 150, month: 300},
+    max: %{minute: 10, hour: 80, day: 400, month: 800}
+  }
+
+  @tiers [:free, :pro, :max]
+
+  def tiers, do: @tiers
+
+  def global_limits(tier) when tier in @tiers, do: merge_overrides(:global, tier, @global[tier])
+
+  def combined_trends_limits(tier) when tier in @tiers,
+    do: merge_overrides(:combined_trends, tier, @combined_trends[tier])
+
+  defp merge_overrides(group, tier, defaults) do
+    overrides =
+      :sanbase
+      |> Application.get_env(__MODULE__, [])
+      |> Keyword.get(group, %{})
+      |> Map.get(tier, %{})
+
+    Map.merge(defaults, overrides)
+  end
+
+  @doc """
+  Returns the MCP tier (`:free | :pro | :max`) for the given user.
+
+  Highest tier wins across all active subscriptions, so a user with both a
+  Sanbase PRO and a SanAPI PRO sub gets `:max` (because SanAPI paid plans
+  are MAX-tier for MCP).
+  """
+  @spec tier_for_user(User.t() | nil) :: :free | :pro | :max
+  def tier_for_user(nil), do: :free
+
+  def tier_for_user(%User{} = user) do
+    case Subscription.user_subscriptions(user) do
+      [] -> :free
+      subs -> subs |> Enum.map(&tier_from_subscription/1) |> highest_tier()
+    end
+  end
+
+  defp tier_from_subscription(%Subscription{plan: %Plan{} = plan}) do
+    product = Product.code_by_id(plan.product_id)
+    classify(product, plan.name)
+  end
+
+  defp tier_from_subscription(_), do: :free
+
+  # SANBASE product
+  defp classify("SANBASE", "FREE"), do: :free
+  defp classify("SANBASE", "PRO"), do: :pro
+  defp classify("SANBASE", "PRO_PLUS"), do: :max
+  defp classify("SANBASE", "MAX"), do: :max
+  defp classify("SANBASE", "BUSINESS_PRO"), do: :max
+  defp classify("SANBASE", "BUSINESS_MAX"), do: :max
+  defp classify("SANBASE", "CUSTOM"), do: :max
+  defp classify("SANBASE", "PREMIUM"), do: :max
+  defp classify("SANBASE", "CUSTOM_" <> _), do: :max
+  defp classify("SANBASE", _), do: :free
+
+  # SANAPI product — any paid plan is MAX-tier for MCP (per pricing decision).
+  defp classify("SANAPI", "FREE"), do: :free
+  defp classify("SANAPI", "BASIC"), do: :max
+  defp classify("SANAPI", "PRO"), do: :max
+  defp classify("SANAPI", "BUSINESS_PRO"), do: :max
+  defp classify("SANAPI", "BUSINESS_MAX"), do: :max
+  defp classify("SANAPI", "CUSTOM"), do: :max
+  defp classify("SANAPI", "PREMIUM"), do: :max
+  defp classify("SANAPI", "CUSTOM_" <> _), do: :max
+  defp classify("SANAPI", _), do: :free
+
+  defp classify(_, _), do: :free
+
+  defp highest_tier([]), do: :free
+  defp highest_tier(tiers), do: Enum.max_by(tiers, &tier_rank/1)
+
+  defp tier_rank(:free), do: 0
+  defp tier_rank(:pro), do: 1
+  defp tier_rank(:max), do: 2
+end

--- a/lib/sanbase/mcp/server.ex
+++ b/lib/sanbase/mcp/server.ex
@@ -7,7 +7,7 @@ defmodule Sanbase.MCP.Server do
     capabilities: [:tools, :prompts]
 
   alias Sanbase.Accounts.User
-  alias Sanbase.MCP.{Auth, ToolInvocation}
+  alias Sanbase.MCP.{Auth, Restrictions, ToolInvocation}
 
   @banned_message "Your account is banned from the Santiment MCP server. Contact support."
 
@@ -109,8 +109,10 @@ defmodule Sanbase.MCP.Server do
     if ToolInvocation.team_member?(user) do
       :ok
     else
-      with {:ok, _} <- ToolInvocation.check_rate_limit(user.id),
-           {:ok, _} <- ToolInvocation.check_tool_rate_limit(user.id, tool_name) do
+      tier = Restrictions.tier_for_user(user)
+
+      with {:ok, _} <- ToolInvocation.check_rate_limit(user.id, tier),
+           {:ok, _} <- ToolInvocation.check_tool_rate_limit(user.id, tool_name, tier) do
         :ok
       else
         {:error, message} -> {:rate_limited, message}

--- a/lib/sanbase/mcp/tool_invocation.ex
+++ b/lib/sanbase/mcp/tool_invocation.ex
@@ -665,11 +665,17 @@ defmodule Sanbase.MCP.ToolInvocation do
         |> maybe_filter_product_code(Keyword.get(opts, :product_code))
 
       combo ->
-        {product, plan} = parse_plan_combo(combo)
+        case parse_plan_combo(combo) do
+          {nil, plan} ->
+            query
+            |> maybe_filter_plan_name(plan)
+            |> where([i], is_nil(i.product_code))
 
-        query
-        |> maybe_filter_plan_name(plan)
-        |> maybe_filter_product_code(product)
+          {product, plan} ->
+            query
+            |> maybe_filter_plan_name(plan)
+            |> maybe_filter_product_code(product)
+        end
     end
   end
 

--- a/lib/sanbase/mcp/tool_invocation.ex
+++ b/lib/sanbase/mcp/tool_invocation.ex
@@ -288,17 +288,47 @@ defmodule Sanbase.MCP.ToolInvocation do
   end
 
   @doc """
-  Distinct, non-null plan_name values that have ever been recorded.
-  Used to populate the admin filter dropdown.
+  Distinct `"PRODUCT/PLAN"` combinations that have ever been recorded.
+  Used to populate the admin filter dropdown. SANBASE PRO and SANAPI PRO
+  are distinct entries so filtering can target one product specifically.
+
+  Rows with a `plan_name` but no `product_code` (i.e. legacy FREE buckets
+  for unsubscribed users) are emitted as just `"FREE"`.
   """
-  def plan_names do
+  def plan_combos do
     from(i in __MODULE__,
       where: not is_nil(i.plan_name),
       distinct: true,
-      select: i.plan_name,
-      order_by: i.plan_name
+      select: {i.product_code, i.plan_name},
+      order_by: [asc: i.product_code, asc: i.plan_name]
     )
     |> Repo.all()
+    |> Enum.map(&format_plan_combo/1)
+  end
+
+  @doc """
+  Renders a `{product_code, plan_name}` pair as a single `"PRODUCT/PLAN"`
+  string for UI display, falling back to just the plan name when product
+  is unknown (e.g. the synthetic FREE bucket).
+  """
+  @spec format_plan_combo({String.t() | nil, String.t() | nil}) :: String.t() | nil
+  def format_plan_combo({_product, nil}), do: nil
+  def format_plan_combo({nil, plan}), do: plan
+  def format_plan_combo({product, plan}), do: "#{product}/#{plan}"
+
+  @doc """
+  Splits a `"PRODUCT/PLAN"` combo string back into `{product, plan}`.
+  Accepts a bare plan name (no slash) and returns `{nil, plan}`.
+  """
+  @spec parse_plan_combo(String.t() | nil) :: {String.t() | nil, String.t() | nil}
+  def parse_plan_combo(nil), do: {nil, nil}
+  def parse_plan_combo(""), do: {nil, nil}
+
+  def parse_plan_combo(combo) when is_binary(combo) do
+    case String.split(combo, "/", parts: 2) do
+      [product, plan] -> {product, plan}
+      [plan] -> {nil, plan}
+    end
   end
 
   @builtin_team_emails ["tsvetozar.penov@gmail.com"]
@@ -350,6 +380,9 @@ defmodule Sanbase.MCP.ToolInvocation do
     * `:kind` (`"tool" | "prompt"`) — filter by kind.
     * `:plan_name` (string) — filter by user's plan at invocation time.
     * `:product_code` (string) — filter by product code (`SANBASE` / `SANAPI`).
+    * `:plan_combo` (string `"PRODUCT/PLAN"`) — convenience for the admin
+      UI; splits into `product_code` + `plan_name` filters. Takes
+      precedence over the individual keys when both are set.
   """
   def time_series(opts) do
     since = Keyword.fetch!(opts, :since)
@@ -361,8 +394,7 @@ defmodule Sanbase.MCP.ToolInvocation do
     |> maybe_filter_tool_name(Keyword.get(opts, :tool_name))
     |> maybe_filter_client(Keyword.get(opts, :client))
     |> maybe_filter_kind(Keyword.get(opts, :kind))
-    |> maybe_filter_plan_name(Keyword.get(opts, :plan_name))
-    |> maybe_filter_product_code(Keyword.get(opts, :product_code))
+    |> apply_plan_filters(opts)
     |> group_by([i], selected_as(:bucket))
     |> order_by([i], asc: selected_as(:bucket))
     |> select(
@@ -417,11 +449,12 @@ defmodule Sanbase.MCP.ToolInvocation do
     base_query()
     |> where([i], i.inserted_at >= ^since)
     |> exclude_noise()
-    |> group_by([i], i.plan_name)
+    |> group_by([i], [i.product_code, i.plan_name])
     |> order_by([i], desc: count(i.id))
     |> limit(^limit)
-    |> select([i], {i.plan_name, count(i.id)})
+    |> select([i], {i.product_code, i.plan_name, count(i.id)})
     |> Repo.all()
+    |> Enum.map(fn {product, plan, count} -> {format_plan_combo({product, plan}), count} end)
   end
 
   @doc """
@@ -464,35 +497,34 @@ defmodule Sanbase.MCP.ToolInvocation do
 
   @doc """
   Check global rate limits for a user across all MCP tool invocations.
-  Returns {:ok, true} if under limits, {:error, message} if rate limited.
-  """
-  def check_rate_limit(user_id) do
-    # `||` fallbacks guard against Config.module_get returning nil when the
-    # module env is registered (e.g. with :team_emails) but lacks these keys.
-    limits = %{
-      minute: Config.module_get(__MODULE__, :global_rate_limit_minute, 25) || 25,
-      hour: Config.module_get(__MODULE__, :global_rate_limit_hour, 100) || 100,
-      day: Config.module_get(__MODULE__, :global_rate_limit_day, 500) || 500
-    }
 
-    do_check_rate_limit(user_id, nil, limits)
+  `tier` is the MCP plan tier (`:free | :pro | :max`); when not supplied it
+  is resolved from the user's current subscriptions. Returns `{:ok, true}`
+  when under limits, `{:error, message}` when any window is hit.
+  """
+  def check_rate_limit(user_id, tier \\ nil) when is_integer(user_id) do
+    tier = tier || Sanbase.MCP.Restrictions.tier_for_user(%User{id: user_id})
+    do_check_rate_limit(user_id, nil, Sanbase.MCP.Restrictions.global_limits(tier))
   end
 
   @doc """
-  Check per-tool rate limits. Only `combined_trends_tool` has specific limits.
-  Other tools return {:ok, true} immediately.
+  Check per-tool rate limits. Only `combined_trends_tool` has a per-tool
+  sub-cap today (it's the only LLM-using tool). All other tools return
+  `{:ok, true}` immediately.
   """
-  def check_tool_rate_limit(user_id, "combined_trends_tool") do
-    limits = %{
-      minute: Config.module_get(__MODULE__, :combined_trends_rate_limit_minute, 3) || 3,
-      hour: Config.module_get(__MODULE__, :combined_trends_rate_limit_hour, 20) || 20,
-      day: Config.module_get(__MODULE__, :combined_trends_rate_limit_day, 50) || 50
-    }
+  def check_tool_rate_limit(user_id, tool_name, tier \\ nil)
 
-    do_check_rate_limit(user_id, "combined_trends_tool", limits)
+  def check_tool_rate_limit(user_id, "combined_trends_tool", tier) when is_integer(user_id) do
+    tier = tier || Sanbase.MCP.Restrictions.tier_for_user(%User{id: user_id})
+
+    do_check_rate_limit(
+      user_id,
+      "combined_trends_tool",
+      Sanbase.MCP.Restrictions.combined_trends_limits(tier)
+    )
   end
 
-  def check_tool_rate_limit(_user_id, _tool_name), do: {:ok, true}
+  def check_tool_rate_limit(_user_id, _tool_name, _tier), do: {:ok, true}
 
   defp do_check_rate_limit(user_id, tool_name, limits) do
     entity_name = if tool_name, do: "#{tool_name} calls", else: "MCP tool calls"
@@ -502,6 +534,11 @@ defmodule Sanbase.MCP.ToolInvocation do
       from(i in __MODULE__,
         where: i.user_id == ^user_id,
         select: %{
+          month:
+            fragment(
+              "COUNT(*) FILTER (WHERE inserted_at >= ?)",
+              ^NaiveDateTime.add(now, -30 * 86_400, :second)
+            ),
           day:
             fragment(
               "COUNT(*) FILTER (WHERE inserted_at >= ?)",
@@ -544,6 +581,11 @@ defmodule Sanbase.MCP.ToolInvocation do
         {:error,
          "Rate limit exceeded: #{counts.day}/#{limits.day} #{entity_name} per day. " <>
            "Daily limit resets after 24 hours from your earliest call."}
+
+      counts.month >= limits.month ->
+        {:error,
+         "Rate limit exceeded: #{counts.month}/#{limits.month} #{entity_name} per 30 days. " <>
+           "Monthly limit uses a rolling 30-day window."}
 
       true ->
         {:ok, true}
@@ -600,11 +642,35 @@ defmodule Sanbase.MCP.ToolInvocation do
     |> maybe_filter_tool_name(Keyword.get(opts, :tool_name))
     |> apply_user_filters(email_search, exclude_team)
     |> maybe_filter_metric(Keyword.get(opts, :metric))
-    |> maybe_filter_plan_name(Keyword.get(opts, :plan_name))
-    |> maybe_filter_product_code(Keyword.get(opts, :product_code))
+    |> apply_plan_filters(opts)
     |> maybe_filter_kind(Keyword.get(opts, :kind))
     |> maybe_filter_client(Keyword.get(opts, :client))
     |> maybe_hide_auto_rejected(Keyword.get(opts, :hide_auto_rejected, false))
+  end
+
+  # Lets the admin UI pass a single `plan_combo: "PRODUCT/PLAN"` (e.g.
+  # "SANBASE/PRO") and have it expand into product_code + plan_name
+  # filters. Falls back to the individual keys when combo is absent so
+  # programmatic callers can still set them directly.
+  defp apply_plan_filters(query, opts) do
+    case Keyword.get(opts, :plan_combo) do
+      nil ->
+        query
+        |> maybe_filter_plan_name(Keyword.get(opts, :plan_name))
+        |> maybe_filter_product_code(Keyword.get(opts, :product_code))
+
+      "" ->
+        query
+        |> maybe_filter_plan_name(Keyword.get(opts, :plan_name))
+        |> maybe_filter_product_code(Keyword.get(opts, :product_code))
+
+      combo ->
+        {product, plan} = parse_plan_combo(combo)
+
+        query
+        |> maybe_filter_plan_name(plan)
+        |> maybe_filter_product_code(product)
+    end
   end
 
   defp maybe_hide_auto_rejected(query, false), do: query

--- a/lib/sanbase_web/live/admin/mcp_tool_invocations_live.ex
+++ b/lib/sanbase_web/live/admin/mcp_tool_invocations_live.ex
@@ -24,7 +24,7 @@ defmodule SanbaseWeb.Admin.McpToolInvocationsLive do
       |> assign(:page, 1)
       |> assign(:page_size, @page_size)
       |> assign(:tool_names, ToolInvocation.tool_names())
-      |> assign(:plan_names, ToolInvocation.plan_names())
+      |> assign(:plan_combos, ToolInvocation.plan_combos())
       |> assign(:modal_invocation, nil)
       |> assign(:timeline_window, "7d")
       |> assign(:ban_target, nil)
@@ -86,10 +86,10 @@ defmodule SanbaseWeb.Admin.McpToolInvocationsLive do
      |> load_invocations()}
   end
 
-  def handle_event("filter_plan", %{"plan_name" => plan}, socket) do
+  def handle_event("filter_plan", %{"plan_combo" => combo}, socket) do
     {:noreply,
      socket
-     |> assign(:plan_filter, plan)
+     |> assign(:plan_filter, combo)
      |> assign(:page, 1)
      |> load_invocations()}
   end
@@ -288,7 +288,7 @@ defmodule SanbaseWeb.Admin.McpToolInvocationsLive do
       tool_name: assigns.tool_name_filter,
       email_search: assigns.email_search,
       metric: assigns.metric_search,
-      plan_name: assigns.plan_filter,
+      plan_combo: assigns.plan_filter,
       exclude_team_members: not assigns.include_team,
       hide_auto_rejected: assigns.hide_auto_rejected,
       page: assigns.page,
@@ -408,12 +408,14 @@ defmodule SanbaseWeb.Admin.McpToolInvocationsLive do
 
       <fieldset class="fieldset">
         <legend class="fieldset-legend">Plan</legend>
-        <select id="plan-filter" phx-change="filter_plan" name="plan_name" class="select select-sm">
-          <option value="">All Plans</option>
-          <option :for={pn <- @plan_names} value={pn} selected={pn == @plan_filter}>
-            {pn}
-          </option>
-        </select>
+        <form phx-change="filter_plan" id="plan-filter-form">
+          <select id="plan-filter" name="plan_combo" class="select select-sm">
+            <option value="">All Plans</option>
+            <option :for={combo <- @plan_combos} value={combo} selected={combo == @plan_filter}>
+              {combo}
+            </option>
+          </select>
+        </form>
       </fieldset>
 
       <fieldset class="fieldset">
@@ -782,14 +784,18 @@ defmodule SanbaseWeb.Admin.McpToolInvocationsLive do
   end
 
   defp plan_badge(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :combo,
+        ToolInvocation.format_plan_combo({assigns[:product_code], assigns[:plan_name]})
+      )
+
     ~H"""
-    <span :if={@plan_name} class={["badge badge-sm", plan_badge_class(@plan_name)]}>
-      {@plan_name}
+    <span :if={@combo} class={["badge badge-sm", plan_badge_class(@plan_name)]}>
+      {@combo}
     </span>
-    <span :if={@plan_name && @product_code} class="badge badge-xs badge-ghost ml-1">
-      {@product_code}
-    </span>
-    <span :if={!@plan_name} class="text-base-content/40">-</span>
+    <span :if={!@combo} class="text-base-content/40">-</span>
     """
   end
 

--- a/test/sanbase/mcp/mcp_rate_limit_test.exs
+++ b/test/sanbase/mcp/mcp_rate_limit_test.exs
@@ -3,188 +3,126 @@ defmodule Sanbase.MCP.RateLimitTest do
 
   import Sanbase.Factory
 
-  alias Sanbase.MCP.ToolInvocation
+  alias Sanbase.MCP.{Restrictions, ToolInvocation}
 
-  describe "check_rate_limit/1 (global)" do
+  describe "check_rate_limit/2 (global)" do
     setup do
       user = insert(:user, username: "rate_limit_user", email: "rate_limit@santiment.net")
       %{user: user}
     end
 
     test "returns {:ok, true} when under all limits", %{user: user} do
-      assert {:ok, true} = ToolInvocation.check_rate_limit(user.id)
+      assert {:ok, true} = ToolInvocation.check_rate_limit(user.id, :free)
     end
 
     test "returns error when minute limit is reached", %{user: user} do
-      original = Application.get_env(:sanbase, Sanbase.MCP.ToolInvocation)
-
-      Application.put_env(
-        :sanbase,
-        Sanbase.MCP.ToolInvocation,
-        Keyword.merge(original, global_rate_limit_minute: 3)
-      )
-
-      for _ <- 1..3 do
-        {:ok, _} =
-          ToolInvocation.create(%{
-            user_id: user.id,
-            tool_name: "fetch_metric_data_tool",
-            params: %{},
-            is_successful: true,
-            duration_ms: 100
-          })
-      end
-
-      assert {:error, msg} = ToolInvocation.check_rate_limit(user.id)
-      assert msg =~ "per minute"
-
-      Application.put_env(:sanbase, Sanbase.MCP.ToolInvocation, original)
+      with_overrides(%{global: %{free: %{minute: 3}}}, fn ->
+        insert_invocations(user.id, "fetch_metric_data_tool", 3)
+        assert {:error, msg} = ToolInvocation.check_rate_limit(user.id, :free)
+        assert msg =~ "per minute"
+      end)
     end
 
     test "returns error when hour limit is reached", %{user: user} do
-      original = Application.get_env(:sanbase, Sanbase.MCP.ToolInvocation)
-
-      Application.put_env(
-        :sanbase,
-        Sanbase.MCP.ToolInvocation,
-        Keyword.merge(original, global_rate_limit_hour: 3, global_rate_limit_minute: 10000)
-      )
-
-      for _ <- 1..3 do
-        {:ok, _} =
-          ToolInvocation.create(%{
-            user_id: user.id,
-            tool_name: "fetch_metric_data_tool",
-            params: %{},
-            is_successful: true,
-            duration_ms: 100
-          })
-      end
-
-      assert {:error, msg} = ToolInvocation.check_rate_limit(user.id)
-      assert msg =~ "per hour"
-
-      Application.put_env(:sanbase, Sanbase.MCP.ToolInvocation, original)
+      with_overrides(%{global: %{free: %{hour: 3}}}, fn ->
+        insert_invocations(user.id, "fetch_metric_data_tool", 3)
+        assert {:error, msg} = ToolInvocation.check_rate_limit(user.id, :free)
+        assert msg =~ "per hour"
+      end)
     end
 
     test "returns error when day limit is reached", %{user: user} do
-      original = Application.get_env(:sanbase, Sanbase.MCP.ToolInvocation)
+      with_overrides(%{global: %{free: %{day: 3}}}, fn ->
+        insert_invocations(user.id, "fetch_metric_data_tool", 3)
+        assert {:error, msg} = ToolInvocation.check_rate_limit(user.id, :free)
+        assert msg =~ "per day"
+      end)
+    end
 
-      Application.put_env(
-        :sanbase,
-        Sanbase.MCP.ToolInvocation,
-        Keyword.merge(original,
-          global_rate_limit_day: 3,
-          global_rate_limit_hour: 10000,
-          global_rate_limit_minute: 10000
-        )
+    test "returns error when monthly (rolling 30d) limit is reached", %{user: user} do
+      with_overrides(%{global: %{free: %{month: 3}}}, fn ->
+        insert_invocations(user.id, "fetch_metric_data_tool", 3)
+        assert {:error, msg} = ToolInvocation.check_rate_limit(user.id, :free)
+        assert msg =~ "per 30 days"
+      end)
+    end
+
+    test "tier choice changes the applicable limits", %{user: user} do
+      # Set Free very low, Pro very high. The same call count is over Free's
+      # cap but under Pro's, proving the tier argument is honored.
+      with_overrides(
+        %{
+          global: %{
+            free: %{minute: 1},
+            pro: %{minute: 100}
+          }
+        },
+        fn ->
+          insert_invocations(user.id, "fetch_metric_data_tool", 2)
+          assert {:error, _} = ToolInvocation.check_rate_limit(user.id, :free)
+          assert {:ok, true} = ToolInvocation.check_rate_limit(user.id, :pro)
+        end
       )
-
-      for _ <- 1..3 do
-        {:ok, _} =
-          ToolInvocation.create(%{
-            user_id: user.id,
-            tool_name: "fetch_metric_data_tool",
-            params: %{},
-            is_successful: true,
-            duration_ms: 100
-          })
-      end
-
-      assert {:error, msg} = ToolInvocation.check_rate_limit(user.id)
-      assert msg =~ "per day"
-
-      Application.put_env(:sanbase, Sanbase.MCP.ToolInvocation, original)
     end
   end
 
-  describe "check_tool_rate_limit/2 (per-tool)" do
+  describe "check_tool_rate_limit/3 (per-tool)" do
     setup do
       user = insert(:user, username: "tool_limit_user", email: "tool_limit@santiment.net")
       %{user: user}
     end
 
     test "combined_trends_tool has its own tighter limits", %{user: user} do
-      original = Application.get_env(:sanbase, Sanbase.MCP.ToolInvocation)
+      with_overrides(%{combined_trends: %{free: %{minute: 2}}}, fn ->
+        insert_invocations(user.id, "combined_trends_tool", 2)
 
-      Application.put_env(
-        :sanbase,
-        Sanbase.MCP.ToolInvocation,
-        Keyword.merge(original, combined_trends_rate_limit_minute: 2)
-      )
+        assert {:error, msg} =
+                 ToolInvocation.check_tool_rate_limit(user.id, "combined_trends_tool", :free)
 
-      for _ <- 1..2 do
-        {:ok, _} =
-          ToolInvocation.create(%{
-            user_id: user.id,
-            tool_name: "combined_trends_tool",
-            params: %{},
-            is_successful: true,
-            duration_ms: 100
-          })
-      end
-
-      assert {:error, msg} = ToolInvocation.check_tool_rate_limit(user.id, "combined_trends_tool")
-      assert msg =~ "combined_trends_tool"
-      assert msg =~ "per minute"
-
-      Application.put_env(:sanbase, Sanbase.MCP.ToolInvocation, original)
+        assert msg =~ "combined_trends_tool"
+        assert msg =~ "per minute"
+      end)
     end
 
     test "other tools are unaffected by combined_trends limits", %{user: user} do
-      original = Application.get_env(:sanbase, Sanbase.MCP.ToolInvocation)
+      with_overrides(%{combined_trends: %{free: %{minute: 2}}}, fn ->
+        insert_invocations(user.id, "fetch_metric_data_tool", 5)
 
-      Application.put_env(
-        :sanbase,
-        Sanbase.MCP.ToolInvocation,
-        Keyword.merge(original, combined_trends_rate_limit_minute: 2)
-      )
-
-      for _ <- 1..5 do
-        {:ok, _} =
-          ToolInvocation.create(%{
-            user_id: user.id,
-            tool_name: "fetch_metric_data_tool",
-            params: %{},
-            is_successful: true,
-            duration_ms: 100
-          })
-      end
-
-      # Other tools have no per-tool limit
-      assert {:ok, true} = ToolInvocation.check_tool_rate_limit(user.id, "fetch_metric_data_tool")
-
-      Application.put_env(:sanbase, Sanbase.MCP.ToolInvocation, original)
+        assert {:ok, true} =
+                 ToolInvocation.check_tool_rate_limit(user.id, "fetch_metric_data_tool", :free)
+      end)
     end
 
-    test "combined_trends_tool invocations don't affect other tool limits", %{user: user} do
-      original = Application.get_env(:sanbase, Sanbase.MCP.ToolInvocation)
+    test "combined_trends invocations don't affect other-tool sub-caps", %{user: user} do
+      with_overrides(%{combined_trends: %{free: %{minute: 2}}}, fn ->
+        insert_invocations(user.id, "combined_trends_tool", 2)
 
-      Application.put_env(
-        :sanbase,
-        Sanbase.MCP.ToolInvocation,
-        Keyword.merge(original, combined_trends_rate_limit_minute: 2)
+        assert {:error, _} =
+                 ToolInvocation.check_tool_rate_limit(user.id, "combined_trends_tool", :free)
+
+        assert {:ok, true} =
+                 ToolInvocation.check_tool_rate_limit(user.id, "fetch_metric_data_tool", :free)
+      end)
+    end
+
+    test "higher tier gets larger combined_trends quota", %{user: user} do
+      with_overrides(
+        %{
+          combined_trends: %{
+            free: %{minute: 1},
+            max: %{minute: 100}
+          }
+        },
+        fn ->
+          insert_invocations(user.id, "combined_trends_tool", 2)
+
+          assert {:error, _} =
+                   ToolInvocation.check_tool_rate_limit(user.id, "combined_trends_tool", :free)
+
+          assert {:ok, true} =
+                   ToolInvocation.check_tool_rate_limit(user.id, "combined_trends_tool", :max)
+        end
       )
-
-      # Create combined_trends invocations at the limit
-      for _ <- 1..2 do
-        {:ok, _} =
-          ToolInvocation.create(%{
-            user_id: user.id,
-            tool_name: "combined_trends_tool",
-            params: %{},
-            is_successful: true,
-            duration_ms: 100
-          })
-      end
-
-      # combined_trends is rate limited
-      assert {:error, _} = ToolInvocation.check_tool_rate_limit(user.id, "combined_trends_tool")
-
-      # but other tools are fine
-      assert {:ok, true} = ToolInvocation.check_tool_rate_limit(user.id, "fetch_metric_data_tool")
-
-      Application.put_env(:sanbase, Sanbase.MCP.ToolInvocation, original)
     end
   end
 
@@ -217,6 +155,53 @@ defmodule Sanbase.MCP.RateLimitTest do
       refute ToolInvocation.team_member?(%{email: "external@example.com"})
       refute ToolInvocation.team_member?(%{email: nil})
       refute ToolInvocation.team_member?(nil)
+    end
+  end
+
+  describe "Restrictions.tier_for_user/1" do
+    test "returns :free for nil and users without subscriptions" do
+      assert :free == Restrictions.tier_for_user(nil)
+      user = insert(:user)
+      assert :free == Restrictions.tier_for_user(user)
+    end
+  end
+
+  defp insert_invocations(user_id, tool_name, count) do
+    for _ <- 1..count do
+      {:ok, _} =
+        ToolInvocation.create(%{
+          user_id: user_id,
+          tool_name: tool_name,
+          params: %{},
+          is_successful: true,
+          duration_ms: 100
+        })
+    end
+  end
+
+  # Deep-merges per-tier overrides into the configured Restrictions limits
+  # for the duration of `fun`, then restores the original config.
+  defp with_overrides(overrides, fun) do
+    original = Application.get_env(:sanbase, Sanbase.MCP.Restrictions, [])
+
+    merged =
+      Enum.reduce(overrides, original, fn {group, tier_map}, acc ->
+        existing_group = Keyword.get(acc, group, %{})
+
+        new_group =
+          Enum.reduce(tier_map, existing_group, fn {tier, fields}, group_acc ->
+            Map.update(group_acc, tier, fields, &Map.merge(&1, fields))
+          end)
+
+        Keyword.put(acc, group, new_group)
+      end)
+
+    Application.put_env(:sanbase, Sanbase.MCP.Restrictions, merged)
+
+    try do
+      fun.()
+    after
+      Application.put_env(:sanbase, Sanbase.MCP.Restrictions, original)
     end
   end
 end

--- a/test/sanbase/mcp/tool_invocation_analytics_test.exs
+++ b/test/sanbase/mcp/tool_invocation_analytics_test.exs
@@ -485,13 +485,13 @@ defmodule Sanbase.MCP.ToolInvocationAnalyticsTest do
       assert length(results) == 2
     end
 
-    test "top_by(:plan_name) returns counts per plan" do
+    test "top_by(:plan_name) returns counts per PRODUCT/PLAN combo" do
       since = DateTime.add(DateTime.utc_now(), -3600, :second)
       rows = ToolInvocation.top_by(:plan_name, since)
 
-      assert {"PRO", 2} in rows
+      assert {"SANBASE/PRO", 2} in rows
       assert {"FREE", 1} in rows
-      assert {"MAX", 1} in rows
+      assert {"SANBASE/MAX", 1} in rows
     end
 
     test "time_series filters by plan_name" do
@@ -502,11 +502,22 @@ defmodule Sanbase.MCP.ToolInvocationAnalyticsTest do
       assert total == 2
     end
 
-    test "plan_names/0 returns distinct non-null plan names" do
-      names = ToolInvocation.plan_names()
-      assert "PRO" in names
-      assert "FREE" in names
-      assert "MAX" in names
+    test "list_invocations filters by plan_combo PRODUCT/PLAN", %{user_pro: user_pro} do
+      results = ToolInvocation.list_invocations(plan_combo: "SANBASE/PRO")
+      assert length(results) == 2
+      assert Enum.all?(results, &(&1.user_id == user_pro.id))
+
+      # A bare plan name (no slash) still works — useful for the FREE bucket
+      # where product_code is nil.
+      free_results = ToolInvocation.list_invocations(plan_combo: "FREE")
+      assert length(free_results) == 1
+    end
+
+    test "plan_combos/0 returns distinct PRODUCT/PLAN strings" do
+      combos = ToolInvocation.plan_combos()
+      assert "SANBASE/PRO" in combos
+      assert "FREE" in combos
+      assert "SANBASE/MAX" in combos
     end
   end
 

--- a/test/sanbase/mcp/tool_invocation_test.exs
+++ b/test/sanbase/mcp/tool_invocation_test.exs
@@ -134,12 +134,20 @@ defmodule Sanbase.MCP.ToolInvocationTest do
   end
 
   test "returns rate limit error when global limit is exceeded", context do
-    original = Application.get_env(:sanbase, Sanbase.MCP.ToolInvocation)
+    original = Application.get_env(:sanbase, Sanbase.MCP.Restrictions, [])
 
     Application.put_env(
       :sanbase,
-      Sanbase.MCP.ToolInvocation,
-      Keyword.merge(original, global_rate_limit_minute: 2)
+      Sanbase.MCP.Restrictions,
+      Keyword.put(
+        original,
+        :global,
+        %{
+          free: %{minute: 2, hour: 10_000, day: 10_000, month: 10_000},
+          pro: %{minute: 2, hour: 10_000, day: 10_000, month: 10_000},
+          max: %{minute: 2, hour: 10_000, day: 10_000, month: 10_000}
+        }
+      )
     )
 
     # Pre-insert invocations to reach the limit
@@ -185,7 +193,7 @@ defmodule Sanbase.MCP.ToolInvocationTest do
     assert rate_limited_inv.error_message =~ "Rate limit exceeded"
     assert rate_limited_inv.duration_ms == 0
 
-    Application.put_env(:sanbase, Sanbase.MCP.ToolInvocation, original)
+    Application.put_env(:sanbase, Sanbase.MCP.Restrictions, original)
   end
 
   test "filters work correctly", context do


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tier-based rate limiting for MCP tool usage with distinct free/pro/max plans and per-plan/month rolling limits.
* **Improvements**
  * Admin dashboard plan filter now shows product/plan combos (e.g., "SANBASE/PRO") and supports combo-based filtering.
  * Combined-trends queries have stricter, separate limits than other tools.
* **Tests**
  * Updated test coverage for tiered limits, rolling-month window, and plan-combo filtering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santiment/sanbase2/pull/5167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->