### PR TITLE
Improve Hyperliquid scraper - audit unsupported, improve stats & logs

### DIFF
--- a/config/scrapers_config.exs
+++ b/config/scrapers_config.exs
@@ -65,3 +65,6 @@ config :sanbase, Sanbase.Cryptocompare.FundingRate.HistoricalScheduler,
 config :sanbase, Sanbase.Hyperliquid.Bbo.WebsocketScraper,
   enabled?: {:system, "HYPERLIQUID_WS_ENABLED", "false"},
   coalesce_window_ms: {:system, "HYPERLIQUID_BBO_COALESCE_MS", "1000"}
+
+config :sanbase, Sanbase.Hyperliquid.Bbo.CoinUniverse,
+  verify_on_write?: {:system, "HYPERLIQUID_VERIFY_COINS_ON_WRITE", "true"}

--- a/config/test.exs
+++ b/config/test.exs
@@ -172,6 +172,9 @@ config :sanbase, Sanbase.Hyperliquid.Bbo.WebsocketScraper,
   enabled?: "false",
   coalesce_window_ms: "1000"
 
+# Never reach out to Hyperliquid to verify coins during tests.
+config :sanbase, Sanbase.Hyperliquid.Bbo.CoinUniverse, verify_on_write?: "false"
+
 # So the router can read it compile time
 System.put_env("TELEGRAM_ENDPOINT_RANDOM_STRING", "random_string")
 

--- a/lib/sanbase/hyperliquid/bbo/bbo_websocket_scraper.ex
+++ b/lib/sanbase/hyperliquid/bbo/bbo_websocket_scraper.ex
@@ -61,6 +61,9 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   @name :hyperliquid_bbo_scraper
   @exporter :hyperliquid_bbo_exporter
   @url "wss://api.hyperliquid.xyz/ws"
+  # REST endpoint that lists HL's full coin universe (perp `meta` + `spotMeta`).
+  # Used to authoritatively tell whether a coin we subscribe to actually exists.
+  @info_url "https://api.hyperliquid.xyz/info"
   @source "hyperliquid"
 
   # Outbound app-level ping; HL closes idle sockets ~60s.
@@ -73,6 +76,12 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   @healthcheck_max_failures 5
   # Resync subscriptions against SourceSlugMapping on this cadence.
   @reconcile_interval 60_000
+  # Throttle for the (best-effort, non-blocking) coin-universe audit run from
+  # reconcile, so a reconnect storm can't hammer the HL `info` endpoint.
+  @audit_interval 300_000
+  # Upper bound on how long a synchronous single-coin verification (used when a
+  # mapping is created) may block before we give up and let the insert through.
+  @verify_timeout 5_000
 
   # Hyperliquid limits outbound client messages to 2000/min (~33/sec). We pace
   # subscribe/unsubscribe frames at 1 per 50ms = 20/sec = 1200/min — ~40%
@@ -109,6 +118,11 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   defp initial_state() do
     %{
       active_subs: MapSet.new(),
+      # Coins Hyperliquid does not know about (per the periodic universe audit).
+      # Excluded from subscriptions in reconcile/2 and kept across reconnects so
+      # a storm never re-subscribes to known-bad coins. Refreshed each audit, so
+      # a coin re-listed on HL is picked back up automatically.
+      unsupported: MapSet.new(),
       slug_map: %{},
       pending_sub_queue: :queue.new(),
       last_emitted: %{},
@@ -117,9 +131,23 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
       last_message_time: System.system_time(:millisecond),
       healthcheck_failures: 0,
       coalesce_window_ms: coalesce_window_ms(),
-      timers: %{}
+      timers: %{},
+      # Diagnostics. Per-connection counters are reset in handle_connect/2;
+      # reconnects is cumulative since boot. All read via Map.get/bump so a
+      # hot recompile against an old state term never raises.
+      connected_at: nil,
+      msgs_out: 0,
+      frames_in: 0,
+      bbo_in: 0,
+      errors_in: 0,
+      reconnects: 0,
+      last_audit_at: 0
     }
   end
+
+  # Safe counter bump — creates the key at 1 if the running process predates it
+  # (relevant when recompiling this module against a live process via `r/1`).
+  defp bump(state, key), do: Map.update(state, key, 1, &(&1 + 1))
 
   defp coalesce_window_ms() do
     case Config.module_get(__MODULE__, :coalesce_window_ms) do
@@ -132,14 +160,20 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   # WebSockex callbacks
 
   def handle_connect(_conn, state) do
-    Logger.info("[HyperliquidBboWS] connected")
+    now = System.system_time(:millisecond)
+
+    Logger.info(
+      "[HyperliquidBboWS] connected reconnects=#{Map.get(state, :reconnects, 0)} backoff_was=#{state.reconnect_backoff_ms}ms"
+    )
 
     state =
       %{
         state
         | reconnect_backoff_ms: @reconnect_initial_ms,
-          last_message_time: System.system_time(:millisecond)
+          last_message_time: now
       }
+      # Reset per-connection diagnostics; Map.merge is recompile-safe.
+      |> Map.merge(%{connected_at: now, msgs_out: 0, frames_in: 0, bbo_in: 0, errors_in: 0})
       |> schedule_all_timers()
 
     send(self(), :reconcile_subscriptions)
@@ -148,9 +182,21 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
 
   def handle_disconnect(status, state) do
     sleep_ms = state.reconnect_backoff_ms
+    now = System.system_time(:millisecond)
+    connected_at = Map.get(state, :connected_at)
+    lifetime_ms = if connected_at, do: now - connected_at, else: nil
 
