### PR TITLE
Scale k-prefix hyperqliquid prices by 1000

### DIFF
--- a/lib/sanbase/hyperliquid/bbo/bbo_prices.ex
+++ b/lib/sanbase/hyperliquid/bbo/bbo_prices.ex
@@ -16,6 +16,9 @@ defmodule Sanbase.Hyperliquid.Bbo.BboPrices do
     only: [timeseries_data_query: 4]
 
   alias Sanbase.ClickhouseRepo
+  alias Sanbase.Project.SourceSlugMapping
+
+  @source "hyperliquid"
 
   @type point :: %{
           datetime: DateTime.t(),
@@ -41,9 +44,15 @@ defmodule Sanbase.Hyperliquid.Bbo.BboPrices do
           {:ok, [point]} | {:error, String.t()}
   def timeseries_data(slug, from, to, interval) do
     query_struct = timeseries_data_query(slug, from, to, interval)
+    k_factor = k_factor(slug)
 
     ClickhouseRepo.query_transform(query_struct, fn
       [time, bid_price, bid_volume, ask_price, ask_volume] ->
+        bid_price = scale_price(bid_price, k_factor)
+        bid_volume = scale_volume(bid_volume, k_factor)
+        ask_price = scale_price(ask_price, k_factor)
+        ask_volume = scale_volume(ask_volume, k_factor)
+
         %{
           datetime: DateTime.from_unix!(time),
           bid_price: bid_price,
@@ -55,6 +64,42 @@ defmodule Sanbase.Hyperliquid.Bbo.BboPrices do
         }
     end)
   end
+
+  # Hyperliquid quotes some low-priced assets per 1000 underlying tokens. The
+  # only signal is a lowercase "k" prefix on the coin name (e.g. "kPEPE",
+  # "kSHIB", "kBONK", "kLUNC", "kFLOKI"); the convention is "k" for kilo, so
+  # one quoted contract represents 1000 of the underlying. Raw fields from
+  # Hyperliquid are therefore:
+  #
+  #   * `px` — USD per 1000 underlying tokens
+  #   * `sz` — number of contracts (each = 1000 underlying tokens)
+  #
+  # To expose values in native-token units while preserving notional
+  # (`price * volume`), price is divided by 1000 and volume is multiplied by
+  # 1000 for k-prefixed coins.
+  #
+  # This convention is NOT formally documented in the Hyperliquid docs
+  # (perpetuals info endpoint, tick/lot size, contract specifications). The
+  # live `POST /info {"type":"meta"}` response exposes `name`, `szDecimals`,
+  # `maxLeverage`, `marginTableId`, `marginMode` per asset — none of which is
+  # a price/size multiplier. The encoding was verified empirically against
+  # `POST /info {"type":"l2Book","coin":"kPEPE"}`: a quoted `px=0.003691` with
+  # `sz=202527` gives notional `0.003691 * 202527 ≈ $748`, which only matches
+  # realistic order sizes if `px` is per 1000 PEPE and `sz` is in contracts.
+  # Matching on the name prefix is the only option short of hardcoding a list,
+  # which would go stale as Hyperliquid adds new k-assets.
+  defp k_factor(sanbase_slug) do
+    case SourceSlugMapping.get_source_slug(sanbase_slug, @source) do
+      "k" <> _ -> 1000
+      _ -> 1
+    end
+  end
+
+  defp scale_price(nil, _factor), do: nil
+  defp scale_price(value, factor), do: value / factor
+
+  defp scale_volume(nil, _factor), do: nil
+  defp scale_volume(value, factor), do: value * factor
 
   defp mid_price(bid, ask) do
     if Enum.all?([bid, ask], &is_number/1), do: (bid + ask) / 2

--- a/lib/sanbase/project/source_slug_mapping.ex
+++ b/lib/sanbase/project/source_slug_mapping.ex
@@ -53,6 +53,22 @@ defmodule Sanbase.Project.SourceSlugMapping do
     |> Repo.one()
   end
 
+  @doc ~s"""
+  Return the source slug (as known to `source`) for the project identified by
+  `project_slug` (Sanbase slug), or `nil` if no mapping exists.
+  """
+  @spec get_source_slug(String.t(), String.t()) :: String.t() | nil
+  def get_source_slug(project_slug, source) do
+    from(
+      ssm in __MODULE__,
+      join: p in assoc(ssm, :project),
+      where: ssm.source == ^source and p.slug == ^project_slug,
+      select: ssm.slug,
+      limit: 1
+    )
+    |> Repo.one()
+  end
+
   def delete_mappings_for_source_and_slugs(source, slugs) do
     from(
       ssm in __MODULE__,

--- a/test/sanbase/hyperliquid/bbo/bbo_prices_test.exs
+++ b/test/sanbase/hyperliquid/bbo/bbo_prices_test.exs
@@ -1,7 +1,10 @@
 defmodule Sanbase.Hyperliquid.Bbo.BboPricesTest do
   use Sanbase.DataCase, async: false
 
+  import Sanbase.Factory
+
   alias Sanbase.Hyperliquid.Bbo.BboPrices
+  alias Sanbase.Project.SourceSlugMapping
 
   setup do
     %{
@@ -80,5 +83,115 @@ defmodule Sanbase.Hyperliquid.Bbo.BboPricesTest do
       assert r.mid_price == 101.0
       assert r.weighted_mid_price == nil
     end)
+  end
+
+  describe "k-prefix scaling" do
+    defp seed_mapping(sanbase_slug, hyperliquid_coin) do
+      project = insert(:project, %{slug: sanbase_slug})
+
+      {:ok, _} =
+        SourceSlugMapping.create(%{
+          source: "hyperliquid",
+          slug: hyperliquid_coin,
+          project_id: project.id
+        })
+
+      :ok
+    end
+
+    test "divides price by 1000 and multiplies volume by 1000 when hyperliquid coin starts with lowercase k",
+         ctx do
+      seed_mapping("pepe", "kPEPE")
+      rows = [[DateTime.to_unix(ctx.t1), 1000.0, 2000.0, 2000.0, 4000.0]]
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        assert {:ok, [r]} =
+                 BboPrices.timeseries_data("pepe", ctx.from, ctx.to, ctx.interval)
+
+        assert r.bid_price == 1.0
+        assert r.bid_volume == 2_000_000.0
+        assert r.ask_price == 2.0
+        assert r.ask_volume == 4_000_000.0
+        assert r.mid_price == 1.5
+        # (1 * 4_000_000 + 2 * 2_000_000) / (2_000_000 + 4_000_000)
+        assert r.weighted_mid_price == 8_000_000.0 / 6_000_000.0
+      end)
+    end
+
+    test "notional is preserved across k-coin scaling", ctx do
+      seed_mapping("pepe", "kPEPE")
+      rows = [[DateTime.to_unix(ctx.t1), 0.003691, 202_527.0, 0.003692, 100_000.0]]
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        assert {:ok, [r]} =
+                 BboPrices.timeseries_data("pepe", ctx.from, ctx.to, ctx.interval)
+
+        assert_in_delta r.bid_price * r.bid_volume, 0.003691 * 202_527.0, 1.0e-6
+        assert_in_delta r.ask_price * r.ask_volume, 0.003692 * 100_000.0, 1.0e-6
+      end)
+    end
+
+    test "leaves values unchanged when hyperliquid coin has no k prefix", ctx do
+      seed_mapping("bitcoin", "BTC")
+      rows = [[DateTime.to_unix(ctx.t1), 100.0, 2.0, 102.0, 4.0]]
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        assert {:ok, [r]} =
+                 BboPrices.timeseries_data("bitcoin", ctx.from, ctx.to, ctx.interval)
+
+        assert r.bid_price == 100.0
+        assert r.bid_volume == 2.0
+        assert r.ask_price == 102.0
+        assert r.ask_volume == 4.0
+      end)
+    end
+
+    test "uppercase K prefix does not trigger scaling", ctx do
+      seed_mapping("kava", "KAVA")
+      rows = [[DateTime.to_unix(ctx.t1), 100.0, 2.0, 102.0, 4.0]]
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        assert {:ok, [r]} =
+                 BboPrices.timeseries_data("kava", ctx.from, ctx.to, ctx.interval)
+
+        assert r.bid_price == 100.0
+        assert r.ask_price == 102.0
+      end)
+    end
+
+    test "missing source_slug_mapping leaves values unchanged", ctx do
+      rows = [[DateTime.to_unix(ctx.t1), 100.0, 2.0, 102.0, 4.0]]
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        assert {:ok, [r]} =
+                 BboPrices.timeseries_data("unmapped", ctx.from, ctx.to, ctx.interval)
+
+        assert r.bid_price == 100.0
+        assert r.ask_price == 102.0
+      end)
+    end
+
+    test "scaled k-coin preserves nil sides", ctx do
+      seed_mapping("pepe", "kPEPE")
+      rows = [[DateTime.to_unix(ctx.t1), nil, nil, 2000.0, 4000.0]]
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        assert {:ok, [r]} =
+                 BboPrices.timeseries_data("pepe", ctx.from, ctx.to, ctx.interval)
+
+        assert r.bid_price == nil
+        assert r.bid_volume == nil
+        assert r.ask_price == 2.0
+        assert r.ask_volume == 4_000_000.0
+        assert r.mid_price == nil
+        assert r.weighted_mid_price == nil
+      end)
+    end
   end
 end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asset-specific scaling applied to per-row bid/ask prices and volumes (assets with a lowercase "k" prefix are rescaled while others remain unchanged), preserving notional and mid/weighted-mid consistency
  * Added source-slug lookup to determine scaling rules

* **Tests**
  * New tests verifying scaling behavior, preservation of notional, nil-handling, and prefix case sensitivity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santiment/sanbase2/pull/5168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->