### PR TITLE
Fix MatchError crash in UniswapPair on RPC failure

### DIFF
--- a/lib/sanbase/accounts/eth_account.ex
+++ b/lib/sanbase/accounts/eth_account.ex
@@ -126,13 +126,14 @@ defmodule Sanbase.Accounts.EthAccount do
 
   defp contract_data_map(contract) do
     with total_supply when is_float(total_supply) <- UniswapPair.total_supply(contract),
-         {_reserves0, _reserves1} = reserves <- UniswapPair.reserves(contract) do
+         {reserves0, reserves1} when is_float(reserves0) and is_float(reserves1) <-
+           UniswapPair.reserves(contract),
+         position when position in [0, 1] <- UniswapPair.get_san_position(contract) do
       %{
         total_supply: total_supply,
-        reserves: reserves |> elem(UniswapPair.get_san_position(contract))
+        reserves: elem({reserves0, reserves1}, position)
       }
     else
-      {:error, _} -> %{total_supply: 0.0, reserves: 0.0}
       _ -> %{total_supply: 0.0, reserves: 0.0}
     end
   end

--- a/lib/sanbase/smart_contracts/uniswap_pair.ex
+++ b/lib/sanbase/smart_contracts/uniswap_pair.ex
@@ -19,16 +19,22 @@ defmodule Sanbase.SmartContracts.UniswapPair do
     decimals
   end
 
-  @spec token0(address) :: address
+  @spec token0(address) :: address | {:error, any()}
   def token0(contract) do
-    [address] = call_contract(contract, "token0()", [], [:address])
-    "0x" <> Base.encode16(address, case: :lower)
+    call_contract(contract, "token0()", [], [:address])
+    |> case do
+      [address] -> "0x" <> Base.encode16(address, case: :lower)
+      {:error, _} = error -> error
+    end
   end
 
-  @spec token1(address) :: address
+  @spec token1(address) :: address | {:error, any()}
   def token1(contract) do
-    [address] = call_contract(contract, "token1()", [], [:address])
-    "0x" <> Base.encode16(address, case: :lower)
+    call_contract(contract, "token1()", [], [:address])
+    |> case do
+      [address] -> "0x" <> Base.encode16(address, case: :lower)
+      {:error, _} = error -> error
+    end
   end
 
   @spec reserves(address) :: {float(), float()} | {:error, any()}
@@ -80,14 +86,29 @@ defmodule Sanbase.SmartContracts.UniswapPair do
     |> Enum.map(fn [balance] -> [format_number(balance, @decimals)] end)
   end
 
-  @spec get_san_position(address) :: 0 | 1
+  @spec get_san_position(address) :: 0 | 1 | {:error, any()}
   def get_san_position(contract) do
+    san_contract = Sanbase.SantimentContract.contract()
+    token0 = token0(contract)
+    token1 = token1(contract)
+
     cond do
-      token0(contract) == Sanbase.SantimentContract.contract() ->
+      token0 == san_contract ->
         0
 
-      token1(contract) == Sanbase.SantimentContract.contract() ->
+      token1 == san_contract ->
         1
+
+      # Propagate the underlying RPC/transport error so callers and logs can
+      # distinguish a failed contract call from "SAN is not part of this pair".
+      match?({:error, _}, token0) ->
+        token0
+
+      match?({:error, _}, token1) ->
+        token1
+
+      true ->
+        {:error, :san_position_not_found}
     end
   end
 end


### PR DESCRIPTION
token0/1 and token1/1 pattern-matched call_contract's result as a list,
crashing with a MatchError when the RPC call returned {:error, _} (e.g.
{:error, %Mint.TransportError{reason: :nxdomain}} on DNS failure). This
propagated up through get_san_position/1 and crashed the
update_all_uniswap_san_staked_users/0 cron job.

- token0/1, token1/1: return {:error, _} instead of raising
- get_san_position/1: add fallback clause returning {:error, :san_position_not_found}
- contract_data_map/1: move get_san_position into the `with` chain so RPC
  errors fall through to the zero-value default

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of contract lookup failures so token and pair metadata are now reported more reliably instead of failing silently.
  * Added clearer fallback behavior when Uniswap pair information can’t be determined.
  * Fixed edge-case calculations to consistently return zero values when staking or supply data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->