### PR TITLE
Use apikey when querying cccagg pairs

### DIFF
--- a/lib/sanbase/cryptocompare/price/price_cccagg_pair_data.ex
+++ b/lib/sanbase/cryptocompare/price/price_cccagg_pair_data.ex
@@ -1,5 +1,6 @@
 defmodule Sanbase.Cryptocompare.Price.CCCAGGPairData do
   alias Sanbase.Project
+  alias Sanbase.Utils.Config
 
   require Logger
 
@@ -115,10 +116,34 @@ defmodule Sanbase.Cryptocompare.Price.CCCAGGPairData do
     end)
   end
 
-  defp raw_data() do
-    {:ok, %HTTPoison.Response{status_code: 200, body: body}} =
-      HTTPoison.get("https://min-api.cryptocompare.com/data/v2/cccagg/pairs")
+  @cccagg_pairs_url "https://min-api.cryptocompare.com/data/v2/cccagg/pairs"
 
-    body |> Jason.decode!() |> get_in(["Data", "pairs"])
+  defp raw_data() do
+    api_key = api_key()
+
+    if is_nil(api_key) or api_key == "" do
+      raise("""
+      Cannot fetch CCCAGG pairs: the Cryptocompare API key is not configured. \
+      Set the CRYPTOCOMPARE_API_KEY environment variable.\
+      """)
+    end
+
+    headers = [{"authorization", "Apikey #{api_key}"}]
+
+    # Req decodes the JSON response body automatically based on the content type.
+    case Req.get(@cccagg_pairs_url, headers: headers) do
+      {:ok, %Req.Response{status: 200, body: body}} ->
+        get_in(body, ["Data", "pairs"])
+
+      {:ok, %Req.Response{status: status, body: body}} ->
+        raise(
+          "Cannot fetch CCCAGG pairs: Cryptocompare returned status #{status}: #{inspect(body)}"
+        )
+
+      {:error, error} ->
+        raise("Cannot fetch CCCAGG pairs: #{inspect(error)}")
+    end
   end
+
+  defp api_key(), do: Config.module_get(Sanbase.Cryptocompare, :api_key)
 end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved price data retrieval from the external market data service by adding the required authorization for requests, helping reduce failed fetches and improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->