### PR TITLE
add computed at

### DIFF
--- a/lib/sanbase/clickhouse/metric/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/metric/metric_adapter.ex
@@ -96,10 +96,16 @@ defmodule Sanbase.Clickhouse.MetricAdapter do
     timeseries_data_per_slug_query(metric, slug, from, to, interval, aggregation, filters, opts)
     |> ClickhouseRepo.query_reduce(
       %{},
-      fn [timestamp, slug, value], acc ->
-        datetime = DateTime.from_unix!(timestamp)
-        elem = %{slug: slug, value: value}
-        Map.update(acc, datetime, [elem], &[elem | &1])
+      fn
+        [timestamp, slug, value], acc ->
+          datetime = DateTime.from_unix!(timestamp)
+          elem = %{slug: slug, value: value}
+          Map.update(acc, datetime, [elem], &[elem | &1])
+
+        [timestamp, slug, value, computed_at], acc ->
+          datetime = DateTime.from_unix!(timestamp)
+          elem = %{slug: slug, value: value, computed_at: DateTime.from_unix!(computed_at)}
+          Map.update(acc, datetime, [elem], &[elem | &1])
       end
     )
     |> maybe_apply_function(fn list ->

--- a/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
+++ b/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
@@ -46,15 +46,19 @@ defmodule Sanbase.Clickhouse.MetricAdapter.SqlQuery do
     {fixed_parameters_str, params} =
       maybe_get_fixed_parameters(metric, version, selector, params, opts ++ [trailing_and: true])
 
+    {computed_at_inner, computed_at_outer} = computed_at_columns(opts)
+
     sql =
       """
       SELECT
         #{to_unix_timestamp(interval, "dt", argument_name: "interval")} AS t,
         #{aggregation(aggregation, "value", "dt")}
+        #{computed_at_outer}
       FROM(
         SELECT
           dt,
           argMax(value, computed_at) AS value
+          #{computed_at_inner}
         FROM {{table:inline}}
         WHERE
           #{finalized_data_filter_str(params.table, only_finalized_data)}
@@ -74,6 +78,29 @@ defmodule Sanbase.Clickhouse.MetricAdapter.SqlQuery do
       """
 
     Sanbase.Clickhouse.Query.new(sql, params)
+  end
+
+  # When `include_computed_at` is set, return the extra SELECT fragments that
+  # carry the latest `computed_at` up through the inner (per-dt) subquery and the
+  # outer (per-interval) aggregation. Both start with a comma so they can be
+  # appended after the value column(s). When unset, both are empty strings so the
+  # generated SQL is byte-identical to before.
+  #
+  # The inner aggregate is aliased `computed_at2` (not `computed_at`) on purpose:
+  # aliasing it `computed_at` would shadow the raw `computed_at` column that the
+  # sibling `argMax(value, computed_at)` uses as its tiebreaker, making ClickHouse
+  # resolve that argument to the aggregate alias and raise ILLEGAL_AGGREGATION
+  # ("aggregate function found inside another aggregate function").
+  # Each fragment goes on its own line in the query and carries a leading comma,
+  # so that when the feature is off (empty strings) no dangling comma is left
+  # behind and the generated SQL stays valid.
+  defp computed_at_columns(opts) do
+    if Keyword.get(opts, :include_computed_at, false) do
+      {", max(computed_at) AS computed_at2",
+       ", toUnixTimestamp(max(computed_at2)) AS computed_at"}
+    else
+      {"", ""}
+    end
   end
 
   defp maybe_get_fixed_parameters(_metric, _version, selector, params, _opts)
@@ -161,16 +188,20 @@ defmodule Sanbase.Clickhouse.MetricAdapter.SqlQuery do
     only_finalized_data = Keyword.get(opts, :only_finalized_data, false)
     {additional_filters, params} = additional_filters(filters, params, trailing_and: true)
 
+    {computed_at_inner, computed_at_outer} = computed_at_columns(opts)
+
     sql = """
     SELECT
       #{to_unix_timestamp(interval, "dt", argument_name: "interval")} AS t,
       dictGetString('asset_metadata_dict', 'name', asset_id) AS slug,
       #{aggregation(aggregation, "value2", "dt")} AS value
+      #{computed_at_outer}
     FROM(
       SELECT
         asset_id,
         dt,
         argMax(value, computed_at) AS value2
+        #{computed_at_inner}
       FROM {{table:inline}}
       WHERE
         #{finalized_data_filter_str(params.table, only_finalized_data)}

--- a/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
+++ b/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
@@ -46,19 +46,22 @@ defmodule Sanbase.Clickhouse.MetricAdapter.SqlQuery do
     {fixed_parameters_str, params} =
       maybe_get_fixed_parameters(metric, version, selector, params, opts ++ [trailing_and: true])
 
-    {computed_at_inner, computed_at_outer} = computed_at_columns(opts)
-
+    # `computed_at` is always selected so the API layer can decide whether to
+    # expose it. The per-dt subquery aliases the aggregate `computed_at2` (not
+    # `computed_at`) on purpose: reusing `computed_at` would shadow the raw column
+    # that the sibling `argMax(value, computed_at)` uses as its tiebreaker and
+    # raise ILLEGAL_AGGREGATION ("aggregate found inside another aggregate").
     sql =
       """
       SELECT
         #{to_unix_timestamp(interval, "dt", argument_name: "interval")} AS t,
-        #{aggregation(aggregation, "value", "dt")}
-        #{computed_at_outer}
+        #{aggregation(aggregation, "value", "dt")},
+        toUnixTimestamp(max(computed_at2)) AS computed_at
       FROM(
         SELECT
           dt,
-          argMax(value, computed_at) AS value
-          #{computed_at_inner}
+          argMax(value, computed_at) AS value,
+          max(computed_at) AS computed_at2
         FROM {{table:inline}}
         WHERE
           #{finalized_data_filter_str(params.table, only_finalized_data)}
@@ -78,29 +81,6 @@ defmodule Sanbase.Clickhouse.MetricAdapter.SqlQuery do
       """
 
     Sanbase.Clickhouse.Query.new(sql, params)
-  end
-
-  # When `include_computed_at` is set, return the extra SELECT fragments that
-  # carry the latest `computed_at` up through the inner (per-dt) subquery and the
-  # outer (per-interval) aggregation. Both start with a comma so they can be
-  # appended after the value column(s). When unset, both are empty strings so the
-  # generated SQL is byte-identical to before.
-  #
-  # The inner aggregate is aliased `computed_at2` (not `computed_at`) on purpose:
-  # aliasing it `computed_at` would shadow the raw `computed_at` column that the
-  # sibling `argMax(value, computed_at)` uses as its tiebreaker, making ClickHouse
-  # resolve that argument to the aggregate alias and raise ILLEGAL_AGGREGATION
-  # ("aggregate function found inside another aggregate function").
-  # Each fragment goes on its own line in the query and carries a leading comma,
-  # so that when the feature is off (empty strings) no dangling comma is left
-  # behind and the generated SQL stays valid.
-  defp computed_at_columns(opts) do
-    if Keyword.get(opts, :include_computed_at, false) do
-      {", max(computed_at) AS computed_at2",
-       ", toUnixTimestamp(max(computed_at2)) AS computed_at"}
-    else
-      {"", ""}
-    end
   end
 
   defp maybe_get_fixed_parameters(_metric, _version, selector, params, _opts)
@@ -188,20 +168,19 @@ defmodule Sanbase.Clickhouse.MetricAdapter.SqlQuery do
     only_finalized_data = Keyword.get(opts, :only_finalized_data, false)
     {additional_filters, params} = additional_filters(filters, params, trailing_and: true)
 
-    {computed_at_inner, computed_at_outer} = computed_at_columns(opts)
-
+    # `computed_at2` alias: see note in timeseries_data_query/8.
     sql = """
     SELECT
       #{to_unix_timestamp(interval, "dt", argument_name: "interval")} AS t,
       dictGetString('asset_metadata_dict', 'name', asset_id) AS slug,
-      #{aggregation(aggregation, "value2", "dt")} AS value
-      #{computed_at_outer}
+      #{aggregation(aggregation, "value2", "dt")} AS value,
+      toUnixTimestamp(max(computed_at2)) AS computed_at
     FROM(
       SELECT
         asset_id,
         dt,
-        argMax(value, computed_at) AS value2
-        #{computed_at_inner}
+        argMax(value, computed_at) AS value2,
+        max(computed_at) AS computed_at2
       FROM {{table:inline}}
       WHERE
         #{finalized_data_filter_str(params.table, only_finalized_data)}

--- a/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
+++ b/lib/sanbase/clickhouse/metric/sql_query/metric_sql_query.ex
@@ -46,11 +46,7 @@ defmodule Sanbase.Clickhouse.MetricAdapter.SqlQuery do
     {fixed_parameters_str, params} =
       maybe_get_fixed_parameters(metric, version, selector, params, opts ++ [trailing_and: true])
 
-    # `computed_at` is always selected so the API layer can decide whether to
-    # expose it. The per-dt subquery aliases the aggregate `computed_at2` (not
-    # `computed_at`) on purpose: reusing `computed_at` would shadow the raw column
-    # that the sibling `argMax(value, computed_at)` uses as its tiebreaker and
-    # raise ILLEGAL_AGGREGATION ("aggregate found inside another aggregate").
+    # computed_at is always selected, but the API layer decides whether or not to return it
     sql =
       """
       SELECT

--- a/lib/sanbase/metric/transform.ex
+++ b/lib/sanbase/metric/transform.ex
@@ -73,6 +73,13 @@ defmodule Sanbase.Metric.Transform do
       [unix, value] ->
         %{datetime: DateTime.from_unix!(unix), value: value}
 
+      [unix, value, computed_at] ->
+        %{
+          datetime: DateTime.from_unix!(unix),
+          value: value,
+          computed_at: DateTime.from_unix!(computed_at)
+        }
+
       [unix, open, high, low, close] ->
         %{
           datetime: DateTime.from_unix!(unix),
@@ -82,6 +89,18 @@ defmodule Sanbase.Metric.Transform do
             low: low,
             close: close
           }
+        }
+
+      [unix, open, high, low, close, computed_at] ->
+        %{
+          datetime: DateTime.from_unix!(unix),
+          value_ohlc: %{
+            open: open,
+            high: high,
+            low: low,
+            close: close
+          },
+          computed_at: DateTime.from_unix!(computed_at)
         }
     end)
   end

--- a/lib/sanbase_web/graphql/helpers/utils.ex
+++ b/lib/sanbase_web/graphql/helpers/utils.ex
@@ -149,40 +149,6 @@ defmodule SanbaseWeb.Graphql.Helpers.Utils do
 
   def requested_fields(_), do: MapSet.new([])
 
-  @doc ~s"""
-  Return true if `field_name` (given in snake_case or camelCase) is selected
-  anywhere in the GraphQL selection tree, at any nesting depth. Unlike
-  `requested_fields/1`, which only inspects the top-level selections, this walks
-  into nested selections. This is needed for fields whose data lives inside a
-  nested object - e.g. `computedAt` inside the `data` list of
-  `timeseriesDataPerSlug`.
-  """
-  @spec field_requested?(%Absinthe.Resolution{}, String.t()) :: boolean()
-  def field_requested?(%Absinthe.Resolution{} = resolution, field_name) do
-    target = Sanbase.Utils.Inflect.camelize(field_name, :lower)
-    do_field_requested?(resolution.definition.selections, target)
-  end
-
-  def field_requested?(_, _), do: false
-
-  defp do_field_requested?(selections, target) when is_list(selections) do
-    Enum.any?(selections, fn selection ->
-      name_match? =
-        case selection do
-          %{name: name} -> Sanbase.Utils.Inflect.camelize(name, :lower) == target
-          _ -> false
-        end
-
-      name_match? or
-        case selection do
-          %{selections: sub} -> do_field_requested?(sub, target)
-          _ -> false
-        end
-    end)
-  end
-
-  defp do_field_requested?(_, _), do: false
-
   # Private functions
 
   @fields [

--- a/lib/sanbase_web/graphql/helpers/utils.ex
+++ b/lib/sanbase_web/graphql/helpers/utils.ex
@@ -149,6 +149,40 @@ defmodule SanbaseWeb.Graphql.Helpers.Utils do
 
   def requested_fields(_), do: MapSet.new([])
 
+  @doc ~s"""
+  Return true if `field_name` (given in snake_case or camelCase) is selected
+  anywhere in the GraphQL selection tree, at any nesting depth. Unlike
+  `requested_fields/1`, which only inspects the top-level selections, this walks
+  into nested selections. This is needed for fields whose data lives inside a
+  nested object - e.g. `computedAt` inside the `data` list of
+  `timeseriesDataPerSlug`.
+  """
+  @spec field_requested?(%Absinthe.Resolution{}, String.t()) :: boolean()
+  def field_requested?(%Absinthe.Resolution{} = resolution, field_name) do
+    target = Sanbase.Utils.Inflect.camelize(field_name, :lower)
+    do_field_requested?(resolution.definition.selections, target)
+  end
+
+  def field_requested?(_, _), do: false
+
+  defp do_field_requested?(selections, target) when is_list(selections) do
+    Enum.any?(selections, fn selection ->
+      name_match? =
+        case selection do
+          %{name: name} -> Sanbase.Utils.Inflect.camelize(name, :lower) == target
+          _ -> false
+        end
+
+      name_match? or
+        case selection do
+          %{selections: sub} -> do_field_requested?(sub, target)
+          _ -> false
+        end
+    end)
+  end
+
+  defp do_field_requested?(_, _), do: false
+
   # Private functions
 
   @fields [

--- a/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
@@ -535,51 +535,30 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     end)
   end
 
-  defp maybe_rename_fields(result, :timeseries_data, %{fields: map})
-       when is_map(map) and map_size(map) > 0 do
+  # For the JSON variants `fields` acts as a selector: only the fields named in
+  # it are returned, emitted under the caller-provided key. A named field that is
+  # absent on the datapoint (e.g. `value` for an OHLC series) is skipped.
+  defp maybe_rename_fields(result, :timeseries_data, %{fields: fields})
+       when is_map(fields) and map_size(fields) > 0 do
     result =
-      result
-      |> Enum.map(fn
-        %{datetime: d, value: v} = point ->
-          %{
-            Map.get(map, :datetime, :datetime) => d,
-            Map.get(map, :value, :value) => v
-          }
-          |> maybe_put_computed_at(map, point)
-
-        %{datetime: d, value_ohlc: ohlc} = point ->
-          %{
-            Map.get(map, :datetime, :datetime) => d,
-            Map.get(map, :value_ohlc, :value_ohlc) => %{
-              Map.get(map, :open, :open) => ohlc.open,
-              Map.get(map, :high, :high) => ohlc.high,
-              Map.get(map, :close, :close) => ohlc.close,
-              Map.get(map, :low, :low) => ohlc.low
-            }
-          }
-          |> maybe_put_computed_at(map, point)
+      Enum.map(result, fn point ->
+        %{}
+        |> put_selected_field(fields, :datetime, point)
+        |> put_selected_field(fields, :value, point)
+        |> put_selected_ohlc(fields, point)
+        |> put_selected_field(fields, :computed_at, point)
       end)
 
     {:ok, result}
   end
 
-  defp maybe_rename_fields(result, :timeseries_data_per_slug, %{fields: map})
-       when is_map(map) and map_size(map) > 0 do
+  defp maybe_rename_fields(result, :timeseries_data_per_slug, %{fields: fields})
+       when is_map(fields) and map_size(fields) > 0 do
     result =
-      result
-      |> Enum.map(fn %{datetime: datetime, data: data} ->
-        %{
-          Map.get(map, :datetime, :datetime) => datetime,
-          Map.get(map, :data, :data) =>
-            Enum.map(data, fn
-              %{value: value, slug: slug} = elem ->
-                %{
-                  Map.get(map, :value, :value) => value,
-                  Map.get(map, :slug, :slug) => slug
-                }
-                |> maybe_put_computed_at(map, elem)
-            end)
-        }
+      Enum.map(result, fn point ->
+        %{}
+        |> put_selected_field(fields, :datetime, point)
+        |> put_selected_data(fields, point)
       end)
 
     {:ok, result}
@@ -587,18 +566,57 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
 
   defp maybe_rename_fields(result, _function, _args), do: {:ok, result}
 
-  # `computed_at` is opt-in for the JSON variants: it is included in the output
-  # only when the caller named it in the `fields` argument. When present, its key
-  # is renamed like the other fields.
-  defp maybe_put_computed_at(acc, fields_map, point) do
-    case {Map.has_key?(fields_map, :computed_at), point} do
-      {true, %{computed_at: computed_at}} ->
-        Map.put(acc, Map.get(fields_map, :computed_at, :computed_at), computed_at)
+  # Copy `field` from the datapoint into the accumulator under its caller-provided
+  # key, but only when it is both selected in `fields` and present on the point.
+  defp put_selected_field(acc, fields, field, point) do
+    case {Map.fetch(fields, field), Map.fetch(point, field)} do
+      {{:ok, out_key}, {:ok, value}} -> Map.put(acc, out_key, value)
+      _ -> acc
+    end
+  end
 
-      _ ->
+  # `value_ohlc` is a nested object; when selected, its inner keys are renamed via
+  # the `open`/`high`/`low`/`close` entries of `fields` (defaulting to their name).
+  defp put_selected_ohlc(acc, fields, %{value_ohlc: ohlc}) do
+    case Map.fetch(fields, :value_ohlc) do
+      {:ok, out_key} ->
+        nested = %{
+          Map.get(fields, :open, :open) => ohlc.open,
+          Map.get(fields, :high, :high) => ohlc.high,
+          Map.get(fields, :low, :low) => ohlc.low,
+          Map.get(fields, :close, :close) => ohlc.close
+        }
+
+        Map.put(acc, out_key, nested)
+
+      :error ->
         acc
     end
   end
+
+  defp put_selected_ohlc(acc, _fields, _point), do: acc
+
+  # `data` is a nested list; when selected, each element is projected over the
+  # selected `slug`/`value`/`computed_at` fields.
+  defp put_selected_data(acc, fields, %{data: data}) do
+    case Map.fetch(fields, :data) do
+      {:ok, out_key} ->
+        projected =
+          Enum.map(data, fn elem ->
+            %{}
+            |> put_selected_field(fields, :slug, elem)
+            |> put_selected_field(fields, :value, elem)
+            |> put_selected_field(fields, :computed_at, elem)
+          end)
+
+        Map.put(acc, out_key, projected)
+
+      :error ->
+        acc
+    end
+  end
+
+  defp put_selected_data(acc, _fields, _point), do: acc
 
   # `computed_at` is always fetched from ClickHouse. The typed fields expose it
   # only when the client selects the `computedAt` field, so nothing to do there.

--- a/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
@@ -513,6 +513,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
          true <- valid_metric_selector_pair?(metric, selector),
          true <- valid_owners_labels_selection?(args),
          true <- valid_timeseries_selection?(requested_fields, args),
+         true <- valid_computed_at_selection?(args, json_variant?),
          {:ok, opts} <- selector_args_to_opts(args),
          opts <- Keyword.put(opts, :only_finalized_data, only_finalized_data),
          opts <- Keyword.put(opts, :version, version),
@@ -521,12 +522,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
          {:ok, result} <-
            apply(Metric, function, [metric, selector, from, to, interval, opts]),
          {:ok, result} <- MetricTransform.apply_transform(transform, result),
-         {:ok, result} <- fit_from_datetime(result, %{args | interval: interval}),
-         {:ok, result} <- maybe_rename_fields(result, function, args) do
+         {:ok, result} <- fit_from_datetime(result, %{args | interval: interval}) do
       result =
         result
         |> Enum.reject(&is_nil/1)
-        |> maybe_drop_computed_at(json_variant?, args)
+        |> format_output(function, args, json_variant?)
 
       {:ok, result}
     end
@@ -535,41 +535,94 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     end)
   end
 
-  # For the JSON variants `fields` acts as a selector: only the fields named in
-  # it are returned, emitted under the caller-provided key. A named field that is
-  # absent on the datapoint (e.g. `value` for an OHLC series) is skipped.
-  defp maybe_rename_fields(result, :timeseries_data, %{fields: fields})
-       when is_map(fields) and map_size(fields) > 0 do
-    result =
-      Enum.map(result, fn point ->
-        %{}
-        |> put_selected_field(fields, :datetime, point)
-        |> put_selected_field(fields, :value, point)
-        |> put_selected_ohlc(fields, point)
-        |> put_selected_field(fields, :computed_at, point)
-      end)
+  # Naming `computedAt` in `fields` only renames the key; `includeComputedAt: true`
+  # is what actually includes it. Naming it while the flag is off is a
+  # contradiction, so reject it rather than silently ignoring one of the two.
+  defp valid_computed_at_selection?(args, true = _json_variant?) do
+    fields = Map.get(args, :fields)
+    include_computed_at? = Map.get(args, :include_computed_at, false)
 
-    {:ok, result}
+    if is_map(fields) and Map.has_key?(fields, :computed_at) and not include_computed_at? do
+      {:error,
+       "`computedAt` is named in `fields` but `includeComputedAt` is false. Set " <>
+         "`includeComputedAt: true` to include it (naming it in `fields` only renames the key)."}
+    else
+      true
+    end
   end
 
-  defp maybe_rename_fields(result, :timeseries_data_per_slug, %{fields: fields})
-       when is_map(fields) and map_size(fields) > 0 do
-    result =
-      Enum.map(result, fn point ->
-        %{}
-        |> put_selected_field(fields, :datetime, point)
-        |> put_selected_data(fields, point)
-      end)
+  defp valid_computed_at_selection?(_args, false = _json_variant?), do: true
 
-    {:ok, result}
+  # Typed variants return the maps unchanged - GraphQL field selection picks the
+  # keys (computed_at is present and exposed only when `computedAt` is selected).
+  defp format_output(result, _function, _args, false = _json_variant?), do: result
+
+  # The `*Json` variants serialize the whole map, so we build each row explicitly:
+  # `fields` selects/renames the core columns (defaulting to datetime + value /
+  # datetime + data when omitted) and `include_computed_at` appends `computedAt`
+  # on top of that selection.
+  defp format_output(result, function, args, true = _json_variant?) do
+    fields = Map.get(args, :fields) || %{}
+
+    # `computedAt` can be included two ways: named in `fields` (returned under the
+    # caller's key, as part of the selection) or via the `include_computed_at`
+    # flag (returned under the default `computedAt` key). The flag only appends
+    # when `fields` does not already name it, so the two never collide.
+    append_computed_at? =
+      Map.get(args, :include_computed_at, false) and not Map.has_key?(fields, :computed_at)
+
+    Enum.map(result, &json_row(&1, function, fields, append_computed_at?))
   end
 
-  defp maybe_rename_fields(result, _function, _args), do: {:ok, result}
+  defp json_row(point, :timeseries_data, fields, append_computed_at?) do
+    point
+    |> select_timeseries_fields(fields)
+    |> maybe_append_computed_at(point, append_computed_at?)
+  end
 
-  # Copy `field` from the datapoint into the accumulator under its caller-provided
-  # key, but only when it is both selected in `fields` and present on the point.
-  defp put_selected_field(acc, fields, field, point) do
-    case {Map.fetch(fields, field), Map.fetch(point, field)} do
+  # For per-slug, `computed_at` belongs to each (datetime, slug) pair, so it is
+  # appended inside every data element rather than at the top level.
+  defp json_row(%{datetime: datetime, data: data}, :timeseries_data_per_slug, fields, append?) do
+    elements =
+      Enum.map(data, fn elem ->
+        elem
+        |> select_slug_fields(fields)
+        |> maybe_append_computed_at(elem, append?)
+      end)
+
+    %{}
+    |> put_or_default(fields, :datetime, datetime)
+    |> put_or_default(fields, :data, elements)
+  end
+
+  # No `fields` -> default columns (datetime + value/value_ohlc). Otherwise only
+  # the named columns (including `computed_at` when named), under the given keys.
+  defp select_timeseries_fields(point, fields) when map_size(fields) == 0,
+    do: Map.delete(point, :computed_at)
+
+  defp select_timeseries_fields(point, fields) do
+    %{}
+    |> put_selected_field(fields, :datetime, point)
+    |> put_selected_field(fields, :value, point)
+    |> put_selected_ohlc(fields, point)
+    |> put_selected_field(fields, :computed_at, point)
+  end
+
+  defp select_slug_fields(elem, fields) when map_size(fields) == 0,
+    do: Map.take(elem, [:slug, :value])
+
+  defp select_slug_fields(elem, fields) do
+    %{}
+    |> put_selected_field(fields, :slug, elem)
+    |> put_selected_field(fields, :value, elem)
+    |> put_selected_field(fields, :computed_at, elem)
+  end
+
+  # Copy `field` from `source` under its caller-provided key, but only when it is
+  # both selected in `fields` and present on the datapoint (e.g. `value` is absent
+  # on an OHLC series).
+  defp put_selected_field(acc, fields, field, source) do
+    case {Map.fetch(fields, field), Map.fetch(source, field)} do
       {{:ok, out_key}, {:ok, value}} -> Map.put(acc, out_key, value)
       _ -> acc
     end
@@ -596,50 +649,24 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
 
   defp put_selected_ohlc(acc, _fields, _point), do: acc
 
-  # `data` is a nested list; when selected, each element is projected over the
-  # selected `slug`/`value`/`computed_at` fields.
-  defp put_selected_data(acc, fields, %{data: data}) do
-    case Map.fetch(fields, :data) do
-      {:ok, out_key} ->
-        projected =
-          Enum.map(data, fn elem ->
-            %{}
-            |> put_selected_field(fields, :slug, elem)
-            |> put_selected_field(fields, :value, elem)
-            |> put_selected_field(fields, :computed_at, elem)
-          end)
+  # With no `fields` the value is kept under its default key; otherwise only when
+  # the field is named, under the caller-provided key.
+  defp put_or_default(acc, fields, field, value) when map_size(fields) == 0,
+    do: Map.put(acc, field, value)
 
-        Map.put(acc, out_key, projected)
-
-      :error ->
-        acc
+  defp put_or_default(acc, fields, field, value) do
+    case Map.fetch(fields, field) do
+      {:ok, out_key} -> Map.put(acc, out_key, value)
+      :error -> acc
     end
   end
 
-  defp put_selected_data(acc, _fields, _point), do: acc
+  # `include_computed_at` appends the compute timestamp under a fixed `computedAt`
+  # key (matching the typed field); `nil` for adapters that do not track it.
+  defp maybe_append_computed_at(row, _source, false), do: row
 
-  # `computed_at` is always fetched from ClickHouse. The typed fields expose it
-  # only when the client selects the `computedAt` field, so nothing to do there.
-  # The `*Json` variants serialize the whole map, so `computed_at` would leak into
-  # every payload - drop it unless the caller opted in by naming it in `fields`
-  # (when opted in, `maybe_rename_fields/3` has emitted it under the caller's key).
-  defp maybe_drop_computed_at(result, json_variant?, args) do
-    if json_variant? and not fields_include_computed_at?(args) do
-      Enum.map(result, &drop_computed_at/1)
-    else
-      result
-    end
-  end
-
-  defp fields_include_computed_at?(%{fields: fields}) when is_map(fields),
-    do: Map.has_key?(fields, :computed_at)
-
-  defp fields_include_computed_at?(_args), do: false
-
-  defp drop_computed_at(%{data: data} = point) when is_list(data),
-    do: %{point | data: Enum.map(data, &Map.delete(&1, :computed_at))}
-
-  defp drop_computed_at(point), do: Map.delete(point, :computed_at)
+  defp maybe_append_computed_at(row, source, true),
+    do: Map.put(row, :computedAt, Map.get(source, :computed_at))
 
   # Which schema field is being resolved - `timeseriesDataJson` /
   # `timeseriesDataPerSlugJson` (raw `:json` scalar) or their typed counterparts.

--- a/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
@@ -266,16 +266,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
 
   def timeseries_data(_root, args, %{source: %{metric: metric, version: version}} = resolution) do
     requested_fields = requested_fields(resolution)
-    include_computed_at? = include_computed_at?(resolution, args)
-
-    fetch_timeseries_data(
-      metric,
-      version,
-      args,
-      requested_fields,
-      :timeseries_data,
-      include_computed_at?
-    )
+    fetch_timeseries_data(metric, version, args, requested_fields, :timeseries_data)
   rescue
     e in [Sanbase.Metric.CatchableError] -> {:error, Exception.message(e)}
     e -> reraise(e, __STACKTRACE__)
@@ -287,21 +278,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
         %{source: %{metric: metric, version: version}} = resolution
       ) do
     requested_fields = requested_fields(resolution)
-    include_computed_at? = include_computed_at?(resolution, args)
 
     # A heap-capped fetch: on overrun the BEAM kills the worker with an
     # untrappable :killed exit, which we turn into a friendly error instead of a
-    # Sentry alert. See run_per_slug_in_bounded_process/5.
-    run_per_slug_in_bounded_process(
-      metric,
-      version,
-      args,
-      requested_fields,
-      include_computed_at?
-    )
+    # Sentry alert. See run_per_slug_in_bounded_process/4.
+    run_per_slug_in_bounded_process(metric, version, args, requested_fields)
   rescue
     # CatchableError raised during the per-slug fetch is handled inside the
-    # bounded worker (see run_per_slug_in_bounded_process/5) and returned as an
+    # bounded worker (see run_per_slug_in_bounded_process/4) and returned as an
     # {:error, message} tuple, so this clause is only a defensive fallback.
     e in [Sanbase.Metric.CatchableError] -> {:error, Exception.message(e)}
     e -> reraise(e, __STACKTRACE__)
@@ -425,13 +409,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   # request process - we just see the :DOWN and return a friendly error. Other
   # outcomes (a CatchableError, or an unexpected raise we still want in Sentry)
   # are caught in the worker and sent back, so inline behaviour is preserved.
-  defp run_per_slug_in_bounded_process(
-         metric,
-         version,
-         args,
-         requested_fields,
-         include_computed_at?
-       ) do
+  defp run_per_slug_in_bounded_process(metric, version, args, requested_fields) do
     parent = self()
     ref = make_ref()
 
@@ -459,8 +437,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
                version,
                args,
                requested_fields,
-               :timeseries_data_per_slug,
-               include_computed_at?
+               :timeseries_data_per_slug
              )}
           rescue
             e in [Sanbase.Metric.CatchableError] -> {:ok, {:error, Exception.message(e)}}
@@ -509,16 +486,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   # timeseries_data and timeseries_data_per_slug are processed and fetched in
   # exactly the same way. The only difference is the function that is called
   # from the Metric module.
-  defp fetch_timeseries_data(
-         metric,
-         version,
-         args,
-         requested_fields,
-         function,
-         include_computed_at?
-       )
+  defp fetch_timeseries_data(metric, version, args, requested_fields, function)
        when function in [:timeseries_data, :timeseries_data_per_slug] do
     only_finalized_data = Map.get(args, :only_finalized_data, false)
+
+    # The `*Json` variants return a `:json` scalar, so they have no GraphQL
+    # sub-selections - an empty `requested_fields` means we're serving a JSON
+    # variant (a typed object field always selects at least one subfield).
+    json? = Enum.empty?(requested_fields)
 
     with {:ok, selector} <- args_to_selector(args, use_process_dictionary: true),
          {:ok, transform} <- MetricTransform.args_to_transform(args),
@@ -529,7 +504,6 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
          {:ok, opts} <- selector_args_to_opts(args),
          opts <- Keyword.put(opts, :only_finalized_data, only_finalized_data),
          opts <- Keyword.put(opts, :version, version),
-         opts <- Keyword.put(opts, :include_computed_at, include_computed_at?),
          {:ok, from, to, interval} <-
            transform_datetime_params(selector, metric, transform, args),
          {:ok, result} <-
@@ -537,7 +511,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
          {:ok, result} <- MetricTransform.apply_transform(transform, result),
          {:ok, result} <- fit_from_datetime(result, %{args | interval: interval}),
          {:ok, result} <- maybe_rename_fields(result, function, args) do
-      result = result |> Enum.reject(&is_nil/1)
+      result =
+        result
+        |> Enum.reject(&is_nil/1)
+        |> maybe_drop_computed_at(json?, args)
 
       {:ok, result}
     end
@@ -611,19 +588,24 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     end
   end
 
-  # `computedAt` is requested when it appears anywhere in the GraphQL selection
-  # tree (for the typed fields - `computedAt` sits at the top level of
-  # `timeseriesData` but nested under `data` for `timeseriesDataPerSlug`), or
-  # when it is named in the `fields` argument (for the *Json variants, whose
-  # selection tree only contains the scalar itself).
-  defp include_computed_at?(resolution, args) do
-    field_requested?(resolution, "computed_at") or fields_include_computed_at?(args)
-  end
+  # `computed_at` is always fetched from ClickHouse. The typed fields expose it
+  # only when the client selects the `computedAt` field, so nothing to do there.
+  # The `*Json` variants serialize the whole map, so `computed_at` would leak into
+  # every payload - drop it unless the caller opted in by naming it in `fields`
+  # (in which case `maybe_rename_fields/3` already projected the keys explicitly).
+  defp maybe_drop_computed_at(result, false = _json?, _args), do: result
 
-  defp fields_include_computed_at?(%{fields: fields}) when is_map(fields),
-    do: Map.has_key?(fields, :computed_at)
+  defp maybe_drop_computed_at(result, true = _json?, %{fields: map})
+       when is_map(map) and map_size(map) > 0,
+       do: result
 
-  defp fields_include_computed_at?(_args), do: false
+  defp maybe_drop_computed_at(result, true = _json?, _args),
+    do: Enum.map(result, &drop_computed_at/1)
+
+  defp drop_computed_at(%{data: data} = point) when is_list(data),
+    do: %{point | data: Enum.map(data, &Map.delete(&1, :computed_at))}
+
+  defp drop_computed_at(point), do: Map.delete(point, :computed_at)
 
   defp transform_datetime_params(selector, metric, transform, args) do
     %{from: from, to: to, interval: interval} = args

--- a/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
@@ -21,6 +21,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   @max_heap_size_in_mbs 500
   @max_heap_size_in_words div(@max_heap_size_in_mbs * 1024 * 1024, @wordsize)
 
+  # The `*Json` schema fields return a raw `:json` scalar (the whole map is
+  # serialized), while the typed fields let GraphQL field selection filter keys.
+  # `timeseries_data/3` and `timeseries_data_per_slug/3` each back both a typed
+  # and a JSON field, so we look at which schema field is being resolved.
+  @json_field_identifiers [:timeseries_data_json, :timeseries_data_per_slug_json]
+
   def get_metric(_root, %{metric: metric} = args, resolution) do
     # TODO: Check that the version is also deprecated
     version = Map.get(args, :version, Sanbase.Metric.default_version())
@@ -266,7 +272,16 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
 
   def timeseries_data(_root, args, %{source: %{metric: metric, version: version}} = resolution) do
     requested_fields = requested_fields(resolution)
-    fetch_timeseries_data(metric, version, args, requested_fields, :timeseries_data)
+    json_variant? = json_variant?(resolution)
+
+    fetch_timeseries_data(
+      metric,
+      version,
+      args,
+      requested_fields,
+      :timeseries_data,
+      json_variant?
+    )
   rescue
     e in [Sanbase.Metric.CatchableError] -> {:error, Exception.message(e)}
     e -> reraise(e, __STACKTRACE__)
@@ -278,14 +293,15 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
         %{source: %{metric: metric, version: version}} = resolution
       ) do
     requested_fields = requested_fields(resolution)
+    json_variant? = json_variant?(resolution)
 
     # A heap-capped fetch: on overrun the BEAM kills the worker with an
     # untrappable :killed exit, which we turn into a friendly error instead of a
-    # Sentry alert. See run_per_slug_in_bounded_process/4.
-    run_per_slug_in_bounded_process(metric, version, args, requested_fields)
+    # Sentry alert. See run_per_slug_in_bounded_process/5.
+    run_per_slug_in_bounded_process(metric, version, args, requested_fields, json_variant?)
   rescue
     # CatchableError raised during the per-slug fetch is handled inside the
-    # bounded worker (see run_per_slug_in_bounded_process/4) and returned as an
+    # bounded worker (see run_per_slug_in_bounded_process/5) and returned as an
     # {:error, message} tuple, so this clause is only a defensive fallback.
     e in [Sanbase.Metric.CatchableError] -> {:error, Exception.message(e)}
     e -> reraise(e, __STACKTRACE__)
@@ -409,7 +425,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   # request process - we just see the :DOWN and return a friendly error. Other
   # outcomes (a CatchableError, or an unexpected raise we still want in Sentry)
   # are caught in the worker and sent back, so inline behaviour is preserved.
-  defp run_per_slug_in_bounded_process(metric, version, args, requested_fields) do
+  defp run_per_slug_in_bounded_process(metric, version, args, requested_fields, json_variant?) do
     parent = self()
     ref = make_ref()
 
@@ -437,7 +453,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
                version,
                args,
                requested_fields,
-               :timeseries_data_per_slug
+               :timeseries_data_per_slug,
+               json_variant?
              )}
           rescue
             e in [Sanbase.Metric.CatchableError] -> {:ok, {:error, Exception.message(e)}}
@@ -486,14 +503,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   # timeseries_data and timeseries_data_per_slug are processed and fetched in
   # exactly the same way. The only difference is the function that is called
   # from the Metric module.
-  defp fetch_timeseries_data(metric, version, args, requested_fields, function)
+  defp fetch_timeseries_data(metric, version, args, requested_fields, function, json_variant?)
        when function in [:timeseries_data, :timeseries_data_per_slug] do
     only_finalized_data = Map.get(args, :only_finalized_data, false)
-
-    # The `*Json` variants return a `:json` scalar, so they have no GraphQL
-    # sub-selections - an empty `requested_fields` means we're serving a JSON
-    # variant (a typed object field always selects at least one subfield).
-    json? = Enum.empty?(requested_fields)
 
     with {:ok, selector} <- args_to_selector(args, use_process_dictionary: true),
          {:ok, transform} <- MetricTransform.args_to_transform(args),
@@ -514,7 +526,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
       result =
         result
         |> Enum.reject(&is_nil/1)
-        |> maybe_drop_computed_at(json?, args)
+        |> maybe_drop_computed_at(json_variant?, args)
 
       {:ok, result}
     end
@@ -593,19 +605,24 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   # The `*Json` variants serialize the whole map, so `computed_at` would leak into
   # every payload - drop it unless the caller opted in by naming it in `fields`
   # (in which case `maybe_rename_fields/3` already projected the keys explicitly).
-  defp maybe_drop_computed_at(result, false = _json?, _args), do: result
+  defp maybe_drop_computed_at(result, false = _json_variant?, _args), do: result
 
-  defp maybe_drop_computed_at(result, true = _json?, %{fields: map})
+  defp maybe_drop_computed_at(result, true = _json_variant?, %{fields: map})
        when is_map(map) and map_size(map) > 0,
        do: result
 
-  defp maybe_drop_computed_at(result, true = _json?, _args),
+  defp maybe_drop_computed_at(result, true = _json_variant?, _args),
     do: Enum.map(result, &drop_computed_at/1)
 
   defp drop_computed_at(%{data: data} = point) when is_list(data),
     do: %{point | data: Enum.map(data, &Map.delete(&1, :computed_at))}
 
   defp drop_computed_at(point), do: Map.delete(point, :computed_at)
+
+  # Which schema field is being resolved - `timeseriesDataJson` /
+  # `timeseriesDataPerSlugJson` (raw `:json` scalar) or their typed counterparts.
+  defp json_variant?(%Absinthe.Resolution{definition: %{schema_node: %{identifier: identifier}}}),
+    do: identifier in @json_field_identifiers
 
   defp transform_datetime_params(selector, metric, transform, args) do
     %{from: from, to: to, interval: interval} = args

--- a/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
@@ -557,27 +557,36 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   # keys (computed_at is present and exposed only when `computedAt` is selected).
   defp format_output(result, _function, _args, false = _json_variant?), do: result
 
-  # The `*Json` variants serialize the whole map, so we build each row explicitly:
-  # `fields` selects/renames the core columns (defaulting to datetime + value /
-  # datetime + data when omitted) and `include_computed_at` appends `computedAt`
-  # on top of that selection.
+  # The `*Json` variants serialize the whole map. `fields` only *renames* the
+  # output keys - every default field is always present; naming one just changes
+  # its key. `include_computed_at` additionally appends `computedAt` (renamable
+  # via the `computed_at` entry of `fields`).
   defp format_output(result, function, args, true = _json_variant?) do
     fields = Map.get(args, :fields) || %{}
-
-    # `computedAt` can be included two ways: named in `fields` (returned under the
-    # caller's key, as part of the selection) or via the `include_computed_at`
-    # flag (returned under the default `computedAt` key). The flag only appends
-    # when `fields` does not already name it, so the two never collide.
-    append_computed_at? =
-      Map.get(args, :include_computed_at, false) and not Map.has_key?(fields, :computed_at)
+    append_computed_at? = Map.get(args, :include_computed_at, false)
 
     Enum.map(result, &json_row(&1, function, fields, append_computed_at?))
   end
 
-  defp json_row(point, :timeseries_data, fields, append_computed_at?) do
-    point
-    |> select_timeseries_fields(fields)
-    |> maybe_append_computed_at(point, append_computed_at?)
+  defp json_row(%{value_ohlc: ohlc} = point, :timeseries_data, fields, append?) do
+    %{
+      output_key(fields, :datetime) => point.datetime,
+      output_key(fields, :value_ohlc) => %{
+        output_key(fields, :open) => ohlc.open,
+        output_key(fields, :high) => ohlc.high,
+        output_key(fields, :low) => ohlc.low,
+        output_key(fields, :close) => ohlc.close
+      }
+    }
+    |> maybe_put_computed_at(point, fields, append?)
+  end
+
+  defp json_row(%{value: value} = point, :timeseries_data, fields, append?) do
+    %{
+      output_key(fields, :datetime) => point.datetime,
+      output_key(fields, :value) => value
+    }
+    |> maybe_put_computed_at(point, fields, append?)
   end
 
   # For per-slug, `computed_at` belongs to each (datetime, slug) pair, so it is
@@ -585,88 +594,30 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   defp json_row(%{datetime: datetime, data: data}, :timeseries_data_per_slug, fields, append?) do
     elements =
       Enum.map(data, fn elem ->
-        elem
-        |> select_slug_fields(fields)
-        |> maybe_append_computed_at(elem, append?)
+        %{
+          output_key(fields, :slug) => elem.slug,
+          output_key(fields, :value) => elem.value
+        }
+        |> maybe_put_computed_at(elem, fields, append?)
       end)
 
-    %{}
-    |> put_or_default(fields, :datetime, datetime)
-    |> put_or_default(fields, :data, elements)
+    %{
+      output_key(fields, :datetime) => datetime,
+      output_key(fields, :data) => elements
+    }
   end
 
-  # No `fields` -> default columns (datetime + value/value_ohlc). Otherwise only
-  # the named columns (including `computed_at` when named), under the given keys.
-  defp select_timeseries_fields(point, fields) when map_size(fields) == 0,
-    do: Map.delete(point, :computed_at)
+  # The output key for `field`: the caller's rename from `fields`, else the field
+  # name itself.
+  defp output_key(fields, field), do: Map.get(fields, field, field)
 
-  defp select_timeseries_fields(point, fields) do
-    %{}
-    |> put_selected_field(fields, :datetime, point)
-    |> put_selected_field(fields, :value, point)
-    |> put_selected_ohlc(fields, point)
-    |> put_selected_field(fields, :computed_at, point)
-  end
+  # `include_computed_at` appends the compute timestamp, renamable via the
+  # `computed_at` entry of `fields` (default key `computedAt`); `nil` for adapters
+  # that do not track it.
+  defp maybe_put_computed_at(row, _source, _fields, false), do: row
 
-  defp select_slug_fields(elem, fields) when map_size(fields) == 0,
-    do: Map.take(elem, [:slug, :value])
-
-  defp select_slug_fields(elem, fields) do
-    %{}
-    |> put_selected_field(fields, :slug, elem)
-    |> put_selected_field(fields, :value, elem)
-    |> put_selected_field(fields, :computed_at, elem)
-  end
-
-  # Copy `field` from `source` under its caller-provided key, but only when it is
-  # both selected in `fields` and present on the datapoint (e.g. `value` is absent
-  # on an OHLC series).
-  defp put_selected_field(acc, fields, field, source) do
-    case {Map.fetch(fields, field), Map.fetch(source, field)} do
-      {{:ok, out_key}, {:ok, value}} -> Map.put(acc, out_key, value)
-      _ -> acc
-    end
-  end
-
-  # `value_ohlc` is a nested object; when selected, its inner keys are renamed via
-  # the `open`/`high`/`low`/`close` entries of `fields` (defaulting to their name).
-  defp put_selected_ohlc(acc, fields, %{value_ohlc: ohlc}) do
-    case Map.fetch(fields, :value_ohlc) do
-      {:ok, out_key} ->
-        nested = %{
-          Map.get(fields, :open, :open) => ohlc.open,
-          Map.get(fields, :high, :high) => ohlc.high,
-          Map.get(fields, :low, :low) => ohlc.low,
-          Map.get(fields, :close, :close) => ohlc.close
-        }
-
-        Map.put(acc, out_key, nested)
-
-      :error ->
-        acc
-    end
-  end
-
-  defp put_selected_ohlc(acc, _fields, _point), do: acc
-
-  # With no `fields` the value is kept under its default key; otherwise only when
-  # the field is named, under the caller-provided key.
-  defp put_or_default(acc, fields, field, value) when map_size(fields) == 0,
-    do: Map.put(acc, field, value)
-
-  defp put_or_default(acc, fields, field, value) do
-    case Map.fetch(fields, field) do
-      {:ok, out_key} -> Map.put(acc, out_key, value)
-      :error -> acc
-    end
-  end
-
-  # `include_computed_at` appends the compute timestamp under a fixed `computedAt`
-  # key (matching the typed field); `nil` for adapters that do not track it.
-  defp maybe_append_computed_at(row, _source, false), do: row
-
-  defp maybe_append_computed_at(row, source, true),
-    do: Map.put(row, :computedAt, Map.get(source, :computed_at))
+  defp maybe_put_computed_at(row, source, fields, true),
+    do: Map.put(row, Map.get(fields, :computed_at, :computedAt), Map.get(source, :computed_at))
 
   # Which schema field is being resolved - `timeseriesDataJson` /
   # `timeseriesDataPerSlugJson` (raw `:json` scalar) or their typed counterparts.

--- a/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
@@ -266,7 +266,16 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
 
   def timeseries_data(_root, args, %{source: %{metric: metric, version: version}} = resolution) do
     requested_fields = requested_fields(resolution)
-    fetch_timeseries_data(metric, version, args, requested_fields, :timeseries_data)
+    include_computed_at? = include_computed_at?(resolution, args)
+
+    fetch_timeseries_data(
+      metric,
+      version,
+      args,
+      requested_fields,
+      :timeseries_data,
+      include_computed_at?
+    )
   rescue
     e in [Sanbase.Metric.CatchableError] -> {:error, Exception.message(e)}
     e -> reraise(e, __STACKTRACE__)
@@ -278,14 +287,21 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
         %{source: %{metric: metric, version: version}} = resolution
       ) do
     requested_fields = requested_fields(resolution)
+    include_computed_at? = include_computed_at?(resolution, args)
 
     # A heap-capped fetch: on overrun the BEAM kills the worker with an
     # untrappable :killed exit, which we turn into a friendly error instead of a
-    # Sentry alert. See run_per_slug_in_bounded_process/4.
-    run_per_slug_in_bounded_process(metric, version, args, requested_fields)
+    # Sentry alert. See run_per_slug_in_bounded_process/5.
+    run_per_slug_in_bounded_process(
+      metric,
+      version,
+      args,
+      requested_fields,
+      include_computed_at?
+    )
   rescue
     # CatchableError raised during the per-slug fetch is handled inside the
-    # bounded worker (see run_per_slug_in_bounded_process/4) and returned as an
+    # bounded worker (see run_per_slug_in_bounded_process/5) and returned as an
     # {:error, message} tuple, so this clause is only a defensive fallback.
     e in [Sanbase.Metric.CatchableError] -> {:error, Exception.message(e)}
     e -> reraise(e, __STACKTRACE__)
@@ -409,7 +425,13 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   # request process - we just see the :DOWN and return a friendly error. Other
   # outcomes (a CatchableError, or an unexpected raise we still want in Sentry)
   # are caught in the worker and sent back, so inline behaviour is preserved.
-  defp run_per_slug_in_bounded_process(metric, version, args, requested_fields) do
+  defp run_per_slug_in_bounded_process(
+         metric,
+         version,
+         args,
+         requested_fields,
+         include_computed_at?
+       ) do
     parent = self()
     ref = make_ref()
 
@@ -437,7 +459,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
                version,
                args,
                requested_fields,
-               :timeseries_data_per_slug
+               :timeseries_data_per_slug,
+               include_computed_at?
              )}
           rescue
             e in [Sanbase.Metric.CatchableError] -> {:ok, {:error, Exception.message(e)}}
@@ -486,7 +509,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   # timeseries_data and timeseries_data_per_slug are processed and fetched in
   # exactly the same way. The only difference is the function that is called
   # from the Metric module.
-  defp fetch_timeseries_data(metric, version, args, requested_fields, function)
+  defp fetch_timeseries_data(
+         metric,
+         version,
+         args,
+         requested_fields,
+         function,
+         include_computed_at?
+       )
        when function in [:timeseries_data, :timeseries_data_per_slug] do
     only_finalized_data = Map.get(args, :only_finalized_data, false)
 
@@ -499,6 +529,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
          {:ok, opts} <- selector_args_to_opts(args),
          opts <- Keyword.put(opts, :only_finalized_data, only_finalized_data),
          opts <- Keyword.put(opts, :version, version),
+         opts <- Keyword.put(opts, :include_computed_at, include_computed_at?),
          {:ok, from, to, interval} <-
            transform_datetime_params(selector, metric, transform, args),
          {:ok, result} <-
@@ -520,13 +551,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     result =
       result
       |> Enum.map(fn
-        %{datetime: d, value: v} ->
+        %{datetime: d, value: v} = point ->
           %{
             Map.get(map, :datetime, :datetime) => d,
             Map.get(map, :value, :value) => v
           }
+          |> maybe_put_computed_at(map, point)
 
-        %{datetime: d, value_ohlc: ohlc} ->
+        %{datetime: d, value_ohlc: ohlc} = point ->
           %{
             Map.get(map, :datetime, :datetime) => d,
             Map.get(map, :value_ohlc, :value_ohlc) => %{
@@ -536,6 +568,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
               Map.get(map, :low, :low) => ohlc.low
             }
           }
+          |> maybe_put_computed_at(map, point)
       end)
 
     {:ok, result}
@@ -550,11 +583,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
           Map.get(map, :datetime, :datetime) => datetime,
           Map.get(map, :data, :data) =>
             Enum.map(data, fn
-              %{value: value, slug: slug} ->
+              %{value: value, slug: slug} = elem ->
                 %{
                   Map.get(map, :value, :value) => value,
                   Map.get(map, :slug, :slug) => slug
                 }
+                |> maybe_put_computed_at(map, elem)
             end)
         }
       end)
@@ -563,6 +597,33 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   end
 
   defp maybe_rename_fields(result, _function, _args), do: {:ok, result}
+
+  # `computed_at` is opt-in for the JSON variants: it is included in the output
+  # only when the caller named it in the `fields` argument. When present, its key
+  # is renamed like the other fields.
+  defp maybe_put_computed_at(acc, fields_map, point) do
+    case {Map.has_key?(fields_map, :computed_at), point} do
+      {true, %{computed_at: computed_at}} ->
+        Map.put(acc, Map.get(fields_map, :computed_at, :computed_at), computed_at)
+
+      _ ->
+        acc
+    end
+  end
+
+  # `computedAt` is requested when it appears anywhere in the GraphQL selection
+  # tree (for the typed fields - `computedAt` sits at the top level of
+  # `timeseriesData` but nested under `data` for `timeseriesDataPerSlug`), or
+  # when it is named in the `fields` argument (for the *Json variants, whose
+  # selection tree only contains the scalar itself).
+  defp include_computed_at?(resolution, args) do
+    field_requested?(resolution, "computed_at") or fields_include_computed_at?(args)
+  end
+
+  defp fields_include_computed_at?(%{fields: fields}) when is_map(fields),
+    do: Map.has_key?(fields, :computed_at)
+
+  defp fields_include_computed_at?(_args), do: false
 
   defp transform_datetime_params(selector, metric, transform, args) do
     %{from: from, to: to, interval: interval} = args

--- a/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
@@ -604,15 +604,19 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   # only when the client selects the `computedAt` field, so nothing to do there.
   # The `*Json` variants serialize the whole map, so `computed_at` would leak into
   # every payload - drop it unless the caller opted in by naming it in `fields`
-  # (in which case `maybe_rename_fields/3` already projected the keys explicitly).
-  defp maybe_drop_computed_at(result, false = _json_variant?, _args), do: result
+  # (when opted in, `maybe_rename_fields/3` has emitted it under the caller's key).
+  defp maybe_drop_computed_at(result, json_variant?, args) do
+    if json_variant? and not fields_include_computed_at?(args) do
+      Enum.map(result, &drop_computed_at/1)
+    else
+      result
+    end
+  end
 
-  defp maybe_drop_computed_at(result, true = _json_variant?, %{fields: map})
-       when is_map(map) and map_size(map) > 0,
-       do: result
+  defp fields_include_computed_at?(%{fields: fields}) when is_map(fields),
+    do: Map.has_key?(fields, :computed_at)
 
-  defp maybe_drop_computed_at(result, true = _json_variant?, _args),
-    do: Enum.map(result, &drop_computed_at/1)
+  defp fields_include_computed_at?(_args), do: false
 
   defp drop_computed_at(%{data: data} = point) when is_list(data),
     do: %{point | data: Enum.map(data, &Map.delete(&1, :computed_at))}

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -657,6 +657,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       arg(:only_finalized_data, :boolean, default_value: false)
       arg(:caching_params, :caching_params_input_object)
       arg(:fields, :timeseries_data_json_fields)
+      arg(:include_computed_at, :boolean, default_value: false)
 
       complexity(&Complexity.from_to_interval/3)
       middleware(AccessControl, resolve_slugs_list: true)
@@ -676,6 +677,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
       arg(:only_finalized_data, :boolean, default_value: false)
       arg(:caching_params, :caching_params_input_object)
       arg(:fields, :timeseries_data_per_slug_json_fields)
+      arg(:include_computed_at, :boolean, default_value: false)
 
       complexity(&Complexity.from_to_interval_selector_weight/3)
       middleware(AccessControl, resolve_slugs_list: true)

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -172,7 +172,6 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:datetime, non_null(:datetime))
     field(:value, :float)
     field(:value_ohlc, :ohlc_data)
-    field(:computed_at, :datetime)
   end
 
   object :ohlc_data do
@@ -185,7 +184,6 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
   object :slug_float_value_pair do
     field(:slug, non_null(:string))
     field(:value, :float)
-    field(:computed_at, :datetime)
   end
 
   object :metric_data_per_slug do

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -133,6 +133,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:high, :string)
     field(:close, :string)
     field(:low, :string)
+    field(:computed_at, :string)
   end
 
   input_object :timeseries_data_per_slug_json_fields do
@@ -140,6 +141,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:data, :string)
     field(:slug, :string)
     field(:value, :string)
+    field(:computed_at, :string)
   end
 
   enum :metric_data_type do
@@ -170,6 +172,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     field(:datetime, non_null(:datetime))
     field(:value, :float)
     field(:value_ohlc, :ohlc_data)
+    field(:computed_at, :datetime)
   end
 
   object :ohlc_data do
@@ -182,6 +185,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
   object :slug_float_value_pair do
     field(:slug, non_null(:string))
     field(:value, :float)
+    field(:computed_at, :datetime)
   end
 
   object :metric_data_per_slug do

--- a/test/sanbase_web/graphql/metric/api_metric_timeseries_computed_at_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_timeseries_computed_at_test.exs
@@ -9,9 +9,10 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
   # `computed_at` is ALWAYS selected in the generated ClickHouse SQL. Whether it
   # is exposed is decided at the API layer:
   #   * typed fields  -> returned only when the client selects `computedAt`
-  #   * *Json fields  -> returned only when `includeComputedAt: true` is passed
-  #                      (`fields` optionally renames the key; naming it there
-  #                      without the flag is an error)
+  #   * *Json fields  -> `fields` only RENAMES keys (all default fields always
+  #                      present); `computedAt` is returned only when
+  #                      `includeComputedAt: true` (renamable via `fields`;
+  #                      naming it there without the flag is an error)
 
   setup do
     %{user: user} =
@@ -127,15 +128,15 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
       assert result == [%{"datetime" => "2019-01-01T00:00:00Z", "value" => 100.0}]
     end
 
-    test "fields acts as a selector - returns only the named fields", context do
+    test "fields only renames keys - unnamed fields keep their default key", context do
       %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
       rows = [row(~U[2019-01-01 00:00:00Z], 100.0, ~U[2019-01-05 00:00:00Z])]
 
       query = json_query(slug, from, to, interval, fields: ~s|{datetime: "d"}|)
       result = run_json(conn, query, rows, "timeseriesDataJson")
 
-      # value is NOT included - only the named `datetime`
-      assert result == [%{"d" => "2019-01-01T00:00:00Z"}]
+      # value is still present under its default key - fields renames, not selects
+      assert result == [%{"d" => "2019-01-01T00:00:00Z", "value" => 100.0}]
     end
 
     test "includeComputedAt appends computedAt to the default fields", context do
@@ -154,7 +155,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
              ]
     end
 
-    test "includeComputedAt composes with a fields selection", context do
+    test "includeComputedAt composes with fields renaming", context do
       %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
       rows = [row(~U[2019-01-01 00:00:00Z], 100.0, ~U[2019-01-05 00:00:00Z])]
 
@@ -166,8 +167,14 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
 
       result = run_json(conn, query, rows, "timeseriesDataJson")
 
-      # only the named `datetime`, plus computedAt - no value
-      assert result == [%{"d" => "2019-01-01T00:00:00Z", "computedAt" => "2019-01-05T00:00:00Z"}]
+      # datetime renamed to "d", value still present under its default key, plus computedAt
+      assert result == [
+               %{
+                 "d" => "2019-01-01T00:00:00Z",
+                 "value" => 100.0,
+                 "computedAt" => "2019-01-05T00:00:00Z"
+               }
+             ]
     end
 
     test "includeComputedAt renames computedAt when it is also named in fields", context do
@@ -278,21 +285,22 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
       assert %{"slug" => p1.slug, "value" => 400, "computedAt" => "2019-01-05T00:00:00Z"} in data
     end
 
-    test "includeComputedAt composes with a fields selection", context do
+    test "renames inner fields and still returns data even when `data` is not named", context do
       %{conn: conn, from: from, to: to, project1: p1, project2: p2} = context
       rows = [per_slug_row(~U[2019-01-01 00:00:00Z], p1.slug, 400, ~U[2019-01-05 00:00:00Z])]
 
+      # names datetime/slug/value/computedAt but NOT `data` - since fields only
+      # renames (never drops), `data` still appears under its default key
       query =
         per_slug_json_query(p1, p2, from, to,
-          fields: ~s|{data: "d", slug: "s", value: "v"}|,
+          fields: ~s|{datetime: "d", slug: "s", value: "v", computedAt: "ca"}|,
           include_computed_at: true
         )
 
       result = run_json(conn, query, rows, "timeseriesDataPerSlugJson")
 
-      # computedAt keeps its fixed key even though slug/value were renamed
-      assert %{"d" => data} = result |> Enum.at(0)
-      assert %{"s" => p1.slug, "v" => 400, "computedAt" => "2019-01-05T00:00:00Z"} in data
+      assert %{"d" => _dt, "data" => data} = result |> Enum.at(0)
+      assert %{"s" => p1.slug, "v" => 400, "ca" => "2019-01-05T00:00:00Z"} in data
     end
   end
 

--- a/test/sanbase_web/graphql/metric/api_metric_timeseries_computed_at_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_timeseries_computed_at_test.exs
@@ -6,13 +6,10 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
 
   @metric "daily_active_addresses"
 
-  # `computed_at` is ALWAYS selected in the generated ClickHouse SQL. Whether it
-  # is exposed is decided at the API layer:
-  #   * typed fields  -> returned only when the client selects `computedAt`
-  #   * *Json fields  -> `fields` only RENAMES keys (all default fields always
-  #                      present); `computedAt` is returned only when
-  #                      `includeComputedAt: true` (renamable via `fields`;
-  #                      naming it there without the flag is an error)
+  # `computed_at` is always selected in the generated ClickHouse SQL, but it is
+  # exposed ONLY through the `*Json` fields, and only when `includeComputedAt: true`
+  # is passed. The deprecated typed fields (`timeseriesData` /
+  # `timeseriesDataPerSlug`) do not expose it at all. `fields` only renames keys.
 
   setup do
     %{user: user} =
@@ -33,92 +30,8 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
     ]
   end
 
-  describe "timeseriesData (typed)" do
-    test "exposes computedAt when the field is selected", context do
-      %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
-
-      rows = [
-        row(~U[2019-01-01 00:00:00Z], 100.0, ~U[2019-01-05 00:00:00Z]),
-        row(~U[2019-01-02 00:00:00Z], 200.0, ~U[2019-01-06 00:00:00Z])
-      ]
-
-      query = """
-      {
-        getMetric(metric: "#{@metric}", storeExecutedClickhouseSql: true){
-          timeseriesData(slug: "#{slug}", from: "#{from}", to: "#{to}", interval: "#{interval}"){
-            datetime
-            value
-            computedAt
-          }
-          executedClickhouseSql
-        }
-      }
-      """
-
-      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
-      |> Sanbase.Mock.run_with_mocks(fn ->
-        %{"data" => %{"getMetric" => metric_data}} =
-          conn
-          |> post("/graphql", query_skeleton(query, "getMetric"))
-          |> json_response(200)
-
-        assert metric_data["timeseriesData"] == [
-                 %{
-                   "datetime" => "2019-01-01T00:00:00Z",
-                   "value" => 100.0,
-                   "computedAt" => "2019-01-05T00:00:00Z"
-                 },
-                 %{
-                   "datetime" => "2019-01-02T00:00:00Z",
-                   "value" => 200.0,
-                   "computedAt" => "2019-01-06T00:00:00Z"
-                 }
-               ]
-
-        assert Enum.join(metric_data["executedClickhouseSql"], "\n") =~ "AS computed_at"
-      end)
-    end
-
-    test "omits computedAt from the response when not selected, though the SQL still selects it",
-         context do
-      %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
-
-      rows = [
-        row(~U[2019-01-01 00:00:00Z], 100.0, ~U[2019-01-05 00:00:00Z]),
-        row(~U[2019-01-02 00:00:00Z], 200.0, ~U[2019-01-06 00:00:00Z])
-      ]
-
-      query = """
-      {
-        getMetric(metric: "#{@metric}", storeExecutedClickhouseSql: true){
-          timeseriesData(slug: "#{slug}", from: "#{from}", to: "#{to}", interval: "#{interval}"){
-            datetime
-            value
-          }
-          executedClickhouseSql
-        }
-      }
-      """
-
-      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
-      |> Sanbase.Mock.run_with_mocks(fn ->
-        %{"data" => %{"getMetric" => metric_data}} =
-          conn
-          |> post("/graphql", query_skeleton(query, "getMetric"))
-          |> json_response(200)
-
-        assert metric_data["timeseriesData"] == [
-                 %{"datetime" => "2019-01-01T00:00:00Z", "value" => 100.0},
-                 %{"datetime" => "2019-01-02T00:00:00Z", "value" => 200.0}
-               ]
-
-        assert Enum.join(metric_data["executedClickhouseSql"], "\n") =~ "AS computed_at"
-      end)
-    end
-  end
-
   describe "timeseriesDataJson" do
-    test "defaults to datetime + value when nothing is selected", context do
+    test "defaults to datetime + value", context do
       %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
       rows = [row(~U[2019-01-01 00:00:00Z], 100.0, ~U[2019-01-05 00:00:00Z])]
 
@@ -139,7 +52,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
       assert result == [%{"d" => "2019-01-01T00:00:00Z", "value" => 100.0}]
     end
 
-    test "includeComputedAt appends computedAt to the default fields", context do
+    test "includeComputedAt appends computedAt", context do
       %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
       rows = [row(~U[2019-01-01 00:00:00Z], 100.0, ~U[2019-01-05 00:00:00Z])]
 
@@ -167,7 +80,6 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
 
       result = run_json(conn, query, rows, "timeseriesDataJson")
 
-      # datetime renamed to "d", value still present under its default key, plus computedAt
       assert result == [
                %{
                  "d" => "2019-01-01T00:00:00Z",
@@ -177,7 +89,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
              ]
     end
 
-    test "includeComputedAt renames computedAt when it is also named in fields", context do
+    test "includeComputedAt renames computedAt when it is named in fields", context do
       %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
       rows = [row(~U[2019-01-01 00:00:00Z], 100.0, ~U[2019-01-05 00:00:00Z])]
 
@@ -189,7 +101,6 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
 
       result = run_json(conn, query, rows, "timeseriesDataJson")
 
-      # computedAt returned under the custom "c" key - no default "computedAt" key
       assert result == [
                %{"d" => "2019-01-01T00:00:00Z", "v" => 100.0, "c" => "2019-01-05T00:00:00Z"}
              ]
@@ -211,53 +122,6 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
         end)
 
       assert error_msg =~ "includeComputedAt"
-    end
-  end
-
-  describe "timeseriesDataPerSlug (typed)" do
-    test "exposes computedAt inside each data element when selected", context do
-      %{conn: conn, from: from, to: to, project1: p1, project2: p2} = context
-
-      dt1 = ~U[2019-01-01 00:00:00Z]
-      computed_at = ~U[2019-01-05 00:00:00Z]
-
-      rows = [
-        per_slug_row(dt1, p1.slug, 400.0, computed_at),
-        per_slug_row(dt1, p2.slug, 100.0, computed_at)
-      ]
-
-      query = """
-        {
-          getMetric(metric: "#{@metric}", storeExecutedClickhouseSql: true){
-            timeseriesDataPerSlug(
-              selector: {slugs: ["#{p1.slug}", "#{p2.slug}"]},
-              from: "#{from}", to: "#{to}", interval: "1d"){
-                datetime
-                data{ slug value computedAt }
-              }
-            executedClickhouseSql
-          }
-        }
-      """
-
-      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
-      |> Sanbase.Mock.run_with_mocks(fn ->
-        %{"data" => %{"getMetric" => metric_data}} =
-          conn
-          |> post("/graphql", query_skeleton(query, "getMetric"))
-          |> json_response(200)
-
-        assert %{"datetime" => dt_str, "data" => data} =
-                 metric_data["timeseriesDataPerSlug"] |> Enum.at(0)
-
-        assert dt_str |> Sanbase.Utils.DateTime.from_iso8601!() == dt1
-
-        assert %{"slug" => p1.slug, "value" => 400.0, "computedAt" => "2019-01-05T00:00:00Z"} in data
-
-        assert %{"slug" => p2.slug, "value" => 100.0, "computedAt" => "2019-01-05T00:00:00Z"} in data
-
-        assert Enum.join(metric_data["executedClickhouseSql"], "\n") =~ "AS computed_at"
-      end)
     end
   end
 

--- a/test/sanbase_web/graphql/metric/api_metric_timeseries_computed_at_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_timeseries_computed_at_test.exs
@@ -1,0 +1,293 @@
+defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import Sanbase.Factory
+  import SanbaseWeb.Graphql.TestHelpers
+
+  @metric "daily_active_addresses"
+
+  setup do
+    %{user: user} =
+      insert(:subscription_pro_sanbase, user: insert(:user, metric_access_level: "alpha"))
+
+    project1 = insert(:random_project, slug: "aaaaa")
+    project2 = insert(:random_project, slug: "bbbbb")
+    conn = setup_jwt_auth(build_conn(), user)
+
+    [
+      conn: conn,
+      project1: project1,
+      project2: project2,
+      slug: project1.slug,
+      from: ~U[2019-01-01 00:00:00Z],
+      to: ~U[2019-01-02 00:00:00Z],
+      interval: "1d"
+    ]
+  end
+
+  describe "timeseriesData" do
+    test "exposes computedAt when the field is selected", context do
+      %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
+
+      dt1 = ~U[2019-01-01 00:00:00Z]
+      dt2 = ~U[2019-01-02 00:00:00Z]
+      computed_at1 = ~U[2019-01-05 00:00:00Z]
+      computed_at2 = ~U[2019-01-06 00:00:00Z]
+
+      # `computed_at` is the 3rd column - matches the SQL built when the flag is on
+      rows = [
+        [DateTime.to_unix(dt1), 100.0, DateTime.to_unix(computed_at1)],
+        [DateTime.to_unix(dt2), 200.0, DateTime.to_unix(computed_at2)]
+      ]
+
+      query = """
+      {
+        getMetric(metric: "#{@metric}", storeExecutedClickhouseSql: true){
+          timeseriesData(slug: "#{slug}", from: "#{from}", to: "#{to}", interval: "#{interval}"){
+            datetime
+            value
+            computedAt
+          }
+          executedClickhouseSql
+        }
+      }
+      """
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        %{"data" => %{"getMetric" => metric_data}} =
+          conn
+          |> post("/graphql", query_skeleton(query, "getMetric"))
+          |> json_response(200)
+
+        assert metric_data["timeseriesData"] == [
+                 %{
+                   "datetime" => "2019-01-01T00:00:00Z",
+                   "value" => 100.0,
+                   "computedAt" => "2019-01-05T00:00:00Z"
+                 },
+                 %{
+                   "datetime" => "2019-01-02T00:00:00Z",
+                   "value" => 200.0,
+                   "computedAt" => "2019-01-06T00:00:00Z"
+                 }
+               ]
+
+        # The selection actually drove the SQL to select the computed_at column.
+        assert Enum.join(metric_data["executedClickhouseSql"], "\n") =~ "AS computed_at"
+      end)
+    end
+
+    test "does not select the computed_at column when the field is not requested", context do
+      %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
+
+      dt1 = ~U[2019-01-01 00:00:00Z]
+      dt2 = ~U[2019-01-02 00:00:00Z]
+
+      # Only 2 columns - matches the SQL built when the flag is off
+      rows = [
+        [DateTime.to_unix(dt1), 100.0],
+        [DateTime.to_unix(dt2), 200.0]
+      ]
+
+      query = """
+      {
+        getMetric(metric: "#{@metric}", storeExecutedClickhouseSql: true){
+          timeseriesData(slug: "#{slug}", from: "#{from}", to: "#{to}", interval: "#{interval}"){
+            datetime
+            value
+          }
+          executedClickhouseSql
+        }
+      }
+      """
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        %{"data" => %{"getMetric" => metric_data}} =
+          conn
+          |> post("/graphql", query_skeleton(query, "getMetric"))
+          |> json_response(200)
+
+        assert metric_data["timeseriesData"] == [
+                 %{"datetime" => "2019-01-01T00:00:00Z", "value" => 100.0},
+                 %{"datetime" => "2019-01-02T00:00:00Z", "value" => 200.0}
+               ]
+
+        refute Enum.join(metric_data["executedClickhouseSql"], "\n") =~ "AS computed_at"
+      end)
+    end
+  end
+
+  describe "timeseriesDataJson" do
+    test "includes computedAt only when named in the fields argument", context do
+      %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
+
+      dt1 = ~U[2019-01-01 00:00:00Z]
+      computed_at1 = ~U[2019-01-05 00:00:00Z]
+
+      # Opted in: `fields` names computedAt -> flag on -> 3-column rows
+      rows_with = [[DateTime.to_unix(dt1), 100.0, DateTime.to_unix(computed_at1)]]
+
+      query_with =
+        json_query(slug, from, to, interval, ~s|{datetime: "d", value: "v", computedAt: "c"}|)
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows_with}})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result =
+          conn
+          |> post("/graphql", query_skeleton(query_with, "getMetric"))
+          |> json_response(200)
+          |> get_in(["data", "getMetric", "timeseriesDataJson"])
+
+        assert result == [
+                 %{"d" => "2019-01-01T00:00:00Z", "v" => 100.0, "c" => "2019-01-05T00:00:00Z"}
+               ]
+      end)
+
+      # Not opted in: `fields` omits computedAt -> flag off -> 2-column rows, no key leaks
+      rows_without = [[DateTime.to_unix(dt1), 100.0]]
+      query_without = json_query(slug, from, to, interval, ~s|{datetime: "d", value: "v"}|)
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows_without}})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result =
+          conn
+          |> post("/graphql", query_skeleton(query_without, "getMetric"))
+          |> json_response(200)
+          |> get_in(["data", "getMetric", "timeseriesDataJson"])
+
+        assert result == [%{"d" => "2019-01-01T00:00:00Z", "v" => 100.0}]
+      end)
+    end
+  end
+
+  describe "timeseriesDataPerSlug" do
+    test "exposes computedAt inside each data element when selected", context do
+      %{conn: conn, from: from, to: to, project1: p1, project2: p2} = context
+
+      dt1 = ~U[2019-01-01 00:00:00Z]
+      computed_at = ~U[2019-01-05 00:00:00Z]
+
+      # `computed_at` is the 4th column - matches the SQL built when the flag is on
+      rows = [
+        [DateTime.to_unix(dt1), p1.slug, 400.0, DateTime.to_unix(computed_at)],
+        [DateTime.to_unix(dt1), p2.slug, 100.0, DateTime.to_unix(computed_at)]
+      ]
+
+      query = """
+        {
+          getMetric(metric: "#{@metric}", storeExecutedClickhouseSql: true){
+            timeseriesDataPerSlug(
+              selector: {slugs: ["#{p1.slug}", "#{p2.slug}"]},
+              from: "#{from}", to: "#{to}", interval: "1d"){
+                datetime
+                data{ slug value computedAt }
+              }
+            executedClickhouseSql
+          }
+        }
+      """
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        %{"data" => %{"getMetric" => metric_data}} =
+          conn
+          |> post("/graphql", query_skeleton(query, "getMetric"))
+          |> json_response(200)
+
+        assert %{"datetime" => dt_str, "data" => data} =
+                 metric_data["timeseriesDataPerSlug"] |> Enum.at(0)
+
+        assert dt_str |> Sanbase.Utils.DateTime.from_iso8601!() == dt1
+
+        assert %{"slug" => p1.slug, "value" => 400.0, "computedAt" => "2019-01-05T00:00:00Z"} in data
+
+        assert %{"slug" => p2.slug, "value" => 100.0, "computedAt" => "2019-01-05T00:00:00Z"} in data
+
+        assert Enum.join(metric_data["executedClickhouseSql"], "\n") =~ "AS computed_at"
+      end)
+    end
+  end
+
+  describe "timeseriesDataPerSlugJson" do
+    test "includes computedAt only when named in the fields argument", context do
+      %{conn: conn, from: from, to: to, project1: p1, project2: p2} = context
+
+      dt1 = ~U[2019-01-01 00:00:00Z]
+      computed_at = ~U[2019-01-05 00:00:00Z]
+
+      rows_with = [
+        [DateTime.to_unix(dt1), p1.slug, 400, DateTime.to_unix(computed_at)]
+      ]
+
+      query_with =
+        per_slug_json_query(
+          p1,
+          p2,
+          from,
+          to,
+          ~s|{data: "d", slug: "s", value: "v", computedAt: "c"}|
+        )
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows_with}})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result =
+          conn
+          |> post("/graphql", query_skeleton(query_with, "getMetric"))
+          |> json_response(200)
+          |> get_in(["data", "getMetric", "timeseriesDataPerSlugJson"])
+
+        assert %{"d" => data} = result |> Enum.at(0)
+        assert %{"s" => p1.slug, "v" => 400, "c" => "2019-01-05T00:00:00Z"} in data
+      end)
+
+      # Not opted in -> flag off -> 3-column rows, no computedAt key
+      rows_without = [[DateTime.to_unix(dt1), p1.slug, 400]]
+
+      query_without =
+        per_slug_json_query(p1, p2, from, to, ~s|{data: "d", slug: "s", value: "v"}|)
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows_without}})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result =
+          conn
+          |> post("/graphql", query_skeleton(query_without, "getMetric"))
+          |> json_response(200)
+          |> get_in(["data", "getMetric", "timeseriesDataPerSlugJson"])
+
+        assert %{"d" => data} = result |> Enum.at(0)
+        assert %{"s" => p1.slug, "v" => 400} in data
+      end)
+    end
+  end
+
+  defp json_query(slug, from, to, interval, fields) do
+    """
+    {
+      getMetric(metric: "#{@metric}"){
+        timeseriesDataJson(
+          slug: "#{slug}"
+          from: "#{from}"
+          to: "#{to}"
+          interval: "#{interval}"
+          fields: #{fields}
+        )
+      }
+    }
+    """
+  end
+
+  defp per_slug_json_query(p1, p2, from, to, fields) do
+    """
+    {
+      getMetric(metric: "#{@metric}"){
+        timeseriesDataPerSlugJson(
+          selector: {slugs: ["#{p1.slug}", "#{p2.slug}"]},
+          from: "#{from}", to: "#{to}", interval: "1d"
+          fields: #{fields})
+      }
+    }
+    """
+  end
+end

--- a/test/sanbase_web/graphql/metric/api_metric_timeseries_computed_at_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_timeseries_computed_at_test.exs
@@ -6,6 +6,12 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
 
   @metric "daily_active_addresses"
 
+  # `computed_at` is ALWAYS selected in the generated ClickHouse SQL (so the rows
+  # returned by ClickHouse always carry it as the last column). Whether it is
+  # exposed is decided at the API layer:
+  #   * typed fields  -> returned only when the client selects `computedAt`
+  #   * *Json fields  -> returned only when named in the `fields` argument
+
   setup do
     %{user: user} =
       insert(:subscription_pro_sanbase, user: insert(:user, metric_access_level: "alpha"))
@@ -34,7 +40,6 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
       computed_at1 = ~U[2019-01-05 00:00:00Z]
       computed_at2 = ~U[2019-01-06 00:00:00Z]
 
-      # `computed_at` is the 3rd column - matches the SQL built when the flag is on
       rows = [
         [DateTime.to_unix(dt1), 100.0, DateTime.to_unix(computed_at1)],
         [DateTime.to_unix(dt2), 200.0, DateTime.to_unix(computed_at2)]
@@ -73,21 +78,23 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
                  }
                ]
 
-        # The selection actually drove the SQL to select the computed_at column.
         assert Enum.join(metric_data["executedClickhouseSql"], "\n") =~ "AS computed_at"
       end)
     end
 
-    test "does not select the computed_at column when the field is not requested", context do
+    test "omits computedAt from the response when not selected, though the SQL still selects it",
+         context do
       %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
 
       dt1 = ~U[2019-01-01 00:00:00Z]
       dt2 = ~U[2019-01-02 00:00:00Z]
+      computed_at1 = ~U[2019-01-05 00:00:00Z]
+      computed_at2 = ~U[2019-01-06 00:00:00Z]
 
-      # Only 2 columns - matches the SQL built when the flag is off
+      # computed_at is always fetched, so ClickHouse returns the extra column
       rows = [
-        [DateTime.to_unix(dt1), 100.0],
-        [DateTime.to_unix(dt2), 200.0]
+        [DateTime.to_unix(dt1), 100.0, DateTime.to_unix(computed_at1)],
+        [DateTime.to_unix(dt2), 200.0, DateTime.to_unix(computed_at2)]
       ]
 
       query = """
@@ -109,55 +116,61 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
           |> post("/graphql", query_skeleton(query, "getMetric"))
           |> json_response(200)
 
+        # GraphQL field selection filters computedAt out of the typed response.
         assert metric_data["timeseriesData"] == [
                  %{"datetime" => "2019-01-01T00:00:00Z", "value" => 100.0},
                  %{"datetime" => "2019-01-02T00:00:00Z", "value" => 200.0}
                ]
 
-        refute Enum.join(metric_data["executedClickhouseSql"], "\n") =~ "AS computed_at"
+        # ...but it is still always part of the query.
+        assert Enum.join(metric_data["executedClickhouseSql"], "\n") =~ "AS computed_at"
       end)
     end
   end
 
   describe "timeseriesDataJson" do
-    test "includes computedAt only when named in the fields argument", context do
+    test "does not leak computedAt when fields are not given", context do
       %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
 
       dt1 = ~U[2019-01-01 00:00:00Z]
       computed_at1 = ~U[2019-01-05 00:00:00Z]
+      rows = [[DateTime.to_unix(dt1), 100.0, DateTime.to_unix(computed_at1)]]
 
-      # Opted in: `fields` names computedAt -> flag on -> 3-column rows
-      rows_with = [[DateTime.to_unix(dt1), 100.0, DateTime.to_unix(computed_at1)]]
+      query = json_query(slug, from, to, interval, nil)
 
-      query_with =
-        json_query(slug, from, to, interval, ~s|{datetime: "d", value: "v", computedAt: "c"}|)
-
-      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows_with}})
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
       |> Sanbase.Mock.run_with_mocks(fn ->
         result =
           conn
-          |> post("/graphql", query_skeleton(query_with, "getMetric"))
+          |> post("/graphql", query_skeleton(query, "getMetric"))
+          |> json_response(200)
+          |> get_in(["data", "getMetric", "timeseriesDataJson"])
+
+        assert result == [%{"datetime" => "2019-01-01T00:00:00Z", "value" => 100.0}]
+      end)
+    end
+
+    test "includes computedAt when named in the fields argument", context do
+      %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
+
+      dt1 = ~U[2019-01-01 00:00:00Z]
+      computed_at1 = ~U[2019-01-05 00:00:00Z]
+      rows = [[DateTime.to_unix(dt1), 100.0, DateTime.to_unix(computed_at1)]]
+
+      query =
+        json_query(slug, from, to, interval, ~s|{datetime: "d", value: "v", computedAt: "c"}|)
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result =
+          conn
+          |> post("/graphql", query_skeleton(query, "getMetric"))
           |> json_response(200)
           |> get_in(["data", "getMetric", "timeseriesDataJson"])
 
         assert result == [
                  %{"d" => "2019-01-01T00:00:00Z", "v" => 100.0, "c" => "2019-01-05T00:00:00Z"}
                ]