+    # Full `status` (not just :reason) surfaces a WS close code/reason if the
+    # remote sent a close frame. `{:remote, :closed}` = abrupt TCP close with
+    # NO close frame — typical of an infra/rate-limit drop rather than an app
+    # error. lifetime_ms tells us whether the socket dies on a fixed cadence
+    # (policy/limit) or randomly (network). bbo_in>0 means subscriptions worked
+    # and data was flowing right up to the drop (so mappings are fine).
     Logger.warning(
-      "[HyperliquidBboWS] disconnect reason=#{inspect(Map.get(status, :reason))} backoff=#{sleep_ms}ms"
+      "[HyperliquidBboWS] disconnect status=#{inspect(status)} lifetime_ms=#{inspect(lifetime_ms)} " <>
+        "frames_in=#{Map.get(state, :frames_in, 0)} bbo_in=#{Map.get(state, :bbo_in, 0)} " <>
+        "errors_in=#{Map.get(state, :errors_in, 0)} msgs_out=#{Map.get(state, :msgs_out, 0)} " <>
+        "active_subs=#{MapSet.size(state.active_subs)} reconnects=#{Map.get(state, :reconnects, 0)} backoff=#{sleep_ms}ms"
     )
 
     state =
@@ -164,6 +210,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
         healthcheck_failures: 0
       })
       |> Map.update!(:reconnect_backoff_ms, fn ms -> min(ms * 2, @reconnect_max_ms) end)
+      |> bump(:reconnects)
 
     Process.sleep(sleep_ms)
     {:reconnect, state}
@@ -175,7 +222,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   end
 
   def handle_frame({:text, json}, state) when is_binary(json) do
-    state = %{state | last_message_time: System.system_time(:millisecond)}
+    state = bump(%{state | last_message_time: System.system_time(:millisecond)}, :frames_in)
 
     case Jason.decode(json) do
       {:ok, decoded} ->
@@ -196,12 +243,12 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   end
 
   defp handle_decoded(%{"channel" => "bbo", "data" => data}, state) do
-    {:ok, handle_bbo(data, state)}
+    {:ok, handle_bbo(data, bump(state, :bbo_in))}
   end
 
   defp handle_decoded(%{"channel" => "error"} = msg, state) do
     Logger.warning("[HyperliquidBboWS] Error frame: #{inspect(msg)}")
-    {:ok, state}
+    {:ok, bump(state, :errors_in)}
   end
 
   defp handle_decoded(_msg, state), do: {:ok, state}
@@ -295,7 +342,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   # handle_info
 
   def handle_info(:ping, state) do
-    state = schedule(state, :ping, @ping_interval)
+    state = schedule(state, :ping, @ping_interval) |> bump(:msgs_out)
     frame = {:text, Jason.encode!(%{method: "ping"})}
     {:reply, frame, state}
   end
@@ -343,7 +390,9 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
 
     case :queue.out(state.pending_sub_queue) do
       {{:value, frame}, queue2} ->
-        state = %{state | pending_sub_queue: queue2} |> maybe_schedule_flush_subs()
+        state =
+          %{state | pending_sub_queue: queue2} |> maybe_schedule_flush_subs() |> bump(:msgs_out)
+
         {:reply, frame, state}
 
       {:empty, _} ->
@@ -375,19 +424,44 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     {:ok, state}
   end
 
+  # Refresh the `unsupported` set from an audit run. Only reconcile when the set
+  # actually changed, so an unchanged audit doesn't churn subscriptions. A fetch
+  # failure returns a non-map result and is ignored (keeps the previous set).
+  def handle_info({:audit_result, %{unsupported: unsupported}}, state) do
+    new_unsupported = MapSet.new(unsupported)
+    old_unsupported = Map.get(state, :unsupported, MapSet.new())
+    state = Map.put(state, :unsupported, new_unsupported)
+
+    if MapSet.equal?(new_unsupported, old_unsupported) do
+      {:ok, state}
+    else
+      Logger.info(
+        "[HyperliquidBboWS] unsupported set updated size=#{MapSet.size(new_unsupported)}; reconciling"
+      )
+
+      send(self(), :reconcile_subscriptions)
+      {:ok, state}
+    end
+  end
+
+  def handle_info({:audit_result, _}, state), do: {:ok, state}
+
   def handle_info(_msg, state), do: {:ok, state}
 
   # Reconcile
 
   defp reconcile(state) do
-    {desired_set, slug_map} = load_mappings()
+    {full_desired, slug_map} = load_mappings()
+    unsupported = Map.get(state, :unsupported, MapSet.new())
+    # Subscribe to everything we're mapped to, minus coins HL doesn't recognise.
+    desired_set = MapSet.difference(full_desired, unsupported)
 
     to_subscribe = MapSet.difference(desired_set, state.active_subs)
     to_unsubscribe = MapSet.difference(state.active_subs, desired_set)
 
     if MapSet.size(to_subscribe) > 0 or MapSet.size(to_unsubscribe) > 0 do
       Logger.info(
-        "[HyperliquidBboWS] reconcile +sub=#{MapSet.size(to_subscribe)} -unsub=#{MapSet.size(to_unsubscribe)} desired=#{MapSet.size(desired_set)}"
+        "[HyperliquidBboWS] reconcile +sub=#{MapSet.size(to_subscribe)} -unsub=#{MapSet.size(to_unsubscribe)} desired=#{MapSet.size(desired_set)} excluded_unsupported=#{MapSet.size(unsupported)}"
       )
     end
 
@@ -411,6 +485,24 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
         pending: Map.drop(state.pending, dropped)
     }
     |> maybe_schedule_flush_subs()
+    # Audit the FULL mapped set (not the reduced one) so a previously
+    # unsupported coin that HL re-lists is detected and re-included.
+    |> maybe_audit_coins(full_desired)
+  end
+
+  # Run the coin-universe audit off the WS process (so the HTTP call never
+  # blocks frame handling) and no more than once per @audit_interval. The task
+  # sends its result back to this process to refresh the `unsupported` set.
+  defp maybe_audit_coins(state, desired_set) do
+    now = System.system_time(:millisecond)
+
+    if now - Map.get(state, :last_audit_at, 0) >= @audit_interval do
+      parent = self()
+      Task.start(fn -> send(parent, {:audit_result, audit_coins(desired_set)}) end)
+      Map.put(state, :last_audit_at, now)
+    else
+      state
+    end
   end
 
   defp sub_frame(method, coin) do
@@ -424,13 +516,153 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     # reconcile (≤60s), unhiding resumes it.
     rows = SourceSlugMapping.get_source_slug_mappings(@source, return: :all)
 
