### PR TITLE
Use reranker in academy search api

### DIFF
--- a/lib/sanbase/ai/academy_ai_service.ex
+++ b/lib/sanbase/ai/academy_ai_service.ex
@@ -5,6 +5,7 @@ defmodule Sanbase.AI.AcademyAIService do
   """
 
   require Logger
+  alias Sanbase.Knowledge
   alias Sanbase.Knowledge.{Academy, Faq}
   alias Sanbase.OpenAI.Question
   alias Sanbase.AI.AcademyTracing, as: Tracing
@@ -14,6 +15,25 @@ defmodule Sanbase.AI.AcademyAIService do
   @model "gpt-5-nano"
   @suggestions_model "gpt-5-nano"
   @similarity_threshold 0.5
+
+  # Coarse cosine retrieval fans out beyond what the answer prompt holds so
+  # the reranker has headroom to reorder; `rerank_chunks/2` then truncates the
+  # reranked list back to @prompt_top_k before prompt assembly. Same
+  # retrieve-then-rerank pattern as `Sanbase.Knowledge`, but the prompt cap
+  # here is 10 (vs its @prompt_top_n of 5) to preserve this service's prior
+  # behavior of feeding 10 chunks to the answer prompt.
+  @retrieval_top_k 20
+  @prompt_top_k 10
+
+  # This runs synchronously inside the `sendChatMessage` mutation, so rerank
+  # latency lands directly on the user's request. The reranker is a best-effort
+  # reordering that falls back to cosine order on any error, so on this
+  # interactive path we disable retries: one slow attempt should degrade to
+  # cosine order rather than multiplying the wait. The per-attempt timeout is
+  # deliberately left to the backend, which knows its own latency profile (a
+  # cross-encoder is sub-second; an LLM listwise reranker needs several seconds)
+  # — hardcoding one here would break whichever backend it doesn't fit.
+  @rerank_max_retries 0
 
   @doc """
   Generates an Academy Q&A response using local database and OpenAI.
@@ -34,9 +54,10 @@ defmodule Sanbase.AI.AcademyAIService do
     session_id = Tracing.generate_session_id(chat_id, user_id)
     chat_history = if chat_id, do: build_chat_history(chat_id), else: []
 
-    with {:ok, chunks} <- Academy.search_chunks(question, 10),
+    with {:ok, chunks} <- Academy.search_chunks(question, @retrieval_top_k),
+         reranked_chunks = rerank_chunks(question, chunks),
          {:ok, answer, sources} <-
-           generate_answer(question, chunks, chat_history, user_id, session_id) do
+           generate_answer(question, reranked_chunks, chat_history, user_id, session_id) do
       suggestions =
         if include_suggestions and answer != @dont_know_message do
           case generate_suggestions(question, answer, sources, user_id, session_id) do
@@ -164,6 +185,18 @@ defmodule Sanbase.AI.AcademyAIService do
 
   defp ai_server_url do
     System.get_env("AI_SERVER_URL") || "http://aiserver.production.san:31080"
+  end
+
+  # Reorders the coarse cosine-retrieved chunks with the configured reranker
+  # and keeps the top @prompt_top_k for the answer prompt. Delegates to the
+  # shared `Sanbase.Knowledge.rerank_entries/4`, which falls back to the input
+  # order if the backend errors — so this never fails the request and can only
+  # improve chunk ordering.
+  defp rerank_chunks(question, chunks) do
+    Knowledge.rerank_entries(question, chunks, :academy,
+      top_n: @prompt_top_k,
+      max_retries: @rerank_max_retries
+    )
   end
 
   defp generate_answer(question, chunks, chat_history, user_id, session_id) do

--- a/lib/sanbase/ai/academy_ai_service.ex
+++ b/lib/sanbase/ai/academy_ai_service.ex
@@ -44,7 +44,11 @@ defmodule Sanbase.AI.AcademyAIService do
     chat_history = if chat_id, do: build_chat_history(chat_id), else: []
 
     with {:ok, chunks} <- Academy.search_chunks(question, @retrieval_top_k),