-      end)
-
-      # Not opted in: `fields` omits computedAt -> flag off -> 2-column rows, no key leaks
-      rows_without = [[DateTime.to_unix(dt1), 100.0]]
-      query_without = json_query(slug, from, to, interval, ~s|{datetime: "d", value: "v"}|)
-
-      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows_without}})
-      |> Sanbase.Mock.run_with_mocks(fn ->
-        result =
-          conn
-          |> post("/graphql", query_skeleton(query_without, "getMetric"))
-          |> json_response(200)
-          |> get_in(["data", "getMetric", "timeseriesDataJson"])
-
-        assert result == [%{"d" => "2019-01-01T00:00:00Z", "v" => 100.0}]
       end)
     end
   end
@@ -169,7 +182,6 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
       dt1 = ~U[2019-01-01 00:00:00Z]
       computed_at = ~U[2019-01-05 00:00:00Z]
 
-      # `computed_at` is the 4th column - matches the SQL built when the flag is on
       rows = [
         [DateTime.to_unix(dt1), p1.slug, 400.0, DateTime.to_unix(computed_at)],
         [DateTime.to_unix(dt1), p2.slug, 100.0, DateTime.to_unix(computed_at)]
@@ -211,17 +223,37 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
   end
 
   describe "timeseriesDataPerSlugJson" do
-    test "includes computedAt only when named in the fields argument", context do
+    test "does not leak computedAt when fields are not given", context do
       %{conn: conn, from: from, to: to, project1: p1, project2: p2} = context
 
       dt1 = ~U[2019-01-01 00:00:00Z]
       computed_at = ~U[2019-01-05 00:00:00Z]
+      rows = [[DateTime.to_unix(dt1), p1.slug, 400, DateTime.to_unix(computed_at)]]
 
-      rows_with = [
-        [DateTime.to_unix(dt1), p1.slug, 400, DateTime.to_unix(computed_at)]
-      ]
+      query = per_slug_json_query(p1, p2, from, to, nil)
 
-      query_with =
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        result =
+          conn
+          |> post("/graphql", query_skeleton(query, "getMetric"))
+          |> json_response(200)
+          |> get_in(["data", "getMetric", "timeseriesDataPerSlugJson"])
+
+        assert %{"data" => data} = result |> Enum.at(0)
+        assert %{"slug" => p1.slug, "value" => 400} in data
+        refute Enum.any?(data, &Map.has_key?(&1, "computedAt"))
+      end)
+    end
+
+    test "includes computedAt when named in the fields argument", context do
+      %{conn: conn, from: from, to: to, project1: p1, project2: p2} = context
+
+      dt1 = ~U[2019-01-01 00:00:00Z]
+      computed_at = ~U[2019-01-05 00:00:00Z]
+      rows = [[DateTime.to_unix(dt1), p1.slug, 400, DateTime.to_unix(computed_at)]]
+
+      query =
         per_slug_json_query(
           p1,
           p2,
@@ -230,34 +262,16 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
           ~s|{data: "d", slug: "s", value: "v", computedAt: "c"}|
         )
 