-    slug_map =
-      Enum.reduce(rows, %{}, fn {coin, slug}, acc ->
-        Map.update(acc, coin, [slug], &[slug | &1])
+    {slug_map, nil_slug_coins} =
+      Enum.reduce(rows, {%{}, []}, fn {coin, slug}, {acc, nils} ->
+        nils = if is_nil(slug), do: [coin | nils], else: nils
+        {Map.update(acc, coin, [slug], &[slug | &1]), nils}
       end)
 
-    {MapSet.new(Map.keys(slug_map)), slug_map}
+    coins = Map.keys(slug_map)
+
+    # Surface anything that could make Hyperliquid reject a subscribe frame or
+    # that indicates a bad row on this environment only.
+    bad_coins = Enum.reject(coins, &valid_coin?/1)
+
+    if bad_coins != [] do
+      Logger.warning("[HyperliquidBboWS] invalid coins in mappings: #{inspect(bad_coins)}")
+    end
+
+    if nil_slug_coins != [] do
+      Logger.warning(
+        "[HyperliquidBboWS] #{length(nil_slug_coins)} mapping row(s) with no sanbase slug (project/non_crypto_asset missing or hidden): " <>
+          "coins=#{inspect(Enum.take(Enum.sort(nil_slug_coins), 30))}"
+      )
+    end
+
+    Logger.info("[HyperliquidBboWS] mappings loaded rows=#{length(rows)} coins=#{length(coins)}")
+
+    {MapSet.new(coins), slug_map}
   end
+
+  # A coin must be a non-empty, whitespace-free string for Hyperliquid to
+  # accept the subscribe frame; anything else is a bad mapping row.
+  defp valid_coin?(c) when is_binary(c), do: c != "" and String.trim(c) == c
+  defp valid_coin?(_), do: false
+
+  # Coin universe audit
+
+  @doc ~s"""
+  Cross-check the coins we would subscribe to against Hyperliquid's live
+  universe. Only Hyperliquid can say whether a coin is real, so this fetches
+  the perp `meta` and `spotMeta` from `#{@info_url}` and reports every desired
+  coin that Hyperliquid does not know about — the authoritative "bad coin"
+  list.
+
+  Safe to run from a remote console:
+
+      Sanbase.Hyperliquid.Bbo.WebsocketScraper.audit_coins()
+
+  Returns `%{desired: n, universe: n, unsupported: [coin, ...]}`, or
+  `{:error, reason}` if the universe could not be fetched.
+  """
+  def audit_coins(desired \\ nil) do
+    desired =
+      (desired || elem(load_mappings(), 0))
+      |> MapSet.new()
+      |> MapSet.to_list()
+      |> Enum.filter(&valid_coin?/1)
+
+    case fetch_universe() do
+      {:ok, universe} ->
+        unsupported = desired |> Enum.reject(&MapSet.member?(universe, &1)) |> Enum.sort()
+
+        if unsupported == [] do
+          Logger.info(
+            "[HyperliquidBboWS] coin audit OK — all #{length(desired)} coins present in HL universe (size=#{MapSet.size(universe)})"
+          )
+        else
+          Logger.warning(
+            "[HyperliquidBboWS] coin audit — #{length(unsupported)}/#{length(desired)} coin(s) NOT in HL universe (size=#{MapSet.size(universe)}): #{inspect(unsupported)}"
+          )
+        end
+
+        %{desired: length(desired), universe: MapSet.size(universe), unsupported: unsupported}
+
+      {:error, reason} = error ->
+        Logger.warning(
+          "[HyperliquidBboWS] coin audit failed to fetch HL universe: #{inspect(reason)}"
+        )
+
+        error
+    end
+  end
+
+  @doc ~s"""
+  Verify a single coin against Hyperliquid's live universe, bounded by
+  `timeout` ms. Meant for the mapping-creation path, where only Hyperliquid
+  can say whether a coin is real.
+
+  Returns:
+    * `:ok` — coin exists in the HL universe.
+    * `:unsupported` — HL was reached and does not know this coin.
+    * `:unverified` — HL could not be reached in time (timeout / fetch error);
+      caller should allow the write but warn.
+  """
+  @spec coin_supported?(String.t(), non_neg_integer()) :: :ok | :unsupported | :unverified
+  def coin_supported?(coin, timeout \\ @verify_timeout) when is_binary(coin) do
+    task = Task.async(fn -> fetch_universe() end)
+
+    case Task.yield(task, timeout) || Task.shutdown(task) do
+      {:ok, {:ok, universe}} -> if MapSet.member?(universe, coin), do: :ok, else: :unsupported
+      _ -> :unverified
+    end
+  end
+
+  # Union of perp coin names (`meta.universe`) and spot names + token names
+  # (`spotMeta.universe`/`spotMeta.tokens`), covering every `coin` form the
+  # bbo channel accepts. If one request fails we still return whatever the
+  # other returned so the audit stays useful.
+  defp fetch_universe() do
+    perp = info_request(%{type: "meta"})
+    spot = info_request(%{type: "spotMeta"})
+
+    perp_names =
+      case perp do
+        {:ok, body} -> universe_names(body)
+        _ -> []
+      end
+
+    spot_names =
+      case spot do
+        {:ok, body} -> universe_names(body) ++ token_names(body)
+        _ -> []
+      end
+
+    case {perp, spot} do
+      {{:error, reason}, {:error, _}} -> {:error, reason}
+      _ -> {:ok, MapSet.new(perp_names ++ spot_names)}
+    end
+  end
+
+  defp info_request(payload) do
+    case Req.post(@info_url, json: payload, receive_timeout: 10_000, retry: :transient) do
+      {:ok, %Req.Response{status: 200, body: body}} when is_map(body) -> {:ok, body}
+      {:ok, %Req.Response{status: status, body: body}} -> {:error, {:http_status, status, body}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp universe_names(%{"universe" => universe}) when is_list(universe) do
+    for %{"name" => name} <- universe, is_binary(name), do: name
+  end
+
+  defp universe_names(_), do: []
+
+  defp token_names(%{"tokens" => tokens}) when is_list(tokens) do
+    for %{"name" => name} <- tokens, is_binary(name), do: name
+  end
+
+  defp token_names(_), do: []
 
   # Timers
 

--- a/lib/sanbase/hyperliquid/bbo/bbo_websocket_scraper.ex
+++ b/lib/sanbase/hyperliquid/bbo/bbo_websocket_scraper.ex
@@ -55,15 +55,13 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   require Logger
 
   alias Sanbase.Hyperliquid.Bbo.BboPoint
+  alias Sanbase.Hyperliquid.Bbo.CoinUniverse
   alias Sanbase.Project.SourceSlugMapping
   alias Sanbase.Utils.Config
 
   @name :hyperliquid_bbo_scraper
   @exporter :hyperliquid_bbo_exporter
   @url "wss://api.hyperliquid.xyz/ws"
-  # REST endpoint that lists HL's full coin universe (perp `meta` + `spotMeta`).
-  # Used to authoritatively tell whether a coin we subscribe to actually exists.
-  @info_url "https://api.hyperliquid.xyz/info"
   @source "hyperliquid"
 
   # Outbound app-level ping; HL closes idle sockets ~60s.
@@ -79,9 +77,6 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   # Throttle for the (best-effort, non-blocking) coin-universe audit run from
   # reconcile, so a reconnect storm can't hammer the HL `info` endpoint.
   @audit_interval 300_000
-  # Upper bound on how long a synchronous single-coin verification (used when a
-  # mapping is created) may block before we give up and let the insert through.
-  @verify_timeout 5_000
 
   # Hyperliquid limits outbound client messages to 2000/min (~33/sec). We pace
   # subscribe/unsubscribe frames at 1 per 50ms = 20/sec = 1200/min — ~40%
@@ -132,14 +127,11 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
       healthcheck_failures: 0,
       coalesce_window_ms: coalesce_window_ms(),
       timers: %{},
-      # Diagnostics. Per-connection counters are reset in handle_connect/2;
-      # reconnects is cumulative since boot. All read via Map.get/bump so a
-      # hot recompile against an old state term never raises.
+      # Diagnostics. connected_at/bbo_in are reset per connection in
+      # handle_connect/2; reconnects is cumulative since boot. Read via
+      # Map.get/bump so a hot recompile against an old state never raises.
       connected_at: nil,
-      msgs_out: 0,
-      frames_in: 0,
       bbo_in: 0,
-      errors_in: 0,
       reconnects: 0,
       last_audit_at: 0
     }
@@ -173,7 +165,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
           last_message_time: now
       }
       # Reset per-connection diagnostics; Map.merge is recompile-safe.
