### PR TITLE
Add mcp widgets versioning

### DIFF
--- a/lib/sanbase/mcp/chart_ui.ex
+++ b/lib/sanbase/mcp/chart_ui.ex
@@ -13,6 +13,10 @@ defmodule Sanbase.MCP.ChartUI do
     name: "chart-ui",
     mime_type: "text/html;profile=mcp-app"
 
+  # Content-versioned URI (overrides the static one above) so hosts re-fetch
+  # the widget whenever the bundled HTML changes. See WidgetAsset.ui_uri/2.
+  def uri, do: Sanbase.MCP.WidgetAsset.ui_uri("chart", "chart.html")
+
   @impl true
   def read(_params, frame), do: Sanbase.MCP.WidgetAsset.serve("chart.html", frame)
 end

--- a/lib/sanbase/mcp/show_chart_tool.ex
+++ b/lib/sanbase/mcp/show_chart_tool.ex
@@ -51,7 +51,7 @@ defmodule Sanbase.MCP.ShowChartTool do
 
   @impl true
   def meta do
-    %{"ui" => %{"resourceUri" => "ui://santiment/chart"}}
+    %{"ui" => %{"resourceUri" => Sanbase.MCP.ChartUI.uri()}}
   end
 
   schema do

--- a/lib/sanbase/mcp/social_trends_ui.ex
+++ b/lib/sanbase/mcp/social_trends_ui.ex
@@ -14,6 +14,10 @@ defmodule Sanbase.MCP.SocialTrendsUI do
     name: "social-trends-ui",
     mime_type: "text/html;profile=mcp-app"
 
+  # Content-versioned URI (overrides the static one above) so hosts re-fetch
+  # the widget whenever the bundled HTML changes. See WidgetAsset.ui_uri/2.
+  def uri, do: Sanbase.MCP.WidgetAsset.ui_uri("social-trends", "social-trends.html")
+
   @impl true
   def read(_params, frame), do: Sanbase.MCP.WidgetAsset.serve("social-trends.html", frame)
 end

--- a/lib/sanbase/mcp/trending_stories_tool.ex
+++ b/lib/sanbase/mcp/trending_stories_tool.ex
@@ -47,7 +47,7 @@ defmodule Sanbase.MCP.TrendingStoriesTool do
 
   @impl true
   def meta do
-    %{"ui" => %{"resourceUri" => "ui://santiment/social-trends"}}
+    %{"ui" => %{"resourceUri" => Sanbase.MCP.SocialTrendsUI.uri()}}
   end
 
   schema do

--- a/lib/sanbase/mcp/widget_asset.ex
+++ b/lib/sanbase/mcp/widget_asset.ex
@@ -29,8 +29,8 @@ defmodule Sanbase.MCP.WidgetAsset do
   @spec serve(filename :: String.t(), Frame.t()) ::
           {:reply, Response.t(), Frame.t()} | {:error, Error.t(), Frame.t()}
   def serve(filename, frame) do
-    case load(filename) do
-      {:ok, html} ->
+    case fetch(filename) do
+      {:ok, {html, _version}} ->
         response =
           Response.resource()
           |> Response.text(html)
@@ -43,7 +43,24 @@ defmodule Sanbase.MCP.WidgetAsset do
     end
   end
 
-  defp load(filename) do
+  @doc """
+  Content-versioned `ui://` URI for a bundled widget, e.g.
+  `ui_uri("chart", "chart.html")` -> `"ui://santiment/chart-1a2b3c4d"`.
+
+  MCP hosts cache app resources by URI, so the version suffix is derived from
+  the artifact's content hash — every widget rebuild automatically busts the
+  host cache, with no manual version bumping. Use it both for the resource's
+  `uri/0` and the tool's `_meta.ui.resourceUri` so they always agree.
+  """
+  @spec ui_uri(base :: String.t(), filename :: String.t()) :: String.t()
+  def ui_uri(base, filename) do
+    case fetch(filename) do
+      {:ok, {_html, version}} -> "ui://santiment/#{base}-#{version}"
+      {:error, _reason} -> "ui://santiment/#{base}"
+    end
+  end
+
+  defp fetch(filename) do
     key = {__MODULE__, filename}
 
     case :persistent_term.get(key, nil) do
@@ -51,12 +68,22 @@ defmodule Sanbase.MCP.WidgetAsset do
         path = Application.app_dir(:sanbase, Path.join(["priv", "mcp_widgets", filename]))
 
         with {:ok, html} <- File.read(path) do
-          :persistent_term.put(key, html)
-          {:ok, html}
+          entry = {html, content_version(html)}
+          if cache?(), do: :persistent_term.put(key, entry)
+          {:ok, entry}
         end
 
-      html ->
-        {:ok, html}
+      entry ->
+        {:ok, entry}
     end
   end
+
+  defp content_version(html) do
+    :crypto.hash(:sha256, html)
+    |> Base.encode16(case: :lower)
+    |> binary_part(0, 8)
+  end
+
+  # In dev, skip the cache so a rebuilt widget is picked up without a restart.
+  defp cache?, do: Application.get_env(:sanbase, :env) != :dev
 end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Widget assets now include automatic content versioning to ensure hosts deliver fresh widget content when updates are made, preventing stale cached versions and improving content reliability across chart and social trends components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->