-      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows_with}})
+      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
       |> Sanbase.Mock.run_with_mocks(fn ->
         result =
           conn
-          |> post("/graphql", query_skeleton(query_with, "getMetric"))
+          |> post("/graphql", query_skeleton(query, "getMetric"))
           |> json_response(200)
           |> get_in(["data", "getMetric", "timeseriesDataPerSlugJson"])
 
         assert %{"d" => data} = result |> Enum.at(0)
         assert %{"s" => p1.slug, "v" => 400, "c" => "2019-01-05T00:00:00Z"} in data
-      end)
-
-      # Not opted in -> flag off -> 3-column rows, no computedAt key
-      rows_without = [[DateTime.to_unix(dt1), p1.slug, 400]]
-
-      query_without =
-        per_slug_json_query(p1, p2, from, to, ~s|{data: "d", slug: "s", value: "v"}|)
-
-      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows_without}})
-      |> Sanbase.Mock.run_with_mocks(fn ->
-        result =
-          conn
-          |> post("/graphql", query_skeleton(query_without, "getMetric"))
-          |> json_response(200)
-          |> get_in(["data", "getMetric", "timeseriesDataPerSlugJson"])
-
-        assert %{"d" => data} = result |> Enum.at(0)
-        assert %{"s" => p1.slug, "v" => 400} in data
       end)
     end
   end
