### PR TITLE
Use modal instead of browser popup

### DIFF
--- a/lib/sanbase_web/live/notifications/broadcast_overview_live.ex
+++ b/lib/sanbase_web/live/notifications/broadcast_overview_live.ex
@@ -2,6 +2,7 @@ defmodule SanbaseWeb.NotificationsLive.BroadcastOverviewLive do
   use SanbaseWeb, :live_view
 
   alias Sanbase.AppNotifications
+  alias Sanbase.Admin.Permissions
 
   @impl true
   def mount(_params, _session, socket) do
@@ -10,6 +11,8 @@ defmodule SanbaseWeb.NotificationsLive.BroadcastOverviewLive do
     socket =
       socket
       |> assign(:page_title, "Broadcast Notifications Overview")
+      |> assign(:can_delete, can_delete?(socket))
+      |> assign(:confirming, nil)
       |> stream(:broadcasts, broadcasts)
 
     {:ok, socket}
@@ -43,11 +46,11 @@ defmodule SanbaseWeb.NotificationsLive.BroadcastOverviewLive do
               <th>Read</th>
               <th>Unread</th>
               <th>Created</th>
-              <th>Actions</th>
+              <th class="sticky right-0 z-10 bg-base-200 border-l border-base-300">Actions</th>
             </tr>
           </thead>
           <tbody id="broadcasts" phx-update="stream">
-            <tr class="hidden only:block">
+            <tr id="broadcasts-empty" class="hidden only:block">
               <td colspan="9" class="px-4 py-8 text-center text-base-content/40">
                 No broadcast notifications found. Use the "New Broadcast" button to create one.
               </td>
@@ -81,16 +84,19 @@ defmodule SanbaseWeb.NotificationsLive.BroadcastOverviewLive do
                 </span>
               </td>
               <td class="whitespace-nowrap text-xs">{format_datetime(b.inserted_at)}</td>
-              <td>
+              <td class="sticky right-0 z-10 bg-base-100 border-l border-base-300">
                 <div class="flex gap-2">
                   <.link href={recipients_url(b.id)} class="btn btn-xs btn-soft btn-info">
                     <.icon name="hero-users" class="size-3.5" /> View Recipients
                   </.link>
                   <button
-                    phx-click="delete"
+                    :if={@can_delete}
+                    type="button"
+                    phx-click="request_delete"
                     phx-value-id={b.id}
+                    phx-value-title={b.title}
+                    phx-value-recipients={b.recipients_count}
                     class="btn btn-xs btn-soft btn-error"
-                    data-confirm={delete_confirm_message(b)}
                   >
                     <.icon name="hero-trash" class="size-3.5" /> Delete
                   </button>
@@ -100,33 +106,92 @@ defmodule SanbaseWeb.NotificationsLive.BroadcastOverviewLive do
           </tbody>
         </table>
       </div>