-      |> Map.merge(%{connected_at: now, msgs_out: 0, frames_in: 0, bbo_in: 0, errors_in: 0})
+      |> Map.merge(%{connected_at: now, bbo_in: 0})
       |> schedule_all_timers()
 
     send(self(), :reconcile_subscriptions)
@@ -189,14 +181,13 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     # Full `status` (not just :reason) surfaces a WS close code/reason if the
     # remote sent a close frame. `{:remote, :closed}` = abrupt TCP close with
     # NO close frame — typical of an infra/rate-limit drop rather than an app
-    # error. lifetime_ms tells us whether the socket dies on a fixed cadence
-    # (policy/limit) or randomly (network). bbo_in>0 means subscriptions worked
-    # and data was flowing right up to the drop (so mappings are fine).
+    # error. lifetime_ms shows whether the socket dies on a fixed cadence
+    # (policy/limit) or randomly (network); bbo_in>0 means data was flowing
+    # right up to the drop (so mappings are fine).
     Logger.warning(
       "[HyperliquidBboWS] disconnect status=#{inspect(status)} lifetime_ms=#{inspect(lifetime_ms)} " <>
-        "frames_in=#{Map.get(state, :frames_in, 0)} bbo_in=#{Map.get(state, :bbo_in, 0)} " <>
-        "errors_in=#{Map.get(state, :errors_in, 0)} msgs_out=#{Map.get(state, :msgs_out, 0)} " <>
-        "active_subs=#{MapSet.size(state.active_subs)} reconnects=#{Map.get(state, :reconnects, 0)} backoff=#{sleep_ms}ms"
+        "bbo_in=#{Map.get(state, :bbo_in, 0)} active_subs=#{MapSet.size(state.active_subs)} " <>
+        "reconnects=#{Map.get(state, :reconnects, 0)} backoff=#{sleep_ms}ms"
     )
 
     state =
@@ -222,7 +213,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   end
 
   def handle_frame({:text, json}, state) when is_binary(json) do
-    state = bump(%{state | last_message_time: System.system_time(:millisecond)}, :frames_in)
+    state = %{state | last_message_time: System.system_time(:millisecond)}
 
     case Jason.decode(json) do
       {:ok, decoded} ->
@@ -248,7 +239,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
 
   defp handle_decoded(%{"channel" => "error"} = msg, state) do
     Logger.warning("[HyperliquidBboWS] Error frame: #{inspect(msg)}")
-    {:ok, bump(state, :errors_in)}
+    {:ok, state}
   end
 
   defp handle_decoded(_msg, state), do: {:ok, state}
@@ -342,7 +333,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   # handle_info
 
   def handle_info(:ping, state) do
-    state = schedule(state, :ping, @ping_interval) |> bump(:msgs_out)
+    state = schedule(state, :ping, @ping_interval)
     frame = {:text, Jason.encode!(%{method: "ping"})}
     {:reply, frame, state}
   end
@@ -390,9 +381,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
 
     case :queue.out(state.pending_sub_queue) do
       {{:value, frame}, queue2} ->
-        state =
-          %{state | pending_sub_queue: queue2} |> maybe_schedule_flush_subs() |> bump(:msgs_out)
-
+        state = %{state | pending_sub_queue: queue2} |> maybe_schedule_flush_subs()
         {:reply, frame, state}
 
       {:empty, _} ->
@@ -424,24 +413,11 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     {:ok, state}
   end
 
-  # Refresh the `unsupported` set from an audit run. Only reconcile when the set
-  # actually changed, so an unchanged audit doesn't churn subscriptions. A fetch
-  # failure returns a non-map result and is ignored (keeps the previous set).
+  # Refresh the `unsupported` set from an audit run; the next scheduled reconcile
+  # (≤60s) applies it. A fetch failure returns a non-map result and is ignored,
+  # keeping the previous set.
   def handle_info({:audit_result, %{unsupported: unsupported}}, state) do
