### PR TITLE
Fix funding rates quеue pause

### DIFF
--- a/lib/sanbase/cryptocompare/funding_rate/funding_rate_pause_resume_worker.ex
+++ b/lib/sanbase/cryptocompare/funding_rate/funding_rate_pause_resume_worker.ex
@@ -1,7 +1,12 @@
 defmodule Sanbase.Cryptocompare.FundingRate.PauseResumeWorker do
+  # NOTE: `states` must exclude :completed. With the default states a *completed*
+  # resume job blocks enqueueing a new one for `period` seconds, so if the queue
+  # is paused again within that window no resume is scheduled and the queue stays
+  # paused forever. Keeping only the non-terminal states still prevents duplicate
+  # pending resumes while always allowing a fresh resume after one finishes.
   use Oban.Worker,
     queue: :cryptocompare_funding_rate_historical_jobs_pause_resume_queue,
-    unique: [period: 60]
+    unique: [period: 60, states: [:available, :scheduled, :executing, :retryable]]
 
   require Logger
 

--- a/lib/sanbase/cryptocompare/handler.ex
+++ b/lib/sanbase/cryptocompare/handler.ex
@@ -81,7 +81,12 @@ defmodule Sanbase.Cryptocompare.Handler do
         process_function.(http_response.body)
         |> maybe_remove_known_timestamps(timestamps, opts)
 
-      {:error_limited, %{value: rate_limited_seconds}} ->
+      {:error_limited, _info} ->
+        rate_limited_seconds =
+          http_response
+          |> HTTPHeaderUtils.rate_limit_reset_seconds()
+          |> capped_reset_seconds()
+
         do_handle_rate_limit(rate_limited_seconds, opts)
     end
   end
@@ -176,6 +181,26 @@ defmodule Sanbase.Cryptocompare.Handler do
   end
 
   defp maybe_remove_known_timestamps({:error, error}, _timestamps, _opts), do: {:error, error}
+
+  # Cryptocompare's monthly window can report a reset that is many days away.
+  # Pausing the whole queue for that long silently stops ingestion (which is
+  # exactly what caused funding rate data to go missing). Cap the pause and let
+  # the queue retry; if the limit is still hit it will simply pause again, and
+  # the long reset is surfaced in the logs.
+  @max_rate_limit_pause_seconds 3600
+
+  defp capped_reset_seconds(seconds)
+       when is_integer(seconds) and seconds > @max_rate_limit_pause_seconds do
+    Logger.warning(
+      "[Cryptocompare] Rate limit reset window is #{seconds}s. Capping pause to " <>
+        "#{@max_rate_limit_pause_seconds}s and will retry."
+    )
+
+    @max_rate_limit_pause_seconds
+  end
+
+  defp capped_reset_seconds(seconds) when is_integer(seconds) and seconds >= 0, do: seconds
+  defp capped_reset_seconds(_), do: 60
 
   defp do_handle_rate_limit(rate_limited_seconds, opts) do
     module = Keyword.fetch!(opts, :module)

--- a/lib/sanbase/cryptocompare/http_header_utils.ex
+++ b/lib/sanbase/cryptocompare/http_header_utils.ex
@@ -89,6 +89,43 @@ defmodule Sanbase.Cryptocompare.HTTPHeaderUtils do
     end
   end
 
+  @default_reset_seconds 60
+
+  @doc ~s"""
+  How many seconds to wait before retrying after a rate limit was hit.
+
+  Looks at which windows are exhausted (0 remaining in `X-RateLimit-Remaining-All`),
+  takes the one with the longest period (the binding constraint) and returns that
+  window's reset time from `X-RateLimit-Reset-All`.
+
+  Unlike `get_biggest_ratelimited_window/1`, which returns the largest reset across
+  *all* windows (e.g. the monthly window, which can be many days away even for a
+  brief per-second burst limit), this returns the reset for the window that is
+  actually exhausted.
+
+  Returns `nil` when the response is not rate limited, and falls back to
+  `#{@default_reset_seconds}` seconds when the reset header is missing or unparseable.
+  """
+  def rate_limit_reset_seconds(resp) do
+    case rate_limited?(resp) do
+      {:error_limited, %{time_period: time_period}} ->
+        reset_seconds_for_window(resp, time_period) || @default_reset_seconds
+
+      false ->
+        nil
+    end
+  end
+
+  defp reset_seconds_for_window(resp, time_period) do
+    with {_header, value} <- get_header(resp, "X-RateLimit-Reset-All"),
+         list when is_list(list) <- parse_value_list(value),
+         %{value: reset_after} <- Enum.find(list, &(&1.time_period == time_period)) do
+      reset_after
+    else
+      _ -> nil
+    end
+  end
+
   def get_header(%HTTPoison.Response{} = resp, header) do
     Enum.find(resp.headers, &match?({^header, _}, &1))
   end

--- a/lib/sanbase/cryptocompare/open_interest/open_interest_pause_resume_worker.ex
+++ b/lib/sanbase/cryptocompare/open_interest/open_interest_pause_resume_worker.ex
@@ -1,7 +1,12 @@
 defmodule Sanbase.Cryptocompare.OpenInterest.PauseResumeWorker do
