### PR TITLE
Knowledge: filter unpublished insights, similarity threshold, citations, SHA-skip reindex

### DIFF
--- a/lib/sanbase/insight/post.ex
+++ b/lib/sanbase/insight/post.ex
@@ -133,6 +133,7 @@ defmodule Sanbase.Insight.Post do
         e in PostEmbedding,
         inner_join: p in Post,
         on: e.post_id == p.id,
+        where: p.ready_state == ^@published and p.state == ^@approved and p.is_deleted != true,
         select: %{
           post_id: e.post_id,
           post_title: p.title,

--- a/lib/sanbase/knowledge/academy.ex
+++ b/lib/sanbase/knowledge/academy.ex
@@ -134,17 +134,19 @@ defmodule Sanbase.Knowledge.Academy do
 
   defp perform_dry_run(branch) do
     with {:ok, tree_entries} <- fetch_repo_markdown_list(branch),
-         {:ok, _articles} <- process_markdown_entries(tree_entries, branch, true) do
+         {:ok, _result} <- process_markdown_entries(tree_entries, branch, true) do
       :ok
     end
   end
 
   defp do_reindex(branch) do
     with {:ok, tree_entries} <- fetch_repo_markdown_list(branch),
-         {:ok, articles} <- process_markdown_entries(tree_entries, branch, false) do
+         {:ok, %{to_index: to_index, unchanged: unchanged}} <-
+           process_markdown_entries(tree_entries, branch, false) do
       Repo.transaction(fn ->
         mark_all_articles_stale()
-        finalize_indexing(articles)
+        clear_stale_for_unchanged(unchanged)
+        finalize_indexing(to_index)
       end)
       |> case do
         {:ok, :ok} -> :ok
@@ -205,17 +207,24 @@ defmodule Sanbase.Knowledge.Academy do
 
   defp process_markdown_entries(entries, branch, dry_run?) do
     total = length(entries)
+    init_acc = %{to_index: [], unchanged: []}
 
     result =
       entries
       |> Enum.with_index()
-      |> Enum.reduce_while({:ok, []}, fn {entry, index}, {:ok, acc} ->
-        with {:ok, article_attrs, chunks_attrs} <-
-               fetch_and_prepare_article(entry, branch, dry_run?) do
-          log_progress(index + 1, total, entry.path)
+      |> Enum.reduce_while({:ok, init_acc}, fn {entry, index}, {:ok, acc} ->
+        case fetch_and_prepare_article(entry, branch, dry_run?) do
+          {:ok, article_attrs, chunks_attrs} ->
+            log_progress(index + 1, total, entry.path)
 
-          {:cont, {:ok, [%{article: article_attrs, chunks: chunks_attrs} | acc]}}
-        else
+            {:cont,
+             {:ok,
+              %{acc | to_index: [%{article: article_attrs, chunks: chunks_attrs} | acc.to_index]}}}
+
+          {:unchanged, article_id} ->
+            log_progress(index + 1, total, "#{entry.path} (unchanged, sha match)")
+            {:cont, {:ok, %{acc | unchanged: [article_id | acc.unchanged]}}}
+
           {:ignore, _reason} ->
             {:cont, {:ok, acc}}
 
@@ -225,8 +234,11 @@ defmodule Sanbase.Knowledge.Academy do
       end)
 
     case result do
-      {:ok, articles} -> {:ok, Enum.reverse(articles)}
-      error -> error
+      {:ok, %{to_index: to_index, unchanged: unchanged}} ->
+        {:ok, %{to_index: Enum.reverse(to_index), unchanged: unchanged}}
+
+      error ->
+        error
     end
   end
 
@@ -235,7 +247,29 @@ defmodule Sanbase.Knowledge.Academy do
     repo_owner = Map.get(entry, :repo_owner, @github_repo_owner)
     repo_name = Map.get(entry, :repo_name, @github_repo_name)
     ref = Map.get(entry, :ref, branch)
+    github_path = Map.get(entry, :github_path, path)
+    incoming_sha = entry[:sha]
 
+    case maybe_use_cached(github_path, incoming_sha, dry_run?) do
+      {:unchanged, article_id} ->
+        {:unchanged, article_id}
+
+      :no_cache ->
+        do_fetch_and_prepare_article(entry, path, ref, repo_owner, repo_name, dry_run?)
+    end
+  end
+
+  defp maybe_use_cached(_github_path, nil, _dry_run?), do: :no_cache
+  defp maybe_use_cached(_github_path, _sha, true), do: :no_cache
+
+  defp maybe_use_cached(github_path, incoming_sha, false) do
+    case Repo.get_by(AcademyArticle, github_path: github_path) do
+      %AcademyArticle{content_sha: ^incoming_sha, id: id} -> {:unchanged, id}
+      _ -> :no_cache
+    end
+  end
+
+  defp do_fetch_and_prepare_article(entry, path, ref, repo_owner, repo_name, dry_run?) do
     case fetch_file_contents(path, ref, repo_owner, repo_name) do
       {:ok, %{content: markdown, sha: fetched_sha}} ->
         content_sha =
@@ -408,6 +442,22 @@ defmodule Sanbase.Knowledge.Academy do
     end)
 
     delete_stale_records()
+    :ok
+  end
+
+  defp clear_stale_for_unchanged([]), do: :ok
+
+  defp clear_stale_for_unchanged(article_ids) when is_list(article_ids) do
+    Repo.update_all(
+      from(a in AcademyArticle, where: a.id in ^article_ids),
+      set: [is_stale: false]
+    )
+
+    Repo.update_all(
+      from(c in AcademyArticleChunk, where: c.article_id in ^article_ids),
+      set: [is_stale: false]
+    )
+
     :ok
   end
 

--- a/lib/sanbase/knowledge/knowledge.ex
+++ b/lib/sanbase/knowledge/knowledge.ex
@@ -1,19 +1,33 @@
 defmodule Sanbase.Knowledge do
+  @default_min_similarity 0.35
+  @no_answer_message "I don't have enough information in the available Santiment FAQ, Academy, or Insights content to answer this question. Please contact Santiment Support for further assistance."
+
   def answer_question(user_input, options \\ []) do
     with {:ok, [embedding]} <- Sanbase.AI.Embedding.generate_embeddings([user_input], 1536),
-         {:ok, prompt} <- build_question_answer_prompt(user_input, embedding, options),
-         {:ok, answer} <- Sanbase.OpenAI.Question.ask(prompt) do
-      {:ok, answer}
+         {:ok, prompt, sources_found?} <-
+           build_question_answer_prompt(user_input, embedding, options) do
+      if sources_found? do
+        Sanbase.OpenAI.Question.ask(prompt)
+      else
+        {:ok, @no_answer_message}
+      end
     end
   end
 
   def smart_search(user_input, options) do
+    min_sim = min_similarity(options)
+
     with {:ok, [embedding]} <- Sanbase.AI.Embedding.generate_embeddings([user_input], 1536),
          {:ok, faq_entries} <- maybe_find_most_similar_faqs(embedding, options),
          {:ok, academy_articles} <- maybe_find_most_similar_academy_articles(embedding, options),
          {:ok, insights} <- maybe_find_most_similar_insights(embedding, options),
          {:ok, answer} <-
-           build_smart_search_result(faq_entries, academy_articles, insights, options) do
+           build_smart_search_result(
+             filter_by_similarity(faq_entries, min_sim),
+             filter_by_similarity(academy_articles, min_sim),
+             filter_by_similarity(insights, min_sim),
+             options
+           ) do
       {:ok, answer}
     end
   end
@@ -61,41 +75,49 @@ defmodule Sanbase.Knowledge do
   end
 
   defp build_question_answer_prompt(user_input, embedding, options) do
+    min_sim = min_similarity(options)
+
     with {:ok, prompt} <- generate_initial_prompt(user_input),
-         {:ok, prompt} <- maybe_add_similar_faqs(prompt, embedding, options),
-         {:ok, prompt} <- maybe_add_similar_insight_chunks(prompt, embedding, options),
-         {:ok, prompt} <- maybe_add_similar_academy_chunks(prompt, embedding, options) do
-      {:ok, prompt}
-    else
-      unexpected ->
-        raise(ArgumentError, "Got #{unexpected}")
+         {:ok, prompt, faq_found?} <-
+           maybe_add_similar_faqs(prompt, embedding, options, min_sim),
+         {:ok, prompt, insights_found?} <-
+           maybe_add_similar_insight_chunks(prompt, embedding, options, min_sim),
+         {:ok, prompt, academy_found?} <-
+           maybe_add_similar_academy_chunks(prompt, embedding, options, min_sim) do
+      {:ok, prompt, faq_found? or insights_found? or academy_found?}
     end
   end
 
-  def maybe_add_similar_faqs(prompt, embedding, options) do
+  defp maybe_add_similar_faqs(prompt, embedding, options, min_sim) do
     if Keyword.get(options, :faq, true) do
       {:ok, faq_entries} = find_most_similar_faqs(embedding, 5)
+      faq_entries = filter_by_similarity(faq_entries, min_sim)
 
-      entries_text =
-        Enum.map(faq_entries, fn faq_entry ->
-          """
-          Question: #{faq_entry.question}
-          Answer: #{faq_entry.answer_markdown}
-          """
-        end)
-        |> Enum.join("\n")
+      if faq_entries == [] do
+        {:ok, prompt, false}
+      else
+        entries_text =
+          Enum.map(faq_entries, fn faq_entry ->
+            """
+            Source: [FAQ:#{faq_entry.id}]
+            Question: #{faq_entry.question}
+            Answer: #{faq_entry.answer_markdown}
+            """
+          end)
+          |> Enum.join("\n")
 
-      prompt =
-        prompt <>
-          """
-          <Similar_FAQ_Entries>
-          #{entries_text}
-          </Similar_FAQ_Entries>
-          """
+        prompt =
+          prompt <>
+            """
+            <Similar_FAQ_Entries>
+            #{entries_text}
+            </Similar_FAQ_Entries>
+            """
 
-      {:ok, prompt}
+        {:ok, prompt, true}
+      end
     else
-      {:ok, prompt}
+      {:ok, prompt, false}
     end
   end
 
@@ -105,6 +127,20 @@ defmodule Sanbase.Knowledge do
     else
       {:ok, []}
     end
+  end
+
+  defp min_similarity(options) do
+    Keyword.get(options, :min_similarity, @default_min_similarity)
+  end
+
+  defp filter_by_similarity(entries, min_sim) do
+    Enum.filter(entries, fn entry ->
+      case Map.get(entry, :similarity) do
+        nil -> false
+        sim when is_number(sim) -> sim >= min_sim
+        _ -> false
+      end
+    end)
   end
 
   defp find_most_similar_faqs(embedding, size) do
@@ -127,23 +163,36 @@ defmodule Sanbase.Knowledge do
     Sanbase.Insight.Post.find_most_similar_insights(embedding, size)
   end
 
-  def maybe_add_similar_insight_chunks(prompt, embedding, options) do
+  defp maybe_add_similar_insight_chunks(prompt, embedding, options, min_sim) do
     if Keyword.get(options, :insights, true) do
       with {:ok, post_embeddings} <- find_most_similar_insight_chunks(embedding, 5) do
-        text_chunks = Enum.map(post_embeddings, & &1.text_chunk) |> Enum.join("\n\n")
+        post_embeddings = filter_by_similarity(post_embeddings, min_sim)
 
-        prompt =
-          prompt <>
-            """
-            <Most_Similar_Santiment_Insight_Chunks>
-            #{text_chunks}
-            </Most_Similar_Santiment_Insight_Chunks>
-            """
+        if post_embeddings == [] do
+          {:ok, prompt, false}
+        else
+          text_chunks =
+            Enum.map(post_embeddings, fn chunk ->
+              """
+              Source: [Insight:#{chunk.post_id}] "#{chunk.post_title}"
+              #{chunk.text_chunk}
+              """
+            end)
+            |> Enum.join("\n\n")
 
-        {:ok, prompt}
+          prompt =
+            prompt <>
+              """
+              <Most_Similar_Santiment_Insight_Chunks>
+              #{text_chunks}
+              </Most_Similar_Santiment_Insight_Chunks>
+              """
+
+          {:ok, prompt, true}
+        end
       end
     else
-      {:ok, prompt}
+      {:ok, prompt, false}
     end
   end
 
@@ -155,35 +204,41 @@ defmodule Sanbase.Knowledge do
     end
   end
 
-  def maybe_add_similar_academy_chunks(prompt, embedding, options \\ []) do
+  defp maybe_add_similar_academy_chunks(prompt, embedding, options, min_sim) do
     if Keyword.get(options, :academy, true) do
       case Sanbase.Knowledge.Academy.search_chunks(embedding, 5) do
         {:ok, academy_chunks} ->
-          academy_text_chunks =
-            Enum.map(academy_chunks, fn academy_chunk ->
-              """
-              Article title: #{academy_chunk.title}
-              Article URL: #{academy_chunk.url}
-              Most relevant chunk from article: #{academy_chunk.chunk}
-              """
-            end)
-            |> Enum.join("\n")
+          academy_chunks = filter_by_similarity(academy_chunks, min_sim)
 
-          prompt =
-            prompt <>
-              """
-              <Academy_Content>
-              #{academy_text_chunks}
-              </Academy_Content>
-              """
+          if academy_chunks == [] do
+            {:ok, prompt, false}
+          else
+            academy_text_chunks =
+              Enum.map(academy_chunks, fn academy_chunk ->
+                """
+                Source: [Academy:#{academy_chunk.url}]
+                Article title: #{academy_chunk.title}
+                Most relevant chunk from article: #{academy_chunk.chunk}
+                """
+              end)
+              |> Enum.join("\n")
 
-          {:ok, prompt}
+            prompt =
+              prompt <>
+                """
+                <Academy_Content>
+                #{academy_text_chunks}
+                </Academy_Content>
+                """
+
+            {:ok, prompt, true}
+          end
 
         _ ->
-          {:ok, prompt}
+          {:ok, prompt, false}
       end
     else
-      {:ok, prompt}
+      {:ok, prompt, false}
     end
   end
 
@@ -208,6 +263,9 @@ defmodule Sanbase.Knowledge do
     8. If the user's question is unclear or ambiguous, politely ask for clarification using only the information provided.
     9. Prioritize accuracy and transparency—if there is any uncertainty, clearly communicate the limitations of the available information.
     10. When possible, summarize key points or actionable steps to help the user resolve their issue efficiently.
+    11. Cite every claim with the source markers exactly as provided: `[FAQ:<id>]`, `[Academy:<url>]`, or `[Insight:<id>]`.
+        Place the marker inline immediately after the sentence or bullet it supports. Do not invent markers and do not omit them.
+    12. End the answer with a `Sources` section listing each unique cited marker on its own bullet.
     </Instructions>
 
     <User_Input>


### PR DESCRIPTION
- Insight chunk search now restricts to published+approved, non-deleted posts
- Knowledge answer_question / smart_search filter retrieved hits below
  configurable cosine threshold (default 0.35) and short-circuit with a
  no-info message instead of feeding noise to the LLM
- Prompt instructs the model to cite [FAQ:id] / [Academy:url] / [Insight:id]
  markers inline and list them in a Sources section
- Academy reindex skips GitHub content fetch + re-embedding when the tree
  blob SHA matches the stored content_sha; only clears the stale flag

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Knowledge base answers now explicitly cite sources and include a sources section.

* **Bug Fixes**
  * Deleted posts are now filtered out from similarity search results.

* **Improvements**
  * Enhanced relevance filtering for search results.
  * Optimized knowledge base reindexing performance with caching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santiment/sanbase2/pull/5181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->