@@ -271,7 +285,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
           from: "#{from}"
           to: "#{to}"
           interval: "#{interval}"
-          fields: #{fields}
+          #{if fields, do: "fields: #{fields}"}
         )
       }
     }
@@ -285,7 +299,7 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
         timeseriesDataPerSlugJson(
           selector: {slugs: ["#{p1.slug}", "#{p2.slug}"]},
           from: "#{from}", to: "#{to}", interval: "1d"
-          fields: #{fields})
+          #{if fields, do: "fields: #{fields}"})
       }
     }
     """

--- a/test/sanbase_web/graphql/metric/api_metric_timeseries_computed_at_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_timeseries_computed_at_test.exs
@@ -6,11 +6,12 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
 
   @metric "daily_active_addresses"
 
-  # `computed_at` is ALWAYS selected in the generated ClickHouse SQL (so the rows
-  # returned by ClickHouse always carry it as the last column). Whether it is
-  # exposed is decided at the API layer:
+  # `computed_at` is ALWAYS selected in the generated ClickHouse SQL. Whether it
+  # is exposed is decided at the API layer:
   #   * typed fields  -> returned only when the client selects `computedAt`
-  #   * *Json fields  -> returned only when named in the `fields` argument
+  #   * *Json fields  -> returned only when `includeComputedAt: true` is passed
+  #                      (`fields` optionally renames the key; naming it there
+  #                      without the flag is an error)
 
   setup do
     %{user: user} =
@@ -31,18 +32,13 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
     ]
   end
 
-  describe "timeseriesData" do
+  describe "timeseriesData (typed)" do
     test "exposes computedAt when the field is selected", context do
       %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
 
-      dt1 = ~U[2019-01-01 00:00:00Z]
-      dt2 = ~U[2019-01-02 00:00:00Z]
-      computed_at1 = ~U[2019-01-05 00:00:00Z]
-      computed_at2 = ~U[2019-01-06 00:00:00Z]
-
       rows = [
-        [DateTime.to_unix(dt1), 100.0, DateTime.to_unix(computed_at1)],
-        [DateTime.to_unix(dt2), 200.0, DateTime.to_unix(computed_at2)]
+        row(~U[2019-01-01 00:00:00Z], 100.0, ~U[2019-01-05 00:00:00Z]),
+        row(~U[2019-01-02 00:00:00Z], 200.0, ~U[2019-01-06 00:00:00Z])
       ]
 
       query = """
