### PR TITLE
Stop Queries access for free users

### DIFF
--- a/lib/sanbase/queries/authorization.ex
+++ b/lib/sanbase/queries/authorization.ex
@@ -46,18 +46,35 @@ defmodule Sanbase.Queries.Authorization do
   end
 
   @doc ~s"""
-  Check if the user has credits left to run a computation.
+  Check if the user is allowed to run a computation.
 
-  Each query has a cost in credits. The cost is computed based on the query
-  profiling details - how much RAM memory it used, how much data it read from
-  the disk, how big is the result, etc.
+  Running queries requires an active subscription. Anonymous users (blocked
+  earlier by the auth middleware) and free-plan users cannot run queries.
+
+  When the user does have access, each query has a cost in credits. The cost is
+  computed based on the query profiling details - how much RAM memory it used,
+  how much data it read from the disk, how big is the result, etc.
   """
-  @spec user_can_execute_query(%User{}, String.t(), String.t()) :: :ok | {:error, String.t()}
+  @spec user_can_execute_query(%User{}, String.t() | nil, String.t() | nil) ::
+          :ok | {:error, String.t()}
   def user_can_execute_query(user, product_code, plan_name) do
-    if user_has_limits?(user) do
-      check_user_limits(user.id, product_code, plan_name)
-    else
-      :ok
+    cond do
+      # Santiment employees bypass both the subscription and the rate-limit checks.
+      not user_has_limits?(user) ->
+        :ok
+
+      # A nil plan corresponds to internal basic-auth requests, which have full access.
+      is_nil(plan_name) ->
+        :ok
+
+      # Running queries requires an active subscription. Anonymous and free-plan
+      # users have the "FREE" plan and are not allowed to execute queries.
+      plan_name == "FREE" ->
+        {:error,
+         "Running queries requires an active subscription. Free and anonymous users cannot run queries. Please upgrade your plan to run queries."}
+
+      true ->
+        check_user_limits(user.id, product_code, plan_name)
     end
   end
 

--- a/test/sanbase/queries/authorization_test.exs
+++ b/test/sanbase/queries/authorization_test.exs
@@ -70,4 +70,25 @@ defmodule Sanbase.Queries.AuthorizationTest do
                Sanbase.ClickhouseRepo.BusinessProUser
     end
   end
+
+  describe "user_can_execute_query/3" do
+    test "Santiment employees can run queries even on the free plan" do
+      # The users built by `insert(:user)` have @santiment.net emails and are
+      # treated as Santiment employees, which bypass the subscription check.
+      employee = insert(:user)
+      assert Authorization.user_can_execute_query(employee, "SANBASE", "FREE") == :ok
+    end
+
+    test "free users without an active subscription cannot run queries" do
+      user = insert(:user, email: "regular-user@example.com")
+
+      assert {:error, error_msg} = Authorization.user_can_execute_query(user, "SANBASE", "FREE")
+      assert error_msg =~ "Running queries requires an active subscription"
+    end
+
+    test "internal basic-auth requests (nil plan) can run queries" do
+      user = insert(:user, email: "regular-user@example.com")
+      assert Authorization.user_can_execute_query(user, nil, nil) == :ok
+    end
+  end
 end

--- a/test/sanbase_web/graphql/queries/queries_api_test.exs
+++ b/test/sanbase_web/graphql/queries/queries_api_test.exs
@@ -159,6 +159,66 @@ defmodule SanbaseWeb.Graphql.QueriesApiTest do
     end
   end
 
+  describe "Subscription required to run queries" do
+    # The users created by `insert(:user)` have @santiment.net emails and are
+    # treated as Santiment employees, which bypass the subscription check. Use a
+    # regular, non-employee user here to exercise the subscription gate.
+    setup do
+      free_user = insert(:user, email: "free-user@example.com")
+      subscribed_user = insert(:user, email: "subscribed-user@example.com")
+      insert(:subscription_pro_sanbase, user: subscribed_user)
+
+      %{
+        free_conn: setup_jwt_auth(build_conn(), free_user),
+        subscribed_conn: setup_jwt_auth(build_conn(), subscribed_user)
+      }
+    end
+
+    test "free user without an active subscription cannot run queries", context do
+      args = %{
+        sql_query_text: "SELECT * FROM intraday_metrics LIMIT {{limit}}",
+        sql_query_parameters: %{limit: 2}
+      }
+
+      response = run_sql_query(context.free_conn, :run_raw_sql_query, args)
+
+      assert get_in(response, ["data", "runRawSqlQuery"]) == nil
+
+      error_msg = get_in(response, ["errors", Access.at(0), "message"])
+      assert error_msg =~ "Running queries requires an active subscription"
+    end
+
+    test "user with an active subscription can run queries", context do
+      Application.put_env(:__sanbase_queries__, :__store_execution_details__, false)
+
+      on_exit(fn ->
+        Application.delete_env(:__sanbase_queries__, :__store_execution_details__)
+      end)
+
+      mock_fun =
+        Sanbase.Mock.wrap_consecutives(
+          [
+            fn -> {:ok, mocked_clickhouse_result()} end,
+            fn -> {:ok, mocked_execution_details_result()} end
+          ],
+          arity: 3
+        )
+
+      Sanbase.Mock.prepare_mock(Sanbase.ClickhouseRepo, :query, mock_fun)
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        args = %{
+          sql_query_text: "SELECT * FROM intraday_metrics LIMIT {{limit}}",
+          sql_query_parameters: %{limit: 2}
+        }
+
+        response = run_sql_query(context.subscribed_conn, :run_raw_sql_query, args)
+
+        assert get_in(response, ["errors"]) in [nil, []]
+        assert get_in(response, ["data", "runRawSqlQuery", "clickhouseQueryId"]) != nil
+      end)
+    end
+  end
+
   describe "Run Queries" do
     test "run raw sql query", context do
       # In test env the storing runs not async and there's a 7500ms sleep


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced authorization for query execution with stricter subscription validation.
  * Free plan users now require an active subscription to run queries.
  * Internal authentication requests and employees bypass subscription requirements.

* **Tests**
  * Added comprehensive test coverage for subscription gating on query execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->