### PR TITLE
Expose defaultAggregation in getAccessRestrictions

### DIFF
--- a/lib/sanbase/billing/plan/restrictions.ex
+++ b/lib/sanbase/billing/plan/restrictions.ex
@@ -20,7 +20,8 @@ defmodule Sanbase.Billing.Plan.Restrictions do
           hard_deprecate_after: DateTime.t() | nil,
           docs: list(String.t()),
           available_selectors: list(atom()),
-          required_selectors: list(list(atom()))
+          required_selectors: list(list(atom())),
+          default_aggregation: atom() | nil
         }
 
   @type query_or_argument :: {:metric, String.t()} | {:signal, String.t()} | {:query, atom()}
@@ -189,6 +190,7 @@ defmodule Sanbase.Billing.Plan.Restrictions do
           docs: metadata.docs,
           available_selectors: metadata.available_selectors,
           required_selectors: metadata.required_selectors,
+          default_aggregation: metadata.default_aggregation,
           status: metadata.status
         }
 

--- a/lib/sanbase_web/graphql/schema/types/user_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/user_types.ex
@@ -453,6 +453,8 @@ defmodule SanbaseWeb.Graphql.UserTypes do
     field(:required_selectors, list_of(list_of(:selector_name)))
     # only metrics have status, for queries and signals it is nil
     field(:status, :string)
+    # only metrics have default_aggregation, for queries and signals it is nil
+    field(:default_aggregation, :aggregation)
 
     field :available_versions, list_of(:metric_version) do
       cache_resolve(&SanbaseWeb.Graphql.Resolvers.AccessControlResolver.available_versions/3,


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Access restrictions now include default aggregation information for metrics, improving visibility into metric configuration settings and requirements
  * Metric restrictions expanded with required selectors data to provide better clarity on available selection options for restricted metrics
  * API responses enhanced with aggregation defaults to support comprehensive metric configuration visibility and proper metric handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santiment/sanbase2/pull/5180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->