-    new_unsupported = MapSet.new(unsupported)
-    old_unsupported = Map.get(state, :unsupported, MapSet.new())
-    state = Map.put(state, :unsupported, new_unsupported)
-
-    if MapSet.equal?(new_unsupported, old_unsupported) do
-      {:ok, state}
-    else
-      Logger.info(
-        "[HyperliquidBboWS] unsupported set updated size=#{MapSet.size(new_unsupported)}; reconciling"
-      )
-
-      send(self(), :reconcile_subscriptions)
-      {:ok, state}
-    end
+    {:ok, Map.put(state, :unsupported, MapSet.new(unsupported))}
   end
 
   def handle_info({:audit_result, _}, state), do: {:ok, state}
@@ -498,7 +474,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
 
     if now - Map.get(state, :last_audit_at, 0) >= @audit_interval do
       parent = self()
-      Task.start(fn -> send(parent, {:audit_result, audit_coins(desired_set)}) end)
+      Task.start(fn -> send(parent, {:audit_result, CoinUniverse.audit(desired_set)}) end)
       Map.put(state, :last_audit_at, now)
     else
       state
@@ -516,153 +492,13 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     # reconcile (≤60s), unhiding resumes it.
     rows = SourceSlugMapping.get_source_slug_mappings(@source, return: :all)
 
