### PR TITLE
Remove unnecessary error flash when login into admin page

### DIFF
--- a/lib/sanbase_web/live/admin_authenticate_live.ex
+++ b/lib/sanbase_web/live/admin_authenticate_live.ex
@@ -85,6 +85,11 @@ defmodule SanbaseWeb.AdminAuthenticateLive do
   end
 
   def handle_event("login", %{"email" => email}, socket) do
+    # Clear any stale flash (e.g. the "You must log in to access this page"
+    # error set by the redirect that brought the user here) so only the
+    # login result is shown.
+    socket = clear_flash(socket)
+
     case login(email) do
       {:ok, :login_email_sent} ->
         {:noreply,


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cleared outdated flash messages before each login attempt, so users now see only the result of the current sign-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->