### PR TITLE
Improve Knowledge Base re-embeddings

### DIFF
--- a/lib/sanbase/insight/post_embedding.ex
+++ b/lib/sanbase/insight/post_embedding.ex
@@ -53,15 +53,54 @@ defmodule Sanbase.Insight.PostEmbedding do
         "[PostEmbedding] Embedding batch ##{index}/#{chunks_count} consisting of #{length(posts)} posts"
       )
 
-      embed_posts_batch(posts)
+      # Log and skip a failing batch rather than aborting the whole reindex. A DB
+      # error inside the transaction raises, so rescue in addition to matching the
+      # {:error, _} rollback case.
+      try do
+        case embed_posts_batch(posts) do
+          {:ok, _} ->
+            Logger.info(
+              "[PostEmbedding] Finished embedding batch ##{index} of #{length(posts)} posts"
+            )
 
-      Logger.info("[PostEmbedding] Finished embedding batch of #{length(posts)} posts")
+          {:error, reason} ->
+            Logger.error("[PostEmbedding] Embedding batch ##{index} failed: #{inspect(reason)}")
+        end
+      rescue
+        e ->
+          Logger.error(
+            "[PostEmbedding] Embedding batch ##{index} crashed: #{Exception.message(e)}"
+          )
+      end
     end)
   end
 
   def drop_post_embeddings(%Sanbase.Insight.Post{id: post_id}) do
     from(pe in __MODULE__, where: pe.post_id == ^post_id)
     |> Sanbase.Repo.delete_all()
+  end
+
+  @doc """
+  Delete embeddings whose post is no longer published. `embed_all_posts/0` only
+  ever (re)embeds published posts, so once a post is unpublished its embeddings
+  are otherwise never removed. Uses the same "published" predicate as
+  `embed_all_posts/0` so the kept set and the embedded set stay in sync.
+
+  The keep set is expressed as a subquery, so the pruning happens in a single
+  DB statement instead of marshalling every published id into the app.
+
+  Returns the number of deleted rows.
+  """
+  def prune_all_stale() do
+    published_ids = from(p in Post, where: p.ready_state == ^Post.published(), select: p.id)
+
+    {deleted, _} =
+      from(pe in __MODULE__, where: pe.post_id not in subquery(published_ids))
+      |> Sanbase.Repo.delete_all()
+
+    Logger.info("[PostEmbedding] Pruned #{deleted} stale insight embeddings")
+
+    deleted
   end
 
   @doc """
@@ -113,7 +152,6 @@ defmodule Sanbase.Insight.PostEmbedding do
       Sanbase.AI.Embedding.generate_embeddings(chunk_texts, 1536)
 
     post_ids = Enum.map(posts, & &1.id)
-    Sanbase.Repo.delete_all(from(pe in __MODULE__, where: pe.post_id in ^post_ids))
 
     data =
       Enum.zip_with(chunks, embeddings, fn chunk, embedding ->
@@ -127,6 +165,13 @@ defmodule Sanbase.Insight.PostEmbedding do
         }
       end)
 
-    Sanbase.Repo.insert_all(__MODULE__, data)
+    # Replace this batch's embeddings atomically: a crash between the delete and
+    # the insert would otherwise leave these posts with their old rows gone and
+    # the new ones not yet written. Embeddings are generated above, before the
+    # transaction, so the slow API call never holds the transaction open.
+    Sanbase.Repo.transaction(fn ->
+      Sanbase.Repo.delete_all(from(pe in __MODULE__, where: pe.post_id in ^post_ids))
+      Sanbase.Repo.insert_all(__MODULE__, data)
+    end)
   end
 end

--- a/test/sanbase/insight/post_embedding_prune_test.exs
+++ b/test/sanbase/insight/post_embedding_prune_test.exs
@@ -1,0 +1,11 @@
+defmodule Sanbase.Insight.PostEmbeddingPruneTest do
+  use Sanbase.DataCase, async: true
+
+  alias Sanbase.Insight.PostEmbedding
+
+  # Executes the real `NOT IN (subquery)` DELETE against Postgres; an invalid
+  # query would raise here rather than return a count.
+  test "prune_all_stale/0 runs against the DB and returns a deleted count" do
+    assert PostEmbedding.prune_all_stale() == 0
+  end
+end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added background capability to remove stale post embeddings automatically.

* **Improvements**
  * Improved embedding processing to be more reliable and consistent by making batch updates atomic and isolating batch failures so reindexes continue.

* **Tests**
  * Added tests covering embedding cleanup and batch processing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->