-    {slug_map, nil_slug_coins} =
-      Enum.reduce(rows, {%{}, []}, fn {coin, slug}, {acc, nils} ->
-        nils = if is_nil(slug), do: [coin | nils], else: nils
-        {Map.update(acc, coin, [slug], &[slug | &1]), nils}
+    slug_map =
+      Enum.reduce(rows, %{}, fn {coin, slug}, acc ->
+        Map.update(acc, coin, [slug], &[slug | &1])
       end)
 
-    coins = Map.keys(slug_map)
-
-    # Surface anything that could make Hyperliquid reject a subscribe frame or
-    # that indicates a bad row on this environment only.
-    bad_coins = Enum.reject(coins, &valid_coin?/1)
-
-    if bad_coins != [] do
-      Logger.warning("[HyperliquidBboWS] invalid coins in mappings: #{inspect(bad_coins)}")
-    end
-
-    if nil_slug_coins != [] do
-      Logger.warning(
-        "[HyperliquidBboWS] #{length(nil_slug_coins)} mapping row(s) with no sanbase slug (project/non_crypto_asset missing or hidden): " <>
-          "coins=#{inspect(Enum.take(Enum.sort(nil_slug_coins), 30))}"
-      )
-    end
-
-    Logger.info("[HyperliquidBboWS] mappings loaded rows=#{length(rows)} coins=#{length(coins)}")
-
-    {MapSet.new(coins), slug_map}
+    {MapSet.new(Map.keys(slug_map)), slug_map}
   end
-
-  # A coin must be a non-empty, whitespace-free string for Hyperliquid to
-  # accept the subscribe frame; anything else is a bad mapping row.
-  defp valid_coin?(c) when is_binary(c), do: c != "" and String.trim(c) == c
-  defp valid_coin?(_), do: false
-
-  # Coin universe audit
-
-  @doc ~s"""
-  Cross-check the coins we would subscribe to against Hyperliquid's live
-  universe. Only Hyperliquid can say whether a coin is real, so this fetches
-  the perp `meta` and `spotMeta` from `#{@info_url}` and reports every desired
-  coin that Hyperliquid does not know about — the authoritative "bad coin"
-  list.
-
-  Safe to run from a remote console:
-
-      Sanbase.Hyperliquid.Bbo.WebsocketScraper.audit_coins()
-
-  Returns `%{desired: n, universe: n, unsupported: [coin, ...]}`, or
-  `{:error, reason}` if the universe could not be fetched.
-  """
-  def audit_coins(desired \\ nil) do
-    desired =
-      (desired || elem(load_mappings(), 0))
-      |> MapSet.new()
-      |> MapSet.to_list()
-      |> Enum.filter(&valid_coin?/1)
-
-    case fetch_universe() do
-      {:ok, universe} ->
-        unsupported = desired |> Enum.reject(&MapSet.member?(universe, &1)) |> Enum.sort()
-
-        if unsupported == [] do
-          Logger.info(
-            "[HyperliquidBboWS] coin audit OK — all #{length(desired)} coins present in HL universe (size=#{MapSet.size(universe)})"
-          )
-        else
-          Logger.warning(
-            "[HyperliquidBboWS] coin audit — #{length(unsupported)}/#{length(desired)} coin(s) NOT in HL universe (size=#{MapSet.size(universe)}): #{inspect(unsupported)}"
-          )
-        end
-
-        %{desired: length(desired), universe: MapSet.size(universe), unsupported: unsupported}
-
-      {:error, reason} = error ->
-        Logger.warning(
-          "[HyperliquidBboWS] coin audit failed to fetch HL universe: #{inspect(reason)}"
-        )
-
-        error
-    end
-  end
-
-  @doc ~s"""
-  Verify a single coin against Hyperliquid's live universe, bounded by
-  `timeout` ms. Meant for the mapping-creation path, where only Hyperliquid
-  can say whether a coin is real.
-
-  Returns:
-    * `:ok` — coin exists in the HL universe.
-    * `:unsupported` — HL was reached and does not know this coin.
-    * `:unverified` — HL could not be reached in time (timeout / fetch error);
-      caller should allow the write but warn.
-  """
-  @spec coin_supported?(String.t(), non_neg_integer()) :: :ok | :unsupported | :unverified
-  def coin_supported?(coin, timeout \\ @verify_timeout) when is_binary(coin) do
-    task = Task.async(fn -> fetch_universe() end)
-
-    case Task.yield(task, timeout) || Task.shutdown(task) do
-      {:ok, {:ok, universe}} -> if MapSet.member?(universe, coin), do: :ok, else: :unsupported
-      _ -> :unverified
-    end
-  end
-
-  # Union of perp coin names (`meta.universe`) and spot names + token names
-  # (`spotMeta.universe`/`spotMeta.tokens`), covering every `coin` form the
-  # bbo channel accepts. If one request fails we still return whatever the
-  # other returned so the audit stays useful.
-  defp fetch_universe() do
-    perp = info_request(%{type: "meta"})
-    spot = info_request(%{type: "spotMeta"})
-
-    perp_names =
-      case perp do
-        {:ok, body} -> universe_names(body)
-        _ -> []
-      end
-
-    spot_names =
-      case spot do
-        {:ok, body} -> universe_names(body) ++ token_names(body)
-        _ -> []
-      end
-
-    case {perp, spot} do
-      {{:error, reason}, {:error, _}} -> {:error, reason}
-      _ -> {:ok, MapSet.new(perp_names ++ spot_names)}
-    end
-  end
-
-  defp info_request(payload) do
-    case Req.post(@info_url, json: payload, receive_timeout: 10_000, retry: :transient) do
-      {:ok, %Req.Response{status: 200, body: body}} when is_map(body) -> {:ok, body}
-      {:ok, %Req.Response{status: status, body: body}} -> {:error, {:http_status, status, body}}
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp universe_names(%{"universe" => universe}) when is_list(universe) do
-    for %{"name" => name} <- universe, is_binary(name), do: name
-  end
-
-  defp universe_names(_), do: []
-
-  defp token_names(%{"tokens" => tokens}) when is_list(tokens) do
-    for %{"name" => name} <- tokens, is_binary(name), do: name
-  end
-
-  defp token_names(_), do: []
 
   # Timers
 

--- a/lib/sanbase/hyperliquid/bbo/coin_universe.ex
+++ b/lib/sanbase/hyperliquid/bbo/coin_universe.ex
@@ -1,0 +1,204 @@
+defmodule Sanbase.Hyperliquid.Bbo.CoinUniverse do
+  @moduledoc ~s"""
+  Hyperliquid's coin universe: fetching the authoritative set of tradeable
+  coins and validating/auditing the coins we subscribe to against it.
+
+  Only Hyperliquid can say whether a coin is real. The universe spans every perp
+  dex — the primary one plus each builder-deployed dex from `perpDexs`, where
+  stocks, commodities, FX and other RWAs live (namespaced like `"xyz:GOLD"`) —
+  and spot. No single endpoint returns all of them, so we list the dexs and
+  union one `meta` request per dex with `spotMeta`.
+  """
+
+  require Logger
+
+  alias Sanbase.Project.SourceSlugMapping
+  alias Sanbase.Utils.Config
+
+  @source "hyperliquid"
+  @info_url "https://api.hyperliquid.xyz/info"
+
+  # Upper bound on how long a synchronous single-coin verification (used when a
+  # mapping is created) may block before we give up and let the insert through.
+  @verify_timeout 5_000
+  # Jaro-distance threshold and cap for "did you mean" suggestions.
+  @suggestion_threshold 0.8
+  @suggestion_limit 3
+  # Stocks/commodities/FX live on the builder dex "xyz" (e.g. "xyz:GOLD"), so a
+  # bare "GOLD" should still surface "xyz:GOLD" as a suggestion.
+  @rwa_dex_prefix "xyz:"
+  # Per-dex `meta`/`spotMeta` requests are fetched concurrently, each bounded so
+  # a single slow dex can't blow the caller's verification budget.
+  @universe_fetch_concurrency 16
+  @universe_fetch_timeout 4_000
+
+  @doc ~s"""
+  Whether creating/editing a `#{@source}` source-slug mapping should be verified
+  against HL's live universe (a synchronous HTTP call). Off in tests so the
+  suite never reaches out to Hyperliquid.
+  """
+  def verify_on_write?() do
+    Config.module_get(__MODULE__, :verify_on_write?)
+    |> to_string()
+    |> String.trim()
+    |> String.downcase()
+    |> Kernel.in(["true", "1"])
+  end
+
+  @doc ~s"""
+  Cross-check the coins we would subscribe to against Hyperliquid's live
+  universe (every perp dex plus spot). Logs and returns every coin HL does not
+  know about — the authoritative "bad coin" list. With no argument it loads the
+  `#{@source}` mappings itself, so it's safe from a remote console:
+
+      Sanbase.Hyperliquid.Bbo.CoinUniverse.audit()
+
+  Returns `%{desired: n, universe: n, unsupported: [coin, ...]}`, or
+  `{:error, reason}` if the universe could not be fetched.
+  """
+  def audit(desired \\ nil) do
+    desired = MapSet.to_list(desired || mapped_coins())
+
+    case fetch() do
+      {:ok, universe} ->
+        unsupported = desired |> Enum.reject(&MapSet.member?(universe, &1)) |> Enum.sort()
+
+        if unsupported == [] do
+          Logger.info(
+            "[HyperliquidCoinUniverse] audit OK — all #{length(desired)} coins present (universe=#{MapSet.size(universe)})"
+          )
+        else
+          Logger.warning(
+            "[HyperliquidCoinUniverse] #{length(unsupported)}/#{length(desired)} coin(s) NOT in HL universe (universe=#{MapSet.size(universe)}): #{inspect(unsupported)}"
+          )
+        end
+
+        %{desired: length(desired), universe: MapSet.size(universe), unsupported: unsupported}
+
+      {:error, reason} = error ->
+        Logger.warning(
+          "[HyperliquidCoinUniverse] failed to fetch HL universe: #{inspect(reason)}"
+        )
+
+        error
+    end
+  end
+
+  @doc ~s"""
+  Verify a single coin against Hyperliquid's live universe, bounded by
+  `timeout` ms. Meant for the mapping-creation path.
+
+  Returns:
+    * `:ok` — coin exists in the HL universe.
+    * `{:unsupported, suggestions}` — HL was reached and does not know this
+      coin; `suggestions` are the closest known names (Jaro), possibly empty.
+    * `:unverified` — HL could not be reached in time (timeout / fetch error);
+      caller should allow the write but warn.
+  """
+  @spec coin_supported?(String.t(), non_neg_integer()) ::
+          :ok | {:unsupported, [String.t()]} | :unverified
+  def coin_supported?(coin, timeout \\ @verify_timeout) when is_binary(coin) do
+    task = Task.async(fn -> fetch() end)
+
+    case Task.yield(task, timeout) || Task.shutdown(task) do
+      {:ok, {:ok, universe}} ->
+        if MapSet.member?(universe, coin),
+          do: :ok,
+          else: {:unsupported, closest_coins(coin, universe)}
+
+      _ ->
+        :unverified
+    end
+  end
+
+  defp mapped_coins() do
+    @source
+    |> SourceSlugMapping.get_source_slug_mappings(return: :all)
+    |> Enum.map(fn {coin, _slug} -> coin end)
+    |> MapSet.new()
+  end
+
+  # Closest known coin names to `coin` by Jaro distance, for a "did you mean"
+  # hint. Case-insensitive; each candidate is scored by the better of the raw
+  # input and the input namespaced under the RWA dex, so a bare "GOLD" surfaces
+  # "xyz:GOLD" (exact prefixed match scores 1.0).
+  defp closest_coins(coin, universe) do
+    target = String.upcase(coin)
+    prefixed = String.upcase(@rwa_dex_prefix <> coin)
+
+    universe
+    |> Enum.map(fn candidate ->
+      up = String.upcase(candidate)
+      distance = max(String.jaro_distance(target, up), String.jaro_distance(prefixed, up))
+      {candidate, distance}
+    end)
+    |> Enum.filter(fn {_candidate, distance} -> distance >= @suggestion_threshold end)
+    |> Enum.sort_by(fn {_candidate, distance} -> distance end, :desc)
+    |> Enum.take(@suggestion_limit)
+    |> Enum.map(fn {candidate, _distance} -> candidate end)
+  end
+
+  # The full set of coins the bbo channel accepts, unioned across every perp dex
+  # (primary + each builder dex from `perpDexs`, which lists the primary as
+  # `null` and builder dexs as maps with a "name") and spot.
+  #
+  # EVERY request must succeed — a partial fetch would omit part of the universe
+  # and wrongly flag real coins as unsupported (blocking valid mapping creates
+  # and unsubscribing live coins). On any failure we return an error so callers
+  # treat it as "could not verify" rather than "empty universe".
+  defp fetch() do
+    with {:ok, dexs} <- info_request(%{type: "perpDexs"}) do
+      meta_requests =
+        Enum.map(List.wrap(dexs), fn
+          %{"name" => name} when is_binary(name) -> %{type: "meta", dex: name}
+          _ -> %{type: "meta"}
+        end)
+
+      results =
+        [%{type: "spotMeta"} | meta_requests]
+        |> Task.async_stream(&info_request/1,
+          max_concurrency: @universe_fetch_concurrency,
+          timeout: @universe_fetch_timeout,
+          on_timeout: :kill_task
+        )
+        |> Enum.map(fn
+          {:ok, result} -> result
+          _ -> {:error, :timeout}
+        end)
+
+      if Enum.all?(results, &match?({:ok, _}, &1)) do
+        {:ok, results |> Enum.flat_map(fn {:ok, body} -> coin_names(body) end) |> MapSet.new()}
+      else
+        {:error, :incomplete_universe}
+      end
+    end
+  end
+
+  # `meta`/`spotMeta` return a JSON object; `perpDexs` returns a JSON array —
+  # accept both as success.
+  defp info_request(payload) do
+    case Req.post(@info_url, json: payload, receive_timeout: 10_000, retry: :transient) do
+      {:ok, %Req.Response{status: 200, body: body}} when is_map(body) or is_list(body) ->
+        {:ok, body}
+
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error, {:http_status, status, body}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # Coin names in a `meta`/`spotMeta` body: `universe[].name` (perp or spot) plus
+  # spot `tokens[].name`.
+  defp coin_names(body) when is_map(body) do
+    Enum.flat_map(["universe", "tokens"], fn key ->
+      case Map.get(body, key) do
+        list when is_list(list) -> for %{"name" => name} <- list, is_binary(name), do: name
+        _ -> []
+      end
+    end)
+  end
+
+  defp coin_names(_), do: []
+end

--- a/lib/sanbase/project/source_slug_mapping.ex
+++ b/lib/sanbase/project/source_slug_mapping.ex
@@ -1,17 +1,26 @@
 defmodule Sanbase.Project.SourceSlugMapping do
   use Ecto.Schema
 
+  require Logger
+
   import Ecto.Query
   import Ecto.Changeset
 
   alias Sanbase.Repo
   alias Sanbase.Project
 
+  @hyperliquid_source "hyperliquid"
+
   @table "source_slug_mappings"
 
   schema @table do
     field(:source, :string)
     field(:slug, :string)
+
+    # Transient marker set by the changeset when a hyperliquid coin could not
+    # be verified against HL's universe in time. Read by the admin
+    # `after_filter/3` to surface a warning; never persisted.
+    field(:coin_verification, :string, virtual: true)
 
     belongs_to(:project, Project)
     belongs_to(:non_crypto_asset, Sanbase.NonCryptoAsset)
@@ -22,8 +31,40 @@ defmodule Sanbase.Project.SourceSlugMapping do
     |> cast(attrs, [:source, :slug, :project_id, :non_crypto_asset_id])
     |> validate_required([:source, :slug])
     |> validate_exactly_one_asset_reference()
+    |> validate_hyperliquid_coin()
     |> check_constraint(:project_id, name: :exactly_one_asset_reference)
     |> unique_constraint(:non_crypto_asset_id, name: :one_mapping_per_source_non_crypto_asset)
+  end
+
+  # For a new/changed `hyperliquid` mapping, block the write when Hyperliquid
+  # confirms the coin does not exist, and allow-but-warn when HL can't be
+  # reached in time. Only Hyperliquid can authoritatively say a coin is bad, so
+  # this is the one place that consults it synchronously. No network call is
+  # made for other sources, empty slugs, or unrelated changesets.
+  defp validate_hyperliquid_coin(changeset) do
+    slug = get_field(changeset, :slug)
+    source = get_field(changeset, :source)
+    slug_or_source_changed? = changed?(changeset, :slug) or changed?(changeset, :source)
+
+    if changeset.valid? and slug_or_source_changed? and source == @hyperliquid_source and
+         is_binary(slug) do
+      case Sanbase.Hyperliquid.Bbo.WebsocketScraper.coin_supported?(slug) do
+        :ok ->
+          changeset
+
+        :unsupported ->
+          add_error(changeset, :slug, "\"#{slug}\" is not a coin in the Hyperliquid universe")
+
+        :unverified ->
+          Logger.warning(
+            "[SourceSlugMapping] could not verify hyperliquid coin \"#{slug}\" against the HL universe (timeout/fetch error); saving without verification"
+          )
+
+          put_change(changeset, :coin_verification, "unverified")
+      end
+    else
+      changeset
+    end
   end
 
   defp validate_exactly_one_asset_reference(changeset) do

--- a/lib/sanbase/project/source_slug_mapping.ex
+++ b/lib/sanbase/project/source_slug_mapping.ex
@@ -6,6 +6,7 @@ defmodule Sanbase.Project.SourceSlugMapping do
   import Ecto.Query
   import Ecto.Changeset
 
+  alias Sanbase.Hyperliquid.Bbo.CoinUniverse
   alias Sanbase.Repo
   alias Sanbase.Project
 
@@ -47,13 +48,13 @@ defmodule Sanbase.Project.SourceSlugMapping do
     slug_or_source_changed? = changed?(changeset, :slug) or changed?(changeset, :source)
 
     if changeset.valid? and slug_or_source_changed? and source == @hyperliquid_source and
-         is_binary(slug) do
-      case Sanbase.Hyperliquid.Bbo.WebsocketScraper.coin_supported?(slug) do
+         is_binary(slug) and CoinUniverse.verify_on_write?() do
+      case CoinUniverse.coin_supported?(slug) do
         :ok ->
           changeset
 
-        :unsupported ->
-          add_error(changeset, :slug, "\"#{slug}\" is not a coin in the Hyperliquid universe")
+        {:unsupported, suggestions} ->
+          add_error(changeset, :slug, unsupported_coin_message(slug, suggestions))
 
         :unverified ->
           Logger.warning(
@@ -65,6 +66,14 @@ defmodule Sanbase.Project.SourceSlugMapping do
     else
       changeset
     end
+  end
+
+  defp unsupported_coin_message(slug, []) do
+    "\"#{slug}\" is not a coin in the Hyperliquid universe"
+  end
+
+  defp unsupported_coin_message(slug, suggestions) do
+    unsupported_coin_message(slug, []) <> " (did you mean: #{Enum.join(suggestions, ", ")}?)"
   end
 
   defp validate_exactly_one_asset_reference(changeset) do

--- a/lib/sanbase_web/components/admin/admin_components.ex
+++ b/lib/sanbase_web/components/admin/admin_components.ex
@@ -47,7 +47,12 @@ defmodule SanbaseWeb.AdminComponents do
     ~H"""
     <div class="flex justify-end">
       <.action_btn resource={@resource} label="Back" color={:white} />
-      <.btn label={if @type == "new", do: "Create", else: "Update"} href="#" type="submit" />
+      <.btn
+        label={if @type == "new", do: "Create", else: "Update"}
+        loading_label={if @type == "new", do: "Creating…", else: "Updating…"}
+        href="#"
+        type="submit"
+      />
     </div>
     """
   end
@@ -974,6 +979,7 @@ defmodule SanbaseWeb.AdminComponents do
   attr(:href, :string, required: false, default: nil)
   attr(:label, :string, required: true)
   attr(:type, :string, required: false, default: "button")
+  attr(:loading_label, :string, required: false, default: nil)
 
   def btn(assigns) do
     if assigns.type != "submit" and is_nil(assigns.href) do
@@ -982,8 +988,22 @@ defmodule SanbaseWeb.AdminComponents do
     end
 
     ~H"""
-    <button :if={@type == "submit"} type="submit" class={btn_classes(@color, @size)}>
-      {@label}
+    <%!--
+      On submit (fires only after HTML validation passes, so it never blocks the
+      POST) show a spinner and disable the button — useful because saving can
+      block server-side while a hyperliquid coin is verified against HL.
+    --%>
+    <button
+      :if={@type == "submit"}
+      type="submit"
+      x-data="{ submitting: false }"
+      x-init="$el.form && $el.form.addEventListener('submit', () => { submitting = true })"
+      x-bind:disabled="submitting"
+      class={btn_classes(@color, @size)}
+    >
+      <span x-show="submitting" x-cloak class="loading loading-spinner loading-sm"></span>
+      <span x-show="!submitting">{@label}</span>
+      <span x-show="submitting" x-cloak>{@loading_label || @label}</span>
     </button>
     <.link :if={@type != "submit"} href={@href} class={btn_classes(@color, @size)}>
       {@label}

--- a/lib/sanbase_web/generic_admin/source_slug_mapping.ex
+++ b/lib/sanbase_web/generic_admin/source_slug_mapping.ex
@@ -35,4 +35,19 @@ defmodule SanbaseWeb.GenericAdmin.SourceSlugMapping do
       }
     }
   end
+
+  # The changeset blocks a confirmed-invalid hyperliquid coin outright (shown as
+  # a form error). When HL could not be reached to verify in time it lets the
+  # write through and marks the changeset; surface that as a warning here so the
+  # admin knows the mapping was saved without verification.
+  def after_filter(_record, %Ecto.Changeset{} = changeset, _changes) do
+    case Ecto.Changeset.get_change(changeset, :coin_verification) do
+      "unverified" ->
+        {:error,
+         "saved, but the coin could not be verified against the Hyperliquid universe (timed out). Double-check the slug."}
+
+      _ ->
+        :ok
+    end
+  end
 end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hyperliquid coin mappings can be verified against the live coin universe before saving (configurable via environment).
  * Unsupported Hyperliquid coins are blocked from being subscribed, based on periodic coin-universe audits.
  * Admin save flow now surfaces verification status, and shows clearer submit progress (“Creating…” / “Updating…”).
* **Bug Fixes**
  * Improved reconciliation logic to exclude unsupported coins and refresh audit results across reconnects.
* **Monitoring**
  * Enhanced websocket diagnostics: structured disconnect details, reconnect/backoff context, and per-connection message counters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->