### PR TITLE
Retry incomplete subscriptions

### DIFF
--- a/lib/sanbase/billing/payment_error.ex
+++ b/lib/sanbase/billing/payment_error.ex
@@ -1,0 +1,142 @@
+defmodule Sanbase.Billing.PaymentError do
+  @moduledoc """
+  Translates a Stripe PaymentIntent `last_payment_error` into values that are
+  safe to expose to end users.
+
+  Stripe's raw `code`/`decline_code`/`message` are not all safe to surface:
+
+    * fraud/security-sensitive decline codes (e.g. `lost_card`, `stolen_card`,
+      `fraudulent`, `merchant_blacklist`) must not be revealed to the cardholder
+      — doing so would tip off someone misusing a flagged/lost/stolen card, and
+    * non-`card_error` failures carry integration/technical messages not meant
+      for end users.
+
+  `safe_code/1` collapses those cases into `"generic_decline"`; `user_message/1`
+  returns curated, user-facing copy with a generic fallback. The frontend should
+  render `user_message` and branch behaviour on `safe_code`, never the raw
+  fields.
+  """
+
+  # Decline codes we never surface raw to the cardholder: revealing them would
+  # tip off someone misusing a flagged/lost/stolen card, and Stripe likewise
+  # recommends showing only a generic message for these. They collapse to
+  # "generic_decline".
+  @sensitive_decline_codes ~w(
+    lost_card stolen_card fraudulent pickup_card
+    merchant_blacklist security_violation restricted_card
+    revocation_of_authorization revocation_of_all_authorizations stop_payment_order
+  )
+
+  # Codes where retrying the *same* card is futile — the user must re-enter or
+  # switch cards. Everything else defaults to a "retry" action.
+  @use_different_card_codes ~w(
+    expired_card incorrect_cvc incorrect_number card_not_supported
+    currency_not_supported
+  )
+
+  @limit_reached_message "Your card's limit has been reached. Retry later, or use a different card."
+
+  # Curated, actionable copy per (non-sensitive) decline code. Note we never tell
+  # the user they were charged — the FE renders a fixed "You haven't been
+  # charged" line on any failed state, so it isn't duplicated here.
+  @messages %{
+    "insufficient_funds" =>
+      "Your bank declined the payment (insufficient funds). This can be temporary — try again. If it keeps failing, check your balance or use a different card.",
+    "expired_card" => "Your card has expired. Please use a different card.",
+    "incorrect_cvc" =>
+      "Your card's security code (CVC) is incorrect. Re-enter your card details and try again.",
+    "incorrect_number" =>
+      "Your card number is incorrect. Re-enter your card details and try again.",
+    "card_velocity_exceeded" => @limit_reached_message,
+    "withdrawal_count_limit_exceeded" => @limit_reached_message,
+    "card_not_supported" =>
+      "Your card isn't supported for this purchase. Please use a different card.",
+    "currency_not_supported" =>
+      "Your card doesn't support this currency. Please use a different card.",
+    "processing_error" =>
+      "Something went wrong while processing your card. Please try again in a few moments.",
+    "do_not_honor" =>
+      "Your bank declined the payment. Contact your bank to authorize it, or use a different card.",
+    "transaction_not_allowed" =>
+      "Your bank doesn't allow this type of payment. Contact your bank, or use a different card."
+  }
+
+  @generic_message "Your payment couldn't be completed. Please try again or use a different card — and contact your bank if it keeps happening."
+
+  @doc """
+  Builds the frontend-safe payload for a Stripe `last_payment_error`, computed
+  once: `%{safe_code, user_message, recommended_action}`, or nil when there's no
+  error. This is what the GraphQL `:payment_error` object resolves from.
+  """
+  @spec to_safe_map(map() | struct() | nil) :: map() | nil
+  def to_safe_map(nil), do: nil
+
+  def to_safe_map(error) do
+    %{
+      safe_code: safe_code(error),
+      user_message: user_message(error),
+      recommended_action: recommended_action(error)
+    }
+  end
+
+  @doc "Returns a frontend-safe code for branching, or nil when there's no error."
+  @spec safe_code(map() | struct() | nil) :: String.t() | nil
+  def safe_code(nil), do: nil
+
+  def safe_code(error) do
+    decline_code = get(error, :decline_code)
+    code = get(error, :code)
+
+    cond do
+      get(error, :type) != "card_error" -> "generic_decline"
+      decline_code in @sensitive_decline_codes -> "generic_decline"
+      code in @sensitive_decline_codes -> "generic_decline"
+      is_binary(decline_code) -> decline_code
+      is_binary(code) -> code
+      true -> "generic_decline"
+    end
+  end
+
+  @doc "Returns user-facing copy for the error, or nil when there's no error."
+  @spec user_message(map() | struct() | nil) :: String.t() | nil
+  def user_message(nil), do: nil
+
+  def user_message(error) do
+    case safe_code(error) do
+      nil -> nil
+      code -> Map.get(@messages, code, @generic_message)
+    end
+  end
+
+  @doc """
+  Primary action the frontend should offer: `"use_different_card"` when retrying
+  the same card is futile, otherwise `"retry"`. The FE should still expose the
+  other action as a secondary option. Nil when there's no error.
+
+  When Stripe's network `advice_code` is present on `last_payment_error` (it is
+  only emitted on recent Stripe API versions), it's the most authoritative
+  signal and takes precedence; otherwise we fall back to the decline code.
+  """
+  @spec recommended_action(map() | struct() | nil) :: String.t() | nil
+  def recommended_action(nil), do: nil
+
+  def recommended_action(error) do
+    case get(error, :advice_code) do
+      "try_again_later" -> "retry"
+      "do_not_try_again" -> "use_different_card"
+      "confirm_card_data" -> "use_different_card"
+      _ -> decline_code_action(error)
+    end
+  end
+
+  defp decline_code_action(error) do
+    if safe_code(error) in @use_different_card_codes, do: "use_different_card", else: "retry"
+  end
+
+  # Stripe's converter may hand us a struct or a map with atom or string keys.
+  defp get(error, key) when is_map(error) do
+    Map.get(error, key) || Map.get(error, to_string(key))
+  end
+
+  defp get(_, _), do: nil
+end

