### PR TITLE
Hyperliquid WS scraper - track last exported in-memory

### DIFF
--- a/lib/sanbase/hyperliquid/bbo/bbo_websocket_scraper.ex
+++ b/lib/sanbase/hyperliquid/bbo/bbo_websocket_scraper.ex
@@ -21,7 +21,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   2. **Reconcile (every 60s).** Loads `SourceSlugMapping` rows for
      `hyperliquid`, builds a `coin -> [slug, ...]` map, and diffs against
      `active_subs`. New coins get a `subscribe` frame queued; removed coins
-     get `unsubscribe` plus their `pending`/`last_emitted` entries pruned.
+     get `unsubscribe` plus their `coalesce_buffer`/`last_emitted` entries pruned.
 
   3. **Outbound pacing.** Sub/unsub frames are drained from the queue one per
      `@flush_subs_interval` (50ms) — Hyperliquid caps outbound at 2000/min.
@@ -32,9 +32,9 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
      to every slug mapped to that coin, and pushed via
      `KafkaExporter.persist_async/2`. Per coin: the first frame in a
      `coalesce_window_ms` window emits immediately; later frames in the same
-     window overwrite a `pending` slot (latest wins).
+     window overwrite a `coalesce_buffer` slot (latest wins).
 
-  5. **Coalesce flush (every 250ms).** Walks `pending` and emits any entry
+  5. **Coalesce flush (every 250ms).** Walks `coalesce_buffer` and emits any entry
      whose window has elapsed. Bounds the worst-case extra latency at the
      window boundary to one tick (~250ms).
 
@@ -45,7 +45,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
      `HealthcheckError` and the supervisor restarts it.
 
   7. **Disconnect.** `handle_disconnect/2` cancels timers, clears
