### PR TITLE
Send only ethereum addresses to ethauth

### DIFF
--- a/lib/sanbase/external_services/project_info.ex
+++ b/lib/sanbase/external_services/project_info.ex
@@ -25,6 +25,7 @@ defmodule Sanbase.ExternalServices.ProjectInfo do
     :facebook_link,
     :whitepaper_link,
     :main_contract_address,
+    :infrastructure_code,
     :ticker,
     :creation_transaction,
     :contract_block_number,
@@ -77,6 +78,7 @@ defmodule Sanbase.ExternalServices.ProjectInfo do
       project
       |> Map.from_struct()
       |> Map.put(:main_contract_address, main_contract_address)
+      |> Map.put(:infrastructure_code, infrastructure_code(project))
       |> Map.to_list()
 
     project_info =
@@ -102,11 +104,23 @@ defmodule Sanbase.ExternalServices.ProjectInfo do
     end
   end
 
-  def fetch_from_ethereum_node(%ProjectInfo{} = project_info) do
-    project_info
-    |> fetch_token_decimals()
-    |> fetch_total_supply()
+  def fetch_from_ethereum_node(%ProjectInfo{main_contract_address: contract} = project_info)
+      when is_binary(contract) do
+    if ethereum_contract?(project_info) do
+      project_info
+      |> fetch_token_decimals()
+      |> fetch_total_supply()
+    else
+      Logger.info(
+        "[ProjectInfo] Skip fetching on-chain data for #{project_info.slug}. " <>
+          "The contract #{contract} is not an Ethereum contract address."
+      )
+
+      project_info
+    end
   end
+
+  def fetch_from_ethereum_node(%ProjectInfo{} = project_info), do: project_info
 
   def fetch_contract_info(%ProjectInfo{main_contract_address: nil} = project_info),
     do: project_info
@@ -226,6 +240,26 @@ defmodule Sanbase.ExternalServices.ProjectInfo do
   end
 
   defp fetch_token_decimals(%ProjectInfo{} = project_info), do: project_info
+
+  defp ethereum_contract?(%ProjectInfo{main_contract_address: contract} = project_info)
+       when is_binary(contract) do
+    ethereum_infrastructure?(project_info.infrastructure_code) and
+      Regex.match?(Sanbase.BlockchainAddress.ethereum_regex(), contract)
+  end
+
+  defp ethereum_contract?(_), do: false
+
+  # Projects without an infrastructure record cannot be ruled out as
+  # non-Ethereum, so only the address format check applies to them.
+  defp ethereum_infrastructure?(nil), do: true
+  defp ethereum_infrastructure?(code) when is_binary(code), do: String.upcase(code) == "ETH"
+
+  defp infrastructure_code(%Project{} = project) do
+    case Project.infrastructure(project) do
+      %{code: code} when is_binary(code) -> code
+      _ -> nil
+    end
+  end
 
   defp fetch_block_number(%ProjectInfo{creation_transaction: nil} = project_info),
     do: project_info

--- a/test/sanbase/external_services/project_info_test.exs
+++ b/test/sanbase/external_services/project_info_test.exs
@@ -2,9 +2,11 @@ defmodule Sanbase.ExternalServices.ProjectInfoTest do
   use Sanbase.DataCase, async: true
 
   import ExUnit.CaptureLog
+  import Mock
   import Sanbase.Factory
 
   alias Sanbase.ExternalServices.ProjectInfo
+  alias Sanbase.InternalServices.Ethauth
   alias Sanbase.Project
   alias Sanbase.Model.Ico
   alias Sanbase.Repo
@@ -152,6 +154,88 @@ defmodule Sanbase.ExternalServices.ProjectInfoTest do
                project
              )
            end) =~ "has already been taken"
+  end
+
+  test "from_project sets the infrastructure code" do
+    project = insert(:random_erc20_project)
+
+    assert ProjectInfo.from_project(project).infrastructure_code == "ETH"
+  end
+
+  test "fetch_from_ethereum_node fetches data for ethereum contracts" do
+    project_info = %ProjectInfo{
+      slug: "santiment",
+      main_contract_address: "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
+      infrastructure_code: "ETH"
+    }
+
+    Sanbase.Mock.prepare_mock2(&Ethauth.total_supply/1, {:ok, 83_000_000})
+    |> Sanbase.Mock.prepare_mock2(&Ethauth.token_decimals/1, {:ok, 18})
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      project_info = ProjectInfo.fetch_from_ethereum_node(project_info)
+
+      assert project_info.total_supply == 83_000_000
+      assert project_info.token_decimals == 18
+    end)
+  end
+
+  test "fetch_from_ethereum_node fetches data when the infrastructure is not set" do
+    project_info = %ProjectInfo{
+      slug: "santiment",
+      main_contract_address: "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
+      infrastructure_code: nil
+    }
+
+    Sanbase.Mock.prepare_mock2(&Ethauth.total_supply/1, {:ok, 83_000_000})
+    |> Sanbase.Mock.prepare_mock2(&Ethauth.token_decimals/1, {:ok, 18})
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      project_info = ProjectInfo.fetch_from_ethereum_node(project_info)
+
+      assert project_info.total_supply == 83_000_000
+      assert project_info.token_decimals == 18
+    end)
+  end
+
+  test "fetch_from_ethereum_node skips contracts that are not ethereum addresses" do
+    project_info = %ProjectInfo{
+      slug: "some-solana-project",
+      main_contract_address: "HNg5PYJmtqcmzXrv6S9zP1CDKk5BgDuyFBxbvNApump",
+      infrastructure_code: nil
+    }
+
+    Sanbase.Mock.prepare_mock2(&Ethauth.total_supply/1, {:ok, 83_000_000})
+    |> Sanbase.Mock.prepare_mock2(&Ethauth.token_decimals/1, {:ok, 18})
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      log =
+        capture_log(fn ->
+          assert ProjectInfo.fetch_from_ethereum_node(project_info) == project_info
+        end)
+
+      assert log =~ "Skip fetching on-chain data for some-solana-project"
+      assert_not_called(Ethauth.total_supply(:_))
+      assert_not_called(Ethauth.token_decimals(:_))
+    end)
+  end
+
+  test "fetch_from_ethereum_node skips contracts on non-ethereum infrastructure" do
+    project_info = %ProjectInfo{
+      slug: "some-bnb-project",
+      main_contract_address: "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
+      infrastructure_code: "BNB"
+    }
+
+    Sanbase.Mock.prepare_mock2(&Ethauth.total_supply/1, {:ok, 83_000_000})
+    |> Sanbase.Mock.prepare_mock2(&Ethauth.token_decimals/1, {:ok, 18})
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      log =
+        capture_log(fn ->
+          assert ProjectInfo.fetch_from_ethereum_node(project_info) == project_info
+        end)
+
+      assert log =~ "Skip fetching on-chain data for some-bnb-project"
+      assert_not_called(Ethauth.total_supply(:_))
+      assert_not_called(Ethauth.token_decimals(:_))
+    end)
   end
 
   test "updating the project info of a project with a contract address" do


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project info now includes infrastructure details to indicate whether it’s associated with Ethereum.
  * Added enrichment for Ethereum token metadata when applicable.

* **Bug Fixes**
  * Prevented on-chain token decimals and total supply lookups for non-Ethereum contract addresses.
  * On Ethereum mismatch, enrichment now skips on-chain requests and records an informational message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->