### PR TITLE
Metric Registry drift check

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -330,7 +330,7 @@ config :ex_audit,
 
 config :sanbase, Sanbase.Metric.Registry.Sync,
   sync_secret: "secret_only_on_prod",
-  export_secret: "export_secret_only_on_prod"
+  export_secret: System.get_env("METRIC_REGISTRY_EXPORT_SECRET") || "export_secret_only_on_prod"
 
 # Import configs
 import_config "ueberauth_config.exs"

--- a/lib/sanbase/metric/registry/drift.ex
+++ b/lib/sanbase/metric/registry/drift.ex
@@ -1,0 +1,231 @@
+defmodule Sanbase.Metric.Registry.Drift do
+  @moduledoc """
+  Detect drift between the metric registry on stage and on prod.
+
+  The regular sync only pushes explicitly selected records from stage to prod,
+  so it cannot detect changes introduced outside of it:
+  - manual DB interventions on either environment;
+  - deletions on stage, which are never propagated to prod;
+  - renames on stage (changes to metric/data_type/fixed_parameters), which are
+    applied on prod as an INSERT of a new record, leaving the record with the
+    old name orphaned on prod.
+
+  This module fetches the full metric registry export from prod and compares
+  it against the local (stage) registry, keyed by (metric, data_type,
+  fixed_parameters). Only fields that are subject to syncing are compared
+  (the fields included in the Registry Jason.Encoder), so env-local fields
+  like id, is_verified, sync_status and last_sync_datetime do not produce
+  false positives.
+
+  The check is strictly read-only and side-effect free: it performs only
+  SELECTs on the local database and a GET request for the prod export. It
+  writes nothing, emits no events and can be run any number of times. The
+  only environment restriction is that it cannot run on prod itself, where
+  it would compare prod against its own export.
+  """
+
+  alias Sanbase.Metric.Registry
+  alias Sanbase.Utils.Config
+
+  @receive_timeout 60_000
+  @env_local_fields ["id", "is_verified", "sync_status", "last_sync_datetime"]
+
+  @type key :: %{metric: String.t(), data_type: String.t(), fixed_parameters: map()}
+
+  @type result :: %{
+          checked_at: DateTime.t(),
+          local_count: non_neg_integer(),
+          remote_count: non_neg_integer(),
+          identical_count: non_neg_integer(),
+          missing_on_prod: [map()],
+          extra_on_prod: [map()],
+          changed: [map()]
+        }
+
+  @doc ~s"""
+  Compare the local (stage) metric registry with the prod one.
+
+  Returns a map with three lists of drift entries:
+  - missing_on_prod -- records that exist locally but not on prod. Expected
+    (pending_sync?: true) if the record is not yet synced, alarming otherwise;
+  - extra_on_prod -- records that exist only on prod. The sync never deletes,
+    so these are orphans left by renames/deletions on stage or records
+    manually created on prod;
+  - changed -- records that exist on both sides but differ in their synced
+    fields. Expected (pending_sync?: true) if the record has local changes
+    that are not yet synced, alarming otherwise.
+  """
+  @spec compute() :: {:ok, result()} | {:error, String.t()}
+  def compute() do
+    with {:ok, url} <- get_export_url(),
+         {:ok, remote_entries} <- fetch_remote_entries(url) do
+      {:ok, compare(local_entries(), remote_entries)}
+    end
+  end
+
+  # Private functions
+
+  defp compare(local_entries, remote_entries) do
+    local_by_key = Map.new(local_entries, &{&1.key, &1})
+    remote_by_key = Map.new(remote_entries, &{&1.key, &1})
+
+    local_keys = local_by_key |> Map.keys() |> MapSet.new()
+    remote_keys = remote_by_key |> Map.keys() |> MapSet.new()
+
+    missing_on_prod =
+      MapSet.difference(local_keys, remote_keys)
+      |> Enum.map(fn key ->
+        local = local_by_key[key]
+
+        %{
+          key: key,
+          id: local.id,
+          sync_status: local.sync_status,
+          pending_sync?: local.sync_status == "not_synced"
+        }
+      end)
+      |> Enum.sort_by(& &1.key.metric)
+
+    extra_on_prod =
+      MapSet.difference(remote_keys, local_keys)
+      |> Enum.map(fn key -> %{key: key} end)
+      |> Enum.sort_by(& &1.key.metric)
+
+    changed =
+      MapSet.intersection(local_keys, remote_keys)
+      |> Enum.reduce([], fn key, acc ->
+        local = local_by_key[key]
+        remote = remote_by_key[key]
+
+        # Diff with prod as the old state and stage as the new state, so the
+        # patch reads as "what needs to change on prod to match stage"
+        case ExAudit.Diff.diff(remote.content, local.content) do
+          :not_changed ->
+            acc
+
+          diff when is_map(diff) ->
+            entry = %{
+              key: key,
+              id: local.id,
+              sync_status: local.sync_status,
+              pending_sync?: local.sync_status == "not_synced",
+              diff: diff
+            }
+
+            [entry | acc]
+        end
+      end)
+      |> Enum.sort_by(& &1.key.metric)
+
+    %{
+      checked_at: DateTime.utc_now() |> DateTime.truncate(:second),
+      local_count: length(local_entries),
+      remote_count: length(remote_entries),
+      identical_count:
+        MapSet.intersection(local_keys, remote_keys) |> MapSet.size() |> Kernel.-(length(changed)),
+      missing_on_prod: missing_on_prod,
+      extra_on_prod: extra_on_prod,
+      changed: changed
+    }
+  end
+
+  defp local_entries() do
+    Registry.all()
+    |> Enum.map(fn %Registry{} = registry ->
+      # Encoding and decoding the struct produces a map with only the fields
+      # that are subject to syncing (see the Jason.Encoder derive in Registry)
+      content = registry |> Jason.encode!() |> Jason.decode!()
+
+      %{
+        key: content_key(content),
+        id: registry.id,
+        sync_status: registry.sync_status,
+        content: content
+      }
+    end)
+  end
+
+  defp fetch_remote_entries(url) do
+    case Req.get(url, receive_timeout: @receive_timeout) do
+      {:ok, %Req.Response{status: 200, body: body}} when is_binary(body) ->
+        parse_ndjson_export(body)
+
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error,
+         "Failed to fetch the prod metric registry export. Status code: #{status}. Body: #{inspect(body)}"}
+
+      {:error, reason} ->
+        {:error, "Failed to fetch the prod metric registry export. Error: #{inspect(reason)}"}
+    end
+  end
+
+  defp parse_ndjson_export(body) do
+    entries =
+      body
+      |> String.split("\n", trim: true)
+      |> Enum.map(&Jason.decode!/1)
+      |> Enum.map(fn map ->
+        content = map |> Map.drop(@env_local_fields) |> normalize_content()
+        %{key: content_key(content), content: content}
+      end)
+
+    {:ok, entries}
+  rescue
+    e ->
+      {:error, "Failed to decode the prod metric registry export. Error: #{Exception.message(e)}"}
+  end
+
+  defp normalize_content(content) when is_map(content) do
+    Map.new(content, fn {key, value} -> {key, normalize_value(value)} end)
+  end
+
+  # Older versions of the export endpoint exploded DateTime structs into maps
+  # instead of encoding them as ISO8601 strings. Convert them back to ISO8601
+  # so they don't produce false positives until prod serves the fixed export.
+  defp normalize_value(%{
+         "calendar" => "Elixir.Calendar.ISO",
+         "year" => year,
+         "month" => month,
+         "day" => day,
+         "hour" => hour,
+         "minute" => minute,
+         "second" => second
+       }) do
+    DateTime.new!(Date.new!(year, month, day), Time.new!(hour, minute, second), "Etc/UTC")
+    |> DateTime.to_iso8601()
+  end
+
+  defp normalize_value(value), do: value
+
+  defp content_key(content) when is_map(content) do
+    %{
+      metric: Map.fetch!(content, "metric"),
+      data_type: Map.fetch!(content, "data_type"),
+      fixed_parameters: Map.fetch!(content, "fixed_parameters")
+    }
+  end
+
+  # The drift check is read-only, so unlike the sync it does not need any
+  # environment write-safety guards. The only restriction is that it cannot
+  # run on prod itself -- there it would compare prod against its own export.
+  # The export secret is expected to have the same value on stage and prod,
+  # the same way the sync secret does.
+  defp get_export_url() do
+    secret = Config.module_get(Sanbase.Metric.Registry.Sync, :export_secret)
+    deployment_env = Config.module_get(Sanbase, :deployment_env)
+    port = Config.module_get(SanbaseWeb.Endpoint, [:http, :port])
+
+    case deployment_env do
+      "prod" ->
+        {:error,
+         "The drift check compares the local registry against the prod one, " <>
+           "so it cannot be run on prod itself"}
+
+      "stage" ->
+        {:ok, "https://api.santiment.net/metric_registry_export?secret=#{secret}"}
+
+      env when env in ["dev", "test"] ->
+        {:ok, "http://localhost:#{port}/metric_registry_export?secret=#{secret}"}
+    end
+  end
+end