-     `active_subs`/`pending_sub_queue`/`pending`/`last_emitted`/
+     `active_subs`/`pending_sub_queue`/`coalesce_buffer`/`last_emitted`/
      `healthcheck_failures`, sleeps the current backoff, then doubles it
      (capped at `@reconnect_max_ms`). Reconnect re-enters step 1.
   """
@@ -121,7 +121,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
       slug_map: %{},
       pending_sub_queue: :queue.new(),
       last_emitted: %{},
-      pending: %{},
+      coalesce_buffer: %{},
       reconnect_backoff_ms: @reconnect_initial_ms,
       last_message_time: System.system_time(:millisecond),
       healthcheck_failures: 0,
@@ -133,8 +133,26 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
       connected_at: nil,
       bbo_in: 0,
       reconnects: 0,
-      last_audit_at: 0
+      last_audit_at: 0,
+      # Diagnostics: per-coin record of the last point actually handed to the
+      # Kafka exporter — %{coin => %{point: map, exported_at_ms: ms, count: n}}.
+      # Never cleared (not on disconnect, not on unsubscribe) so it answers
+      # "has this coin ever exported, when, and how many times" via
+      # :sys.get_state/1 even after reconnects. Bounded by the mapped-coin set.
+      last_exported: %{}
     }
+  end
+
+  # Record a successful emit for diagnostics. Map.update with a default (not
+  # `%{state | ...}`) so a live process predating this key never raises.
+  defp record_exported(state, coin, data) do
+    entry = %{
+      point: data,
+      exported_at_ms: System.system_time(:millisecond),
+      count: get_in(state, [:last_exported, coin, :count]) |> Kernel.||(0) |> Kernel.+(1)
+    }
+
+    Map.update(state, :last_exported, %{coin => entry}, &Map.put(&1, coin, entry))
   end
 
   # Safe counter bump — creates the key at 1 if the running process predates it
@@ -196,7 +214,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
       |> Map.merge(%{
         active_subs: MapSet.new(),
         pending_sub_queue: :queue.new(),
-        pending: %{},
+        coalesce_buffer: %{},
         last_emitted: %{},
         healthcheck_failures: 0
       })
@@ -272,10 +290,11 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
         %{
           state
           | last_emitted: Map.put(state.last_emitted, coin, now),
-            pending: Map.delete(state.pending, coin)
+            coalesce_buffer: Map.delete(state.coalesce_buffer, coin)
         }
+        |> record_exported(coin, point_data)
       else
-        %{state | pending: Map.put(state.pending, coin, point_data)}
+        %{state | coalesce_buffer: Map.put(state.coalesce_buffer, coin, point_data)}
       end
     else
       _ -> state
@@ -393,21 +412,31 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     now = System.system_time(:millisecond)
     window = state.coalesce_window_ms
 
-    {to_emit, still_pending} =
-      Enum.split_with(state.pending, fn {coin, _} ->
+    # Reconcile prunes the buffer only for coins that were in active_subs, so a
+    # coin buffered before its sub was confirmed can outlive its slug_map entry.
+    # Drop such coins instead of crashing on the emit lookup below.
+    buffer =
+      Enum.filter(state.coalesce_buffer, fn {coin, _} ->
+        Map.has_key?(state.slug_map, coin)
+      end)
+
+    {to_emit, still_buffered} =
+      Enum.split_with(buffer, fn {coin, _} ->
         last = Map.get(state.last_emitted, coin)
         is_nil(last) or now - last >= window
       end)
 
-    Enum.each(to_emit, fn {coin, data} ->
-      emit(Map.fetch!(state.slug_map, coin), data)
-    end)
+    state =
+      Enum.reduce(to_emit, state, fn {coin, data}, acc ->
+        emit(Map.fetch!(acc.slug_map, coin), data)
+        record_exported(acc, coin, data)
+      end)
 
     new_last_emitted =
       Enum.reduce(to_emit, state.last_emitted, fn {coin, _}, acc -> Map.put(acc, coin, now) end)
 
     state =
-      %{state | pending: Map.new(still_pending), last_emitted: new_last_emitted}
+      %{state | coalesce_buffer: Map.new(still_buffered), last_emitted: new_last_emitted}
       |> schedule(:flush_coalesced, @flush_coalesced_interval)
 
     {:ok, state}
@@ -458,7 +487,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
       | slug_map: slug_map,
         pending_sub_queue: new_queue,
         last_emitted: Map.drop(state.last_emitted, dropped),
-        pending: Map.drop(state.pending, dropped)
+        coalesce_buffer: Map.drop(state.coalesce_buffer, dropped)
     }
     |> maybe_schedule_flush_subs()
     # Audit the FULL mapped set (not the reduced one) so a previously

--- a/test/sanbase/hyperliquid/bbo/bbo_websocket_scraper_test.exs
+++ b/test/sanbase/hyperliquid/bbo/bbo_websocket_scraper_test.exs
@@ -31,7 +31,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
       slug_map: %{},
       pending_sub_queue: :queue.new(),
       last_emitted: %{},
-      pending: %{},
+      coalesce_buffer: %{},
       reconnect_backoff_ms: 1000,
       last_message_time: System.system_time(:millisecond),
       healthcheck_failures: 0,
@@ -127,7 +127,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
 
       assert drain_topic() == []
       assert new_state.last_emitted == %{}
-      assert new_state.pending == %{}
+      assert new_state.coalesce_buffer == %{}
     end
 
     test "multi-slug fanout: one coin -> N slugs emits N Kafka rows" do
@@ -159,7 +159,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
 
       assert length(drain_topic()) == 1
       assert Map.has_key?(new_state.last_emitted, "BTC")
-      assert new_state.pending == %{}
+      assert new_state.coalesce_buffer == %{}
     end
 
     test "burst within window: 1 immediate emit + buffered latest" do
@@ -203,8 +203,8 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
       Sanbase.InMemoryKafka.Producer.clear_state()
 
       # Last buffered frame retained
-      assert state.pending["BTC"].bid_price == 62008.0
-      assert state.pending["BTC"].ask_price == 62009.0
+      assert state.coalesce_buffer["BTC"].bid_price == 62008.0
+      assert state.coalesce_buffer["BTC"].ask_price == 62009.0
 
       # Force the window to have elapsed by backdating last_emitted
       now = System.system_time(:millisecond)
@@ -217,7 +217,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
       assert decoded["bid_price"] == 62008.0
       assert decoded["ask_price"] == 62009.0
       assert decoded["timestamp_ms"] == 1_700_000_000_400
-      assert state.pending == %{}
+      assert state.coalesce_buffer == %{}
     end
 
     test "timestamp_ms equals frame data.time for both immediate and buffer-flushed emits" do
@@ -249,6 +249,37 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
       assert Jason.decode!(json)["timestamp_ms"] == 1_700_000_000_500
     end
 
+    test "flush drops buffered coin whose slug mapping was removed" do
+      state = build_state(slug_map: %{"BTC" => ["bitcoin"]}, coalesce_window_ms: 1000)
+
+      # First frame emits, second lands in the buffer
+      {:ok, state} =
+        WebsocketScraper.handle_frame(
+          bbo_frame("BTC", 1_700_000_000_000, side(62000, 1.0), side(62001, 1.0)),
+          state
+        )
+
+      {:ok, state} =
+        WebsocketScraper.handle_frame(
+          bbo_frame("BTC", 1_700_000_000_100, side(62002, 1.0), side(62003, 1.0)),
+          state
+        )
+
+      assert Map.has_key?(state.coalesce_buffer, "BTC")
+      assert length(drain_topic()) == 1
+      Sanbase.InMemoryKafka.Producer.clear_state()
+
+      # Mapping removed (e.g. reconcile with the coin never in active_subs),
+      # window elapsed — flush must drop the entry instead of raising
+      now = System.system_time(:millisecond)
+      state = %{state | slug_map: %{}, last_emitted: %{"BTC" => now - 2_000}}
+
+      {:ok, state} = WebsocketScraper.handle_info(:flush_coalesced, state)
+
+      assert drain_topic() == []
+      assert state.coalesce_buffer == %{}
+    end
+
     test "frame after window emits immediately" do
       slug_map = %{"BTC" => ["bitcoin"]}
       state = build_state(slug_map: slug_map, coalesce_window_ms: 1000)
@@ -264,7 +295,73 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
 
       assert length(drain_topic()) == 1
       assert new_state.last_emitted["BTC"] >= now
-      assert new_state.pending == %{}
+      assert new_state.coalesce_buffer == %{}
+    end
+  end
+
+  describe "last_exported diagnostics" do
+    test "immediate emit records point, export timestamp and count" do
+      state = build_state(slug_map: %{"xyz:GOLD" => ["gold"]})
+
+      {:ok, state} =
+        WebsocketScraper.handle_frame(
+          bbo_frame("xyz:GOLD", 1_700_000_000_000, side(4087.4, 2.8), side(4087.5, 0.01)),
+          state
+        )
+
+      assert %{point: point, exported_at_ms: at, count: 1} = state.last_exported["xyz:GOLD"]
+      assert point.coin == "xyz:GOLD"
+      assert point.timestamp_ms == 1_700_000_000_000
+      assert point.bid_price == 4087.4
+      assert is_integer(at)
+
+      # The recorded point is the one that reached Kafka
+      assert [{_key, json}] = drain_topic()
+      assert Jason.decode!(json)["timestamp_ms"] == 1_700_000_000_000
+    end
+
+    test "buffer flush records the flushed point and increments count" do
+      state = build_state(slug_map: %{"xyz:GOLD" => ["gold"]})
+
+      {:ok, state} =
+        WebsocketScraper.handle_frame(
+          bbo_frame("xyz:GOLD", 1_700_000_000_000, side(4087.4, 1.0), side(4087.5, 1.0)),
+          state
+        )
+
+      # Within the window: buffered, not exported yet
+      {:ok, state} =
+        WebsocketScraper.handle_frame(
+          bbo_frame("xyz:GOLD", 1_700_000_000_100, side(4088.0, 1.0), side(4088.1, 1.0)),
+          state
+        )
+
+      assert state.last_exported["xyz:GOLD"].count == 1
+
+      now = System.system_time(:millisecond)
+      state = put_in(state.last_emitted["xyz:GOLD"], now - 2_000)
+
+      {:ok, state} = WebsocketScraper.handle_info(:flush_coalesced, state)
+
+      assert %{point: point, count: 2} = state.last_exported["xyz:GOLD"]
+      assert point.timestamp_ms == 1_700_000_000_100
+      assert point.bid_price == 4088.0
+      assert state.coalesce_buffer == %{}
+    end
+
+    test "live state predating the last_exported key does not raise" do
+      # Simulates a hot-recompiled process whose state lacks :last_exported
+      state =
+        build_state(slug_map: %{"BTC" => ["bitcoin"]})
+        |> Map.delete(:last_exported)
+
+      {:ok, state} =
+        WebsocketScraper.handle_frame(
+          bbo_frame("BTC", 1_700_000_000_000, side(62000, 1.0), side(62001, 1.0)),
+          state
+        )
+
+      assert state.last_exported["BTC"].count == 1
     end
   end
 
@@ -348,7 +445,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
       assert methods_by_coin == %{"ETH" => "subscribe", "OLD" => "unsubscribe"}
     end
 
-    test "unsubscribed coin's pending and last_emitted entries are pruned" do
+    test "unsubscribed coin's coalesce_buffer and last_emitted entries are pruned" do
       btc = insert(:project, %{name: "Bitcoin", slug: "bitcoin"})
 
       Sanbase.Project.SourceSlugMapping.create(%{
@@ -361,7 +458,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
         build_state(
           active_subs: MapSet.new(["BTC", "DROPME"]),
           last_emitted: %{"BTC" => 100, "DROPME" => 200},
-          pending: %{
+          coalesce_buffer: %{
             "BTC" => %{coin: "BTC"},
             "DROPME" => %{coin: "DROPME"}
           }
@@ -370,9 +467,9 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
       {:ok, state} = WebsocketScraper.handle_info(:reconcile_subscriptions, state)
 
       refute Map.has_key?(state.last_emitted, "DROPME")
-      refute Map.has_key?(state.pending, "DROPME")
+      refute Map.has_key?(state.coalesce_buffer, "DROPME")
       assert Map.has_key?(state.last_emitted, "BTC")
-      assert Map.has_key?(state.pending, "BTC")
+      assert Map.has_key?(state.coalesce_buffer, "BTC")
     end
   end
 
@@ -497,7 +594,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
         build_state(
           active_subs: MapSet.new(["BTC", "ETH"]),
           pending_sub_queue: :queue.in({:text, "x"}, :queue.new()),
-          pending: %{"BTC" => %{coin: "BTC"}},
+          coalesce_buffer: %{"BTC" => %{coin: "BTC"}},
           last_emitted: %{"BTC" => 1},
           healthcheck_failures: 4,
           reconnect_backoff_ms: 1
@@ -508,7 +605,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
 
       assert new_state.active_subs == MapSet.new()
       assert :queue.is_empty(new_state.pending_sub_queue)
-      assert new_state.pending == %{}
+      assert new_state.coalesce_buffer == %{}
       assert new_state.last_emitted == %{}
       assert new_state.healthcheck_failures == 0
       assert new_state.reconnect_backoff_ms == 2


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time BBO update coalescing to ensure the latest updates are emitted reliably.
  * Prevented stale data from persisting after subscription changes or websocket reconnects.
  * Added clearer export tracking and diagnostics to support more consistent market-data delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->