### PR TITLE
Improve flaky kafka test

### DIFF
--- a/test/sanbase/kafka/kafka_exporter_test.exs
+++ b/test/sanbase/kafka/kafka_exporter_test.exs
@@ -43,26 +43,30 @@ defmodule KafkaExporterTest do
   end
 
   test "batching api calls works after flush timeout time has passed", %{topic: topic} do
+    # Pre-build payloads so the flush timer is not racing the expensive data
+    # generation (random bytes, gzip, Faker, JSON encode) on slow CI machines.
+    payloads = for _ <- 1..50, do: api_call_data()
+
     {:ok, exporter_pid} =
       Sanbase.KafkaExporter.start_link(
         name: rand_atom(),
         buffering_max_messages: 5000,
-        kafka_flush_timeout: 200,
+        kafka_flush_timeout: 1000,
         can_send_after_interval: 0,
         topic: topic
       )
 
-    for _ <- 1..50, do: :ok = Sanbase.KafkaExporter.persist_async(api_call_data(), exporter_pid)
+    for data <- payloads, do: :ok = Sanbase.KafkaExporter.persist_async(data, exporter_pid)
 
     # No data even after 50 api calls were persisted and some time has passed
-    Process.sleep(100)
+    Process.sleep(200)
 
     state = Sanbase.InMemoryKafka.Producer.get_state()
 
     assert Map.get(state, topic) == nil
 
-    # Aftert the kafka flush timeout has been reached the data is flushed
-    Process.sleep(200)
+    # After the kafka flush timeout has been reached the data is flushed
+    Process.sleep(1500)
     state = Sanbase.InMemoryKafka.Producer.get_state()
     topic_data = Map.get(state, topic)
     assert length(topic_data) == 50


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved stability of Kafka export batching tests by pre-generating payloads before the exporter starts and increasing the flush timeout. Adjusted wait expectations so buffered data flushes reliably, reducing timing races and test flakiness on slow CI, yielding more consistent test results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santiment/sanbase2/pull/5186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->