--- a/lib/sanbase/metric/registry/permissions.ex
+++ b/lib/sanbase/metric/registry/permissions.ex
@@ -66,6 +66,12 @@ defmodule Sanbase.Metric.Registry.Permissions do
     true
   end
 
+  def check_permission(:run_sync_drift_check, _) do
+    # The drift check fetches the prod registry export and compares it
+    # against the local one, so it can be run only from stage or dev
+    stage_or_dev?()
+  end
+
   # Helpers
 
   defp stage_or_dev?() do

--- a/lib/sanbase_web/controllers/metric_registry_controller.ex
+++ b/lib/sanbase_web/controllers/metric_registry_controller.ex
@@ -101,6 +101,12 @@ defmodule SanbaseWeb.MetricRegistryController do
     |> Enum.intersperse("\n")
   end
 
+  # Do not explode calendar structs into maps -- Jason encodes them
+  # as ISO8601 strings, the same way they are encoded in the sync content
+  defp transform(%DateTime{} = data), do: data
+  defp transform(%NaiveDateTime{} = data), do: data
+  defp transform(%Date{} = data), do: data
+
   defp transform(struct) when is_struct(struct) do
     struct
     |> Map.from_struct()

--- a/lib/sanbase_web/live/admin_authenticate_live.ex
+++ b/lib/sanbase_web/live/admin_authenticate_live.ex
@@ -116,8 +116,13 @@ defmodule SanbaseWeb.AdminAuthenticateLive do
   end
 
   defp login(email) do