+
+      <.modal
+        :if={@confirming}
+        id="confirm-delete-broadcast"
+        show
+        on_cancel={JS.push("cancel_delete")}
+      >
+        <h3 class="text-lg font-semibold">Delete this broadcast?</h3>
+        <p class="py-4 text-sm">
+          <span class="font-medium">"{@confirming.title}"</span>
+          will immediately disappear from all
+          <span class="font-semibold">{@confirming.recipients}</span>
+          recipients' notifications. This can be undone by an engineer.
+        </p>
+        <div class="flex justify-end gap-2">
+          <button type="button" class="btn btn-sm btn-ghost" phx-click={JS.push("cancel_delete")}>
+            Cancel
+          </button>
+          <button type="button" class="btn btn-sm btn-error" phx-click="confirm_delete">
+            <.icon name="hero-trash" class="size-4" /> Delete broadcast
+          </button>
+        </div>
+      </.modal>
     </div>
     """
   end
 
   @impl true
-  def handle_event("delete", %{"id" => id}, socket) do
-    id = String.to_integer(id)
+  def handle_event("request_delete", %{"id" => id} = params, socket) do
+    if can_delete?(socket) do
+      confirming = %{
+        id: String.to_integer(id),
+        title: params["title"] || "",
+        recipients: params["recipients"] || "0"
+      }
 
-    case AppNotifications.soft_delete_broadcast_notification(id) do
-      {:ok, _notification} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Broadcast deleted. It no longer appears for any user.")
-         |> stream_delete_by_dom_id(:broadcasts, "broadcasts-#{id}")}
-
-      {:error, :not_found} ->
-        {:noreply, put_flash(socket, :error, "Broadcast not found.")}
-
-      {:error, _changeset} ->
-        {:noreply, put_flash(socket, :error, "Could not delete broadcast. Please try again.")}
+      {:noreply, assign(socket, :confirming, confirming)}
+    else
+      {:noreply, deny_delete(socket)}
     end
   end
 
-  defp delete_confirm_message(broadcast) do
-    "Delete this broadcast? It will immediately disappear from all " <>
-      "#{broadcast.recipients_count} recipients' notifications. " <>
-      "This can be undone by an engineer."
+  def handle_event("cancel_delete", _params, socket) do
+    {:noreply, assign(socket, :confirming, nil)}
+  end
+
+  def handle_event("confirm_delete", _params, socket) do
+    with true <- can_delete?(socket),
+         %{id: id} <- socket.assigns.confirming,
+         {:ok, _notification} <- AppNotifications.soft_delete_broadcast_notification(id) do
+      {:noreply,
+       socket
+       |> assign(:confirming, nil)
+       |> put_flash(:info, "Broadcast deleted. It no longer appears for any user.")
+       |> stream_delete_by_dom_id(:broadcasts, "broadcasts-#{id}")}
+    else
+      false ->
+        {:noreply, deny_delete(socket)}
+
+      nil ->
+        {:noreply, assign(socket, :confirming, nil)}
+
+      {:error, :not_found} ->
+        {:noreply,
+         socket
+         |> assign(:confirming, nil)
+         |> put_flash(:error, "Broadcast not found.")}
+
+      {:error, _changeset} ->
+        {:noreply,
+         socket
+         |> assign(:confirming, nil)
+         |> put_flash(:error, "Could not delete broadcast. Please try again.")}
+    end
+  end
+
+  # Editor and Owner can delete; Viewer cannot. Mirrors the generic admin's
+  # delete gating (Sanbase.Admin.Permissions.can?(:delete, ...)).
+  defp can_delete?(socket) do
+    Permissions.can?(:delete, roles: socket.assigns[:current_user_role_names] || [])
+  end
+
+  defp deny_delete(socket) do
+    socket
+    |> assign(:confirming, nil)
+    |> put_flash(:error, "You don't have permission to delete broadcasts.")
   end
 
   defp recipients_url(notification_id) do

--- a/test/sanbase_web/live/notifications/broadcast_overview_live_test.exs
+++ b/test/sanbase_web/live/notifications/broadcast_overview_live_test.exs
@@ -1,0 +1,102 @@
+defmodule SanbaseWeb.NotificationsLive.BroadcastOverviewLiveTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Sanbase.Factory
+
+  alias Sanbase.AppNotifications
+  alias Sanbase.AppNotifications.Notification
+
+  @path "/admin/notifications/broadcast/overview"
+
+  defp login_with_role(role_factory) do
+    user = insert(:user)
+    role = insert(role_factory)
+    Sanbase.Accounts.UserRole.create(user.id, role.id)
+    {:ok, jwt_tokens} = SanbaseWeb.Guardian.get_jwt_tokens(user)
+    conn = Plug.Test.init_test_session(build_conn(), jwt_tokens)
+    %{conn: conn, user: user}
+  end
+
+  defp create_broadcast(title \\ "New feature") do
+    {:ok, %{notification: notification}} =
+      AppNotifications.create_broadcast_notification(%{
+        type: "santiment_broadcast_new_features",
+        title: title,
+        content: "We shipped something new."
+      })
+
+    notification
+  end
+
+  describe "as an Admin Panel Editor" do
+    setup do
+      login_with_role(:role_admin_panel_editor)
+    end
+
+    test "soft-deletes a broadcast via the in-app confirmation modal", %{conn: conn} do
+      notification = create_broadcast()
+
+      {:ok, view, html} = live(conn, @path)
+
+      # The broadcast and its delete button are visible
+      assert html =~ "New feature"
+      assert has_element?(view, "button[phx-value-id='#{notification.id}']")
+
+      # Clicking Delete opens our own modal (server-rendered, not a native dialog)
+      html = view |> element("button[phx-value-id='#{notification.id}']") |> render_click()
+      assert html =~ "Delete this broadcast?"
+
+      # Confirming performs the soft delete and removes the row
+      html = view |> element("button[phx-click='confirm_delete']") |> render_click()
+
+      refute html =~ "New feature"
+      assert Sanbase.Repo.get(Notification, notification.id).is_deleted == true
+    end
+
+    test "cancelling the modal does not delete", %{conn: conn} do
+      notification = create_broadcast()
+      {:ok, view, _html} = live(conn, @path)
+
+      view |> element("button[phx-value-id='#{notification.id}']") |> render_click()
+      html = view |> element("button", "Cancel") |> render_click()
+
+      refute html =~ "Delete this broadcast?"
+      assert Sanbase.Repo.get(Notification, notification.id).is_deleted == false
+    end
+  end
+
+  describe "as an Admin Panel Viewer" do
+    setup do
+      login_with_role(:role_admin_panel_viewer)
+    end
+
+    test "does not see a delete button", %{conn: conn} do
+      _notification = create_broadcast()
+      {:ok, view, html} = live(conn, @path)
+
+      assert html =~ "New feature"
+      refute has_element?(view, "button[phx-click='request_delete']")
+    end
+
+    test "is denied server-side even when the event is pushed directly", %{conn: conn} do
+      notification = create_broadcast()
+      {:ok, view, _html} = live(conn, @path)
+
+      html =
+        render_click(view, "request_delete", %{
+          "id" => to_string(notification.id),
+          "title" => notification.title,
+          "recipients" => "1"
+        })
+
+      # No modal opened and nothing deleted
+      refute html =~ "Delete this broadcast?"
+      assert Sanbase.Repo.get(Notification, notification.id).is_deleted == false
+
+      # Even a forced confirm_delete is rejected
+      render_click(view, "confirm_delete", %{})
+      assert Sanbase.Repo.get(Notification, notification.id).is_deleted == false
+    end
+  end
+end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Broadcast deletion now requires modal confirmation displaying broadcast title and recipient count.

* **Bug Fixes**
  * Enforced role-based permission controls for broadcast deletion operations.

* **Tests**
  * Added test coverage for broadcast deletion workflow and permission enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->