@@ -86,15 +82,9 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
          context do
       %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
 
-      dt1 = ~U[2019-01-01 00:00:00Z]
-      dt2 = ~U[2019-01-02 00:00:00Z]
-      computed_at1 = ~U[2019-01-05 00:00:00Z]
-      computed_at2 = ~U[2019-01-06 00:00:00Z]
-
-      # computed_at is always fetched, so ClickHouse returns the extra column
       rows = [
-        [DateTime.to_unix(dt1), 100.0, DateTime.to_unix(computed_at1)],
-        [DateTime.to_unix(dt2), 200.0, DateTime.to_unix(computed_at2)]
+        row(~U[2019-01-01 00:00:00Z], 100.0, ~U[2019-01-05 00:00:00Z]),
+        row(~U[2019-01-02 00:00:00Z], 200.0, ~U[2019-01-06 00:00:00Z])
       ]
 
       query = """
@@ -116,66 +106,108 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
           |> post("/graphql", query_skeleton(query, "getMetric"))
           |> json_response(200)
 
-        # GraphQL field selection filters computedAt out of the typed response.
         assert metric_data["timeseriesData"] == [
                  %{"datetime" => "2019-01-01T00:00:00Z", "value" => 100.0},
                  %{"datetime" => "2019-01-02T00:00:00Z", "value" => 200.0}
                ]
 
-        # ...but it is still always part of the query.
         assert Enum.join(metric_data["executedClickhouseSql"], "\n") =~ "AS computed_at"
       end)
     end
   end
 
   describe "timeseriesDataJson" do
-    test "does not leak computedAt when fields are not given", context do
+    test "defaults to datetime + value when nothing is selected", context do
       %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
+      rows = [row(~U[2019-01-01 00:00:00Z], 100.0, ~U[2019-01-05 00:00:00Z])]
 
-      dt1 = ~U[2019-01-01 00:00:00Z]
-      computed_at1 = ~U[2019-01-05 00:00:00Z]
-      rows = [[DateTime.to_unix(dt1), 100.0, DateTime.to_unix(computed_at1)]]
+      result =
+        run_json(conn, json_query(slug, from, to, interval, []), rows, "timeseriesDataJson")
 
-      query = json_query(slug, from, to, interval, nil)
-
-      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
-      |> Sanbase.Mock.run_with_mocks(fn ->
-        result =
-          conn
-          |> post("/graphql", query_skeleton(query, "getMetric"))
-          |> json_response(200)
-          |> get_in(["data", "getMetric", "timeseriesDataJson"])
-
-        assert result == [%{"datetime" => "2019-01-01T00:00:00Z", "value" => 100.0}]
-      end)
+      assert result == [%{"datetime" => "2019-01-01T00:00:00Z", "value" => 100.0}]
     end
 
-    test "includes computedAt when named in the fields argument", context do
+    test "fields acts as a selector - returns only the named fields", context do
       %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
+      rows = [row(~U[2019-01-01 00:00:00Z], 100.0, ~U[2019-01-05 00:00:00Z])]
 
-      dt1 = ~U[2019-01-01 00:00:00Z]
-      computed_at1 = ~U[2019-01-05 00:00:00Z]
-      rows = [[DateTime.to_unix(dt1), 100.0, DateTime.to_unix(computed_at1)]]
+      query = json_query(slug, from, to, interval, fields: ~s|{datetime: "d"}|)
+      result = run_json(conn, query, rows, "timeseriesDataJson")
+
+      # value is NOT included - only the named `datetime`
+      assert result == [%{"d" => "2019-01-01T00:00:00Z"}]
+    end
+
+    test "includeComputedAt appends computedAt to the default fields", context do
+      %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
+      rows = [row(~U[2019-01-01 00:00:00Z], 100.0, ~U[2019-01-05 00:00:00Z])]
+
+      query = json_query(slug, from, to, interval, include_computed_at: true)
+      result = run_json(conn, query, rows, "timeseriesDataJson")
+
+      assert result == [
+               %{
+                 "datetime" => "2019-01-01T00:00:00Z",
+                 "value" => 100.0,
+                 "computedAt" => "2019-01-05T00:00:00Z"
+               }
+             ]
+    end
+
+    test "includeComputedAt composes with a fields selection", context do
+      %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
+      rows = [row(~U[2019-01-01 00:00:00Z], 100.0, ~U[2019-01-05 00:00:00Z])]
 
       query =
-        json_query(slug, from, to, interval, ~s|{datetime: "d", value: "v", computedAt: "c"}|)
+        json_query(slug, from, to, interval,
+          fields: ~s|{datetime: "d"}|,
+          include_computed_at: true
+        )
 
-      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
-      |> Sanbase.Mock.run_with_mocks(fn ->
-        result =
+      result = run_json(conn, query, rows, "timeseriesDataJson")
+
+      # only the named `datetime`, plus computedAt - no value
+      assert result == [%{"d" => "2019-01-01T00:00:00Z", "computedAt" => "2019-01-05T00:00:00Z"}]
+    end
+
+    test "includeComputedAt renames computedAt when it is also named in fields", context do
+      %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
+      rows = [row(~U[2019-01-01 00:00:00Z], 100.0, ~U[2019-01-05 00:00:00Z])]
+
+      query =
+        json_query(slug, from, to, interval,
+          fields: ~s|{datetime: "d", value: "v", computedAt: "c"}|,
+          include_computed_at: true
+        )
+
+      result = run_json(conn, query, rows, "timeseriesDataJson")
+
+      # computedAt returned under the custom "c" key - no default "computedAt" key
+      assert result == [
+               %{"d" => "2019-01-01T00:00:00Z", "v" => 100.0, "c" => "2019-01-05T00:00:00Z"}
+             ]
+    end
+
+    test "naming computedAt in fields without includeComputedAt returns an error", context do
+      %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
+      rows = [row(~U[2019-01-01 00:00:00Z], 100.0, ~U[2019-01-05 00:00:00Z])]
+
+      query = json_query(slug, from, to, interval, fields: ~s|{datetime: "d", computedAt: "c"}|)
+
+      error_msg =
+        Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
+        |> Sanbase.Mock.run_with_mocks(fn ->
           conn
           |> post("/graphql", query_skeleton(query, "getMetric"))
           |> json_response(200)
-          |> get_in(["data", "getMetric", "timeseriesDataJson"])
+          |> get_in(["errors", Access.at(0), "message"])
+        end)
 
-        assert result == [
-                 %{"d" => "2019-01-01T00:00:00Z", "v" => 100.0, "c" => "2019-01-05T00:00:00Z"}
-               ]
-      end)
+      assert error_msg =~ "includeComputedAt"
     end
   end
 
-  describe "timeseriesDataPerSlug" do
+  describe "timeseriesDataPerSlug (typed)" do
     test "exposes computedAt inside each data element when selected", context do
       %{conn: conn, from: from, to: to, project1: p1, project2: p2} = context
 
@@ -183,8 +215,8 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
       computed_at = ~U[2019-01-05 00:00:00Z]
 
       rows = [
-        [DateTime.to_unix(dt1), p1.slug, 400.0, DateTime.to_unix(computed_at)],
-        [DateTime.to_unix(dt1), p2.slug, 100.0, DateTime.to_unix(computed_at)]
+        per_slug_row(dt1, p1.slug, 400.0, computed_at),
+        per_slug_row(dt1, p2.slug, 100.0, computed_at)
       ]
 
       query = """
