### PR TITLE
Persist subs in promo trial table

### DIFF
--- a/lib/sanbase/billing/subscription/promo_trial.ex
+++ b/lib/sanbase/billing/subscription/promo_trial.ex
@@ -125,7 +125,8 @@ defmodule Sanbase.Billing.Subscription.PromoTrial do
 
   defp create_promo_subscriptions(%User{} = user, plans, trial_days) when is_list(plans) do
     with {:ok, user} <- Billing.create_or_update_stripe_customer(user),
-         {:ok, subscriptions} <- promo_subscribe(user, plans, trial_days) do
+         {:ok, subscriptions} <- promo_subscribe(user, plans, trial_days),
+         {:ok, _promo_trial} <- insert_promo_trial_record(user.id, plans, trial_days) do
       {:ok, subscriptions}
     else
       {:error, error} ->
@@ -135,12 +136,21 @@ defmodule Sanbase.Billing.Subscription.PromoTrial do
 
   defp create_promo_subscription(%User{} = user, plan_id, trial_days) do
     with {:ok, user} <- Billing.create_or_update_stripe_customer(user),
-         {:ok, subscription} <- promo_subscribe(user, plan_id, trial_days) do
+         {:ok, subscription} <- promo_subscribe(user, plan_id, trial_days),
+         {:ok, _promo_trial} <- insert_promo_trial_record(user.id, [plan_id], trial_days) do
       {:ok, subscription}
     else
       {:error, error} ->
         handle_error(user, error)
     end
+  end
+
+  defp insert_promo_trial_record(user_id, plans, trial_days) do
+    plan_ids = Enum.map(plans, &to_string/1)
+
+    %__MODULE__{}
+    |> changeset(%{user_id: user_id, trial_days: trial_days, plans: plan_ids})
+    |> Sanbase.Repo.insert()
   end
 
   defp promo_subscribe(user, plan_ids, trial_days) when is_list(plan_ids) do

--- a/test/sanbase/billing/promo_trial_test.exs
+++ b/test/sanbase/billing/promo_trial_test.exs
@@ -5,6 +5,7 @@ defmodule Sanbase.Billing.PromoTrialTest do
   import Mock
 
   alias Sanbase.Billing.Subscription.PromoTrial
+  alias Sanbase.Repo
   alias Sanbase.StripeApi
   alias Sanbase.StripeApiTestResponse
 
@@ -43,6 +44,10 @@ defmodule Sanbase.Billing.PromoTrialTest do
       assert is_integer(args.trial_end)
       assert args.cancel_at == args.trial_end - 60
       assert args.customer == "cus_test_promo"
+
+      promo_trial = Repo.get_by(PromoTrial, user_id: context.user.id)
+      assert promo_trial.trial_days == 14
+      assert promo_trial.plans == ["Sanbase by Santiment / PRO (month)"]
     end
 
     test "passes cancel_at 60s before trial_end for single plan_id variant", context do
@@ -57,6 +62,10 @@ defmodule Sanbase.Billing.PromoTrialTest do
 
       assert_receive {:stripe_create_subscription, args}
       assert args.cancel_at == args.trial_end - 60
+
+      promo_trial = Repo.get_by(PromoTrial, user_id: context.user.id)
+      assert promo_trial.trial_days == 7
+      assert promo_trial.plans == ["Sanbase by Santiment / PRO (month)"]
     end
 
     test "string-keyed params variant also sets cancel_at 60s before trial_end", context do
@@ -71,6 +80,31 @@ defmodule Sanbase.Billing.PromoTrialTest do
 
       assert_receive {:stripe_create_subscription, args}
       assert args.cancel_at == args.trial_end - 60
+
+      promo_trial = Repo.get_by(PromoTrial, user_id: context.user.id)
+      assert promo_trial.trial_days == 30
+      assert promo_trial.plans == ["Sanbase by Santiment / PRO (month)"]
+    end
+
+    test "persists one promo_trials row for multiple plans", context do
+      sanbase_plan = context.plans.plan_pro_sanbase
+      api_plan = context.plans.plan_pro
+
+      assert {:ok, subscriptions} =
+               PromoTrial.create_promo_trial(%{
+                 user_id: context.user.id,
+                 plans: [sanbase_plan.id, api_plan.id],
+                 trial_days: 14
+               })
+
+      assert length(subscriptions) == 2
+      assert Repo.aggregate(PromoTrial, :count, :id) == 1
+
+      promo_trial = Repo.get_by(PromoTrial, user_id: context.user.id)
+      assert promo_trial.trial_days == 14
+      assert length(promo_trial.plans) == 2
+      assert "Sanbase by Santiment / PRO (month)" in promo_trial.plans
+      assert "Sanapi by Santiment / PRO (month)" in promo_trial.plans
     end
 
     test "trial_end timestamp roughly matches requested trial_days", context do


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Promotional trial records now properly persist to the database when promotional subscriptions are created, ensuring accurate tracking of trial duration and associated plans.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santiment/sanbase2/pull/5175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->