### PR TITLE
Soft delete broadcast notifications

### DIFF
--- a/lib/sanbase/app_notifications/app_notifications.ex
+++ b/lib/sanbase/app_notifications/app_notifications.ex
@@ -121,6 +121,7 @@ defmodule Sanbase.AppNotifications do
         type: n.type,
         inserted_at: n.inserted_at,
         recipients_count: count(nrs.id),
+        read_count: filter(count(nrs.id), not is_nil(nrs.read_at)),
         unread_count: filter(count(nrs.id), is_nil(nrs.read_at))
       }
     )

--- a/lib/sanbase/app_notifications/app_notifications.ex
+++ b/lib/sanbase/app_notifications/app_notifications.ex
@@ -128,6 +128,29 @@ defmodule Sanbase.AppNotifications do
   end
 
   @doc """
+  Soft-deletes a broadcast notification by setting `is_deleted` to true.
+
+  Once soft-deleted, the notification immediately disappears from every user's
+  notification list and unread counts, because all read queries filter out
+  notifications where `is_deleted == true`. The per-user read-status rows are
+  left untouched, so the action is fully reversible (set `is_deleted` back to
+  false). Only broadcast notifications can be soft-deleted through this function.
+  """
+  @spec soft_delete_broadcast_notification(pos_integer()) ::
+          {:ok, Notification.t()} | {:error, :not_found | Ecto.Changeset.t()}
+  def soft_delete_broadcast_notification(notification_id) when is_integer(notification_id) do
+    case Repo.get_by(Notification, id: notification_id, is_broadcast: true) do
+      %Notification{} = notification ->
+        notification
+        |> Ecto.Changeset.change(is_deleted: true)
+        |> Repo.update()
+
+      nil ->
+        {:error, :not_found}
+    end
+  end
+
+  @doc """
   Creates a notification entry.
   """
   @spec create_notification(map()) ::

--- a/lib/sanbase_web/live/notifications/broadcast_overview_live.ex
+++ b/lib/sanbase_web/live/notifications/broadcast_overview_live.ex
@@ -40,6 +40,7 @@ defmodule SanbaseWeb.NotificationsLive.BroadcastOverviewLive do
               <th>Content</th>
               <th>Type</th>
               <th>Recipients</th>
+              <th>Read</th>
               <th>Unread</th>
               <th>Created</th>
               <th>Actions</th>
@@ -47,7 +48,7 @@ defmodule SanbaseWeb.NotificationsLive.BroadcastOverviewLive do
           </thead>
           <tbody id="broadcasts" phx-update="stream">
             <tr class="hidden only:block">
-              <td colspan="8" class="px-4 py-8 text-center text-base-content/40">
+              <td colspan="9" class="px-4 py-8 text-center text-base-content/40">
                 No broadcast notifications found. Use the "New Broadcast" button to create one.
               </td>
             </tr>
@@ -67,6 +68,9 @@ defmodule SanbaseWeb.NotificationsLive.BroadcastOverviewLive do
               </td>
               <td class="text-center">
                 <span class="font-semibold">{b.recipients_count}</span>