-    if @compile_env in [:dev, :test] and
-         Sanbase.Utils.Config.module_get(Sanbase, :deployment_env) == "dev" do
+    # The compile-time env alone decides. Deployed envs run releases compiled
+    # with MIX_ENV=prod, so they always use the email flow. Locally compiled
+    # code always uses direct login -- checking the runtime deployment_env
+    # here would only break local login when DEPLOYMENT_ENVIRONMENT is set to
+    # a non-dev value (e.g. when testing stage-only features), because the
+    # email flow can never work from localhost anyway.
+    if @compile_env in [:dev, :test] do
       direct_login(email)
     else
       send_email_login(email)

--- a/lib/sanbase_web/live/metric_registry/metric_registry_sync_drift_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_sync_drift_live.ex
@@ -1,0 +1,181 @@
+defmodule SanbaseWeb.MetricRegistrySyncDriftLive do
+  use SanbaseWeb, :live_view
+
+  alias SanbaseWeb.AdminSharedComponents
+  alias Sanbase.Metric.Registry.Drift
+  alias Sanbase.Metric.Registry.Permissions
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(
+       page_title: "Metric Registry | Sync Drift",
+       result: nil,
+       error: nil,
+       running?: false
+     )}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="flex flex-col">
+      <AdminSharedComponents.page_header
+        title="Metric Registry Sync Drift"
+        current_user={@current_user}
+        current_user_role_names={@current_user_role_names}
+        trim_role_prefix="Metric Registry "
+      />
+      <div class="text-base-content/50 text-sm py-2 max-w-3xl">
+        Compare the full local (stage) metric registry against the prod one and report
+        the differences. This detects drift that the sync itself cannot see: manual DB
+        interventions, deletions (which are never synced) and renames (which leave an
+        orphaned record with the old name on prod). Records are matched by
+        (metric, data_type, fixed_parameters) and only synced fields are compared.
+      </div>
+      <div class="my-4">
+        <AdminSharedComponents.nav_button
+          text="Back to Metric Registry"
+          href={~p"/admin/metric_registry"}
+          icon="hero-home"
+        />
+
+        <AdminSharedComponents.nav_button
+          text="Sync Metrics"
+          href={~p"/admin/metric_registry/sync"}
+          icon="hero-arrows-right-left"
+        />
+
+        <AdminSharedComponents.nav_button
+          text="List Sync Runs"
+          href={~p"/admin/metric_registry/sync_runs"}
+          icon="hero-list-bullet"
+        />
+      </div>
+
+      <AdminSharedComponents.action_button
+        :if={Permissions.can?(:run_sync_drift_check, roles: @current_user_role_names)}
+        text={if @running?, do: "Running...", else: "Run Drift Check"}
+        phx_click="run_drift_check"
+        class="min-w-42 btn-primary"
+        phx_disable_with="Running..."
+      />
+
+      <div :if={@error} class="my-4 text-error font-bold">
+        {@error}
+      </div>
+
+      <.drift_result :if={@result} result={@result} />
+    </div>
+    """
+  end
+
+  defp drift_result(assigns) do
+    ~H"""
+    <div class="flex flex-col my-4 space-y-8">
+      <div class="text-sm text-base-content/70">
+        Checked at {@result.checked_at}. Local records: {@result.local_count},
+        prod records: {@result.remote_count}, identical: {@result.identical_count}.
+      </div>
+
+      <div :if={no_drift?(@result)} class="text-primary font-bold text-xl">
+        No drift detected. Stage and prod registries are in sync.
+      </div>
+
+      <div :if={@result.extra_on_prod != []}>
+        <span class="text-error font-bold text-xl">
+          Records existing only on PROD ({length(@result.extra_on_prod)})
+        </span>
+        <div class="text-sm text-base-content/50 max-w-3xl">
+          The sync never deletes records, so these are either orphans left after a
+          rename/deletion on stage, or records manually created on prod. They can
+          only be cleaned up manually.
+        </div>
+        <.table id="extra_on_prod" rows={@result.extra_on_prod}>
+          <:col :let={row} label="Metric">{row.key.metric}</:col>
+          <:col :let={row} label="Data Type">{row.key.data_type}</:col>
+          <:col :let={row} label="Fixed Parameters">{inspect(row.key.fixed_parameters)}</:col>
+        </.table>
+      </div>
+
+      <div :if={@result.missing_on_prod != []}>
+        <span class="text-warning font-bold text-xl">
+          Records missing on PROD ({length(@result.missing_on_prod)})
+        </span>
+        <div class="text-sm text-base-content/50 max-w-3xl">
+          Records marked as "pending sync" are new/renamed records that are expected to
+          appear on prod after the next sync. Records without it claim to be synced,
+          so they indicate a manual intervention (e.g. deleted on prod).
+        </div>
+        <.table id="missing_on_prod" rows={@result.missing_on_prod}>
+          <:col :let={row} label="ID">{row.id}</:col>
+          <:col :let={row} label="Metric">{row.key.metric}</:col>
+          <:col :let={row} label="Data Type">{row.key.data_type}</:col>
+          <:col :let={row} label="Fixed Parameters">{inspect(row.key.fixed_parameters)}</:col>
+          <:col :let={row} label="Status">
+            <.drift_status_badge pending_sync?={row.pending_sync?} />
+          </:col>
+        </.table>
+      </div>
+
+      <div :if={@result.changed != []}>
+        <span class="text-warning font-bold text-xl">
+          Records with different content ({length(@result.changed)})
+        </span>
+        <div class="text-sm text-base-content/50 max-w-3xl">
+          The diff shows what needs to change on prod so it matches stage. Records
+          marked as "pending sync" have local changes awaiting sync. Records without
+          it claim to be synced, so they indicate a manual intervention on either side.
+        </div>
+        <.table id="changed" rows={@result.changed}>
+          <:col :let={row} label="ID">{row.id}</:col>
+          <:col :let={row} label="Metric">{row.key.metric}</:col>
+          <:col :let={row} label="Status">
+            <.drift_status_badge pending_sync?={row.pending_sync?} />
+          </:col>
+          <:col :let={row} label="Diff (prod -> stage)">
+            {Sanbase.ExAudit.Patch.format_patch(%{patch: row.diff})}
+          </:col>
+        </.table>
+      </div>
+    </div>
+    """
+  end
+
+  defp drift_status_badge(assigns) do
+    ~H"""
+    <span :if={@pending_sync?} class="badge badge-warning">pending sync</span>
+    <span :if={!@pending_sync?} class="badge badge-error">manual drift</span>
+    """
+  end
+
+  @impl true
+  def handle_event("run_drift_check", _params, socket) do
+    Permissions.raise_if_cannot(:run_sync_drift_check,
+      roles: socket.assigns.current_user_role_names
+    )
+
+    {:noreply,
+     socket
+     |> assign(running?: true, error: nil)
+     |> start_async(:drift_check, fn -> Drift.compute() end)}
+  end
+
+  @impl true
+  def handle_async(:drift_check, {:ok, {:ok, result}}, socket) do
+    {:noreply, assign(socket, result: result, running?: false)}
+  end
+
+  def handle_async(:drift_check, {:ok, {:error, error}}, socket) do
+    {:noreply, assign(socket, error: error, running?: false)}
+  end
+
+  def handle_async(:drift_check, {:exit, reason}, socket) do
+    {:noreply, assign(socket, error: "Drift check crashed: #{inspect(reason)}", running?: false)}
+  end
+
+  defp no_drift?(result) do
+    result.missing_on_prod == [] and result.extra_on_prod == [] and result.changed == []
+  end
+end

--- a/lib/sanbase_web/live/metric_registry/metric_registry_sync_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_sync_live.ex
@@ -55,6 +55,12 @@ defmodule SanbaseWeb.MetricRegistrySyncLive do
           href={~p"/admin/metric_registry/sync_runs"}
           icon="hero-list-bullet"
         />
+
+        <AdminSharedComponents.nav_button
+          text="Check Sync Drift"
+          href={~p"/admin/metric_registry/sync_drift"}
+          icon="hero-scale"
+        />
       </div>
 
       <div class="flex items-center mb-4">

--- a/lib/sanbase_web/live/metric_registry/metric_registry_sync_runs_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_sync_runs_live.ex
@@ -40,6 +40,12 @@ defmodule SanbaseWeb.MetricRegistrySyncRunsLive do
           href={~p"/admin/metric_registry/sync"}
           icon="hero-arrow-uturn-left"
         />
+
+        <AdminSharedComponents.nav_button
+          text="Check Sync Drift"
+          href={~p"/admin/metric_registry/sync_drift"}
+          icon="hero-scale"
+        />
       </div>
       <.table id="metrics_registry_sync_runs" rows={@syncs}>
         <:col :let={row} label="Run Type">

--- a/lib/sanbase_web/plug/admin_email_auth.ex
+++ b/lib/sanbase_web/plug/admin_email_auth.ex
@@ -35,9 +35,14 @@ defmodule SanbaseWeb.Plug.AdminEmailAuthPlug do
     end
   end
 
+  # The compile-time env alone decides, same as the login gate in
+  # SanbaseWeb.AdminAuthenticateLive. Deployed envs run releases compiled with
+  # MIX_ENV=prod, so the token flow is always enforced there. Checking the
+  # runtime deployment_env here would only break local login when
+  # DEPLOYMENT_ENVIRONMENT is set to a non-dev value (e.g. when testing
+  # stage-only features locally).
   defp passwordless_dev_login_allowed?() do
-    @compile_env in [:dev, :test] and
-      Sanbase.Utils.Config.module_get(Sanbase, :deployment_env) == "dev"
+    @compile_env in [:dev, :test]
   end
 
   defp check_and_login(conn, email, token) do

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -155,6 +155,7 @@ defmodule SanbaseWeb.Router do
         live("/new", MetricRegistryFormLive, :new)
         live("/sync", MetricRegistrySyncLive, :new)
         live("/sync_runs", MetricRegistrySyncRunsLive, :new)
+        live("/sync_drift", MetricRegistrySyncDriftLive)
         live("/sync/:sync_type/:uuid", MetricRegistrySyncRunDetailsLive, :new)
         live("/display_order", MetricDisplayOrderLive)
         live("/display_order/show/:metric_id", MetricDisplayOrderShowLive)

--- a/test/sanbase/metric_registry/metric_registry_drift_test.exs
+++ b/test/sanbase/metric_registry/metric_registry_drift_test.exs
@@ -1,0 +1,191 @@
+defmodule Sanbase.MetricRegistryDriftTest do
+  use SanbaseWeb.ConnCase
+
+  alias Sanbase.Metric.Registry
+  alias Sanbase.Metric.Registry.Drift
+
+  @moduletag capture_log: true
+
+  test "no drift when the prod export matches the local registry", %{conn: conn} do
+    body = get_export_body(conn)
+
+    mock_remote_export(body, fn ->
+      assert {:ok, result} = Drift.compute()
+
+      assert result.missing_on_prod == []
+      assert result.extra_on_prod == []
+      assert result.changed == []
+      assert result.local_count == result.remote_count
+      assert result.identical_count == result.local_count
+      assert result.local_count > 0
+    end)
+  end
+
+  test "detects missing, extra and changed records", %{conn: conn} do
+    # Mark one local record as not_synced so its drift is reported as pending sync
+    {:ok, m} = Registry.by_name("mvrv_usd")
+
+    {:ok, _} =
+      Registry.changeset(m, %{sync_status: "not_synced"})
+      |> Sanbase.Repo.update()
+
+    remote_records =
+      get_export_body(conn)
+      |> String.split("\n", trim: true)
+      |> Enum.map(&Jason.decode!/1)
+
+    # Simulate drift in the remote (prod) registry:
+    # - price_usd_5m has a different min_interval on prod (manual intervention)
+    # - mvrv_usd is missing on prod (not synced yet locally => pending sync)
+    # - social_volume_total is missing on prod (but marked synced locally => manual)
+    # - a fabricated metric exists only on prod (orphan after rename/delete on stage)
+    fake_record =
+      remote_records
+      |> Enum.find(&(&1["metric"] == "price_usd_5m"))
+      |> Map.put("metric", "metric_existing_only_on_prod")
+
+    tampered_records =
+      remote_records
+      |> Enum.reject(&(&1["metric"] in ["mvrv_usd", "social_volume_total"]))
+      |> Enum.map(fn
+        %{"metric" => "price_usd_5m"} = map -> Map.put(map, "min_interval", "123d")
+        map -> map
+      end)
+      |> Kernel.++([fake_record])
+
+    tampered_body = Enum.map_join(tampered_records, "\n", &Jason.encode!/1)
+
+    mock_remote_export(tampered_body, fn ->
+      assert {:ok, result} = Drift.compute()
+
+      # Missing on prod
+      assert [missing1, missing2] = Enum.sort_by(result.missing_on_prod, & &1.key.metric)
+      assert missing1.key.metric == "mvrv_usd"
+      assert missing1.pending_sync? == true
+      assert missing2.key.metric == "social_volume_total"
+      assert missing2.pending_sync? == false
+
+      # Extra on prod
+      assert [extra] = result.extra_on_prod
+      assert extra.key.metric == "metric_existing_only_on_prod"
+
+      # Changed
+      assert [changed] = result.changed
+      assert changed.key.metric == "price_usd_5m"
+      assert changed.pending_sync? == false
+
+      # The diff direction is prod (old) -> stage (new)
+      assert %{"min_interval" => {:changed, {:primitive_change, "123d", local_min_interval}}} =
+               changed.diff
+
+      assert local_min_interval != "123d"
+    end)
+  end
+
+  test "env-local fields do not produce false positives", %{conn: conn} do
+    remote_records =
+      get_export_body(conn)
+      |> String.split("\n", trim: true)
+      |> Enum.map(&Jason.decode!/1)
+
+    # Tamper only with fields that are not subject to syncing
+    tampered_body =
+      remote_records
+      |> Enum.map(fn map ->
+        map
+        |> Map.put("id", map["id"] + 1000)
+        |> Map.put("is_verified", not map["is_verified"])
+        |> Map.put("sync_status", "not_synced")
+      end)
+      |> Enum.map_join("\n", &Jason.encode!/1)
+
+    mock_remote_export(tampered_body, fn ->
+      assert {:ok, result} = Drift.compute()
+
+      assert result.missing_on_prod == []
+      assert result.extra_on_prod == []
+      assert result.changed == []
+    end)
+  end
+
+  test "legacy export format with exploded DateTime maps does not produce false positives",
+       %{conn: conn} do
+    record_with_deprecation = Registry.all() |> Enum.find(& &1.hard_deprecate_after)
+    assert record_with_deprecation, "test requires a seeded record with hard_deprecate_after"
+
+    dt = record_with_deprecation.hard_deprecate_after
+    {microsecond, precision} = dt.microsecond
+
+    exploded_datetime = %{
+      "calendar" => "Elixir.Calendar.ISO",
+      "year" => dt.year,
+      "month" => dt.month,
+      "day" => dt.day,
+      "hour" => dt.hour,
+      "minute" => dt.minute,
+      "second" => dt.second,
+      "microsecond" => [microsecond, precision],
+      "std_offset" => 0,
+      "utc_offset" => 0,
+      "time_zone" => "Etc/UTC",
+      "zone_abbrev" => "UTC"
+    }
+
+    tampered_body =
+      get_export_body(conn)
+      |> String.split("\n", trim: true)
+      |> Enum.map(&Jason.decode!/1)
+      |> Enum.map(fn
+        %{"metric" => metric} = map when metric == record_with_deprecation.metric ->
+          Map.put(map, "hard_deprecate_after", exploded_datetime)
+
+        map ->
+          map
+      end)
+      |> Enum.map_join("\n", &Jason.encode!/1)
+
+    mock_remote_export(tampered_body, fn ->
+      assert {:ok, result} = Drift.compute()
+
+      assert result.missing_on_prod == []
+      assert result.extra_on_prod == []
+      assert result.changed == []
+    end)
+  end
+
+  test "refuses to run on prod, where it would compare prod against itself" do
+    Sanbase.Mock.prepare_mock(Sanbase.Utils.Config, :module_get, fn
+      Sanbase, :deployment_env -> "prod"
+      module, key -> :meck.passthrough([module, key])
+    end)
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      assert {:error, error} = Drift.compute()
+      assert error =~ "cannot be run on prod itself"
+    end)
+  end
+
+  test "error when the export cannot be fetched" do
+    Sanbase.Mock.prepare_mock2(&Req.get/2, {:ok, %Req.Response{status: 500, body: "error"}})
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      assert {:error, error} = Drift.compute()
+      assert error =~ "Status code: 500"
+    end)
+  end
+
+  # Helpers
+
+  defp get_export_body(conn) do
+    # Use the real export endpoint so the test verifies that the drift check
+    # is compatible with the actual export format served by prod
+    secret = Sanbase.Utils.Config.module_get(Sanbase.Metric.Registry.Sync, :export_secret)
+
+    conn
+    |> get("/metric_registry_export?secret=#{secret}")
+    |> response(200)
+  end
+
+  defp mock_remote_export(body, fun) do
+    Sanbase.Mock.prepare_mock2(&Req.get/2, {:ok, %Req.Response{status: 200, body: body}})
+    |> Sanbase.Mock.run_with_mocks(fun)
+  end
+end


### PR DESCRIPTION
## Changes
Add a tool that allows us to monitor if stage and prod metric registry have diverted due to manual changes or other unexpected circumstances.

<img width="1508" height="662" alt="image" src="https://github.com/user-attachments/assets/9aa2f1f9-21b0-4c0a-a770-5a10372bbd5f" />

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin tool to compare metric registries and identify missing, extra, or changed records.
  * Added drift summaries, detailed differences, and sync-status indicators.
  * Added navigation links to the new drift-check page from metric registry screens.
  * Export credentials can now be configured through an environment variable.

* **Bug Fixes**
  * Improved date and time formatting in registry exports.
  * Standardized login behavior based on the environment used to build the release.
  * Added appropriate access controls for drift checks.

* **Tests**
  * Added coverage for matching registries, detected differences, export failures, and safety restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->