@@ -223,60 +255,67 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
   end
 
   describe "timeseriesDataPerSlugJson" do
-    test "does not leak computedAt when fields are not given", context do
+    test "does not include computedAt by default", context do
       %{conn: conn, from: from, to: to, project1: p1, project2: p2} = context
+      rows = [per_slug_row(~U[2019-01-01 00:00:00Z], p1.slug, 400, ~U[2019-01-05 00:00:00Z])]
 
-      dt1 = ~U[2019-01-01 00:00:00Z]
-      computed_at = ~U[2019-01-05 00:00:00Z]
-      rows = [[DateTime.to_unix(dt1), p1.slug, 400, DateTime.to_unix(computed_at)]]
+      query = per_slug_json_query(p1, p2, from, to, [])
+      result = run_json(conn, query, rows, "timeseriesDataPerSlugJson")
 
-      query = per_slug_json_query(p1, p2, from, to, nil)
-
-      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
-      |> Sanbase.Mock.run_with_mocks(fn ->
-        result =
-          conn
-          |> post("/graphql", query_skeleton(query, "getMetric"))
-          |> json_response(200)
-          |> get_in(["data", "getMetric", "timeseriesDataPerSlugJson"])
-
-        assert %{"data" => data} = result |> Enum.at(0)
-        assert %{"slug" => p1.slug, "value" => 400} in data
-        refute Enum.any?(data, &Map.has_key?(&1, "computedAt"))
-      end)
+      assert %{"data" => data} = result |> Enum.at(0)
+      assert %{"slug" => p1.slug, "value" => 400} in data
+      refute Enum.any?(data, &Map.has_key?(&1, "computedAt"))
     end
 
