### PR TITLE
Fix a test error caused by the ordered: false fix in Parallel map

### DIFF
--- a/test/sanbase/alerts/wallet/trigger_wallet_usd_valuation_test.exs
+++ b/test/sanbase/alerts/wallet/trigger_wallet_usd_valuation_test.exs
@@ -74,12 +74,30 @@ defmodule Sanbase.Alert.WalletUsdValuationTriggerSettingsTest do
     ] do
       Scheduler.run_alert(WalletUsdValuationTriggerSettings)
 
-      assert_receive({:telegram_to_self, message})
+      # Two alerts fire (amount_down and percent_down). They are evaluated
+      # concurrently via Sanbase.Parallel.map(ordered: false), so the order in
+      # which they reach Telegram is not deterministic. Collect both messages
+      # and assert on the amount_down one regardless of arrival order.
+      assert_receive({:telegram_to_self, message1})
+      assert_receive({:telegram_to_self, message2})
 
-      assert message =~
-               "The address #{context.address}'s total USD valuation has decreased by 177.70 Million"
+      IO.inspect({message1, message2})
 
-      assert message =~ "Was: 2.07 Billion\nNow: 1.90 Billion"
+      amount_down_message =
+        Enum.find([message1, message2], fn message ->
+          message =~ "valuation has decreased by 177.70 Million"
+        end)
+
+      percent_down_message =
+        Enum.find([message1, message2], fn message ->
+          message =~ "valuation has decreased by 8.56%"
+        end)
+
+      assert amount_down_message
+      assert amount_down_message =~ "Was: 2.07 Billion\nNow: 1.90 Billion"
+
+      assert percent_down_message
+      assert percent_down_message =~ "Was: 2.07 Billion\nNow: 1.90 Billion"
     end
   end
 


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated wallet alert tests to correctly handle concurrent evaluation of multiple valuation alerts and validate each alert’s expected “Was/Now” values, regardless of message arrival order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->