+  # NOTE: `states` must exclude :completed. With the default states a *completed*
+  # resume job blocks enqueueing a new one for `period` seconds, so if the queue
+  # is paused again within that window no resume is scheduled and the queue stays
+  # paused forever. Keeping only the non-terminal states still prevents duplicate
+  # pending resumes while always allowing a fresh resume after one finishes.
   use Oban.Worker,
     queue: :cryptocompare_open_interest_historical_jobs_pause_resume_queue,
-    unique: [period: 60]
+    unique: [period: 60, states: [:available, :scheduled, :executing, :retryable]]
 
   require Logger
 

--- a/lib/sanbase/cryptocompare/price/price_pause_resume_worker.ex
+++ b/lib/sanbase/cryptocompare/price/price_pause_resume_worker.ex
@@ -1,7 +1,12 @@
 defmodule Sanbase.Cryptocompare.Price.PauseResumeWorker do
+  # NOTE: `states` must exclude :completed. With the default states a *completed*
+  # resume job blocks enqueueing a new one for `period` seconds, so if the queue
+  # is paused again within that window no resume is scheduled and the queue stays
+  # paused forever. Keeping only the non-terminal states still prevents duplicate
+  # pending resumes while always allowing a fresh resume after one finishes.
   use Oban.Worker,
     queue: :cryptocompare_historical_jobs_pause_resume_queue,
-    unique: [period: 60]
+    unique: [period: 60, states: [:available, :scheduled, :executing, :retryable]]
 
   require Logger
 

--- a/test/sanbase/cryptocompare/http_header_utils_test.exs
+++ b/test/sanbase/cryptocompare/http_header_utils_test.exs
@@ -1,5 +1,60 @@
 defmodule Sanbase.Cryptocompare.HTTPHeaderUtilsTest do
   use ExUnit.Case, async: true
 
+  alias Sanbase.Cryptocompare.HTTPHeaderUtils
+
   doctest Sanbase.Cryptocompare.HTTPHeaderUtils
+
+  # value before `;window=` in Remaining-All is the remaining request count,
+  # in Reset-All it is the seconds until that window resets.
+  defp resp(remaining, reset) do
+    headers =
+      [{"X-RateLimit-Remaining-All", remaining}] ++
+        if reset, do: [{"X-RateLimit-Reset-All", reset}], else: []
+
+    %HTTPoison.Response{status_code: 200, body: "", headers: headers}
+  end
+
+  @reset "100, 1;window=1, 30;window=60, 2000;window=3600, 80000;window=86400, 1200000;window=2592000"
+
+  describe "rate_limit_reset_seconds/1" do
+    test "returns nil when not rate limited" do
+      remaining =
+        "100, 9500;window=1, 9500;window=60, 9500;window=3600, 38673;window=86400, 1220397;window=2592000"
+
+      assert HTTPHeaderUtils.rate_limit_reset_seconds(resp(remaining, @reset)) == nil
+    end
+
+    test "waits for the exhausted short window, not the longest overall window" do
+      # only the per-second window is exhausted -> wait 1s (its reset), not the
+      # ~14 day monthly reset that get_biggest_ratelimited_window/1 would return.
+      remaining =
+        "100, 0;window=1, 50;window=60, 1000;window=3600, 5000;window=86400, 99999;window=2592000"
+
+      assert HTTPHeaderUtils.rate_limit_reset_seconds(resp(remaining, @reset)) == 1
+      # contrast with the pre-existing function that ignores which window is exhausted
+      assert HTTPHeaderUtils.get_biggest_ratelimited_window(resp(remaining, @reset)) == 1_200_000
+    end
+
+    test "uses the reset of the exhausted window" do
+      remaining =
+        "100, 5;window=1, 5;window=60, 0;window=3600, 5000;window=86400, 99999;window=2592000"
+
+      assert HTTPHeaderUtils.rate_limit_reset_seconds(resp(remaining, @reset)) == 2000
+    end
+
+    test "picks the longest exhausted window when several are exhausted" do
+      remaining =
+        "100, 0;window=1, 0;window=60, 0;window=3600, 5000;window=86400, 99999;window=2592000"
+
+      assert HTTPHeaderUtils.rate_limit_reset_seconds(resp(remaining, @reset)) == 2000
+    end
+
+    test "falls back to 60s when the reset header is missing" do
+      remaining =
+        "100, 0;window=1, 50;window=60, 1000;window=3600, 5000;window=86400, 99999;window=2592000"
+
+      assert HTTPHeaderUtils.rate_limit_reset_seconds(resp(remaining, nil)) == 60
+    end
+  end
 end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

 Funding-rate data for every centralized-exchange market (binance, bybit, bitmex, bitfinex, kraken, okex, crypto.com) stopped landing in CH after 2026-06-17, while `hyperliquid` kept flowing. 
 The data from CC was coming ok. The cause was entirely internal: the `cryptocompare_funding_rate_historical_jobs_queue` hit a CCData rate limit, paused itself, and never resumed because the resume was scheduled with a 0s delay and immediately deduped against the just-completed resume job — leaving the queue permanently paused (266K jobs piled up, 0 executing) with no resume pending. Hyperliquid only appears healthy because it's fed by a separate, non-CC producer

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
