### PR TITLE
Fix crash of fetching first datetime for social active users

### DIFF
--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -359,6 +359,17 @@ defmodule Sanbase.SocialData.MetricAdapter do
     {:ok, ~U[2009-01-01 00:00:00Z]}
   end
 
+  def first_datetime("social_active_users", selector, _opts) do
+    case selector do
+      %{source: source} when is_binary(source) ->
+        source_first_datetime(source)
+
+      _ ->
+        {:error,
+         "The selector must have a source field when fetching social_active_users first datetime"}
+    end
+  end
+
   def first_datetime(metric, _selector, _opts) do
     {_metric, source} = SocialHelper.split_by_source(metric)
     source |> source_first_datetime()
@@ -376,6 +387,13 @@ defmodule Sanbase.SocialData.MetricAdapter do
   defp source_first_datetime("bitcointalk"), do: {:ok, ~U[2011-06-01 00:00:00Z]}
   defp source_first_datetime("youtube_videos"), do: {:ok, ~U[2018-02-13 00:00:00Z]}
   defp source_first_datetime("4chan"), do: {:ok, ~U[2018-02-13 00:00:00Z]}
+  defp source_first_datetime("farcaster"), do: {:ok, ~U[2024-01-01 00:00:00Z]}
+  # twitter_crypto is not a source itself, but a source selector value of social_active_users
+  defp source_first_datetime("twitter_crypto"), do: source_first_datetime("twitter")
+
+  defp source_first_datetime(source) do
+    {:error, "The source #{inspect(source)} does not have a first datetime defined"}
+  end
 
   defp docs_links(metric) do
     list =

--- a/test/sanbase/social_data/metric_adapter_test.exs
+++ b/test/sanbase/social_data/metric_adapter_test.exs
@@ -1,0 +1,46 @@
+defmodule Sanbase.SocialData.MetricAdapterTest do
+  use SanbaseWeb.ConnCase, async: true
+
+  alias Sanbase.SocialData.MetricAdapter
+
+  describe "first_datetime/3" do
+    test "for metrics with a source suffix" do
+      assert MetricAdapter.first_datetime("social_volume_telegram", %{text: "btc"}, []) ==
+               {:ok, ~U[2016-03-29 00:00:00Z]}
+
+      assert MetricAdapter.first_datetime("sentiment_positive_reddit", %{text: "btc"}, []) ==
+               {:ok, ~U[2016-01-01 00:00:00Z]}
+
+      assert MetricAdapter.first_datetime("social_dominance_total", %{text: "btc"}, []) ==
+               {:ok, ~U[2011-06-01 00:00:00Z]}
+    end
+
+    test "for farcaster metrics" do
+      assert MetricAdapter.first_datetime("social_volume_farcaster", %{text: "btc"}, []) ==
+               {:ok, ~U[2024-01-01 00:00:00Z]}
+
+      assert MetricAdapter.first_datetime("sentiment_balance_farcaster", %{text: "btc"}, []) ==
+               {:ok, ~U[2024-01-01 00:00:00Z]}
+    end
+
+    test "for social_active_users" do
+      assert MetricAdapter.first_datetime("social_active_users", %{source: "telegram"}, []) ==
+               {:ok, ~U[2016-03-29 00:00:00Z]}
+
+      assert MetricAdapter.first_datetime("social_active_users", %{source: "twitter_crypto"}, []) ==
+               {:ok, ~U[2018-02-13 00:00:00Z]}
+    end
+
+    test "for social_active_users without a source returns an error" do
+      assert {:error, error} = MetricAdapter.first_datetime("social_active_users", %{}, [])
+      assert error =~ "must have a source"
+    end
+
+    test "for an unknown source returns an error instead of raising" do
+      assert {:error, error} =
+               MetricAdapter.first_datetime("social_active_users", %{source: "myspace"}, [])
+
+      assert error =~ "does not have a first datetime defined"
+    end
+  end
+end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving the first available datetime for social active user metrics by source, including Farcaster.
  * Added clear validation errors when a source is missing, invalid, or unsupported.

* **Bug Fixes**
  * Prevented unsupported social data sources from causing errors during datetime lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->