--- a/lib/sanbase_web/graphql/schema/types/billing_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/billing_types.ex
@@ -130,5 +130,34 @@ defmodule SanbaseWeb.Graphql.BillingTypes do
     field(:id, non_null(:string))
     field(:status, non_null(:string))
     field(:client_secret, non_null(:string))
+
+    field :last_payment_error, :payment_error do
+      # Translate the raw Stripe error into its frontend-safe payload once here,
+      # so the :payment_error fields below are plain reads (no per-field recompute).
+      resolve(fn payment_intent, _, _ ->
+        error = Map.get(payment_intent, :last_payment_error)
+        {:ok, Sanbase.Billing.PaymentError.to_safe_map(error)}
+      end)
+    end
+  end
+
+  # Populated only when the PaymentIntent has a failed attempt (e.g. a declined
+  # card). Resolved from the virtual `payment_intent` map on the subscription.
+  #
+  # Only sanitized, frontend-safe values are exposed — fraud-sensitive decline
+  # codes and non-card (technical) errors collapse to a generic code/message, so
+  # raw Stripe values never cross the wire. The raw decline reason stays
+  # available internally via the Stripe Dashboard and the failed-payment Discord
+  # notification.
+  object :payment_error do
+    # Stable code for analytics / fine-grained copy. Fraud and technical errors
+    # collapse to "generic_decline".
+    field(:safe_code, :string)
+
+    # Curated, user-facing copy to display as-is.
+    field(:user_message, :string)
+
+    # Primary CTA the FE should offer: "retry" or "use_different_card".
+    field(:recommended_action, :string)
   end
 end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

```
getSubscriptionWithPaymentIntent {
    payment_intent {
	status
	client_secret
	last_payment_error {
		user_message        // ready-to-display copy — render as-is
		recommended_action  // "retry" | "use_different_card" — drives the primary button
		safe_code           // stable code, for analytics / conditional logic
	}
    }
}
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment intent endpoints now include comprehensive error details for failed transactions. Data includes sanitized decline codes, user-friendly error messages, and recommended recovery actions (such as retrying the payment or using a different payment method). This enables applications to provide better error context and meaningful guidance to users navigating payment failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->