-    test "includes computedAt when named in the fields argument", context do
+    test "includeComputedAt appends computedAt inside each data element", context do
       %{conn: conn, from: from, to: to, project1: p1, project2: p2} = context
+      rows = [per_slug_row(~U[2019-01-01 00:00:00Z], p1.slug, 400, ~U[2019-01-05 00:00:00Z])]
 
-      dt1 = ~U[2019-01-01 00:00:00Z]
-      computed_at = ~U[2019-01-05 00:00:00Z]
-      rows = [[DateTime.to_unix(dt1), p1.slug, 400, DateTime.to_unix(computed_at)]]
+      query = per_slug_json_query(p1, p2, from, to, include_computed_at: true)
+      result = run_json(conn, query, rows, "timeseriesDataPerSlugJson")
+
+      assert %{"data" => data} = result |> Enum.at(0)
+      assert %{"slug" => p1.slug, "value" => 400, "computedAt" => "2019-01-05T00:00:00Z"} in data
+    end
+
+    test "includeComputedAt composes with a fields selection", context do
+      %{conn: conn, from: from, to: to, project1: p1, project2: p2} = context
+      rows = [per_slug_row(~U[2019-01-01 00:00:00Z], p1.slug, 400, ~U[2019-01-05 00:00:00Z])]
 
       query =