+              </td>
+              <td class="text-center">
+                <span class="font-semibold text-success">{b.read_count}</span>
               </td>
               <td class="text-center">
                 <span class={[

--- a/lib/sanbase_web/live/notifications/broadcast_overview_live.ex
+++ b/lib/sanbase_web/live/notifications/broadcast_overview_live.ex
@@ -78,9 +78,19 @@ defmodule SanbaseWeb.NotificationsLive.BroadcastOverviewLive do
               </td>
               <td class="whitespace-nowrap text-xs">{format_datetime(b.inserted_at)}</td>
               <td>
-                <.link href={recipients_url(b.id)} class="btn btn-xs btn-soft btn-info">
-                  <.icon name="hero-users" class="size-3.5" /> View Recipients
-                </.link>
+                <div class="flex gap-2">
+                  <.link href={recipients_url(b.id)} class="btn btn-xs btn-soft btn-info">
+                    <.icon name="hero-users" class="size-3.5" /> View Recipients
+                  </.link>
+                  <button
+                    phx-click="delete"
+                    phx-value-id={b.id}
+                    class="btn btn-xs btn-soft btn-error"
+                    data-confirm={delete_confirm_message(b)}
+                  >
+                    <.icon name="hero-trash" class="size-3.5" /> Delete
+                  </button>
+                </div>
               </td>
             </tr>
           </tbody>
@@ -88,6 +98,31 @@ defmodule SanbaseWeb.NotificationsLive.BroadcastOverviewLive do
       </div>
     </div>
     """
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    id = String.to_integer(id)
+
+    case AppNotifications.soft_delete_broadcast_notification(id) do
+      {:ok, _notification} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Broadcast deleted. It no longer appears for any user.")
+         |> stream_delete_by_dom_id(:broadcasts, "broadcasts-#{id}")}
+
+      {:error, :not_found} ->
+        {:noreply, put_flash(socket, :error, "Broadcast not found.")}
+
+      {:error, _changeset} ->
+        {:noreply, put_flash(socket, :error, "Could not delete broadcast. Please try again.")}
+    end
+  end
+
+  defp delete_confirm_message(broadcast) do
+    "Delete this broadcast? It will immediately disappear from all " <>
+      "#{broadcast.recipients_count} recipients' notifications. " <>
+      "This can be undone by an engineer."
   end
 
   defp recipients_url(notification_id) do

--- a/test/sanbase/app_notifications/app_notifications_test.exs
+++ b/test/sanbase/app_notifications/app_notifications_test.exs
@@ -330,6 +330,66 @@ defmodule Sanbase.AppNotificationsTest do
     end
   end
 
+  describe "soft_delete_broadcast_notification/1" do
+    test "hides the broadcast from the admin overview and from recipients" do
+      user = insert(:user)
+
+      {:ok, %{notification: notification, recipients_count: count}} =
+        AppNotifications.create_broadcast_notification(%{
+          type: "santiment_broadcast_new_features",
+          title: "New feature",
+          content: "We shipped something new."
+        })
+
+      assert count >= 1
+
+      # Visible before deletion: in the admin overview and in the recipient's list
+      assert Enum.any?(
+               AppNotifications.list_broadcast_notifications(),
+               &(&1.id == notification.id)
+             )
+
+      assert Enum.any?(
+               AppNotifications.list_notifications_for_user(user.id),
+               &(&1.id == notification.id)
+             )
+
+      assert {:ok, deleted} = AppNotifications.soft_delete_broadcast_notification(notification.id)
+      assert deleted.is_deleted == true
+
+      # Gone from the admin overview
+      refute Enum.any?(
+               AppNotifications.list_broadcast_notifications(),
+               &(&1.id == notification.id)
+             )
+
+      # Gone from the recipient's notifications
+      refute Enum.any?(
+               AppNotifications.list_notifications_for_user(user.id),
+               &(&1.id == notification.id)
+             )
+    end
+
+    test "returns :not_found for a missing notification" do
+      assert {:error, :not_found} = AppNotifications.soft_delete_broadcast_notification(-1)
+    end
+
+    test "returns :not_found for a non-broadcast notification" do
+      author = insert(:user)
+
+      {:ok, notification} =
+        AppNotifications.create_notification(%{
+          type: "create_watchlist",
+          user_id: author.id,
+          entity_type: "watchlist",
+          entity_id: 1
+        })
+
+      assert {:error, :not_found} =
+               AppNotifications.soft_delete_broadcast_notification(notification.id)
+    end
+  end
+
   describe "get_notification_for_user/2" do
     setup do
       follower = insert(:user)

--- a/test/sanbase/app_notifications/app_notifications_test.exs
+++ b/test/sanbase/app_notifications/app_notifications_test.exs
@@ -1446,11 +1446,42 @@ defmodule Sanbase.AppNotificationsTest do
                %{
                  id: notification_id,
                  recipients_count: 0,
+                 read_count: 0,
                  unread_count: 0
                }
              ] = AppNotifications.list_broadcast_notifications()
 
       assert notification_id == notification.id
+    end
+
+    test "reports read and unread counts that stay consistent" do
+      user = insert(:user)
+
+      {:ok, %{notification: notification, recipients_count: recipients}} =
+        AppNotifications.create_broadcast_notification(%{
+          type: "santiment_broadcast_new_features",
+          title: "New feature",
+          content: "We shipped something new."
+        })
+
+      assert recipients >= 1
+
+      entry =
+        AppNotifications.list_broadcast_notifications() |> Enum.find(&(&1.id == notification.id))
+
+      assert entry.recipients_count == recipients
+      assert entry.read_count == 0
+      assert entry.unread_count == recipients
+      assert entry.read_count + entry.unread_count == entry.recipients_count
+
+      {:ok, :updated} = AppNotifications.set_read_status(user.id, notification.id, true)
+
+      entry =
+        AppNotifications.list_broadcast_notifications() |> Enum.find(&(&1.id == notification.id))
+
+      assert entry.read_count == 1
+      assert entry.unread_count == recipients - 1
+      assert entry.read_count + entry.unread_count == entry.recipients_count
     end
   end
 end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Administrators can now delete broadcast notifications directly from the broadcast overview interface.
  * Soft-deleted notifications are automatically removed from the broadcast overview and disappear from all recipient notification lists and associated unread counts.
  * The delete action includes a confirmation dialog to help prevent accidental removal of notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->