-         reranked_chunks = rerank_chunks(question, chunks),
+         reranked_chunks =
+           Knowledge.rerank_entries(question, chunks, :academy,
+             top_n: @prompt_top_k,
+             max_retries: @rerank_max_retries
+           ),
          {:ok, answer, sources} <-
            generate_answer(question, reranked_chunks, chat_history, user_id, session_id) do
       suggestions =
@@ -174,13 +178,6 @@ defmodule Sanbase.AI.AcademyAIService do
 
   defp ai_server_url do
     System.get_env("AI_SERVER_URL") || "http://aiserver.production.san:31080"
-  end
-
-  defp rerank_chunks(question, chunks) do
-    Knowledge.rerank_entries(question, chunks, :academy,
-      top_n: @prompt_top_k,
-      max_retries: @rerank_max_retries
-    )
   end
 
   defp generate_answer(question, chunks, chat_history, user_id, session_id) do

--- a/lib/sanbase/ai/academy_ai_service.ex
+++ b/lib/sanbase/ai/academy_ai_service.ex
@@ -16,23 +16,12 @@ defmodule Sanbase.AI.AcademyAIService do
   @suggestions_model "gpt-5-nano"
   @similarity_threshold 0.5
 
-  # Coarse cosine retrieval fans out beyond what the answer prompt holds so
-  # the reranker has headroom to reorder; `rerank_chunks/2` then truncates the
-  # reranked list back to @prompt_top_k before prompt assembly. Same
-  # retrieve-then-rerank pattern as `Sanbase.Knowledge`, but the prompt cap
-  # here is 10 (vs its @prompt_top_n of 5) to preserve this service's prior
-  # behavior of feeding 10 chunks to the answer prompt.
+  # Retrieve wide, rerank, keep top_k for the prompt.
   @retrieval_top_k 20
   @prompt_top_k 10
 
-  # This runs synchronously inside the `sendChatMessage` mutation, so rerank
-  # latency lands directly on the user's request. The reranker is a best-effort
-  # reordering that falls back to cosine order on any error, so on this
-  # interactive path we disable retries: one slow attempt should degrade to
-  # cosine order rather than multiplying the wait. The per-attempt timeout is
-  # deliberately left to the backend, which knows its own latency profile (a
-  # cross-encoder is sub-second; an LLM listwise reranker needs several seconds)
-  # — hardcoding one here would break whichever backend it doesn't fit.
+  # Runs synchronously in the sendChatMessage mutation; don't retry a
+  # best-effort rerank on the user's request path.
   @rerank_max_retries 0
 
   @doc """
@@ -187,11 +176,6 @@ defmodule Sanbase.AI.AcademyAIService do
     System.get_env("AI_SERVER_URL") || "http://aiserver.production.san:31080"
   end
 
-  # Reorders the coarse cosine-retrieved chunks with the configured reranker
-  # and keeps the top @prompt_top_k for the answer prompt. Delegates to the
-  # shared `Sanbase.Knowledge.rerank_entries/4`, which falls back to the input
-  # order if the backend errors — so this never fails the request and can only
-  # improve chunk ordering.
   defp rerank_chunks(question, chunks) do
     Knowledge.rerank_entries(question, chunks, :academy,
       top_n: @prompt_top_k,

--- a/lib/sanbase/knowledge/knowledge.ex
+++ b/lib/sanbase/knowledge/knowledge.ex
@@ -117,25 +117,10 @@ defmodule Sanbase.Knowledge do
   end
 
   @doc """