-        per_slug_json_query(
-          p1,
-          p2,
-          from,
-          to,
-          ~s|{data: "d", slug: "s", value: "v", computedAt: "c"}|
+        per_slug_json_query(p1, p2, from, to,
+          fields: ~s|{data: "d", slug: "s", value: "v"}|,
+          include_computed_at: true
         )
 
-      Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
-      |> Sanbase.Mock.run_with_mocks(fn ->
-        result =
-          conn
-          |> post("/graphql", query_skeleton(query, "getMetric"))
-          |> json_response(200)
-          |> get_in(["data", "getMetric", "timeseriesDataPerSlugJson"])
+      result = run_json(conn, query, rows, "timeseriesDataPerSlugJson")
 
-        assert %{"d" => data} = result |> Enum.at(0)
-        assert %{"s" => p1.slug, "v" => 400, "c" => "2019-01-05T00:00:00Z"} in data
-      end)
+      # computedAt keeps its fixed key even though slug/value were renamed
+      assert %{"d" => data} = result |> Enum.at(0)
+      assert %{"s" => p1.slug, "v" => 400, "computedAt" => "2019-01-05T00:00:00Z"} in data
     end
   end
 
-  defp json_query(slug, from, to, interval, fields) do
+  defp row(dt, value, computed_at),
+    do: [DateTime.to_unix(dt), value, DateTime.to_unix(computed_at)]
+
+  defp per_slug_row(dt, slug, value, computed_at),
+    do: [DateTime.to_unix(dt), slug, value, DateTime.to_unix(computed_at)]
+
+  defp run_json(conn, query, rows, key) do
+    Sanbase.Mock.prepare_mock2(&Sanbase.ClickhouseRepo.query/3, {:ok, %{rows: rows}})
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      conn
+      |> post("/graphql", query_skeleton(query, "getMetric"))
+      |> json_response(200)
+      |> get_in(["data", "getMetric", key])
+    end)
+  end
+
+  defp json_query(slug, from, to, interval, opts) do
+    fields = Keyword.get(opts, :fields)
+    include_computed_at? = Keyword.get(opts, :include_computed_at, false)
+
     """
     {
       getMetric(metric: "#{@metric}"){
@@ -286,20 +325,25 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesComputedAtTest do
           to: "#{to}"
           interval: "#{interval}"
           #{if fields, do: "fields: #{fields}"}
+          includeComputedAt: #{include_computed_at?}
         )
       }
     }
     """
   end
 
-  defp per_slug_json_query(p1, p2, from, to, fields) do
+  defp per_slug_json_query(p1, p2, from, to, opts) do
+    fields = Keyword.get(opts, :fields)
+    include_computed_at? = Keyword.get(opts, :include_computed_at, false)
+
     """
     {
       getMetric(metric: "#{@metric}"){
         timeseriesDataPerSlugJson(
           selector: {slugs: ["#{p1.slug}", "#{p2.slug}"]},
           from: "#{from}", to: "#{to}", interval: "1d"
-          #{if fields, do: "fields: #{fields}"})
+          #{if fields, do: "fields: #{fields}"}
+          includeComputedAt: #{include_computed_at?})
       }
     }
     """


### PR DESCRIPTION
## Changes

Exposes the ClickHouse `computed_at` timestamp (the moment a metric value was computed) on the two json timeseries metric queries:

- `timeseriesDataPerSlug`
- `timeseriesDataPerSlugJson`

Previously `computed_at` was only used internally as the `argMax(value, computed_at)` dedup tiebreaker

Consumers need to know *when* each returned value was computed (freshness / recompute detection), not just the value and its `dt`.

### Behavior

`computed_at` is now **always selected** in the generated ClickHouse SQL for v2 metrics; the API layer decides whether it reaches the client.

**Typed fields** (`timeseriesData`, `timeseriesDataPerSlug`, DEPRECATED and not documented in Academy)

As these queries are deprecated, the computedAt is not exposed in them so not to encourage people to use them.

**JSON fields** (`timeseriesDataJson`, `timeseriesDataPerSlugJson`)

- `fields` remains a **rename-only** map — every default field is always present; naming a field only changes its output key. *(No behavior change vs. before this branch.)*
- New arg **`includeComputedAt: Boolean = false`** is the gate for `computedAt`. When `true`, `computedAt` is appended under the key `computedAt` (datapoint level / inside each `data` element).
- To rename the key, name `computedAt` in `fields` **and** set `includeComputedAt: true`.
- Naming `computedAt` in `fields` while `includeComputedAt: false` returns a validation error (contradictory intent).

Examples (`timeseriesDataJson`):

| Args | Output keys |
|---|---|
| _(none)_ | `datetime`, `value` |
| `fields: {datetime:"d"}` | `d`, `value` |
| `includeComputedAt: true` | `datetime`, `value`, `computedAt` |
| `fields: {datetime:"d"}, includeComputedAt: true` | `d`, `value`, `computedAt` |
| `fields: {computedAt:"c"}, includeComputedAt: true` | `datetime`, `value`, `c` |
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timeseries metric results can now include a `computed_at` timestamp (surfaced as `computedAt`).
  * Added GraphQL support for `includeComputedAt` on JSON timeseries endpoints, including per-slug variants.
* **Bug Fixes**
  * Updated ClickHouse timeseries decoding to correctly handle results that include an additional computed-at column.
  * Ensured `computedAt` is only returned when requested via the appropriate GraphQL field selection/flags.
* **Tests**
  * Added end-to-end coverage for typed and JSON timeseries GraphQL endpoints, validating SQL selection and response shaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->