-  Rerank coarse-retrieval `entries` for `source` against `query` and return
-  the original entry maps re-ordered by relevance (optionally truncated to
-  `:top_n`).
-
-  `entries` are the raw retrieval maps for the source (FAQ rows, Academy
-  chunks, Insight chunks). They are normalized to reranker candidates via
-  `CandidateFormatter`, reranked by the configured backend, and unwrapped
-  back to the same maps — so callers get their input shape back, only
-  reordered and (optionally) shortened.
-
-  Options:
-
-    * `:reranker` — reranker module override; defaults to
-      `Reranker.default_impl/0`.
-    * `:top_n` — truncate the reranked list to this many entries.
-
-  Any other option is forwarded to the backend. On a backend error the
-  dispatcher falls back to input order (truncated to `:top_n`), so this
-  never raises or fails the caller — it can only improve ordering.
+  Rerank `entries` for `source` against `query`, returning the original maps
+  reordered by relevance (truncated to `:top_n` if given). Falls back to input
+  order on backend error. Options other than `:reranker`/`:top_n` are forwarded
+  to the backend.
   """
   @spec rerank_entries(String.t(), [map()], CandidateFormatter.source(), keyword()) :: [map()]
   def rerank_entries(query, entries, source, opts \\ [])

--- a/lib/sanbase/knowledge/knowledge.ex
+++ b/lib/sanbase/knowledge/knowledge.ex
@@ -116,6 +116,46 @@ defmodule Sanbase.Knowledge do
     end
   end
 
+  @doc """
+  Rerank coarse-retrieval `entries` for `source` against `query` and return
+  the original entry maps re-ordered by relevance (optionally truncated to
+  `:top_n`).
+
+  `entries` are the raw retrieval maps for the source (FAQ rows, Academy
+  chunks, Insight chunks). They are normalized to reranker candidates via
+  `CandidateFormatter`, reranked by the configured backend, and unwrapped
+  back to the same maps — so callers get their input shape back, only
+  reordered and (optionally) shortened.
+
+  Options:
+
+    * `:reranker` — reranker module override; defaults to
+      `Reranker.default_impl/0`.
+    * `:top_n` — truncate the reranked list to this many entries.
+
+  Any other option is forwarded to the backend. On a backend error the
+  dispatcher falls back to input order (truncated to `:top_n`), so this
+  never raises or fails the caller — it can only improve ordering.
+  """
+  @spec rerank_entries(String.t(), [map()], CandidateFormatter.source(), keyword()) :: [map()]
+  def rerank_entries(query, entries, source, opts \\ [])
+
+  def rerank_entries(_query, [], _source, _opts), do: []
+
+  def rerank_entries(query, entries, source, opts) do
+    reranker_mod = Keyword.get(opts, :reranker) || Reranker.default_impl()
+
+    rerank_opts =
+      opts
+      |> Keyword.put(:source, source)
+      |> Keyword.put_new(:reranker, reranker_mod)
+
+    entries
+    |> CandidateFormatter.to_candidates(source, reranker_mod)
+    |> then(&Reranker.call(query, &1, rerank_opts))
+    |> Enum.map(& &1.metadata)
+  end
+
   # Private functions
 
   defp build_smart_search_result(faq_entries, academy_articles, insights, options) do
@@ -369,20 +409,8 @@ defmodule Sanbase.Knowledge do
     end
   end
 
-  defp rerank([], _user_input, _source, _options, _opts), do: []
-
   defp rerank(entries, user_input, source, options, opts) do
-    reranker_mod = Keyword.get(options, :reranker) || Reranker.default_impl()
-
-    rerank_opts =
-      opts
-      |> Keyword.put(:source, source)
-      |> maybe_put_reranker(options)
-
-    entries
-    |> CandidateFormatter.to_candidates(source, reranker_mod)
-    |> then(&Reranker.call(user_input, &1, rerank_opts))
-    |> from_candidates()
+    rerank_entries(user_input, entries, source, maybe_put_reranker(opts, options))
   end
 
   defp maybe_put_reranker(opts, options) do
@@ -391,8 +419,6 @@ defmodule Sanbase.Knowledge do
       mod -> Keyword.put(opts, :reranker, mod)
     end
   end
-
-  defp from_candidates(candidates), do: Enum.map(candidates, & &1.metadata)
 
   defp generate_initial_prompt(question) do
     prompt = """

--- a/test/sanbase/knowledge/knowledge_test.exs
+++ b/test/sanbase/knowledge/knowledge_test.exs
@@ -1,0 +1,54 @@
+defmodule Sanbase.KnowledgeTest do
+  use ExUnit.Case, async: true
+
+  alias Sanbase.Knowledge
+
+  defmodule ReverseStub do
+    @behaviour Sanbase.Knowledge.Reranker
+    @impl true
+    def rerank(_query, candidates, _opts), do: {:ok, Enum.reverse(candidates)}
+  end
+
+  defmodule FailingStub do
+    @behaviour Sanbase.Knowledge.Reranker
+    @impl true
+    def rerank(_query, _candidates, _opts), do: {:error, :boom}
+  end
+
+  describe "rerank_entries/4" do
+    setup do
+      entries = [
+        %{title: "A", chunk: "alpha", similarity: 0.9, github_path: "a.md"},
+        %{title: "B", chunk: "bravo", similarity: 0.7, github_path: "b.md"},
+        %{title: "C", chunk: "charlie", similarity: 0.5, github_path: "c.md"}
+      ]
+
+      {:ok, entries: entries}
+    end
+
+    test "returns [] for empty entries" do
+      assert Knowledge.rerank_entries("q", [], :academy) == []
+    end
+
+    test "returns the original entry maps re-ordered by the reranker", %{entries: entries} do
+      result = Knowledge.rerank_entries("q", entries, :academy, reranker: ReverseStub)
+
+      # The candidate normalization round-trips: callers get their input maps
+      # back, only reordered.
+      assert result == Enum.reverse(entries)
+    end
+
+    test "truncates to :top_n", %{entries: entries} do
+      result = Knowledge.rerank_entries("q", entries, :academy, reranker: ReverseStub, top_n: 2)
+
+      assert length(result) == 2
+      assert Enum.map(result, & &1.title) == ["C", "B"]
+    end
+
+    test "falls back to input order (truncated) when the backend errors", %{entries: entries} do
+      result = Knowledge.rerank_entries("q", entries, :academy, reranker: FailingStub, top_n: 2)
+
+      assert Enum.map(result, & &1.title) == ["A", "B"]
+    end
+  end
+end

--- a/test/sanbase/knowledge/knowledge_test.exs
+++ b/test/sanbase/knowledge/knowledge_test.exs
@@ -9,46 +9,20 @@ defmodule Sanbase.KnowledgeTest do
     def rerank(_query, candidates, _opts), do: {:ok, Enum.reverse(candidates)}
   end
 
-  defmodule FailingStub do
-    @behaviour Sanbase.Knowledge.Reranker
-    @impl true
-    def rerank(_query, _candidates, _opts), do: {:error, :boom}
-  end
-
   describe "rerank_entries/4" do
-    setup do
+    # Empty input and error-fallback live in Reranker.call (see reranker_test.exs).
+    # This guards the wrapper: callers get their original maps back, reordered,
+    # and :top_n is forwarded through the to_candidates -> call -> map pipeline.
+    test "round-trips the original entry maps, reordered and truncated to :top_n" do
       entries = [
         %{title: "A", chunk: "alpha", similarity: 0.9, github_path: "a.md"},
         %{title: "B", chunk: "bravo", similarity: 0.7, github_path: "b.md"},
         %{title: "C", chunk: "charlie", similarity: 0.5, github_path: "c.md"}
       ]
 
-      {:ok, entries: entries}
-    end
-
-    test "returns [] for empty entries" do
-      assert Knowledge.rerank_entries("q", [], :academy) == []
-    end
-
-    test "returns the original entry maps re-ordered by the reranker", %{entries: entries} do
-      result = Knowledge.rerank_entries("q", entries, :academy, reranker: ReverseStub)
-
-      # The candidate normalization round-trips: callers get their input maps
-      # back, only reordered.
-      assert result == Enum.reverse(entries)
-    end
-
-    test "truncates to :top_n", %{entries: entries} do
       result = Knowledge.rerank_entries("q", entries, :academy, reranker: ReverseStub, top_n: 2)
 
-      assert length(result) == 2
-      assert Enum.map(result, & &1.title) == ["C", "B"]
-    end
-
-    test "falls back to input order (truncated) when the backend errors", %{entries: entries} do
-      result = Knowledge.rerank_entries("q", entries, :academy, reranker: FailingStub, top_n: 2)
-
-      assert Enum.map(result, & &1.title) == ["A", "B"]
+      assert result == [Enum.at(entries, 2), Enum.at(entries, 1)]
     end
   end
 end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI Academy responses now rerank retrieved knowledge chunks and select the top results before generating answers, improving relevance and quality.

* **Tests**
  * Added test coverage for the knowledge reranking behavior to ensure correct reordering and truncation of retrieved chunks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santiment/sanbase2/pull/5195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->