### PR TITLE
Improve hyperliquid disconnect handling and bad assets subscriptions

### DIFF
--- a/config/scrapers_config.exs
+++ b/config/scrapers_config.exs
@@ -68,3 +68,11 @@ config :sanbase, Sanbase.Hyperliquid.Bbo.WebsocketScraper,
 
 config :sanbase, Sanbase.Hyperliquid.Bbo.CoinUniverse,
   verify_on_write?: {:system, "HYPERLIQUID_VERIFY_COINS_ON_WRITE", "true"}
+
+# ignored_coins: comma-separated coin names the BBO scraper must never
+# subscribe to — operator escape hatch for coins whose subscribe kills the
+# connection. enabled?: toggles the probation/probe/conviction workflow
+# (the ignore list and the universe audit stay active regardless).
+config :sanbase, Sanbase.Hyperliquid.Bbo.Quarantine,
+  ignored_coins: {:system, "HYPERLIQUID_IGNORED_COINS", ""},
+  enabled?: {:system, "HYPERLIQUID_QUARANTINE_ENABLED", "true"}

--- a/lib/sanbase/hyperliquid/bbo/bbo_point.ex
+++ b/lib/sanbase/hyperliquid/bbo/bbo_point.ex
@@ -26,4 +26,45 @@ defmodule Sanbase.Hyperliquid.Bbo.BboPoint do
     key = "hyperliquid_bbo_#{point.slug}_#{point.timestamp_ms}"
     {key, Jason.encode!(point)}
   end
+
+  @doc ~s"""
+  Parse the payload of a `bbo` frame (`data.coin`/`data.time`/`data.bbo`
+  sides) into the slug-less field map used to build one `#{inspect(__MODULE__)}`
+  per mapped slug. Returns nil when both sides are empty (nothing to export)
+  — one-sided books are kept, with the missing side's fields nil.
+  """
+  def parse_frame_data(coin, time_ms, bid, ask) do
+    {bp, bv} = parse_side(bid)
+    {ap, av} = parse_side(ask)
+
+    if Enum.all?([bp, bv, ap, av], &is_nil/1) do
+      nil
+    else
+      %{
+        coin: coin,
+        timestamp_ms: time_ms,
+        bid_price: bp,
+        bid_volume: bv,
+        ask_price: ap,
+        ask_volume: av
+      }
+    end
+  end
+
+  defp parse_side(%{"px" => px, "sz" => sz}) do
+    {parse_float(px), parse_float(sz)}
+  end
+
+  defp parse_side(_), do: {nil, nil}
+
+  defp parse_float(n) when is_number(n), do: n * 1.0
+
+  defp parse_float(s) when is_binary(s) do
+    case Float.parse(s) do
+      {f, _} -> f
+      :error -> nil
+    end
+  end
+
+  defp parse_float(_), do: nil
 end

--- a/lib/sanbase/hyperliquid/bbo/bbo_point.ex
+++ b/lib/sanbase/hyperliquid/bbo/bbo_point.ex
@@ -51,8 +51,13 @@ defmodule Sanbase.Hyperliquid.Bbo.BboPoint do
     end
   end
 
+  # A side is all-or-nothing: exporting a price without its volume (or a
+  # half-parsed "1oops" price) would violate the struct invariant above.
   defp parse_side(%{"px" => px, "sz" => sz}) do
-    {parse_float(px), parse_float(sz)}
+    case {parse_float(px), parse_float(sz)} do
+      {price, volume} when is_float(price) and is_float(volume) -> {price, volume}
+      _ -> {nil, nil}
+    end
   end
 
   defp parse_side(_), do: {nil, nil}
@@ -61,8 +66,8 @@ defmodule Sanbase.Hyperliquid.Bbo.BboPoint do
 
   defp parse_float(s) when is_binary(s) do
     case Float.parse(s) do
-      {f, _} -> f
-      :error -> nil
+      {f, ""} -> f
+      _ -> nil
     end
   end
 

--- a/lib/sanbase/hyperliquid/bbo/bbo_websocket_scraper.ex
+++ b/lib/sanbase/hyperliquid/bbo/bbo_websocket_scraper.ex
@@ -121,8 +121,21 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
 
   def start_link() do
     state = initial_state()
-    Logger.info("[HyperliquidBboWS] starting url=#{@url}")
-    WebSockex.start_link(@url, __MODULE__, state, name: @name)
+
+    # The pid identifies the process INSTANCE: a new pid in these logs means
+    # a supervisor restart (fresh state — quarantine/probation forgotten),
+    # while reconnects keep the pid. Logged here and on every
+    # connect/disconnect/terminate line to make restarts vs reconnects
+    # obvious.
+    case WebSockex.start_link(@url, __MODULE__, state, name: @name) do
+      {:ok, pid} = ok ->
+        Logger.info("[HyperliquidBboWS] started pid=#{inspect(pid)} url=#{@url}")
+        ok
+
+      {:error, reason} = error ->
+        Logger.warning("[HyperliquidBboWS] failed to start: #{inspect(reason)}")
+        error
+    end
   end
 
   def enabled?() do
@@ -188,7 +201,8 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     connect_times = Reconnect.track_connect(Map.get(state, :connect_times, []), now)
 
     Logger.info(
-      "[HyperliquidBboWS] connected reconnects=#{Map.get(state, :reconnects, 0)} " <>
+      "[HyperliquidBboWS] connected pid=#{inspect(self())} " <>
+        "reconnects=#{Map.get(state, :reconnects, 0)} " <>
         "backoff_was=#{state.reconnect_backoff_ms}ms connects_last_60s=#{length(connect_times)} " <>
         "(HL allows 30 new conns/min per IP, all clients behind the IP combined)"
     )
@@ -238,7 +252,8 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     # died mid-drain of the subscribe queue; last_subs_sent points at the
     # trigger when the same coin keeps preceding the crash.
     Logger.warning(
-      "[HyperliquidBboWS] disconnect cause=#{Reconnect.describe_cause(reason)} attempt=#{attempt} " <>
+      "[HyperliquidBboWS] disconnect pid=#{inspect(self())} " <>
+        "cause=#{Reconnect.describe_cause(reason)} attempt=#{attempt} " <>
         "lifetime_ms=#{inspect(lifetime_ms)} " <>
         "last_frame_age_ms=#{now - state.last_message_time} " <>
         "bbo_in=#{Map.get(state, :bbo_in, 0)} active_subs=#{MapSet.size(state.active_subs)} " <>
@@ -269,8 +284,13 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     {:reconnect, state}
   end
 
+  # A terminate log with a pid that never reappears = the supervisor started
+  # a REPLACEMENT process with fresh state (quarantine/probation forgotten).
   def terminate(reason, _state) do
-    Logger.warning("[HyperliquidBboWS] terminate reason=#{inspect(reason)}")
+    Logger.warning(
+      "[HyperliquidBboWS] terminate pid=#{inspect(self())} reason=#{inspect(reason)}"
+    )
+
     :ok
   end
 
@@ -453,12 +473,23 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
 
     case :queue.out(state.pending_sub_queue) do
       {{:value, {method, coin}}, queue2} ->
-        state =
-          %{state | pending_sub_queue: queue2}
-          |> track_sub_send(method, coin)
-          |> maybe_schedule_flush_subs()
+        state = %{state | pending_sub_queue: queue2}
 
-        {:reply, sub_frame(method, coin), state}
+        if send_banned?(state, method, coin) do
+          Logger.info(
+            "[HyperliquidBboWS] dropping queued subscribe coin=#{coin} — " <>
+              "excluded or probated after it was queued"
+          )
+
+          {:ok, maybe_schedule_flush_subs(state)}
+        else
+          state =
+            state
+            |> track_sub_send(method, coin)
+            |> maybe_schedule_flush_subs()
+
+          {:reply, sub_frame(method, coin), state}
+        end
 
       {:empty, _} ->
         {:ok, state}
@@ -503,10 +534,14 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     {:ok, state |> maybe_start_audit() |> schedule(:audit, @audit_interval)}
   end
 
-  # An audit verdict from the separate audit process — Quarantine applies it;
-  # the next reconcile (≤60s) unsubscribes anything newly excluded. A failed
-  # audit sends an error tuple and keeps the previous verdicts.
+  # An audit verdict from the separate audit process — Quarantine applies it.
+  # New exclusions trigger an immediate reconcile (instead of waiting out the
+  # 60s tick) so actively subscribed offenders are unsubscribed right away;
+  # already-queued subscribes are dropped at send time by send_banned?/3. A
+  # failed audit sends an error tuple and keeps the previous verdicts.
   def handle_info({:audit_result, %{reasons: reasons}}, state) do
+    if map_size(reasons) > 0, do: send(self(), :reconcile_subscriptions)
+
     {:ok, Map.put(state, :quarantine, Quarantine.apply_audit(quarantine_state(state), reasons))}
   end
 
@@ -653,6 +688,20 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     {:text, Jason.encode!(%{method: method, subscription: %{type: "bbo", coin: coin}})}
   end
 
+  # A subscribe queued before an audit verdict, conviction or probation
+  # landed must not reach the wire — the queue can lag reconcile's decision
+  # by (queue length x @flush_subs_interval). Unsubscribes always pass, and
+  # so do probe subscribes: their coin is on probation by design, marked
+  # in-flight in Quarantine before the frame is queued.
+  defp send_banned?(state, "subscribe", coin) do
+    q = quarantine_state(state)
+
+    Map.has_key?(Quarantine.excluded(q), coin) or
+      (coin in Quarantine.probation(q) and coin not in Quarantine.probing_coins(q))
+  end
+
+  defp send_banned?(_state, _method, _coin), do: false
+
   # Quarantine glue
 
   # Crash forensics — probe verdicts and probation live in Quarantine; this
@@ -690,17 +739,26 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     end
   end
 
-  # Run the universe audit in its own process (the HTTP calls must never
-  # block frame handling), at most once per @audit_min_gap_ms no matter what
-  # triggers it — last_audit_at survives disconnects, so a crash-connect loop
-  # stays rate-limited. The task audits the FULL mapped set (audit/0 loads it
-  # itself) and sends {:audit_result, ...} back to this process.
+  # Run the universe audit in its own supervised process (the HTTP calls
+  # must never block frame handling; the supervisor makes a crash visible),
+  # at most once per @audit_min_gap_ms no matter what triggers it —
+  # last_audit_at survives disconnects, so a crash-connect loop stays
+  # rate-limited. The timestamp deliberately advances at SPAWN, not at
+  # result receipt: the gap bounds requests against HL, and a crashed audit
+  # is retried by the next :audit tick anyway (fetch failures don't crash —
+  # they return an error tuple that keeps the previous verdicts). The task
+  # audits the FULL mapped set (audit/0 loads it itself) and sends
+  # {:audit_result, ...} back to this process.
   defp maybe_start_audit(state) do
     now = System.system_time(:millisecond)
 
     if now - Map.get(state, :last_audit_at, 0) >= @audit_min_gap_ms do
       parent = self()
-      Task.start(fn -> send(parent, {:audit_result, CoinUniverse.audit()}) end)
+
+      Task.Supervisor.start_child(Sanbase.TaskSupervisor, fn ->
+        send(parent, {:audit_result, CoinUniverse.audit()})
+      end)
+
       Map.put(state, :last_audit_at, now)
     else
       state

--- a/lib/sanbase/hyperliquid/bbo/bbo_websocket_scraper.ex
+++ b/lib/sanbase/hyperliquid/bbo/bbo_websocket_scraper.ex
@@ -66,7 +66,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
      sleeps the `Reconnect` backoff (plus jitter) before reconnecting into
      step 1.
 
-  7. **Probes (`:probe_next`, every 500ms).** `Quarantine.probe_tick/5`
+  7. **Probes (`:probe_next`, every 400ms).** `Quarantine.probe_tick/5`
      re-tries probation coins on a settled connection — pipelined, paced by
      Quarantine's spacing — and tells this process which subscribe frame to
      queue.
@@ -113,8 +113,11 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   # Default debounce window per coin; overridable via app config.
   @coalesce_window_default_ms 1_000
   # Cadence of the probation worker tick; probe windows and pacing live in
-  # Quarantine.
-  @probe_interval 500
+  # Quarantine. Probe starts land on this tick grid, so it must divide the
+  # 1600ms probe spacing evenly (4 x 400) — a 500ms tick would stretch the
+  # effective spacing to 2000ms and slow the probation drain below the
+  # documented ~1 coin per 1.6s.
+  @probe_interval 400
 
   def child_spec(_opts \\ []) do
     %{id: __MODULE__, start: {__MODULE__, :start_link, []}}
@@ -178,6 +181,8 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
       # first — compared against HL's 30 new connections/min/IP limit.
       connect_times: [],
       last_audit_at: 0,
+      # Ref of the newest in-flight audit; only its result is applied.
+      audit_ref: nil,
       # Diagnostics: per-coin record of the last point actually handed to the
       # Kafka exporter — %{coin => %{point: map, exported_at_ms: ms, count: n}}.
       # Never cleared (not on disconnect, not on unsubscribe) so it answers
@@ -251,7 +256,10 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     # (policy/limit) or randomly (network); bbo_in>0 means data was flowing
     # right up to the drop (so mappings are fine); pending_subs>0 means we
     # died mid-drain of the subscribe queue; last_subs_sent points at the
-    # trigger when the same coin keeps preceding the crash.
+    # trigger when the same coin keeps preceding the crash. Quarantine ages
+    # use monotonic time so NTP steps can't skew suspect/probe windows.
+    mono_now = System.monotonic_time(:millisecond)
+
     Logger.warning(
       "[HyperliquidBboWS] disconnect pid=#{inspect(self())} " <>
         "cause=#{Reconnect.describe_cause(reason)} attempt=#{attempt} " <>
@@ -259,7 +267,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
         "last_frame_age_ms=#{now - state.last_message_time} " <>
         "bbo_in=#{Map.get(state, :bbo_in, 0)} active_subs=#{MapSet.size(state.active_subs)} " <>
         "pending_subs=#{:queue.len(state.pending_sub_queue)} " <>
-        "last_subs_sent=[#{Quarantine.recent_sends_summary(q, now)}] " <>
+        "last_subs_sent=[#{Quarantine.recent_sends_summary(q, mono_now)}] " <>
         "probation=#{length(Quarantine.probation(q))} " <>
         "quarantined=#{map_size(q.quarantined)} " <>
         "reconnects=#{Map.get(state, :reconnects, 0)} backoff=#{sleep_ms}ms"
@@ -267,7 +275,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
 
     state =
       state
-      |> handle_crash_suspects(now, attempt)
+      |> handle_crash_suspects(mono_now, attempt)
       |> cancel_timers()
       |> Map.merge(%{
         active_subs: MapSet.new(),
@@ -435,7 +443,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
         state.active_subs,
         connection_uptime_ms(state),
         :queue.is_empty(state.pending_sub_queue),
-        System.system_time(:millisecond)
+        System.monotonic_time(:millisecond)
       )
 
     state = Map.put(state, :quarantine, q)
@@ -536,17 +544,29 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   end
 
   # An audit verdict from the separate audit process — Quarantine applies it.
-  # New exclusions trigger an immediate reconcile (instead of waiting out the
-  # 60s tick) so actively subscribed offenders are unsubscribed right away;
-  # already-queued subscribes are dropped at send time by send_banned?/3. A
-  # failed audit sends an error tuple and keeps the previous verdicts.
-  def handle_info({:audit_result, %{reasons: reasons}}, state) do
-    if map_size(reasons) > 0, do: send(self(), :reconcile_subscriptions)
+  # Only the NEWEST in-flight audit's result counts: the ref must match the
+  # one stored at spawn, else a slow older audit that outlived the
+  # @audit_min_gap_ms could reply after a newer one and overwrite fresh
+  # verdicts with stale ones. Any change to the exclusion *set* (new
+  # offenders OR recovered coins) triggers an immediate reconcile so we
+  # don't wait out the 60s tick; already-queued subscribes are dropped at
+  # send time by send_banned?/3. A failed audit sends an error tuple and
+  # keeps the previous verdicts.
+  def handle_info({:audit_result, ref, %{reasons: reasons}}, state) do
+    if ref == Map.get(state, :audit_ref) do
+      prev_keys = quarantine_state(state).audit_excluded |> Map.keys() |> MapSet.new()
+      next_keys = reasons |> Map.keys() |> MapSet.new()
+      if prev_keys != next_keys, do: send(self(), :reconcile_subscriptions)
 
-    {:ok, Map.put(state, :quarantine, Quarantine.apply_audit(quarantine_state(state), reasons))}
+      {:ok, Map.put(state, :quarantine, Quarantine.apply_audit(quarantine_state(state), reasons))}
+    else
+      Logger.info("[HyperliquidBboWS] ignoring stale audit result (a newer audit was started)")
+      {:ok, state}
+    end
   end
 
-  def handle_info({:audit_result, _}, state), do: {:ok, state}
+  # Failed audit (error tuple) — keep the previous verdicts.
+  def handle_info({:audit_result, _ref, _}, state), do: {:ok, state}
 
   def handle_info(_msg, state), do: {:ok, state}
 
@@ -563,7 +583,6 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     # (those are re-tried by the probe worker, never by the bulk subscribe).
     desired_set =
       full_desired
-      |> MapSet.put("ANSEM")
       |> MapSet.difference(MapSet.new(Map.keys(excluded)))
       |> MapSet.difference(MapSet.new(probation))
 
@@ -722,7 +741,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
         quarantine_state(state),
         coin,
         Map.get(state.slug_map, coin, []),
-        System.system_time(:millisecond)
+        System.monotonic_time(:millisecond)
       )
 
     Map.put(state, :quarantine, q)
@@ -756,12 +775,18 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
 
     if now - Map.get(state, :last_audit_at, 0) >= @audit_min_gap_ms do
       parent = self()
+      # Correlates the async result with the newest request — the gap bounds
+      # audit STARTS, not durations, so audits can overlap and a stale reply
+      # must not overwrite a newer verdict (see the :audit_result handler).
+      ref = make_ref()
 
       Task.Supervisor.start_child(Sanbase.TaskSupervisor, fn ->
-        send(parent, {:audit_result, CoinUniverse.audit()})
+        send(parent, {:audit_result, ref, CoinUniverse.audit()})
       end)
 
-      Map.put(state, :last_audit_at, now)
+      state
+      |> Map.put(:last_audit_at, now)
+      |> Map.put(:audit_ref, ref)
     else
       state
     end

--- a/lib/sanbase/hyperliquid/bbo/bbo_websocket_scraper.ex
+++ b/lib/sanbase/hyperliquid/bbo/bbo_websocket_scraper.ex
@@ -14,9 +14,9 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
 
   ## Lifecycle
 
-  1. **Boot.** `start_link/0` opens the WebSocket. On `handle_connect/2` the
-     reconnect backoff is reset, all periodic timers are armed, and an
-     immediate `:reconcile_subscriptions` is sent to populate subs.
+  1. **Boot.** `start_link/0` opens the WebSocket. On `handle_connect/2` all
+     periodic timers are armed and an immediate `:reconcile_subscriptions` is
+     sent to populate subs.
 
   2. **Reconcile (every 60s).** Loads `SourceSlugMapping` rows for
      `hyperliquid`, builds a `coin -> [slug, ...]` map, and diffs against
@@ -46,8 +46,15 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
 
   7. **Disconnect.** `handle_disconnect/2` cancels timers, clears
      `active_subs`/`pending_sub_queue`/`coalesce_buffer`/`last_emitted`/
-     `healthcheck_failures`, sleeps the current backoff, then doubles it
-     (capped at `@reconnect_max_ms`). Reconnect re-enters step 1.
+     `healthcheck_failures`, then sleeps a backoff (plus jitter) before
+     reconnecting. The backoff doubles per disconnect (total sleep, jitter
+     included, capped at `@reconnect_max_ms`) and resets to
+     `@reconnect_initial_ms` only after a
+     connection survives `@stable_connection_ms` — a connection that dies
+     young keeps backing off, so a remote that kills us seconds after connect
+     (e.g. per-IP rate limiting) slows us down instead of locking us into a
+     reconnect storm that keeps the IP over the limit. Reconnect re-enters
+     step 1.
   """
 
   use WebSockex
@@ -89,8 +96,21 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   @coalesce_window_default_ms 1_000
   # First reconnect delay; doubles per consecutive disconnect, capped below.
   @reconnect_initial_ms 1_000
-  # Upper bound on the exponential reconnect backoff.
-  @reconnect_max_ms 30_000
+  # Hard ceiling on a single reconnect sleep, jitter included.
+  @reconnect_max_ms 20_000
+  # A connection must live this long before the next disconnect starts the
+  # backoff over from @reconnect_initial_ms; anything shorter keeps doubling.
+  @stable_connection_ms 60_000
+  # Cap on the random jitter added to each reconnect sleep, so instances
+  # sharing an egress IP don't reconnect in lockstep (HL limits are per IP,
+  # aggregated across every client behind it).
+  @reconnect_jitter_max_ms 1_000
+  # The exponential part of the backoff caps here so base + jitter never
+  # exceeds @reconnect_max_ms.
+  @reconnect_base_cap_ms @reconnect_max_ms - @reconnect_jitter_max_ms
+  # Rolling window for counting our own connects, matching the window of HL's
+  # "30 new connections per minute per IP" limit.
+  @connects_window_ms 60_000
 
   def child_spec(_opts \\ []) do
     %{id: __MODULE__, start: {__MODULE__, :start_link, []}}
@@ -118,6 +138,11 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
       # a storm never re-subscribes to known-bad coins. Refreshed each audit, so
       # a coin re-listed on HL is picked back up automatically.
       unsupported: MapSet.new(),
+      # Coins that were already awaiting a subscribe confirmation at the end
+      # of the previous reconcile round. warn_unconfirmed/2 only flags coins
+      # present in BOTH rounds, so a coin queued for the first time this
+      # round is never reported as "never confirmed". Cleared on disconnect.
+      prev_unconfirmed: MapSet.new(),
       slug_map: %{},
       pending_sub_queue: :queue.new(),
       last_emitted: %{},
@@ -133,6 +158,9 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
       connected_at: nil,
       bbo_in: 0,
       reconnects: 0,
+      # Timestamps (ms) of successful connects in the last minute, newest
+      # first — compared against HL's 30 new connections/min/IP limit.
+      connect_times: [],
       last_audit_at: 0,
       # Diagnostics: per-coin record of the last point actually handed to the
       # Kafka exporter — %{coin => %{point: map, exported_at_ms: ms, count: n}}.
@@ -172,18 +200,30 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   def handle_connect(_conn, state) do
     now = System.system_time(:millisecond)
 
+    connect_times =
+      [now | Map.get(state, :connect_times, [])]
+      |> Enum.take_while(&(now - &1 < @connects_window_ms))
+
     Logger.info(
-      "[HyperliquidBboWS] connected reconnects=#{Map.get(state, :reconnects, 0)} backoff_was=#{state.reconnect_backoff_ms}ms"
+      "[HyperliquidBboWS] connected reconnects=#{Map.get(state, :reconnects, 0)} " <>
+        "backoff_was=#{state.reconnect_backoff_ms}ms connects_last_60s=#{length(connect_times)} " <>
+        "(HL allows 30 new conns/min per IP, all clients behind the IP combined)"
     )
 
     state =
-      %{
-        state
-        | reconnect_backoff_ms: @reconnect_initial_ms,
-          last_message_time: now
-      }
-      # Reset per-connection diagnostics; Map.merge is recompile-safe.
-      |> Map.merge(%{connected_at: now, bbo_in: 0})
+      %{state | last_message_time: now}
+      # Reset per-connection diagnostics; Map.merge is recompile-safe. The
+      # reconnect backoff is deliberately NOT reset here — only a connection
+      # that survives @stable_connection_ms earns a reset (handle_disconnect),
+      # otherwise a remote that drops us seconds after connect pins the
+      # backoff at its minimum forever. connected_at is monotonic because the
+      # backoff-reset decision depends on it — an NTP step of the wall clock
+      # must not fake a "stable" lifetime.
+      |> Map.merge(%{
+        connected_at: System.monotonic_time(:millisecond),
+        bbo_in: 0,
+        connect_times: connect_times
+      })
       |> schedule_all_timers()
 
     send(self(), :reconcile_subscriptions)
@@ -191,20 +231,32 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   end
 
   def handle_disconnect(status, state) do
-    sleep_ms = state.reconnect_backoff_ms
-    now = System.system_time(:millisecond)
     connected_at = Map.get(state, :connected_at)
-    lifetime_ms = if connected_at, do: now - connected_at, else: nil
 
-    # Full `status` (not just :reason) surfaces a WS close code/reason if the
-    # remote sent a close frame. `{:remote, :closed}` = abrupt TCP close with
-    # NO close frame — typical of an infra/rate-limit drop rather than an app
-    # error. lifetime_ms shows whether the socket dies on a fixed cadence
+    lifetime_ms =
+      if connected_at, do: System.monotonic_time(:millisecond) - connected_at, else: nil
+
+    # WebSockex always passes a connection-status map here; crash loudly if
+    # that contract ever changes rather than guessing at the shape.
+    reason = Map.get(status, :reason)
+    attempt = Map.get(status, :attempt_number, 1)
+
+    {base_ms, next_backoff_ms} = backoff_plan(state.reconnect_backoff_ms, lifetime_ms, attempt)
+    # Jitter de-syncs instances sharing an egress IP; proportional to the
+    # backoff so a healthy single reconnect stays fast, and bounded so
+    # base + jitter never exceeds @reconnect_max_ms.
+    sleep_ms = base_ms + :rand.uniform(min(base_ms, @reconnect_jitter_max_ms))
+
+    # lifetime_ms shows whether the socket dies on a fixed cadence
     # (policy/limit) or randomly (network); bbo_in>0 means data was flowing
-    # right up to the drop (so mappings are fine).
+    # right up to the drop (so mappings are fine); pending_subs>0 means we
+    # died mid-drain of the subscribe queue.
     Logger.warning(
-      "[HyperliquidBboWS] disconnect status=#{inspect(status)} lifetime_ms=#{inspect(lifetime_ms)} " <>
+      "[HyperliquidBboWS] disconnect cause=#{disconnect_cause(reason)} attempt=#{attempt} " <>
+        "lifetime_ms=#{inspect(lifetime_ms)} " <>
+        "last_frame_age_ms=#{System.system_time(:millisecond) - state.last_message_time} " <>
         "bbo_in=#{Map.get(state, :bbo_in, 0)} active_subs=#{MapSet.size(state.active_subs)} " <>
+        "pending_subs=#{:queue.len(state.pending_sub_queue)} " <>
         "reconnects=#{Map.get(state, :reconnects, 0)} backoff=#{sleep_ms}ms"
     )
 
@@ -216,14 +268,53 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
         pending_sub_queue: :queue.new(),
         coalesce_buffer: %{},
         last_emitted: %{},
-        healthcheck_failures: 0
+        healthcheck_failures: 0,
+        connected_at: nil,
+        prev_unconfirmed: MapSet.new(),
+        reconnect_backoff_ms: next_backoff_ms
       })
-      |> Map.update!(:reconnect_backoff_ms, fn ms -> min(ms * 2, @reconnect_max_ms) end)
       |> bump(:reconnects)
 
     Process.sleep(sleep_ms)
     {:reconnect, state}
   end
+
+  @doc false
+  # The reconnect schedule after a disconnect: `{sleep_base_ms, next_backoff_ms}`.
+  # `sleep_base_ms` is slept now (plus jitter); `next_backoff_ms` is stored for
+  # the disconnect after this one, so the ladder walks
+  # @reconnect_initial_ms, 2x, 4x, ... up to @reconnect_base_cap_ms. Only a
+  # dropped live connection (attempt == 1) that survived @stable_connection_ms
+  # restarts the ladder; short-lived connections and failed reconnect attempts
+  # (attempt > 1, where lifetime_ms is nil) keep climbing. Public only for
+  # tests — handle_disconnect/2 can't be exercised without a real 1s+ sleep.
+  def backoff_plan(current_backoff_ms, lifetime_ms, attempt) do
+    stable? = attempt == 1 and is_integer(lifetime_ms) and lifetime_ms >= @stable_connection_ms
+
+    base_ms =
+      if stable?,
+        do: @reconnect_initial_ms,
+        else: min(current_backoff_ms, @reconnect_base_cap_ms)
+
+    {base_ms, min(base_ms * 2, @reconnect_base_cap_ms)}
+  end
+
+  # The remote's stated reason for the drop, in words. `{:remote, :closed}` is
+  # an abrupt TCP close with NO WebSocket close frame — the remote never said
+  # why; no more detail exists on the wire. HL/CloudFront drop connections
+  # this way when per-IP limits are exceeded (10 concurrent conns, 30 new
+  # conns/min, 2000 client msgs/min, 1000 subs — aggregated over every client
+  # behind the IP), so persistent short lifetimes + this cause usually mean
+  # IP-level rate limiting rather than an app error. A graceful close frame
+  # (code + message) surfaces via the clause below.
+  defp disconnect_cause({:remote, :closed}),
+    do: "remote dropped TCP without a close frame (no reason on wire; rate-limit/infra style)"
+
+  defp disconnect_cause({:remote, code, msg}),
+    do: "remote sent close frame code=#{inspect(code)} msg=#{inspect(msg)}"
+
+  defp disconnect_cause({:local, reason}), do: "closed by our side: #{inspect(reason)}"
+  defp disconnect_cause(other), do: inspect(other)
 
   def terminate(reason, _state) do
     Logger.warning("[HyperliquidBboWS] terminate reason=#{inspect(reason)}")
@@ -464,6 +555,8 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     to_subscribe = MapSet.difference(desired_set, state.active_subs)
     to_unsubscribe = MapSet.difference(state.active_subs, desired_set)
 
+    warn_unconfirmed(state, to_subscribe)
+
     if MapSet.size(to_subscribe) > 0 or MapSet.size(to_unsubscribe) > 0 do
       Logger.info(
         "[HyperliquidBboWS] reconcile +sub=#{MapSet.size(to_subscribe)} -unsub=#{MapSet.size(to_unsubscribe)} desired=#{MapSet.size(desired_set)} excluded_unsupported=#{MapSet.size(unsupported)}"
@@ -489,10 +582,44 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
         last_emitted: Map.drop(state.last_emitted, dropped),
         coalesce_buffer: Map.drop(state.coalesce_buffer, dropped)
     }
+    |> Map.put(:prev_unconfirmed, to_subscribe)
     |> maybe_schedule_flush_subs()
     # Audit the FULL mapped set (not the reduced one) so a previously
     # unsupported coin that HL re-lists is detected and re-included.
     |> maybe_audit_coins(full_desired)
+  end
+
+  # Ground truth on coin support: a subscribe frame sent long ago that never
+  # got a subscriptionResponse means HL silently ignored it. The universe
+  # audit can overcount — spot *token* names pass it, but `bbo` only accepts
+  # tradeable pair names (perps like "BTC"/"xyz:GOLD", spot pairs like
+  # "@107") — so this is the check that proves a coin actually streams. Warns
+  # only about coins already awaiting confirmation on the PREVIOUS reconcile
+  # round (a coin appearing in to_subscribe for the first time hasn't even
+  # had its subscribe frame queued yet — that happens after this check), and
+  # only once the connection has outlived a couple of reconcile rounds with
+  # an empty outbound queue; during connection churn it stays silent.
+  defp warn_unconfirmed(state, to_subscribe) do
+    still_unconfirmed =
+      MapSet.intersection(to_subscribe, Map.get(state, :prev_unconfirmed, MapSet.new()))
+
+    connected_at = Map.get(state, :connected_at)
+
+    age_ms =
+      if connected_at, do: System.monotonic_time(:millisecond) - connected_at, else: 0
+
+    if age_ms > 2 * @reconcile_interval and MapSet.size(still_unconfirmed) > 0 and
+         :queue.is_empty(state.pending_sub_queue) do
+      coins = still_unconfirmed |> MapSet.to_list() |> Enum.sort()
+
+      Logger.warning(
+        "[HyperliquidBboWS] #{length(coins)} coin(s) never confirmed by HL " <>
+          "after #{div(age_ms, 1000)}s connected (subscribe sent, no subscriptionResponse): " <>
+          "#{inspect(coins)}"
+      )
+    end
+
+    :ok
   end
 
   # Run the coin-universe audit off the WS process (so the HTTP call never

--- a/lib/sanbase/hyperliquid/bbo/bbo_websocket_scraper.ex
+++ b/lib/sanbase/hyperliquid/bbo/bbo_websocket_scraper.ex
@@ -12,49 +12,63 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   emit per coin per `coalesce_window_ms` (trailing-edge debounce) and pushed to
   the `:hyperliquid_bbo_exporter` Kafka exporter.
 
+  This process owns the socket, the subscription lifecycle and the export
+  path. Everything else lives in sibling modules it drives:
+
+    * `Sanbase.Hyperliquid.Bbo.Quarantine` — which coins must not be
+      subscribed and why: crash forensics, probation, pipelined probes,
+      convictions, audit verdicts, the env ignore list, and the send log
+      used as crash evidence.
+    * `Sanbase.Hyperliquid.Bbo.CoinUniverse` — the audit itself: fetching
+      HL's tradeable universe and flagging unsubscribable coins with reasons.
+    * `Sanbase.Hyperliquid.Bbo.Reconnect` — the backoff ladder, jitter,
+      connect-rate tracking and disconnect-cause wording.
+    * `Sanbase.Hyperliquid.Bbo.BboPoint` — frame payload parsing and the
+      Kafka key/value encoding.
+
   ## Lifecycle
 
   1. **Boot.** `start_link/0` opens the WebSocket. On `handle_connect/2` all
-     periodic timers are armed and an immediate `:reconcile_subscriptions` is
-     sent to populate subs.
+     periodic timers are armed, an immediate `:reconcile_subscriptions` is
+     sent to populate subs, and a universe audit is kicked off (rate-limited
+     to one per `@audit_min_gap_ms`, so a crash-looping scraper never hammers
+     the HL info endpoint; also refreshed every `@audit_interval`).
 
-  2. **Reconcile (every 60s).** Loads `SourceSlugMapping` rows for
-     `hyperliquid`, builds a `coin -> [slug, ...]` map, and diffs against
-     `active_subs`. New coins get a `subscribe` frame queued; removed coins
-     get `unsubscribe` plus their `coalesce_buffer`/`last_emitted` entries pruned.
+  2. **Reconcile (every 60s).** Loads the mappings, diffs the desired coin
+     set against `active_subs`, and queues `subscribe`/`unsubscribe` frames.
+     Coins excluded by Quarantine are skipped and unsubscribed if active;
+     coins on probation are left to the probe worker; new bulk subscribes
+     are deferred while probes are in flight (verdicts must stay
+     unambiguous) and queued in random order (so a fixed-point-in-drain kill
+     can't implicate the same innocent coins every time). A coin whose
+     subscribe went out a full round ago without a `subscriptionResponse`
+     moves to probation instead of being re-sent forever.
 
-  3. **Outbound pacing.** Sub/unsub frames are drained from the queue one per
-     `@flush_subs_interval` (50ms) — Hyperliquid caps outbound at 2000/min.
-     The drain timer self-disarms when the queue empties and re-arms when
-     reconcile queues more frames.
+  3. **Outbound pacing.** Sub/unsub frames drain from the queue one per
+     `@flush_subs_interval` (200ms) — Hyperliquid caps outbound at 2000/min.
+     Every sent subscribe is recorded in Quarantine's send log.
 
-  4. **Inbound BBO.** A `bbo` frame is parsed into a `BboPoint`, fanned out
-     to every slug mapped to that coin, and pushed via
+  4. **Inbound BBO.** A `bbo` frame is parsed (`BboPoint.parse_frame_data/4`),
+     fanned out to every slug mapped to that coin, and pushed via
      `KafkaExporter.persist_async/2`. Per coin: the first frame in a
      `coalesce_window_ms` window emits immediately; later frames in the same
-     window overwrite a `coalesce_buffer` slot (latest wins).
+     window overwrite a `coalesce_buffer` slot (latest wins). A
+     `:flush_coalesced` tick (every 250ms) emits buffered entries whose
+     window has elapsed.
 
-  5. **Coalesce flush (every 250ms).** Walks `coalesce_buffer` and emits any entry
-     whose window has elapsed. Bounds the worst-case extra latency at the
-     window boundary to one tick (~250ms).
+  5. **Liveness.** Outbound `ping` every 30s (HL closes idle sockets ~60s).
+     A `:healthcheck` tick every 60s counts misses when no frame arrived for
+     `@healthcheck_tolerance`; too many consecutive misses raise
+     `HealthcheckError` so the supervisor restarts the process.
 
-  6. **Liveness.** Outbound `ping` every 50s. A `:healthcheck` tick every 60s
-     checks `now - last_message_time`; if it exceeds
-     `@healthcheck_tolerance`, a miss is counted. After
-     `@healthcheck_max_failures` consecutive misses the process raises
-     `HealthcheckError` and the supervisor restarts it.
-
-  7. **Disconnect.** `handle_disconnect/2` cancels timers, clears
-     `active_subs`/`pending_sub_queue`/`coalesce_buffer`/`last_emitted`/
-     `healthcheck_failures`, then sleeps a backoff (plus jitter) before
-     reconnecting. The backoff doubles per disconnect (total sleep, jitter
-     included, capped at `@reconnect_max_ms`) and resets to
-     `@reconnect_initial_ms` only after a
-     connection survives `@stable_connection_ms` — a connection that dies
-     young keeps backing off, so a remote that kills us seconds after connect
-     (e.g. per-IP rate limiting) slows us down instead of locking us into a
-     reconnect storm that keeps the IP over the limit. Reconnect re-enters
+  6. **Disconnect.** `handle_disconnect/2` first runs crash forensics
+     (`Quarantine.handle_crash/3`), then clears the connection state and
+     sleeps the `Reconnect` backoff (plus jitter) before reconnecting into
      step 1.
+
+  7. **Probes (`:probe_next`, every 500ms).** `Quarantine.probe_tick/5`
+     re-tries probation coins on a settled connection — pipelined, ~2
+     coins/s — and tells this process which subscribe frame to queue.
   """
 
   use WebSockex
@@ -63,6 +77,8 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
 
   alias Sanbase.Hyperliquid.Bbo.BboPoint
   alias Sanbase.Hyperliquid.Bbo.CoinUniverse
+  alias Sanbase.Hyperliquid.Bbo.Quarantine
+  alias Sanbase.Hyperliquid.Bbo.Reconnect
   alias Sanbase.Project.SourceSlugMapping
   alias Sanbase.Utils.Config
 
@@ -81,36 +97,23 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   @healthcheck_max_failures 5
   # Resync subscriptions against SourceSlugMapping on this cadence.
   @reconcile_interval 60_000
-  # Throttle for the (best-effort, non-blocking) coin-universe audit run from
-  # reconcile, so a reconnect storm can't hammer the HL `info` endpoint.
+  # Refresh the universe audit on this cadence while connected.
   @audit_interval 300_000
-
+  # Hard floor between audit runs, whatever triggers them (connect or the
+  # periodic tick) — a scraper crash-looping every few seconds must not
+  # hammer the HL info endpoint.
+  @audit_min_gap_ms 30_000
   # Hyperliquid limits outbound client messages to 2000/min (~33/sec). We pace
-  # subscribe/unsubscribe frames at 1 per 50ms = 20/sec = 1200/min — ~40%
-  # headroom. Cold-start burst of ~200 coins drains in ~10s, well under.
-  @flush_subs_interval 50
-
+  # subscribe/unsubscribe frames at 1 per 200ms = 5/sec = 300/min — ~85%
+  # headroom. Cold-start burst of ~200 coins drains in ~40s.
+  @flush_subs_interval 200
   # Tick rate for draining the per-coin coalesce buffer.
   @flush_coalesced_interval 250
   # Default debounce window per coin; overridable via app config.
   @coalesce_window_default_ms 1_000
-  # First reconnect delay; doubles per consecutive disconnect, capped below.
-  @reconnect_initial_ms 1_000
-  # Hard ceiling on a single reconnect sleep, jitter included.
-  @reconnect_max_ms 20_000
-  # A connection must live this long before the next disconnect starts the
-  # backoff over from @reconnect_initial_ms; anything shorter keeps doubling.
-  @stable_connection_ms 60_000
-  # Cap on the random jitter added to each reconnect sleep, so instances
-  # sharing an egress IP don't reconnect in lockstep (HL limits are per IP,
-  # aggregated across every client behind it).
-  @reconnect_jitter_max_ms 1_000
-  # The exponential part of the backoff caps here so base + jitter never
-  # exceeds @reconnect_max_ms.
-  @reconnect_base_cap_ms @reconnect_max_ms - @reconnect_jitter_max_ms
-  # Rolling window for counting our own connects, matching the window of HL's
-  # "30 new connections per minute per IP" limit.
-  @connects_window_ms 60_000
+  # Cadence of the probation worker tick; probe windows and pacing live in
+  # Quarantine.
+  @probe_interval 500
 
   def child_spec(_opts \\ []) do
     %{id: __MODULE__, start: {__MODULE__, :start_link, []}}
@@ -133,21 +136,20 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   defp initial_state() do
     %{
       active_subs: MapSet.new(),
-      # Coins Hyperliquid does not know about (per the periodic universe audit).
-      # Excluded from subscriptions in reconcile/2 and kept across reconnects so
-      # a storm never re-subscribes to known-bad coins. Refreshed each audit, so
-      # a coin re-listed on HL is picked back up automatically.
-      unsupported: MapSet.new(),
+      # Coin discipline (audit exclusions, probation, probes, convictions,
+      # send log) — see Sanbase.Hyperliquid.Bbo.Quarantine. Kept across
+      # reconnects.
+      quarantine: Quarantine.new(),
       # Coins that were already awaiting a subscribe confirmation at the end
-      # of the previous reconcile round. warn_unconfirmed/2 only flags coins
-      # present in BOTH rounds, so a coin queued for the first time this
-      # round is never reported as "never confirmed". Cleared on disconnect.
+      # of the previous reconcile round. probate_unconfirmed/2 moves coins
+      # present in BOTH rounds to probation, so a coin queued for the first
+      # time this round is never flagged. Cleared on disconnect.
       prev_unconfirmed: MapSet.new(),
       slug_map: %{},
       pending_sub_queue: :queue.new(),
       last_emitted: %{},
       coalesce_buffer: %{},
-      reconnect_backoff_ms: @reconnect_initial_ms,
+      reconnect_backoff_ms: Reconnect.initial_backoff_ms(),
       last_message_time: System.system_time(:millisecond),
       healthcheck_failures: 0,
       coalesce_window_ms: coalesce_window_ms(),
@@ -171,22 +173,6 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     }
   end
 
-  # Record a successful emit for diagnostics. Map.update with a default (not
-  # `%{state | ...}`) so a live process predating this key never raises.
-  defp record_exported(state, coin, data) do
-    entry = %{
-      point: data,
-      exported_at_ms: System.system_time(:millisecond),
-      count: get_in(state, [:last_exported, coin, :count]) |> Kernel.||(0) |> Kernel.+(1)
-    }
-
-    Map.update(state, :last_exported, %{coin => entry}, &Map.put(&1, coin, entry))
-  end
-
-  # Safe counter bump — creates the key at 1 if the running process predates it
-  # (relevant when recompiling this module against a live process via `r/1`).
-  defp bump(state, key), do: Map.update(state, key, 1, &(&1 + 1))
-
   defp coalesce_window_ms() do
     case Config.module_get(__MODULE__, :coalesce_window_ms) do
       ms when is_integer(ms) -> ms
@@ -199,10 +185,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
 
   def handle_connect(_conn, state) do
     now = System.system_time(:millisecond)
-
-    connect_times =
-      [now | Map.get(state, :connect_times, [])]
-      |> Enum.take_while(&(now - &1 < @connects_window_ms))
+    connect_times = Reconnect.track_connect(Map.get(state, :connect_times, []), now)
 
     Logger.info(
       "[HyperliquidBboWS] connected reconnects=#{Map.get(state, :reconnects, 0)} " <>
@@ -214,7 +197,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
       %{state | last_message_time: now}
       # Reset per-connection diagnostics; Map.merge is recompile-safe. The
       # reconnect backoff is deliberately NOT reset here — only a connection
-      # that survives @stable_connection_ms earns a reset (handle_disconnect),
+      # that survives the stability threshold earns a reset (see Reconnect),
       # otherwise a remote that drops us seconds after connect pins the
       # backoff at its minimum forever. connected_at is monotonic because the
       # backoff-reset decision depends on it — an NTP step of the wall clock
@@ -222,9 +205,11 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
       |> Map.merge(%{
         connected_at: System.monotonic_time(:millisecond),
         bbo_in: 0,
-        connect_times: connect_times
+        connect_times: connect_times,
+        quarantine: Quarantine.on_connect(quarantine_state(state))
       })
       |> schedule_all_timers()
+      |> maybe_start_audit()
 
     send(self(), :reconcile_subscriptions)
     {:ok, state}
@@ -241,27 +226,32 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     reason = Map.get(status, :reason)
     attempt = Map.get(status, :attempt_number, 1)
 
-    {base_ms, next_backoff_ms} = backoff_plan(state.reconnect_backoff_ms, lifetime_ms, attempt)
-    # Jitter de-syncs instances sharing an egress IP; proportional to the
-    # backoff so a healthy single reconnect stays fast, and bounded so
-    # base + jitter never exceeds @reconnect_max_ms.
-    sleep_ms = base_ms + :rand.uniform(min(base_ms, @reconnect_jitter_max_ms))
+    {base_ms, next_backoff_ms} = Reconnect.plan(state.reconnect_backoff_ms, lifetime_ms, attempt)
+    sleep_ms = base_ms + Reconnect.jitter_ms(base_ms)
+
+    now = System.system_time(:millisecond)
+    q = quarantine_state(state)
 
     # lifetime_ms shows whether the socket dies on a fixed cadence
     # (policy/limit) or randomly (network); bbo_in>0 means data was flowing
     # right up to the drop (so mappings are fine); pending_subs>0 means we
-    # died mid-drain of the subscribe queue.
+    # died mid-drain of the subscribe queue; last_subs_sent points at the
+    # trigger when the same coin keeps preceding the crash.
     Logger.warning(
-      "[HyperliquidBboWS] disconnect cause=#{disconnect_cause(reason)} attempt=#{attempt} " <>
+      "[HyperliquidBboWS] disconnect cause=#{Reconnect.describe_cause(reason)} attempt=#{attempt} " <>
         "lifetime_ms=#{inspect(lifetime_ms)} " <>
-        "last_frame_age_ms=#{System.system_time(:millisecond) - state.last_message_time} " <>
+        "last_frame_age_ms=#{now - state.last_message_time} " <>
         "bbo_in=#{Map.get(state, :bbo_in, 0)} active_subs=#{MapSet.size(state.active_subs)} " <>
         "pending_subs=#{:queue.len(state.pending_sub_queue)} " <>
+        "last_subs_sent=[#{Quarantine.recent_sends_summary(q, now)}] " <>
+        "probation=#{length(Quarantine.probation(q))} " <>
+        "quarantined=#{map_size(q.quarantined)} " <>
         "reconnects=#{Map.get(state, :reconnects, 0)} backoff=#{sleep_ms}ms"
     )
 
     state =
       state
+      |> handle_crash_suspects(now, attempt)
       |> cancel_timers()
       |> Map.merge(%{
         active_subs: MapSet.new(),
@@ -278,43 +268,6 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     Process.sleep(sleep_ms)
     {:reconnect, state}
   end
-
-  @doc false
-  # The reconnect schedule after a disconnect: `{sleep_base_ms, next_backoff_ms}`.
-  # `sleep_base_ms` is slept now (plus jitter); `next_backoff_ms` is stored for
-  # the disconnect after this one, so the ladder walks
-  # @reconnect_initial_ms, 2x, 4x, ... up to @reconnect_base_cap_ms. Only a
-  # dropped live connection (attempt == 1) that survived @stable_connection_ms
-  # restarts the ladder; short-lived connections and failed reconnect attempts
-  # (attempt > 1, where lifetime_ms is nil) keep climbing. Public only for
-  # tests — handle_disconnect/2 can't be exercised without a real 1s+ sleep.
-  def backoff_plan(current_backoff_ms, lifetime_ms, attempt) do
-    stable? = attempt == 1 and is_integer(lifetime_ms) and lifetime_ms >= @stable_connection_ms
-
-    base_ms =
-      if stable?,
-        do: @reconnect_initial_ms,
-        else: min(current_backoff_ms, @reconnect_base_cap_ms)
-
-    {base_ms, min(base_ms * 2, @reconnect_base_cap_ms)}
-  end
-
-  # The remote's stated reason for the drop, in words. `{:remote, :closed}` is
-  # an abrupt TCP close with NO WebSocket close frame — the remote never said
-  # why; no more detail exists on the wire. HL/CloudFront drop connections
-  # this way when per-IP limits are exceeded (10 concurrent conns, 30 new
-  # conns/min, 2000 client msgs/min, 1000 subs — aggregated over every client
-  # behind the IP), so persistent short lifetimes + this cause usually mean
-  # IP-level rate limiting rather than an app error. A graceful close frame
-  # (code + message) surfaces via the clause below.
-  defp disconnect_cause({:remote, :closed}),
-    do: "remote dropped TCP without a close frame (no reason on wire; rate-limit/infra style)"
-
-  defp disconnect_cause({:remote, code, msg}),
-    do: "remote sent close frame code=#{inspect(code)} msg=#{inspect(msg)}"
-
-  defp disconnect_cause({:local, reason}), do: "closed by our side: #{inspect(reason)}"
-  defp disconnect_cause(other), do: inspect(other)
 
   def terminate(reason, _state) do
     Logger.warning("[HyperliquidBboWS] terminate reason=#{inspect(reason)}")
@@ -369,9 +322,12 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
 
   defp handle_sub_response(_other, state), do: state
 
+  # Export path
+
   defp handle_bbo(%{"coin" => coin, "time" => time_ms, "bbo" => [bid, ask]}, state) do
     with slugs when is_list(slugs) <- Map.get(state.slug_map, coin),
-         point_data when not is_nil(point_data) <- build_point_data(coin, time_ms, bid, ask) do
+         point_data when not is_nil(point_data) <-
+           BboPoint.parse_frame_data(coin, time_ms, bid, ask) do
       now = System.system_time(:millisecond)
       last = Map.get(state.last_emitted, coin)
 
@@ -394,42 +350,6 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
 
   defp handle_bbo(_, state), do: state
 
-  defp build_point_data(coin, time_ms, bid, ask) do
-    {bp, bv} = parse_side(bid)
-    {ap, av} = parse_side(ask)
-
-    if Enum.all?([bp, bv, ap, av], &is_nil/1) do
-      nil
-    else
-      %{
-        coin: coin,
-        timestamp_ms: time_ms,
-        bid_price: bp,
-        bid_volume: bv,
-        ask_price: ap,
-        ask_volume: av
-      }
-    end
-  end
-
-  defp parse_side(nil), do: {nil, nil}
-
-  defp parse_side(%{"px" => px, "sz" => sz}) do
-    {parse_float(px), parse_float(sz)}
-  end
-
-  defp parse_side(_), do: {nil, nil}
-
-  defp parse_float(nil), do: nil
-  defp parse_float(n) when is_number(n), do: n * 1.0
-
-  defp parse_float(s) when is_binary(s) do
-    case Float.parse(s) do
-      {f, _} -> f
-      :error -> nil
-    end
-  end
-
   defp emit(slugs, data) do
     tuples =
       Enum.map(slugs, fn slug ->
@@ -438,6 +358,18 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
       end)
 
     :ok = Sanbase.KafkaExporter.persist_async(tuples, @exporter)
+  end
+
+  # Record a successful emit for diagnostics. Map.update with a default (not
+  # `%{state | ...}`) so a live process predating this key never raises.
+  defp record_exported(state, coin, data) do
+    entry = %{
+      point: data,
+      exported_at_ms: System.system_time(:millisecond),
+      count: get_in(state, [:last_exported, coin, :count]) |> Kernel.||(0) |> Kernel.+(1)
+    }
+
+    Map.update(state, :last_exported, %{coin => entry}, &Map.put(&1, coin, entry))
   end
 
   # handle_info
@@ -472,6 +404,35 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     {:ok, state}
   end
 
+  # Probation worker tick — verdicts and probe selection live in Quarantine;
+  # this provides the connection facts and queues the subscribe frame when a
+  # probe starts.
+  def handle_info(:probe_next, state) do
+    {q, action} =
+      Quarantine.probe_tick(
+        quarantine_state(state),
+        state.active_subs,
+        connection_uptime_ms(state),
+        :queue.is_empty(state.pending_sub_queue),
+        System.system_time(:millisecond)
+      )
+
+    state = Map.put(state, :quarantine, q)
+
+    state =
+      case action do
+        {:subscribe, coin} ->
+          state
+          |> Map.update!(:pending_sub_queue, &:queue.in({"subscribe", coin}, &1))
+          |> maybe_schedule_flush_subs()
+
+        :noop ->
+          state
+      end
+
+    {:ok, schedule(state, :probe_next, @probe_interval)}
+  end
+
   def handle_info(:reconcile_subscriptions, state) do
     state =
       state
@@ -485,14 +446,19 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
   # Re-arms only if more frames remain — when queue empties the timer stops
   # until reconcile kicks it again. The just-fired timer ref is stale; clear
   # it before deciding whether to re-arm so maybe_schedule_flush_subs/1 sees
-  # an accurate timer state.
+  # an accurate timer state. Sent subscribes are recorded in Quarantine as
+  # crash evidence (slugs resolved now — slug_map may differ by crash time).
   def handle_info(:flush_subs, state) do
     state = %{state | timers: Map.delete(state.timers, :flush_subs)}
 
     case :queue.out(state.pending_sub_queue) do
-      {{:value, frame}, queue2} ->
-        state = %{state | pending_sub_queue: queue2} |> maybe_schedule_flush_subs()
-        {:reply, frame, state}
+      {{:value, {method, coin}}, queue2} ->
+        state =
+          %{state | pending_sub_queue: queue2}
+          |> track_sub_send(method, coin)
+          |> maybe_schedule_flush_subs()
+
+        {:reply, sub_frame(method, coin), state}
 
       {:empty, _} ->
         {:ok, state}
@@ -533,11 +499,15 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     {:ok, state}
   end
 
-  # Refresh the `unsupported` set from an audit run; the next scheduled reconcile
-  # (≤60s) applies it. A fetch failure returns a non-map result and is ignored,
-  # keeping the previous set.
-  def handle_info({:audit_result, %{unsupported: unsupported}}, state) do
-    {:ok, Map.put(state, :unsupported, MapSet.new(unsupported))}
+  def handle_info(:audit, state) do
+    {:ok, state |> maybe_start_audit() |> schedule(:audit, @audit_interval)}
+  end
+
+  # An audit verdict from the separate audit process — Quarantine applies it;
+  # the next reconcile (≤60s) unsubscribes anything newly excluded. A failed
+  # audit sends an error tuple and keeps the previous verdicts.
+  def handle_info({:audit_result, %{reasons: reasons}}, state) do
+    {:ok, Map.put(state, :quarantine, Quarantine.apply_audit(quarantine_state(state), reasons))}
   end
 
   def handle_info({:audit_result, _}, state), do: {:ok, state}
@@ -548,29 +518,54 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
 
   defp reconcile(state) do
     {full_desired, slug_map} = load_mappings()
-    unsupported = Map.get(state, :unsupported, MapSet.new())
-    # Subscribe to everything we're mapped to, minus coins HL doesn't recognise.
-    desired_set = MapSet.difference(full_desired, unsupported)
+    q = quarantine_state(state)
+    excluded = Quarantine.excluded(q)
+    probation = Quarantine.probation(q)
+
+    # Subscribe to everything we're mapped to, minus excluded coins (env
+    # ignores, audit verdicts, probe convictions) and coins on probation
+    # (those are re-tried by the probe worker, never by the bulk subscribe).
+    desired_set =
+      full_desired
+      |> MapSet.difference(MapSet.new(Map.keys(excluded)))
+      |> MapSet.difference(MapSet.new(probation))
+
+    # In-flight probes subscribed their coins deliberately — don't let the
+    # probation exclusion above unsubscribe them mid-verdict.
+    probe_exempt = MapSet.new(Quarantine.probing_coins(q))
 
     to_subscribe = MapSet.difference(desired_set, state.active_subs)
-    to_unsubscribe = MapSet.difference(state.active_subs, desired_set)
+    {state, to_subscribe} = probate_unconfirmed(state, to_subscribe)
+    to_subscribe = defer_while_probing(to_subscribe, q)
 
-    warn_unconfirmed(state, to_subscribe)
+    to_unsubscribe =
+      state.active_subs
+      |> MapSet.difference(desired_set)
+      |> MapSet.difference(probe_exempt)
 
     if MapSet.size(to_subscribe) > 0 or MapSet.size(to_unsubscribe) > 0 do
       Logger.info(
-        "[HyperliquidBboWS] reconcile +sub=#{MapSet.size(to_subscribe)} -unsub=#{MapSet.size(to_unsubscribe)} desired=#{MapSet.size(desired_set)} excluded_unsupported=#{MapSet.size(unsupported)}"
+        "[HyperliquidBboWS] reconcile +sub=#{MapSet.size(to_subscribe)} -unsub=#{MapSet.size(to_unsubscribe)} desired=#{MapSet.size(desired_set)} excluded=#{map_size(excluded)} probation=#{length(probation)}"
       )
     end
 
+    # Queue {method, coin} tuples, not encoded frames — flush_subs builds the
+    # frame at send time and needs the coin to record what was just sent.
+    # Shuffled: MapSet iteration order is deterministic for the same coin set,
+    # so if the remote kills the connection at a fixed point in the drain
+    # (e.g. an IP-level limit), the SAME innocent coins would sit newest-
+    # before-death on every disconnect and look guilty. Random order makes a
+    # repeat offender in the crash-suspect window a real per-coin signal.
     new_queue =
-      Enum.reduce(to_subscribe, state.pending_sub_queue, fn coin, q ->
-        :queue.in(sub_frame("subscribe", coin), q)
+      to_subscribe
+      |> Enum.shuffle()
+      |> Enum.reduce(state.pending_sub_queue, fn coin, queue ->
+        :queue.in({"subscribe", coin}, queue)
       end)
 
     new_queue =
-      Enum.reduce(to_unsubscribe, new_queue, fn coin, q ->
-        :queue.in(sub_frame("unsubscribe", coin), q)
+      Enum.reduce(to_unsubscribe, new_queue, fn coin, queue ->
+        :queue.in({"unsubscribe", coin}, queue)
       end)
 
     dropped = MapSet.to_list(to_unsubscribe)
@@ -584,61 +579,59 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     }
     |> Map.put(:prev_unconfirmed, to_subscribe)
     |> maybe_schedule_flush_subs()
-    # Audit the FULL mapped set (not the reduced one) so a previously
-    # unsupported coin that HL re-lists is detected and re-included.
-    |> maybe_audit_coins(full_desired)
   end
 
-  # Ground truth on coin support: a subscribe frame sent long ago that never
-  # got a subscriptionResponse means HL silently ignored it. The universe
-  # audit can overcount — spot *token* names pass it, but `bbo` only accepts
-  # tradeable pair names (perps like "BTC"/"xyz:GOLD", spot pairs like
-  # "@107") — so this is the check that proves a coin actually streams. Warns
-  # only about coins already awaiting confirmation on the PREVIOUS reconcile
-  # round (a coin appearing in to_subscribe for the first time hasn't even
-  # had its subscribe frame queued yet — that happens after this check), and
-  # only once the connection has outlived a couple of reconcile rounds with
-  # an empty outbound queue; during connection churn it stays silent.
-  defp warn_unconfirmed(state, to_subscribe) do
-    still_unconfirmed =
-      MapSet.intersection(to_subscribe, Map.get(state, :prev_unconfirmed, MapSet.new()))
+  # Probe verdicts must stay unambiguous: while probes are in flight, defer
+  # NEW bulk subscribes to the next reconcile (≤60s) so probe frames are the
+  # only unconfirmed subscribes on the wire. Unsubscribes proceed — they
+  # don't trigger kills. Deferred coins also stay out of prev_unconfirmed
+  # (nothing was queued for them this round).
+  defp defer_while_probing(to_subscribe, q) do
+    case Quarantine.probing_coins(q) do
+      [] ->
+        to_subscribe
 
-    connected_at = Map.get(state, :connected_at)
+      probing_coins ->
+        if MapSet.size(to_subscribe) > 0 do
+          Logger.info(
+            "[HyperliquidBboWS] deferring #{MapSet.size(to_subscribe)} subscribe(s) " <>
+              "until the probes of #{inspect(probing_coins)} resolve"
+          )
+        end
 
-    age_ms =
-      if connected_at, do: System.monotonic_time(:millisecond) - connected_at, else: 0
-
-    if age_ms > 2 * @reconcile_interval and MapSet.size(still_unconfirmed) > 0 and
-         :queue.is_empty(state.pending_sub_queue) do
-      coins = still_unconfirmed |> MapSet.to_list() |> Enum.sort()
-
-      Logger.warning(
-        "[HyperliquidBboWS] #{length(coins)} coin(s) never confirmed by HL " <>
-          "after #{div(age_ms, 1000)}s connected (subscribe sent, no subscriptionResponse): " <>
-          "#{inspect(coins)}"
-      )
+        MapSet.new()
     end
-
-    :ok
   end
 
-  # Run the coin-universe audit off the WS process (so the HTTP call never
-  # blocks frame handling) and no more than once per @audit_interval. The task
-  # sends its result back to this process to refresh the `unsupported` set.
-  defp maybe_audit_coins(state, desired_set) do
-    now = System.system_time(:millisecond)
+  # Ground truth on coin support: a subscribe frame sent a full reconcile
+  # round ago that never got a subscriptionResponse means HL silently ignored
+  # it — the audit validates against tradeable pair names, but only this
+  # proves a coin actually streams. Such coins move to probation for an
+  # individual probe verdict instead of being re-queued forever. Only coins
+  # already awaiting confirmation on the PREVIOUS round count (a coin in
+  # to_subscribe for the first time hasn't had its frame queued yet — that
+  # happens after this), and only once the connection has outlived two
+  # reconcile rounds with an empty outbound queue; during churn it's silent.
+  defp probate_unconfirmed(state, to_subscribe) do
+    age_ms = connection_uptime_ms(state)
 
-    if now - Map.get(state, :last_audit_at, 0) >= @audit_interval do
-      parent = self()
-      Task.start(fn -> send(parent, {:audit_result, CoinUniverse.audit(desired_set)}) end)
-      Map.put(state, :last_audit_at, now)
+    stuck =
+      if age_ms > 2 * @reconcile_interval and :queue.is_empty(state.pending_sub_queue),
+        do: MapSet.intersection(to_subscribe, Map.get(state, :prev_unconfirmed, MapSet.new())),
+        else: MapSet.new()
+
+    if MapSet.size(stuck) == 0 do
+      {state, to_subscribe}
     else
-      state
-    end
-  end
+      q =
+        Quarantine.probate(
+          quarantine_state(state),
+          stuck |> MapSet.to_list() |> Enum.sort(),
+          "subscribe sent, no subscriptionResponse after #{div(age_ms, 1000)}s connected"
+        )
 
-  defp sub_frame(method, coin) do
-    {:text, Jason.encode!(%{method: method, subscription: %{type: "bbo", coin: coin}})}
+      {Map.put(state, :quarantine, q), MapSet.difference(to_subscribe, stuck)}
+    end
   end
 
   defp load_mappings() do
@@ -656,6 +649,64 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     {MapSet.new(Map.keys(slug_map)), slug_map}
   end
 
+  defp sub_frame(method, coin) do
+    {:text, Jason.encode!(%{method: method, subscription: %{type: "bbo", coin: coin}})}
+  end
+
+  # Quarantine glue
+
+  # Crash forensics — probe verdicts and probation live in Quarantine; this
+  # runs BEFORE active_subs is cleared. attempt > 1 = failed reconnect
+  # attempt — no new frames were sent, nothing to learn.
+  defp handle_crash_suspects(state, _now, attempt) when attempt != 1, do: state
+
+  defp handle_crash_suspects(state, now, 1) do
+    q = Quarantine.handle_crash(quarantine_state(state), state.active_subs, now)
+    Map.put(state, :quarantine, q)
+  end
+
+  defp track_sub_send(state, "subscribe", coin) do
+    q =
+      Quarantine.track_send(
+        quarantine_state(state),
+        coin,
+        Map.get(state.slug_map, coin, []),
+        System.system_time(:millisecond)
+      )
+
+    Map.put(state, :quarantine, q)
+  end
+
+  defp track_sub_send(state, _method, _coin), do: state
+
+  # Recompile-safe accessor: a live process predating the :quarantine key
+  # gets a fresh struct instead of a crash.
+  defp quarantine_state(state), do: Map.get(state, :quarantine) || Quarantine.new()
+
+  defp connection_uptime_ms(state) do
+    case Map.get(state, :connected_at) do
+      nil -> 0
+      at -> System.monotonic_time(:millisecond) - at
+    end
+  end
+
+  # Run the universe audit in its own process (the HTTP calls must never
+  # block frame handling), at most once per @audit_min_gap_ms no matter what
+  # triggers it — last_audit_at survives disconnects, so a crash-connect loop
+  # stays rate-limited. The task audits the FULL mapped set (audit/0 loads it
+  # itself) and sends {:audit_result, ...} back to this process.
+  defp maybe_start_audit(state) do
+    now = System.system_time(:millisecond)
+
+    if now - Map.get(state, :last_audit_at, 0) >= @audit_min_gap_ms do
+      parent = self()
+      Task.start(fn -> send(parent, {:audit_result, CoinUniverse.audit()}) end)
+      Map.put(state, :last_audit_at, now)
+    else
+      state
+    end
+  end
+
   # Timers
 
   defp schedule_all_timers(state) do
@@ -664,6 +715,8 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     |> schedule(:healthcheck, @healthcheck_interval)
     |> schedule(:flush_coalesced, @flush_coalesced_interval)
     |> schedule(:reconcile_subscriptions, @reconcile_interval)
+    |> schedule(:probe_next, @probe_interval)
+    |> schedule(:audit, @audit_interval)
   end
 
   # Arms :flush_subs only when there's something to drain and no timer is
@@ -675,6 +728,10 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
       true -> schedule(state, :flush_subs, @flush_subs_interval)
     end
   end
+
+  # Safe counter bump — creates the key at 1 if the running process predates it
+  # (relevant when recompiling this module against a live process via `r/1`).
+  defp bump(state, key), do: Map.update(state, key, 1, &(&1 + 1))
 
   defp schedule(state, key, ms) do
     case Map.get(state.timers, key) do

--- a/lib/sanbase/hyperliquid/bbo/bbo_websocket_scraper.ex
+++ b/lib/sanbase/hyperliquid/bbo/bbo_websocket_scraper.ex
@@ -67,8 +67,9 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
      step 1.
 
   7. **Probes (`:probe_next`, every 500ms).** `Quarantine.probe_tick/5`
-     re-tries probation coins on a settled connection — pipelined, ~2
-     coins/s — and tells this process which subscribe frame to queue.
+     re-tries probation coins on a settled connection — pipelined, paced by
+     Quarantine's spacing — and tells this process which subscribe frame to
+     queue.
   """
 
   use WebSockex
@@ -562,6 +563,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraper do
     # (those are re-tried by the probe worker, never by the bulk subscribe).
     desired_set =
       full_desired
+      |> MapSet.put("ANSEM")
       |> MapSet.difference(MapSet.new(Map.keys(excluded)))
       |> MapSet.difference(MapSet.new(probation))
 

--- a/lib/sanbase/hyperliquid/bbo/coin_universe.ex
+++ b/lib/sanbase/hyperliquid/bbo/coin_universe.ex
@@ -139,7 +139,9 @@ defmodule Sanbase.Hyperliquid.Bbo.CoinUniverse do
           | {:unsupported, :spot_token_only | :not_in_universe, [String.t()]}
           | :unverified
   def coin_supported?(coin, timeout \\ @verify_timeout) when is_binary(coin) do
-    task = Task.async(fn -> fetch() end)
+    # async_nolink: a crash inside fetch/0 must degrade to :unverified, not
+    # take down the caller (a changeset validation) with it.
+    task = Task.Supervisor.async_nolink(Sanbase.TaskSupervisor, fn -> fetch() end)
 
     case Task.yield(task, timeout) || Task.shutdown(task) do
       {:ok, {:ok, %{valid: valid, spot_tokens: spot_tokens, token_pairs: token_pairs}}} ->

--- a/lib/sanbase/hyperliquid/bbo/coin_universe.ex
+++ b/lib/sanbase/hyperliquid/bbo/coin_universe.ex
@@ -8,6 +8,14 @@ defmodule Sanbase.Hyperliquid.Bbo.CoinUniverse do
   stocks, commodities, FX and other RWAs live (namespaced like `"xyz:GOLD"`) —
   and spot. No single endpoint returns all of them, so we list the dexs and
   union one `meta` request per dex with `spotMeta`.
+
+  A name is valid for the `bbo` channel only if it is a *tradeable pair*: a
+  perp name (`"BTC"`, `"xyz:GOLD"`) or a spot pair name (`"@107"`,
+  `"PURR/USDC"`). Spot *token* names (`spotMeta.tokens[].name`, e.g. a bare
+  `"ANSEM"`) are deliberately NOT part of the valid set — a token with no perp
+  market cannot be streamed under its bare name, and subscribing it is at best
+  silently ignored. Such coins are flagged with a dedicated reason and, when
+  the token has spot pairs, the pair names to use instead.
   """
 
   require Logger
@@ -47,33 +55,45 @@ defmodule Sanbase.Hyperliquid.Bbo.CoinUniverse do
 
   @doc ~s"""
   Cross-check the coins we would subscribe to against Hyperliquid's live
-  universe (every perp dex plus spot). Logs and returns every coin HL does not
-  know about — the authoritative "bad coin" list. With no argument it loads the
-  `#{@source}` mappings itself, so it's safe from a remote console:
+  universe (every perp dex plus spot). Logs and returns every coin that cannot
+  be streamed over `bbo`, each with the reason — either not known to HL at
+  all, or existing only as a spot token with no perp market (in which case the
+  reason names the spot pair(s) to map instead, when any exist). With no
+  argument it loads the `#{@source}` mappings itself, so it's safe from a
+  remote console:
 
       Sanbase.Hyperliquid.Bbo.CoinUniverse.audit()
 
-  Returns `%{desired: n, universe: n, unsupported: [coin, ...]}`, or
-  `{:error, reason}` if the universe could not be fetched.
+  Returns `%{desired: n, universe: n, unsupported: [coin, ...],
+  reasons: %{coin => reason}}`, or `{:error, reason}` if the universe could
+  not be fetched.
   """
   def audit(desired \\ nil) do
     desired = MapSet.to_list(desired || mapped_coins())
 
     case fetch() do
-      {:ok, universe} ->
-        unsupported = desired |> Enum.reject(&MapSet.member?(universe, &1)) |> Enum.sort()
+      {:ok, %{valid: valid} = universe} ->
+        unsupported = desired |> Enum.reject(&MapSet.member?(valid, &1)) |> Enum.sort()
+        reasons = Map.new(unsupported, fn coin -> {coin, unsupported_reason(coin, universe)} end)
 
         if unsupported == [] do
           Logger.info(
-            "[HyperliquidCoinUniverse] audit OK — all #{length(desired)} coins present (universe=#{MapSet.size(universe)})"
+            "[HyperliquidCoinUniverse] audit OK — all #{length(desired)} coins subscribable (universe=#{MapSet.size(valid)})"
           )
         else
+          details = Enum.map_join(unsupported, "; ", fn coin -> "#{coin}: #{reasons[coin]}" end)
+
           Logger.warning(
-            "[HyperliquidCoinUniverse] #{length(unsupported)}/#{length(desired)} coin(s) NOT in HL universe (universe=#{MapSet.size(universe)}): #{inspect(unsupported)}"
+            "[HyperliquidCoinUniverse] #{length(unsupported)}/#{length(desired)} coin(s) not subscribable over bbo (universe=#{MapSet.size(valid)}): #{details}"
           )
         end
 
-        %{desired: length(desired), universe: MapSet.size(universe), unsupported: unsupported}
+        %{
+          desired: length(desired),
+          universe: MapSet.size(valid),
+          unsupported: unsupported,
+          reasons: reasons
+        }
 
       {:error, reason} = error ->
         Logger.warning(
@@ -84,27 +104,56 @@ defmodule Sanbase.Hyperliquid.Bbo.CoinUniverse do
     end
   end
 
+  defp unsupported_reason(coin, %{spot_tokens: spot_tokens, token_pairs: token_pairs}) do
+    if MapSet.member?(spot_tokens, coin) do
+      case Map.get(token_pairs, coin, []) do
+        [] ->
+          "only a spot token on HL (no perp market, no spot pair) — bbo cannot stream it"
+
+        pairs ->
+          "only a spot token on HL (no perp market) — bbo needs a pair name, " <>
+            "map it as: #{Enum.join(Enum.take(pairs, @suggestion_limit), ", ")}"
+      end
+    else
+      "not in Hyperliquid's universe"
+    end
+  end
+
   @doc ~s"""
   Verify a single coin against Hyperliquid's live universe, bounded by
   `timeout` ms. Meant for the mapping-creation path.
 
   Returns:
-    * `:ok` — coin exists in the HL universe.
-    * `{:unsupported, suggestions}` — HL was reached and does not know this
-      coin; `suggestions` are the closest known names (Jaro), possibly empty.
+    * `:ok` — coin is a bbo-subscribable name (perp or spot pair).
+    * `{:unsupported, :spot_token_only, suggestions}` — HL knows the name only
+      as a spot token with no perp market; `suggestions` are the spot pair
+      names to map instead (possibly empty).
+    * `{:unsupported, :not_in_universe, suggestions}` — HL does not know this
+      name at all; `suggestions` are the closest known names (Jaro), possibly
+      empty.
     * `:unverified` — HL could not be reached in time (timeout / fetch error);
       caller should allow the write but warn.
   """
   @spec coin_supported?(String.t(), non_neg_integer()) ::
-          :ok | {:unsupported, [String.t()]} | :unverified
+          :ok
+          | {:unsupported, :spot_token_only | :not_in_universe, [String.t()]}
+          | :unverified
   def coin_supported?(coin, timeout \\ @verify_timeout) when is_binary(coin) do
     task = Task.async(fn -> fetch() end)
 
     case Task.yield(task, timeout) || Task.shutdown(task) do
-      {:ok, {:ok, universe}} ->
-        if MapSet.member?(universe, coin),
-          do: :ok,
-          else: {:unsupported, closest_coins(coin, universe)}
+      {:ok, {:ok, %{valid: valid, spot_tokens: spot_tokens, token_pairs: token_pairs}}} ->
+        cond do
+          MapSet.member?(valid, coin) ->
+            :ok
+
+          MapSet.member?(spot_tokens, coin) ->
+            pairs = Map.get(token_pairs, coin, []) |> Enum.take(@suggestion_limit)
+            {:unsupported, :spot_token_only, pairs}
+
+          true ->
+            {:unsupported, :not_in_universe, closest_coins(coin, valid)}
+        end
 
       _ ->
         :unverified
@@ -138,9 +187,15 @@ defmodule Sanbase.Hyperliquid.Bbo.CoinUniverse do
     |> Enum.map(fn {candidate, _distance} -> candidate end)
   end
 
-  # The full set of coins the bbo channel accepts, unioned across every perp dex
-  # (primary + each builder dex from `perpDexs`, which lists the primary as
-  # `null` and builder dexs as maps with a "name") and spot.
+  # The categorized universe:
+  #   valid       — names the bbo channel accepts: perp names from every dex
+  #                 (primary + each builder dex from `perpDexs`, which lists
+  #                 the primary as `null` and builder dexs as maps with a
+  #                 "name") plus spot PAIR names ("@107", "PURR/USDC").
+  #   spot_tokens — spot token names ("PURR"); NOT valid for bbo, tracked so
+  #                 a token-only mapping gets a precise reason.
+  #   token_pairs — %{token name => [spot pair names it is the base of]}, for
+  #                 "map it as @107 instead" suggestions.
   #
   # EVERY request must succeed — a partial fetch would omit part of the universe
   # and wrongly flag real coins as unsupported (blocking valid mapping creates
@@ -154,6 +209,8 @@ defmodule Sanbase.Hyperliquid.Bbo.CoinUniverse do
           _ -> %{type: "meta"}
         end)
 
+      # Order is preserved by Task.async_stream, so results align with
+      # [spotMeta | meta_requests].
       results =
         [%{type: "spotMeta"} | meta_requests]
         |> Task.async_stream(&info_request/1,
@@ -167,7 +224,15 @@ defmodule Sanbase.Hyperliquid.Bbo.CoinUniverse do
         end)
 
       if Enum.all?(results, &match?({:ok, _}, &1)) do
-        {:ok, results |> Enum.flat_map(fn {:ok, body} -> coin_names(body) end) |> MapSet.new()}
+        [{:ok, spot_body} | meta_oks] = results
+        perp_names = Enum.flat_map(meta_oks, fn {:ok, body} -> universe_names(body) end)
+
+        {:ok,
+         %{
+           valid: MapSet.new(perp_names ++ universe_names(spot_body)),
+           spot_tokens: MapSet.new(token_names(spot_body)),
+           token_pairs: token_pair_map(spot_body)
+         }}
       else
         {:error, :incomplete_universe}
       end
@@ -189,16 +254,46 @@ defmodule Sanbase.Hyperliquid.Bbo.CoinUniverse do
     end
   end
 
-  # Coin names in a `meta`/`spotMeta` body: `universe[].name` (perp or spot) plus
-  # spot `tokens[].name`.
-  defp coin_names(body) when is_map(body) do
-    Enum.flat_map(["universe", "tokens"], fn key ->
-      case Map.get(body, key) do
-        list when is_list(list) -> for %{"name" => name} <- list, is_binary(name), do: name
-        _ -> []
-      end
+  # Tradeable pair names in a `meta`/`spotMeta` body: `universe[].name`
+  # (perp names or spot pair names, depending on the endpoint).
+  defp universe_names(body), do: names_at(body, "universe")
+
+  # Spot token names (`spotMeta.tokens[].name`) — deliberately kept separate
+  # from the valid set; see the moduledoc.
+  defp token_names(body), do: names_at(body, "tokens")
+
+  defp names_at(body, key) when is_map(body) do
+    case Map.get(body, key) do
+      list when is_list(list) -> for %{"name" => name} <- list, is_binary(name), do: name
+      _ -> []
+    end
+  end
+
+  defp names_at(_, _), do: []
+
+  # %{token name => [spot pair names]} for pairs where the token is the BASE
+  # (`universe[].tokens` is `[base_index, quote_index]`), so an unsupported
+  # bare token can be reported with the pair name(s) to map instead.
+  defp token_pair_map(body) when is_map(body) do
+    index_to_name =
+      for %{"name" => name, "index" => index} <- Map.get(body, "tokens", []) |> List.wrap(),
+          is_binary(name) and is_integer(index),
+          into: %{},
+          do: {index, name}
+
+    Map.get(body, "universe", [])
+    |> List.wrap()
+    |> Enum.reduce(%{}, fn
+      %{"name" => pair, "tokens" => [base, _quote]}, acc when is_binary(pair) ->
+        case Map.get(index_to_name, base) do
+          nil -> acc
+          token -> Map.update(acc, token, [pair], &(&1 ++ [pair]))
+        end
+
+      _, acc ->
+        acc
     end)
   end
 
-  defp coin_names(_), do: []
+  defp token_pair_map(_), do: %{}
 end

--- a/lib/sanbase/hyperliquid/bbo/coin_universe.ex
+++ b/lib/sanbase/hyperliquid/bbo/coin_universe.ex
@@ -45,6 +45,7 @@ defmodule Sanbase.Hyperliquid.Bbo.CoinUniverse do
   against HL's live universe (a synchronous HTTP call). Off in tests so the
   suite never reaches out to Hyperliquid.
   """
+  @spec verify_on_write?() :: boolean()
   def verify_on_write?() do
     Config.module_get(__MODULE__, :verify_on_write?)
     |> to_string()
@@ -68,6 +69,13 @@ defmodule Sanbase.Hyperliquid.Bbo.CoinUniverse do
   reasons: %{coin => reason}}`, or `{:error, reason}` if the universe could
   not be fetched.
   """
+  @type audit_ok :: %{
+          desired: non_neg_integer(),
+          universe: non_neg_integer(),
+          unsupported: [String.t()],
+          reasons: %{optional(String.t()) => String.t()}
+        }
+  @spec audit(MapSet.t(String.t()) | nil) :: audit_ok() | {:error, term()}
   def audit(desired \\ nil) do
     desired = MapSet.to_list(desired || mapped_coins())
 

--- a/lib/sanbase/hyperliquid/bbo/quarantine.ex
+++ b/lib/sanbase/hyperliquid/bbo/quarantine.ex
@@ -1,4 +1,7 @@
 defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
+  # Declared before @moduledoc so the docs can interpolate it.
+  @probe_strikes_to_convict 2
+
   @moduledoc ~s"""
   Coin discipline for the Hyperliquid BBO scraper: which coins must not be
   subscribed, why, and the probation → probe → verdict workflow that decides
@@ -19,7 +22,7 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
       (unknown to HL, spot-token-only, ...). Replaced wholesale via
       `apply_audit/2` so a coin HL re-lists recovers automatically.
     * `quarantined` — probe convictions: the coin's solo subscribe killed the
-      connection `#{2}` times, or HL silently ignores it. Never
+      connection `#{@probe_strikes_to_convict}` times, or HL silently ignores it. Never
       auto-refreshed; a process restart clears it.
     * `ignored_coins/0` — operator escape hatch via the
       `HYPERLIQUID_IGNORED_COINS` env var (comma-separated coin names).
@@ -36,9 +39,9 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
   excluded from bulk subscribing and re-tried by probes (`probe_tick/5`) on a
   settled connection. Probes are PIPELINED: a new probe starts every
   `@probe_spacing_ms` while earlier ones await their `@probe_verdict_ms`
-  verdicts (~1 coin per 1.5s, a typical 5-8 coin sweep drains in ~10s).
-  Attribution stays unambiguous because the strike window never exceeds the
-  spacing, so a crash implicates at most one in-flight probe:
+  verdicts (~1 coin per 1.6s, a typical 5-8 coin sweep drains in ~10s).
+  Attribution stays unambiguous because the strike window is strictly smaller
+  than the spacing, so a crash implicates at most one in-flight probe:
 
     * crash within `@probe_strike_window_ms` of the probe → a strike; at
       `@probe_strikes_to_convict` strikes the coin is quarantined (two, so a
@@ -73,17 +76,17 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
   # strike; later crashes are infra noise (the coin keeps its probation
   # spot, no strike). Kill lag is typically 200-300ms but jitters higher —
   # observed kills near 500ms went unattributed and left strike counts stuck
-  # below conviction, so the window carries generous margin. Equal to
-  # @probe_spacing_ms so a crash implicates AT MOST ONE in-flight probe.
+  # below conviction, so the window carries generous margin. Strictly less
+  # than @probe_spacing_ms so a crash at the exact spacing boundary cannot
+  # blame two in-flight probes (ages 0 and spacing both fit a `<= spacing`
+  # window).
   @probe_strike_window_ms 1_500
   # Minimum gap between consecutive probe starts. Probes are pipelined — a
   # new one starts every spacing while earlier ones await verdicts — so a
-  # probation sweep drains at ~1 coin per 1.5s (typical 5-8 coin sweep in
-  # ~10s). Must not be smaller than @probe_strike_window_ms, else a crash
-  # could implicate several probes at once.
-  @probe_spacing_ms 1_500
-  # Probe crashes before conviction; see moduledoc.
-  @probe_strikes_to_convict 2
+  # probation sweep drains at ~1 coin per 1.6s (typical 5-8 coin sweep in
+  # ~10s). Must exceed @probe_strike_window_ms, else a crash could implicate
+  # several probes at once.
+  @probe_spacing_ms 1_600
   # Don't start a probe until the connection has been up this long with an
   # empty outbound queue, so the verdict isn't polluted by startup churn.
   @probe_min_uptime_ms 10_000
@@ -162,9 +165,9 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
 
     # A probe's strike/verdict clock restarts when its frame actually reaches
     # the wire. started_ms is first set at QUEUE time, but the flush pacing
-    # can burn up to 200ms before the send — added to the 200-300ms kill lag
-    # that eats the whole 500ms strike window, and real kills would go
-    # unattributed (strikes stuck below conviction forever).
+    # can burn up to 200ms before the send — added to the kill lag that can
+    # approach the strike window, and real kills would go unattributed
+    # (strikes stuck below conviction forever).
     probing =
       Enum.map(q.probing, fn
         %{coin: ^coin} = probe -> %{probe | started_ms: now}

--- a/lib/sanbase/hyperliquid/bbo/quarantine.ex
+++ b/lib/sanbase/hyperliquid/bbo/quarantine.ex
@@ -1,0 +1,390 @@
+defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
+  @moduledoc ~s"""
+  Coin discipline for the Hyperliquid BBO scraper: which coins must not be
+  subscribed, why, and the probation → probe → verdict workflow that decides
+  it. Pure data and functions — the `WebsocketScraper` process keeps one
+  struct in its state and calls in on connection events; nothing here talks
+  to the network or spawns processes.
+
+  ## Why this exists
+
+  Hyperliquid reacts to a subscribe it dislikes in one of two ways: it
+  silently ignores the frame (no `subscriptionResponse`), or it drops the
+  whole TCP connection — killing the stream for every other coin. Without
+  discipline, every reconnect re-subscribes the trigger and dies again.
+
+  ## Exclusion sources (all `%{coin => reason}`)
+
+    * `audit_excluded` — verdicts of the latest `CoinUniverse.audit/0`
+      (unknown to HL, spot-token-only, ...). Replaced wholesale via
+      `apply_audit/2` so a coin HL re-lists recovers automatically.
+    * `quarantined` — probe convictions: the coin's solo subscribe killed the
+      connection `#{2}` times, or HL silently ignores it. Never
+      auto-refreshed; a process restart clears it.
+    * `ignored_coins/0` — operator escape hatch via the
+      `HYPERLIQUID_IGNORED_COINS` env var (comma-separated coin names).
+
+  `excluded/1` merges all three; the scraper's reconcile skips (and
+  unsubscribes) every coin in it.
+
+  ## Probation → probe → verdict
+
+  A crash puts every unconfirmed subscribe sent within `@suspect_window_ms`
+  of death on `probation` (`handle_crash/4`) — the whole window, not just the
+  newest send, because the TCP drop can lag the offending subscribe by a few
+  pacing ticks, letting innocent frames go out after it. Probation coins are
+  excluded from bulk subscribing and re-tried by probes (`probe_tick/5`) on a
+  settled connection. Probes are PIPELINED: a new probe starts every
+  `@probe_spacing_ms` while earlier ones await their `@probe_verdict_ms`
+  verdicts (~2 coins/s, a 20-coin sweep drains in ~11s). Attribution stays
+  unambiguous because the kill lands within 200-300ms — always younger than
+  the spacing — so a crash implicates at most one in-flight probe:
+
+    * crash within `@probe_strike_window_ms` of the probe → a strike; at
+      `@probe_strikes_to_convict` strikes the coin is quarantined (two, so a
+      coincidental infra drop can't convict). After a first strike the coin
+      goes to the END of probation so other suspects get probed before its
+      retry.
+    * confirmed and alive `@probe_verdict_ms` after the probe → innocent,
+      cleared back to normal subscriptions.
+    * never confirmed but the connection lives → HL silently ignores the
+      coin; quarantined so we stop re-sending a subscribe HL won't answer.
+  """
+
+  require Logger
+
+  alias Sanbase.Utils.Config
+
+  # A disconnect this soon after an unconfirmed subscribe puts that coin on
+  # probation as a suspect for having triggered the drop. Observed: HL kills
+  # the connection within 200-300ms of the offending subscribe — every time —
+  # so 1.5s is ~5x margin. At the scraper's 200ms send pacing it sweeps the
+  # culprit plus ~4-6 neighbouring sends per crash, deliberately erring on
+  # the side of a few extra innocents (each is cleared by a quick probe)
+  # rather than ever missing the trigger.
+  @suspect_window_ms 1_500
+  # A probed coin that got confirmed and whose connection is still alive this
+  # long after the probe subscribe is innocent. This is the floor: the kill
+  # lands within 200-300ms of the subscribe, the queued frame reaches the
+  # wire up to 200ms after the clock starts, and the confirmation needs a
+  # round trip — below ~1s a verdict can't tell "innocent" from "kill still
+  # in flight", and a wrong clearance costs a full crash.
+  @probe_verdict_ms 1_000
+  # A crash more than this after a probe subscribe is NOT attributed to that
+  # probe — the coin keeps its probation spot, no strike. Kept tight (the
+  # kill lands in 200-300ms) so random infra drops can't rack up false
+  # strikes, and equal to @probe_spacing_ms so a crash implicates AT MOST ONE
+  # in-flight probe even with pipelining.
+  @probe_strike_window_ms 500
+  # Minimum gap between consecutive probe starts. Probes are pipelined — a
+  # new one starts every spacing while earlier ones await verdicts — so a
+  # probation sweep drains at ~2 coins/s (20 coins in ~11s). Must exceed the
+  # observed 200-300ms kill lag so a crash points at exactly one probe.
+  @probe_spacing_ms 500
+  # Probe crashes before conviction; see moduledoc.
+  @probe_strikes_to_convict 2
+  # Don't start a probe until the connection has been up this long with an
+  # empty outbound queue, so the verdict isn't polluted by startup churn.
+  @probe_min_uptime_ms 10_000
+  # How many recently-sent subscribe frames to remember as crash evidence.
+  # MUST cover @suspect_window_ms at the scraper's 200ms send pacing — a
+  # culprit that falls off this list before the crash is never caught.
+  # 10 entries = 2s of sends, above the window.
+  @recent_sends_size 10
+
+  defstruct probation: [],
+            # In-flight probes, newest first — [%{coin: _, started_ms: _}].
+            probing: [],
+            probe_strikes: %{},
+            quarantined: %{},
+            audit_excluded: %{},
+            # Crash evidence: the last @recent_sends_size subscribe frames the
+            # scraper actually sent on the CURRENT connection, newest first —
+            # %{coin: _, slugs: _, sent_at_ms: _}. Fed by track_send/4, reset
+            # by on_connect/1, consumed by handle_crash/3.
+            recent_sends: []
+
+  @type t :: %__MODULE__{}
+
+  def new(), do: %__MODULE__{}
+
+  @doc ~s"""
+  Whether the probation/probe/conviction workflow is active, from the
+  `HYPERLIQUID_QUARANTINE_ENABLED` env var. Enabled unless explicitly set to
+  `false`/`0`. When disabled, crashes add no suspects, no probes run and
+  nothing new is quarantined — but the audit exclusions and the
+  `HYPERLIQUID_IGNORED_COINS` list still apply (they are separate features
+  that only share the `excluded/1` merge).
+  """
+  def enabled?() do
+    Config.module_get(__MODULE__, :enabled?, "true")
+    |> Config.parse_boolean_value()
+    |> Kernel.!=(false)
+  end
+
+  @doc "How close to a disconnect a subscribe must be to count as a suspect."
+  def suspect_window_ms(), do: @suspect_window_ms
+
+  @doc ~s"""
+  Everything that must not be subscribed, as `%{coin => reason}`: env-ignored
+  coins, the latest audit verdicts, probe convictions (later sources win the
+  reason on overlap).
+  """
+  def excluded(%__MODULE__{} = q) do
+    ignored_coins()
+    |> Map.merge(q.audit_excluded)
+    |> Map.merge(q.quarantined)
+  end
+
+  @doc "Coins awaiting an individual probe, head probed first."
+  def probation(%__MODULE__{} = q), do: q.probation
+
+  @doc "Coins whose probes are in flight, newest first (empty when idle)."
+  def probing_coins(%__MODULE__{} = q), do: Enum.map(q.probing, & &1.coin)
+
+  @doc ~s"""
+  Record a subscribe frame the scraper just sent (crash evidence, newest
+  first, capped at #{@recent_sends_size}). Slugs are resolved by the caller
+  at send time — the slug map may differ by crash time.
+  """
+  def track_send(%__MODULE__{} = q, coin, slugs, now) do
+    entry = %{coin: coin, slugs: slugs, sent_at_ms: now}
+    %{q | recent_sends: Enum.take([entry | q.recent_sends], @recent_sends_size)}
+  end
+
+  @doc "Reset the per-connection crash evidence; call on every (re)connect."
+  def on_connect(%__MODULE__{} = q), do: %{q | recent_sends: []}
+
+  @doc ~s"""
+  The newest `limit` tracked sends as one log-friendly string — if a
+  disconnect consistently follows the same coin/slug with a small ms_ago,
+  that subscription is the trigger.
+  """
+  def recent_sends_summary(%__MODULE__{} = q, now, limit \\ 5) do
+    q.recent_sends
+    |> Enum.take(limit)
+    |> Enum.map_join(", ", fn %{coin: coin, slugs: slugs, sent_at_ms: at} ->
+      "#{coin}=#{Enum.join(slugs, "|")} #{now - at}ms_ago"
+    end)
+  end
+
+  @doc ~s"""
+  Operator-managed ignore list from the `HYPERLIQUID_IGNORED_COINS` env var
+  (comma-separated coin names), as `%{coin => reason}`.
+  """
+  def ignored_coins() do
+    Config.module_get(__MODULE__, :ignored_coins)
+    |> to_string()
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Map.new(&{&1, "ignored via HYPERLIQUID_IGNORED_COINS"})
+  end
+
+  @doc ~s"""
+  Crash forensics, called on every real disconnect (not on failed reconnect
+  attempts) BEFORE the scraper clears its connection state. Resolves the
+  in-flight probes (the crash is the young one's verdict — a strike,
+  convicting at #{@probe_strikes_to_convict}) and puts every unconfirmed
+  subscribe from `recent_sends` within #{@suspect_window_ms}ms of death on
+  probation. `active_subs` are the confirmed coins — confirmed means
+  innocent.
+  """
+  def handle_crash(%__MODULE__{} = q, active_subs, now) do
+    if enabled?() do
+      q = resolve_probe_crash(q, now)
+
+      suspects =
+        q.recent_sends
+        |> Enum.filter(fn %{sent_at_ms: at} -> now - at <= @suspect_window_ms end)
+        |> Enum.map(& &1.coin)
+        |> Enum.reject(&MapSet.member?(active_subs, &1))
+
+      probate(
+        q,
+        suspects,
+        "unconfirmed subscribe(s) sent <#{@suspect_window_ms}ms before the disconnect"
+      )
+    else
+      q
+    end
+  end
+
+  @doc ~s"""
+  Put `coins` on probation (skipping ones already there or excluded), logging
+  `why`. Probation coins are excluded from bulk subscribing and re-tried one
+  at a time by `probe_tick/5`.
+  """
+  def probate(%__MODULE__{} = q, coins, why) do
+    excluded = excluded(q)
+
+    new_coins =
+      coins
+      |> Enum.uniq()
+      |> Enum.reject(fn coin -> coin in q.probation or Map.has_key?(excluded, coin) end)
+
+    if new_coins == [] or not enabled?() do
+      q
+    else
+      Logger.warning(
+        "[HyperliquidQuarantine] probation += #{inspect(new_coins)} — #{why}; " <>
+          "each will be probed individually"
+      )
+
+      %{q | probation: q.probation ++ new_coins}
+    end
+  end
+
+  @doc ~s"""
+  Apply an audit verdict: REPLACES (never merges) `audit_excluded` so a coin
+  HL re-lists recovers automatically; coins the audit condemned leave
+  probation too — the audit's reason beats a probe verdict.
+  """
+  def apply_audit(%__MODULE__{} = q, reasons) when is_map(reasons) do
+    if map_size(reasons) > 0 do
+      Logger.warning(
+        "[HyperliquidQuarantine] audit excluded #{map_size(reasons)} coin(s): #{inspect(reasons)}"
+      )
+    end
+
+    %{
+      q
+      | audit_excluded: reasons,
+        probation: Enum.reject(q.probation, &Map.has_key?(reasons, &1))
+    }
+  end
+
+  @doc ~s"""
+  The probe worker step, called on the scraper's `:probe_next` tick. Either
+  resolves the in-flight probe's survival verdict (crash verdicts arrive via
+  `handle_crash/4`) or, when the connection is settled — up at least
+  #{@probe_min_uptime_ms}ms with an empty outbound queue — starts the next
+  probe. Returns `{q, {:subscribe, coin} | :noop}`; the scraper queues the
+  subscribe frame.
+  """
+  def probe_tick(%__MODULE__{} = q, active_subs, uptime_ms, queue_empty?, now) do
+    if enabled?(),
+      do: do_probe_tick(q, active_subs, uptime_ms, queue_empty?, now),
+      else: {q, :noop}
+  end
+
+  defp do_probe_tick(%__MODULE__{} = q, active_subs, uptime_ms, queue_empty?, now) do
+    # Resolve every probe whose verdict window has elapsed (probes pipeline,
+    # so several can come due together), then start the next probe if the
+    # spacing since the newest in-flight one has passed.
+    {due, in_flight} =
+      Enum.split_with(q.probing, fn %{started_ms: started} ->
+        now - started >= @probe_verdict_ms
+      end)
+
+    q =
+      Enum.reduce(due, %{q | probing: in_flight}, fn %{coin: coin}, acc ->
+        resolve_probe_survival(acc, coin, active_subs)
+      end)
+
+    maybe_start_probe(q, uptime_ms, queue_empty?, now)
+  end
+
+  # The crash's verdict on the in-flight probes. Only a probe younger than
+  # @probe_strike_window_ms is blamed — at most one, since probes start
+  # @probe_spacing_ms apart. Older unresolved probes just fall back to
+  # probation (they keep their spot, no strike) and get re-probed. A struck
+  # coin is convicted at @probe_strikes_to_convict, otherwise it moves to the
+  # END of probation so the other suspects get their probe before its retry.
+  defp resolve_probe_crash(%__MODULE__{} = q, now) do
+    guilty =
+      Enum.filter(q.probing, fn %{started_ms: started} ->
+        now - started <= @probe_strike_window_ms
+      end)
+
+    Enum.reduce(guilty, %{q | probing: []}, fn %{coin: coin, started_ms: started}, acc ->
+      strike(acc, coin, now - started)
+    end)
+  end
+
+  defp strike(%__MODULE__{} = q, coin, age_ms) do
+    strikes = Map.update(q.probe_strikes, coin, 1, &(&1 + 1))
+    count = Map.fetch!(strikes, coin)
+
+    if count >= @probe_strikes_to_convict do
+      %{q | probe_strikes: Map.delete(strikes, coin), probation: List.delete(q.probation, coin)}
+      |> quarantine(
+        coin,
+        "probe conviction — connection died #{age_ms}ms after its subscribe " <>
+          "(strike #{count}/#{@probe_strikes_to_convict})"
+      )
+    else
+      Logger.warning(
+        "[HyperliquidQuarantine] probe strike coin=#{coin} — connection died " <>
+          "#{age_ms}ms after its probe subscribe " <>
+          "(strike #{count}/#{@probe_strikes_to_convict}); will re-probe"
+      )
+
+      %{
+        q
+        | probe_strikes: strikes,
+          probation: List.delete(q.probation, coin) ++ [coin]
+      }
+    end
+  end
+
+  # The connection survived @probe_verdict_ms after the probe subscribe.
+  # Confirmed -> innocent, back to normal subscriptions (it is already
+  # subscribed and streaming; reconcile keeps it). Never confirmed -> HL
+  # silently ignores this coin ("bbo" only accepts tradeable pair names);
+  # quarantine it so we stop re-sending a subscribe HL won't answer.
+  # The caller has already dropped the probe from `probing`.
+  defp resolve_probe_survival(%__MODULE__{} = q, coin, active_subs) do
+    q = %{q | probation: List.delete(q.probation, coin)}
+
+    if MapSet.member?(active_subs, coin) do
+      Logger.info(
+        "[HyperliquidQuarantine] probe cleared coin=#{coin} — confirmed and the connection " <>
+          "survived #{@probe_verdict_ms}ms; back to normal subscriptions"
+      )
+
+      %{q | probe_strikes: Map.delete(q.probe_strikes, coin)}
+    else
+      quarantine(q, coin, "probe never confirmed — HL silently ignores its subscribe")
+    end
+  end
+
+  # Starts the next probe when it can produce a clean verdict: connection
+  # settled, and at least @probe_spacing_ms since the newest in-flight probe.
+  # A coin stays in probation until its verdict; `probing` marks it in flight.
+  defp maybe_start_probe(%__MODULE__{} = q, uptime_ms, true = _queue_empty?, now)
+       when uptime_ms >= @probe_min_uptime_ms do
+    in_flight = probing_coins(q)
+
+    spacing_ok? =
+      case q.probing do
+        [] -> true
+        [%{started_ms: newest} | _] -> now - newest >= @probe_spacing_ms
+      end
+
+    case {spacing_ok?, Enum.find(q.probation, &(&1 not in in_flight))} do
+      {true, coin} when is_binary(coin) ->
+        Logger.info(
+          "[HyperliquidQuarantine] probing coin=#{coin} " <>
+            "strikes=#{Map.get(q.probe_strikes, coin, 0)}/#{@probe_strikes_to_convict} " <>
+            "in_flight=#{length(q.probing) + 1} probation_left=#{length(q.probation)}"
+        )
+
+        {%{q | probing: [%{coin: coin, started_ms: now} | q.probing]}, {:subscribe, coin}}
+
+      _ ->
+        {q, :noop}
+    end
+  end
+
+  defp maybe_start_probe(%__MODULE__{} = q, _uptime_ms, _queue_empty?, _now), do: {q, :noop}
+
+  defp quarantine(%__MODULE__{} = q, coin, reason) do
+    Logger.warning(
+      "[HyperliquidQuarantine] quarantining coin=#{coin} — #{reason}; " <>
+        "excluded until process restart"
+    )
+
+    %{q | quarantined: Map.put(q.quarantined, coin, reason)}
+  end
+end

--- a/lib/sanbase/hyperliquid/bbo/quarantine.ex
+++ b/lib/sanbase/hyperliquid/bbo/quarantine.ex
@@ -30,7 +30,7 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
   ## Probation → probe → verdict
 
   A crash puts every unconfirmed subscribe sent within `@suspect_window_ms`
-  of death on `probation` (`handle_crash/4`) — the whole window, not just the
+  of death on `probation` (`handle_crash/3`) — the whole window, not just the
   newest send, because the TCP drop can lag the offending subscribe by a few
   pacing ticks, letting innocent frames go out after it. Probation coins are
   excluded from bulk subscribing and re-tried by probes (`probe_tick/5`) on a
@@ -105,7 +105,10 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
             recent_sends: []
 
   @type t :: %__MODULE__{}
+  @type coin :: String.t()
+  @type reason :: String.t()
 
+  @spec new() :: t()
   def new(), do: %__MODULE__{}
 
   @doc ~s"""
@@ -116,6 +119,7 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
   `HYPERLIQUID_IGNORED_COINS` list still apply (they are separate features
   that only share the `excluded/1` merge).
   """
+  @spec enabled?() :: boolean()
   def enabled?() do
     Config.module_get(__MODULE__, :enabled?, "true")
     |> Config.parse_boolean_value()
@@ -123,6 +127,7 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
   end
 
   @doc "How close to a disconnect a subscribe must be to count as a suspect."
+  @spec suspect_window_ms() :: pos_integer()
   def suspect_window_ms(), do: @suspect_window_ms
 
   @doc ~s"""
@@ -130,6 +135,7 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
   coins, the latest audit verdicts, probe convictions (later sources win the
   reason on overlap).
   """
+  @spec excluded(t()) :: %{coin() => reason()}
   def excluded(%__MODULE__{} = q) do
     ignored_coins()
     |> Map.merge(q.audit_excluded)
@@ -137,9 +143,11 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
   end
 
   @doc "Coins awaiting an individual probe, head probed first."
+  @spec probation(t()) :: [coin()]
   def probation(%__MODULE__{} = q), do: q.probation
 
   @doc "Coins whose probes are in flight, newest first (empty when idle)."
+  @spec probing_coins(t()) :: [coin()]
   def probing_coins(%__MODULE__{} = q), do: Enum.map(q.probing, & &1.coin)
 
   @doc ~s"""
@@ -147,12 +155,14 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
   first, capped at #{@recent_sends_size}). Slugs are resolved by the caller
   at send time — the slug map may differ by crash time.
   """
+  @spec track_send(t(), coin(), [String.t()], integer()) :: t()
   def track_send(%__MODULE__{} = q, coin, slugs, now) do
     entry = %{coin: coin, slugs: slugs, sent_at_ms: now}
     %{q | recent_sends: Enum.take([entry | q.recent_sends], @recent_sends_size)}
   end
 
   @doc "Reset the per-connection crash evidence; call on every (re)connect."
+  @spec on_connect(t()) :: t()
   def on_connect(%__MODULE__{} = q), do: %{q | recent_sends: []}
 
   @doc ~s"""
@@ -160,6 +170,7 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
   disconnect consistently follows the same coin/slug with a small ms_ago,
   that subscription is the trigger.
   """
+  @spec recent_sends_summary(t(), integer(), pos_integer()) :: String.t()
   def recent_sends_summary(%__MODULE__{} = q, now, limit \\ 5) do
     q.recent_sends
     |> Enum.take(limit)
@@ -172,6 +183,7 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
   Operator-managed ignore list from the `HYPERLIQUID_IGNORED_COINS` env var
   (comma-separated coin names), as `%{coin => reason}`.
   """
+  @spec ignored_coins() :: %{coin() => reason()}
   def ignored_coins() do
     Config.module_get(__MODULE__, :ignored_coins)
     |> to_string()
@@ -190,6 +202,7 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
   probation. `active_subs` are the confirmed coins — confirmed means
   innocent.
   """
+  @spec handle_crash(t(), MapSet.t(coin()), integer()) :: t()
   def handle_crash(%__MODULE__{} = q, active_subs, now) do
     if enabled?() do
       q = resolve_probe_crash(q, now)
@@ -215,6 +228,7 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
   `why`. Probation coins are excluded from bulk subscribing and re-tried one
   at a time by `probe_tick/5`.
   """
+  @spec probate(t(), [coin()], String.t()) :: t()
   def probate(%__MODULE__{} = q, coins, why) do
     excluded = excluded(q)
 
@@ -240,6 +254,7 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
   HL re-lists recovers automatically; coins the audit condemned leave
   probation too — the audit's reason beats a probe verdict.
   """
+  @spec apply_audit(t(), %{coin() => reason()}) :: t()
   def apply_audit(%__MODULE__{} = q, reasons) when is_map(reasons) do
     if map_size(reasons) > 0 do
       Logger.warning(
@@ -257,11 +272,13 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
   @doc ~s"""
   The probe worker step, called on the scraper's `:probe_next` tick. Either
   resolves the in-flight probe's survival verdict (crash verdicts arrive via
-  `handle_crash/4`) or, when the connection is settled — up at least
+  `handle_crash/3`) or, when the connection is settled — up at least
   #{@probe_min_uptime_ms}ms with an empty outbound queue — starts the next
   probe. Returns `{q, {:subscribe, coin} | :noop}`; the scraper queues the
   subscribe frame.
   """
+  @spec probe_tick(t(), MapSet.t(coin()), non_neg_integer(), boolean(), integer()) ::
+          {t(), {:subscribe, coin()} | :noop}
   def probe_tick(%__MODULE__{} = q, active_subs, uptime_ms, queue_empty?, now) do
     if enabled?(),
       do: do_probe_tick(q, active_subs, uptime_ms, queue_empty?, now),

--- a/lib/sanbase/hyperliquid/bbo/quarantine.ex
+++ b/lib/sanbase/hyperliquid/bbo/quarantine.ex
@@ -36,9 +36,9 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
   excluded from bulk subscribing and re-tried by probes (`probe_tick/5`) on a
   settled connection. Probes are PIPELINED: a new probe starts every
   `@probe_spacing_ms` while earlier ones await their `@probe_verdict_ms`
-  verdicts (~2 coins/s, a 20-coin sweep drains in ~11s). Attribution stays
-  unambiguous because the kill lands within 200-300ms — always younger than
-  the spacing — so a crash implicates at most one in-flight probe:
+  verdicts (~1 coin per 1.5s, a typical 5-8 coin sweep drains in ~10s).
+  Attribution stays unambiguous because the strike window never exceeds the
+  spacing, so a crash implicates at most one in-flight probe:
 
     * crash within `@probe_strike_window_ms` of the probe → a strike; at
       `@probe_strikes_to_convict` strikes the coin is quarantined (two, so a
@@ -64,23 +64,24 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
   # rather than ever missing the trigger.
   @suspect_window_ms 1_500
   # A probed coin that got confirmed and whose connection is still alive this
-  # long after the probe subscribe is innocent. This is the floor: the kill
-  # lands within 200-300ms of the subscribe, the queued frame reaches the
-  # wire up to 200ms after the clock starts, and the confirmation needs a
-  # round trip — below ~1s a verdict can't tell "innocent" from "kill still
-  # in flight", and a wrong clearance costs a full crash.
-  @probe_verdict_ms 1_000
-  # A crash more than this after a probe subscribe is NOT attributed to that
-  # probe — the coin keeps its probation spot, no strike. Kept tight (the
-  # kill lands in 200-300ms) so random infra drops can't rack up false
-  # strikes, and equal to @probe_spacing_ms so a crash implicates AT MOST ONE
-  # in-flight probe even with pipelining.
-  @probe_strike_window_ms 500
+  # long after the probe subscribe hit the wire (track_send/4 restarts the
+  # clock at the actual send) is innocent. Must exceed
+  # @probe_strike_window_ms — a coin must never be cleared innocent while a
+  # kill could still be attributed to its probe.
+  @probe_verdict_ms 2_000
+  # A crash within this window after a probe subscribe is that probe's
+  # strike; later crashes are infra noise (the coin keeps its probation
+  # spot, no strike). Kill lag is typically 200-300ms but jitters higher —
+  # observed kills near 500ms went unattributed and left strike counts stuck
+  # below conviction, so the window carries generous margin. Equal to
+  # @probe_spacing_ms so a crash implicates AT MOST ONE in-flight probe.
+  @probe_strike_window_ms 1_500
   # Minimum gap between consecutive probe starts. Probes are pipelined — a
   # new one starts every spacing while earlier ones await verdicts — so a
-  # probation sweep drains at ~2 coins/s (20 coins in ~11s). Must exceed the
-  # observed 200-300ms kill lag so a crash points at exactly one probe.
-  @probe_spacing_ms 500
+  # probation sweep drains at ~1 coin per 1.5s (typical 5-8 coin sweep in
+  # ~10s). Must not be smaller than @probe_strike_window_ms, else a crash
+  # could implicate several probes at once.
+  @probe_spacing_ms 1_500
   # Probe crashes before conviction; see moduledoc.
   @probe_strikes_to_convict 2
   # Don't start a probe until the connection has been up this long with an
@@ -158,7 +159,23 @@ defmodule Sanbase.Hyperliquid.Bbo.Quarantine do
   @spec track_send(t(), coin(), [String.t()], integer()) :: t()
   def track_send(%__MODULE__{} = q, coin, slugs, now) do
     entry = %{coin: coin, slugs: slugs, sent_at_ms: now}
-    %{q | recent_sends: Enum.take([entry | q.recent_sends], @recent_sends_size)}
+
+    # A probe's strike/verdict clock restarts when its frame actually reaches
+    # the wire. started_ms is first set at QUEUE time, but the flush pacing
+    # can burn up to 200ms before the send — added to the 200-300ms kill lag
+    # that eats the whole 500ms strike window, and real kills would go
+    # unattributed (strikes stuck below conviction forever).
+    probing =
+      Enum.map(q.probing, fn
+        %{coin: ^coin} = probe -> %{probe | started_ms: now}
+        probe -> probe
+      end)
+
+    %{
+      q
+      | probing: probing,
+        recent_sends: Enum.take([entry | q.recent_sends], @recent_sends_size)
+    }
   end
 
   @doc "Reset the per-connection crash evidence; call on every (re)connect."

--- a/lib/sanbase/hyperliquid/bbo/reconnect.ex
+++ b/lib/sanbase/hyperliquid/bbo/reconnect.ex
@@ -34,6 +34,7 @@ defmodule Sanbase.Hyperliquid.Bbo.Reconnect do
   @connects_window_ms 60_000
 
   @doc "The backoff a fresh process starts from."
+  @spec initial_backoff_ms() :: pos_integer()
   def initial_backoff_ms(), do: @initial_ms
 
   @doc ~s"""
@@ -45,6 +46,8 @@ defmodule Sanbase.Hyperliquid.Bbo.Reconnect do
   the ladder; short-lived connections and failed reconnect attempts
   (attempt > 1, where lifetime_ms is nil) keep climbing.
   """
+  @spec plan(pos_integer(), non_neg_integer() | nil, pos_integer()) ::
+          {pos_integer(), pos_integer()}
   def plan(current_backoff_ms, lifetime_ms, attempt) do
     stable? = attempt == 1 and is_integer(lifetime_ms) and lifetime_ms >= @stable_connection_ms
 
@@ -61,6 +64,7 @@ defmodule Sanbase.Hyperliquid.Bbo.Reconnect do
   a healthy single reconnect stays fast, and bounded so base + jitter never
   exceeds #{@max_ms}ms.
   """
+  @spec jitter_ms(pos_integer()) :: pos_integer()
   def jitter_ms(base_ms), do: :rand.uniform(min(base_ms, @jitter_max_ms))
 
   @doc ~s"""
@@ -68,6 +72,7 @@ defmodule Sanbase.Hyperliquid.Bbo.Reconnect do
   #{@connects_window_ms}ms window — the count is compared against HL's
   30 new connections/min/IP limit in the connect log.
   """
+  @spec track_connect([integer()], integer()) :: [integer()]
   def track_connect(connect_times, now) do
     [now | connect_times]
     |> Enum.take_while(&(now - &1 < @connects_window_ms))
@@ -82,6 +87,7 @@ defmodule Sanbase.Hyperliquid.Bbo.Reconnect do
   IP), so persistent short lifetimes with this cause usually mean IP-level
   rate limiting rather than an app error.
   """
+  @spec describe_cause(term()) :: String.t()
   def describe_cause({:remote, :closed}),
     do: "remote dropped TCP without a close frame (no reason on wire; rate-limit/infra style)"
 

--- a/lib/sanbase/hyperliquid/bbo/reconnect.ex
+++ b/lib/sanbase/hyperliquid/bbo/reconnect.ex
@@ -1,0 +1,93 @@
+defmodule Sanbase.Hyperliquid.Bbo.Reconnect do
+  @moduledoc ~s"""
+  Reconnect policy for the Hyperliquid BBO websocket: the backoff ladder, the
+  jitter that de-syncs instances sharing an egress IP, the rolling count of
+  our own connects (HL allows 30 new connections/min per IP, aggregated over
+  every client behind it), and the wording of disconnect causes. Pure
+  functions — the `WebsocketScraper` process keeps the backoff value and
+  connect timestamps in its state and calls in around connect/disconnect.
+
+  The ladder is gentle on purpose (x#{1.1} per consecutive disconnect):
+  bad-coin crash loops are handled by `Quarantine`, so the backoff only
+  guards infra churn and should recover fast. Only a connection that
+  survived the stability threshold restarts the ladder — a remote that
+  drops us seconds after connect keeps it climbing, so we slow down instead
+  of locking the IP over its limits with a reconnect storm.
+  """
+
+  # First reconnect delay; grows x@backoff_factor per consecutive disconnect.
+  @initial_ms 1_000
+  # Growth factor per consecutive disconnect.
+  @backoff_factor 1.1
+  # Hard ceiling on a single reconnect sleep, jitter included.
+  @max_ms 20_000
+  # A connection must live this long before the next disconnect starts the
+  # ladder over from @initial_ms; anything shorter keeps climbing.
+  @stable_connection_ms 60_000
+  # Cap on the random jitter added to each reconnect sleep.
+  @jitter_max_ms 1_000
+  # The growing part of the backoff caps here so base + jitter never
+  # exceeds @max_ms.
+  @base_cap_ms @max_ms - @jitter_max_ms
+  # Rolling window for counting our own connects, matching the window of
+  # HL's "30 new connections per minute per IP" limit.
+  @connects_window_ms 60_000
+
+  @doc "The backoff a fresh process starts from."
+  def initial_backoff_ms(), do: @initial_ms
+
+  @doc ~s"""
+  The reconnect schedule after a disconnect: `{sleep_base_ms, next_backoff_ms}`.
+  `sleep_base_ms` is slept now (plus `jitter_ms/1`); `next_backoff_ms` is
+  stored for the disconnect after this one, so the ladder climbs
+  x#{@backoff_factor} per step up to #{@base_cap_ms}ms. Only a dropped live
+  connection (attempt == 1) that survived #{@stable_connection_ms}ms restarts
+  the ladder; short-lived connections and failed reconnect attempts
+  (attempt > 1, where lifetime_ms is nil) keep climbing.
+  """
+  def plan(current_backoff_ms, lifetime_ms, attempt) do
+    stable? = attempt == 1 and is_integer(lifetime_ms) and lifetime_ms >= @stable_connection_ms
+
+    base_ms =
+      if stable?,
+        do: @initial_ms,
+        else: min(current_backoff_ms, @base_cap_ms)
+
+    {base_ms, min(ceil(base_ms * @backoff_factor), @base_cap_ms)}
+  end
+
+  @doc ~s"""
+  Random jitter to add to a reconnect sleep — proportional to the backoff so
+  a healthy single reconnect stays fast, and bounded so base + jitter never
+  exceeds #{@max_ms}ms.
+  """
+  def jitter_ms(base_ms), do: :rand.uniform(min(base_ms, @jitter_max_ms))
+
+  @doc ~s"""
+  Prepend this connect's timestamp and drop entries older than the rolling
+  #{@connects_window_ms}ms window — the count is compared against HL's
+  30 new connections/min/IP limit in the connect log.
+  """
+  def track_connect(connect_times, now) do
+    [now | connect_times]
+    |> Enum.take_while(&(now - &1 < @connects_window_ms))
+  end
+
+  @doc ~s"""
+  The remote's stated reason for a drop, in words. `{:remote, :closed}` is an
+  abrupt TCP close with NO WebSocket close frame — the remote never said why;
+  no more detail exists on the wire. HL/CloudFront drop connections this way
+  when per-IP limits are exceeded (10 concurrent conns, 30 new conns/min,
+  2000 client msgs/min, 1000 subs — aggregated over every client behind the
+  IP), so persistent short lifetimes with this cause usually mean IP-level
+  rate limiting rather than an app error.
+  """
+  def describe_cause({:remote, :closed}),
+    do: "remote dropped TCP without a close frame (no reason on wire; rate-limit/infra style)"
+
+  def describe_cause({:remote, code, msg}),
+    do: "remote sent close frame code=#{inspect(code)} msg=#{inspect(msg)}"
+
+  def describe_cause({:local, reason}), do: "closed by our side: #{inspect(reason)}"
+  def describe_cause(other), do: inspect(other)
+end

--- a/lib/sanbase/project/source_slug_mapping.ex
+++ b/lib/sanbase/project/source_slug_mapping.ex
@@ -53,8 +53,8 @@ defmodule Sanbase.Project.SourceSlugMapping do
         :ok ->
           changeset
 
-        {:unsupported, suggestions} ->
-          add_error(changeset, :slug, unsupported_coin_message(slug, suggestions))
+        {:unsupported, reason, suggestions} ->
+          add_error(changeset, :slug, unsupported_coin_message(slug, reason, suggestions))
 
         :unverified ->
           Logger.warning(
@@ -68,12 +68,23 @@ defmodule Sanbase.Project.SourceSlugMapping do
     end
   end
 
-  defp unsupported_coin_message(slug, []) do
+  defp unsupported_coin_message(slug, :spot_token_only, []) do
+    "\"#{slug}\" exists on Hyperliquid only as a spot token — it has no perp market " <>
+      "and no spot pair, so the bbo stream cannot carry it"
+  end
+
+  defp unsupported_coin_message(slug, :spot_token_only, pairs) do
+    "\"#{slug}\" exists on Hyperliquid only as a spot token (no perp market); " <>
+      "the bbo stream needs a tradeable pair name — map it as: #{Enum.join(pairs, ", ")}"
+  end
+
+  defp unsupported_coin_message(slug, :not_in_universe, []) do
     "\"#{slug}\" is not a coin in the Hyperliquid universe"
   end
 
-  defp unsupported_coin_message(slug, suggestions) do
-    unsupported_coin_message(slug, []) <> " (did you mean: #{Enum.join(suggestions, ", ")}?)"
+  defp unsupported_coin_message(slug, :not_in_universe, suggestions) do
+    unsupported_coin_message(slug, :not_in_universe, []) <>
+      " (did you mean: #{Enum.join(suggestions, ", ")}?)"
   end
 
   defp validate_exactly_one_asset_reference(changeset) do

--- a/test/sanbase/hyperliquid/bbo/bbo_websocket_scraper_test.exs
+++ b/test/sanbase/hyperliquid/bbo/bbo_websocket_scraper_test.exs
@@ -57,7 +57,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
   end
 
   defp sub_send(coin, ms_ago) do
-    %{coin: coin, slugs: [], sent_at_ms: System.system_time(:millisecond) - ms_ago}
+    %{coin: coin, slugs: [], sent_at_ms: System.monotonic_time(:millisecond) - ms_ago}
   end
 
   defp side(px, sz), do: %{"px" => to_string(px), "sz" => to_string(sz), "n" => 1}
@@ -799,7 +799,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
     end
 
     test "probe survival with confirmation clears the coin back to normal" do
-      now = System.system_time(:millisecond)
+      now = System.monotonic_time(:millisecond)
 
       state =
         build_state(
@@ -818,7 +818,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
     end
 
     test "probe survival without confirmation quarantines the silently-ignored coin" do
-      now = System.system_time(:millisecond)
+      now = System.monotonic_time(:millisecond)
 
       state =
         build_state(
@@ -834,7 +834,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
     end
 
     test "crash during probe strikes; second strike convicts and quarantines" do
-      now = System.system_time(:millisecond)
+      now = System.monotonic_time(:millisecond)
 
       state =
         build_state(
@@ -855,7 +855,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
         state
         | quarantine: %{
             state.quarantine
-            | probing: [%{coin: "X", started_ms: System.system_time(:millisecond) - 250}]
+            | probing: [%{coin: "X", started_ms: System.monotonic_time(:millisecond) - 250}]
           }
       }
 
@@ -867,7 +867,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
     end
 
     test "crash long after the probe subscribe is not attributed to it" do
-      now = System.system_time(:millisecond)
+      now = System.monotonic_time(:millisecond)
 
       state =
         build_state(
@@ -922,7 +922,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
       state =
         build_state(
           probation: ["BTC"],
-          probing: [%{coin: "BTC", started_ms: System.system_time(:millisecond)}],
+          probing: [%{coin: "BTC", started_ms: System.monotonic_time(:millisecond)}],
           active_subs: MapSet.new(["BTC"])
         )
 
@@ -942,7 +942,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
       state =
         build_state(
           probation: ["X"],
-          probing: [%{coin: "X", started_ms: System.system_time(:millisecond)}]
+          probing: [%{coin: "X", started_ms: System.monotonic_time(:millisecond)}]
         )
 
       {:ok, new_state} = WebsocketScraper.handle_info(:reconcile_subscriptions, state)
@@ -1001,7 +1001,10 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
     @describetag capture_log: true
 
     test "audit_result replaces audit_excluded and prunes probation" do
-      state = build_state(probation: ["BAD", "Y"], audit_excluded: %{"OLD" => "gone"})
+      ref = make_ref()
+
+      state =
+        build_state(probation: ["BAD", "Y"], audit_excluded: %{"OLD" => "gone"}, audit_ref: ref)
 
       result = %{
         desired: 3,
@@ -1010,7 +1013,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
         reasons: %{"BAD" => "only a spot token on HL (no perp market)"}
       }
 
-      {:ok, new_state} = WebsocketScraper.handle_info({:audit_result, result}, state)
+      {:ok, new_state} = WebsocketScraper.handle_info({:audit_result, ref, result}, state)
 
       # Replaced, not merged — "OLD" recovered; "BAD" left probation too.
       assert new_state.quarantine.audit_excluded == %{
@@ -1021,10 +1024,16 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
     end
 
     test "audit exclusion triggers an immediate reconcile and drops the queued subscribe" do
-      state = build_state(pending_sub_queue: :queue.in({"subscribe", "BTC"}, :queue.new()))
+      ref = make_ref()
+
+      state =
+        build_state(
+          pending_sub_queue: :queue.in({"subscribe", "BTC"}, :queue.new()),
+          audit_ref: ref
+        )
 
       result = %{desired: 1, universe: 10, unsupported: ["BTC"], reasons: %{"BTC" => "r"}}
-      {:ok, state} = WebsocketScraper.handle_info({:audit_result, result}, state)
+      {:ok, state} = WebsocketScraper.handle_info({:audit_result, ref, result}, state)
 
       # New exclusions don't wait for the 60s reconcile tick.
       assert_receive :reconcile_subscriptions
@@ -1034,6 +1043,39 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
       assert {:ok, new_state} = WebsocketScraper.handle_info(:flush_subs, state)
       assert :queue.is_empty(new_state.pending_sub_queue)
       assert new_state.quarantine.recent_sends == []
+    end
+
+    test "audit recovery (empty reasons) also triggers an immediate reconcile" do
+      ref = make_ref()
+      state = build_state(audit_excluded: %{"BTC" => "r"}, audit_ref: ref)
+
+      result = %{desired: 1, universe: 10, unsupported: [], reasons: %{}}
+      {:ok, new_state} = WebsocketScraper.handle_info({:audit_result, ref, result}, state)
+
+      assert_receive :reconcile_subscriptions
+      assert new_state.quarantine.audit_excluded == %{}
+    end
+
+    test "unchanged audit exclusion set does not trigger reconcile" do
+      ref = make_ref()
+      state = build_state(audit_excluded: %{"BTC" => "r"}, audit_ref: ref)
+
+      result = %{desired: 1, universe: 10, unsupported: ["BTC"], reasons: %{"BTC" => "r"}}
+      {:ok, _} = WebsocketScraper.handle_info({:audit_result, ref, result}, state)
+
+      refute_receive :reconcile_subscriptions, 50
+    end
+
+    test "a stale audit result (superseded by a newer audit) is ignored" do
+      state = build_state(audit_excluded: %{"KEEP" => "r"}, audit_ref: make_ref())
+
+      stale_result = %{desired: 1, universe: 10, unsupported: [], reasons: %{}}
+
+      {:ok, new_state} =
+        WebsocketScraper.handle_info({:audit_result, make_ref(), stale_result}, state)
+
+      assert new_state.quarantine.audit_excluded == %{"KEEP" => "r"}
+      refute_receive :reconcile_subscriptions, 50
     end
 
     test "probation drops a queued bulk subscribe but lets the probe frame through" do
@@ -1052,7 +1094,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
         build_state(
           pending_sub_queue: :queue.in({"subscribe", "X"}, :queue.new()),
           probation: ["X"],
-          probing: [%{coin: "X", started_ms: System.system_time(:millisecond)}]
+          probing: [%{coin: "X", started_ms: System.monotonic_time(:millisecond)}]
         )
 
       assert {:reply, {:text, _}, new_state} = WebsocketScraper.handle_info(:flush_subs, state)
@@ -1060,10 +1102,11 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
     end
 
     test "failed audit keeps the previous verdicts" do
-      state = build_state(audit_excluded: %{"BAD" => "reason"})
+      ref = make_ref()
+      state = build_state(audit_excluded: %{"BAD" => "reason"}, audit_ref: ref)
 
       {:ok, new_state} =
-        WebsocketScraper.handle_info({:audit_result, {:error, :nxdomain}}, state)
+        WebsocketScraper.handle_info({:audit_result, ref, {:error, :nxdomain}}, state)
 
       assert new_state.quarantine.audit_excluded == %{"BAD" => "reason"}
     end
@@ -1090,7 +1133,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
         WebsocketScraper.handle_connect(:fake_conn, build_state(last_audit_at: recent))
 
       assert new_state.last_audit_at == recent
-      refute_receive {:audit_result, _}, 100
+      refute_receive {:audit_result, _, _}, 100
     end
 
     test "connect starts an audit when the gap has passed" do
@@ -1102,7 +1145,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
           WebsocketScraper.handle_connect(:fake_conn, build_state(last_audit_at: stale))
 
         assert new_state.last_audit_at > stale
-        assert_receive {:audit_result, %{reasons: %{}}}, 1_000
+        assert_receive {:audit_result, _ref, %{reasons: %{}}}, 1_000
       end
     end
 
@@ -1111,7 +1154,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
       {:ok, new_state} = WebsocketScraper.handle_info(:reconcile_subscriptions, state)
 
       assert Map.get(new_state, :last_audit_at, 0) == 0
-      refute_receive {:audit_result, _}, 100
+      refute_receive {:audit_result, _, _}, 100
     end
   end
 

--- a/test/sanbase/hyperliquid/bbo/bbo_websocket_scraper_test.exs
+++ b/test/sanbase/hyperliquid/bbo/bbo_websocket_scraper_test.exs
@@ -609,6 +609,48 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
       assert new_state.last_emitted == %{}
       assert new_state.healthcheck_failures == 0
       assert new_state.reconnect_backoff_ms == 2
+      assert new_state.prev_unconfirmed == MapSet.new()
+    end
+
+    test "short-lived connection keeps doubling the backoff and clears connected_at" do
+      state =
+        build_state(
+          connected_at: System.monotonic_time(:millisecond) - 3_000,
+          reconnect_backoff_ms: 4
+        )
+
+      {:reconnect, new_state} =
+        WebsocketScraper.handle_disconnect(%{reason: {:remote, :closed}}, state)
+
+      assert new_state.reconnect_backoff_ms == 8
+      assert new_state.connected_at == nil
+    end
+  end
+
+  # The stable-reset paths are tested through backoff_plan/3 because
+  # handle_disconnect/2 sleeps its result for real — the reset branch would
+  # block the suite for @reconnect_initial_ms (1s) plus jitter per test.
+  describe "backoff_plan/3" do
+    test "connection that lived past the stable threshold restarts the ladder" do
+      assert {1_000, 2_000} = WebsocketScraper.backoff_plan(16_000, 120_000, 1)
+    end
+
+    test "short lifetime keeps climbing the ladder" do
+      assert {4_000, 8_000} = WebsocketScraper.backoff_plan(4_000, 3_000, 1)
+    end
+
+    test "failed reconnect attempt (attempt_number > 1) never restarts the ladder" do
+      assert {4_000, 8_000} = WebsocketScraper.backoff_plan(4_000, 120_000, 2)
+    end
+
+    test "nil lifetime (no live connection was dropped) keeps climbing" do
+      assert {4_000, 8_000} = WebsocketScraper.backoff_plan(4_000, nil, 1)
+    end
+
+    test "sleep base plus max jitter never exceeds the 20s ceiling" do
+      {base, next} = WebsocketScraper.backoff_plan(1_000_000, 3_000, 1)
+      assert base + 1_000 <= 20_000
+      assert next + 1_000 <= 20_000
     end
   end
 
@@ -623,8 +665,12 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
 
       {:ok, new_state} = WebsocketScraper.handle_connect(:fake_conn, state)
 
-      assert new_state.reconnect_backoff_ms == 1_000
+      # Backoff must survive connect — it only resets after a connection
+      # proves stable (see handle_disconnect), else a flapping remote keeps
+      # the reconnect loop at full speed forever.
+      assert new_state.reconnect_backoff_ms == 16_000
       assert new_state.last_message_time > 0
+      assert [_connected_now] = new_state.connect_times
 
       for key <- [:ping, :healthcheck, :flush_coalesced, :reconcile_subscriptions] do
         assert Map.has_key?(new_state.timers, key), "missing #{key} timer"

--- a/test/sanbase/hyperliquid/bbo/bbo_websocket_scraper_test.exs
+++ b/test/sanbase/hyperliquid/bbo/bbo_websocket_scraper_test.exs
@@ -135,6 +135,20 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
       assert decoded["ask_volume"] == nil
     end
 
+    test "malformed side is rejected atomically (no partial price/volume export)" do
+      state = build_state(slug_map: %{"BTC" => ["bitcoin"]})
+
+      # Parseable price but garbage volume: the whole bid side must be nil,
+      # and since the ask is missing too, nothing is exported.
+      {:ok, _state} =
+        WebsocketScraper.handle_frame(
+          bbo_frame("BTC", 1_700_000_000_000, %{"px" => "62000", "sz" => "bad", "n" => 1}, nil),
+          state
+        )
+
+      assert drain_topic() == []
+    end
+
     test "both sides null is skipped" do
       state = build_state(slug_map: %{"BTC" => ["bitcoin"]})
 
@@ -1004,6 +1018,45 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
              }
 
       assert new_state.quarantine.probation == ["Y"]
+    end
+
+    test "audit exclusion triggers an immediate reconcile and drops the queued subscribe" do
+      state = build_state(pending_sub_queue: :queue.in({"subscribe", "BTC"}, :queue.new()))
+
+      result = %{desired: 1, universe: 10, unsupported: ["BTC"], reasons: %{"BTC" => "r"}}
+      {:ok, state} = WebsocketScraper.handle_info({:audit_result, result}, state)
+
+      # New exclusions don't wait for the 60s reconcile tick.
+      assert_receive :reconcile_subscriptions
+
+      # The already-queued frame is dropped at send time ({:ok, _}, no reply)
+      # and never recorded as sent.
+      assert {:ok, new_state} = WebsocketScraper.handle_info(:flush_subs, state)
+      assert :queue.is_empty(new_state.pending_sub_queue)
+      assert new_state.quarantine.recent_sends == []
+    end
+
+    test "probation drops a queued bulk subscribe but lets the probe frame through" do
+      # Bulk-queued subscribe for a coin that got probated meanwhile: dropped.
+      state =
+        build_state(
+          pending_sub_queue: :queue.in({"subscribe", "X"}, :queue.new()),
+          probation: ["X"]
+        )
+
+      assert {:ok, new_state} = WebsocketScraper.handle_info(:flush_subs, state)
+      assert new_state.quarantine.recent_sends == []
+
+      # The probe's own frame (coin marked in-flight) is sent normally.
+      state =
+        build_state(
+          pending_sub_queue: :queue.in({"subscribe", "X"}, :queue.new()),
+          probation: ["X"],
+          probing: [%{coin: "X", started_ms: System.system_time(:millisecond)}]
+        )
+
+      assert {:reply, {:text, _}, new_state} = WebsocketScraper.handle_info(:flush_subs, state)
+      assert [%{coin: "X"}] = new_state.quarantine.recent_sends
     end
 
     test "failed audit keeps the previous verdicts" do

--- a/test/sanbase/hyperliquid/bbo/bbo_websocket_scraper_test.exs
+++ b/test/sanbase/hyperliquid/bbo/bbo_websocket_scraper_test.exs
@@ -1,12 +1,24 @@
 defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
   use Sanbase.DataCase, async: false
 
+  import Mock
   import Sanbase.Factory
 
+  alias Sanbase.Hyperliquid.Bbo.Quarantine
   alias Sanbase.Hyperliquid.Bbo.WebsocketScraper
 
   @topic "hyperliquid_bbo_prices"
   @exporter :hyperliquid_bbo_exporter
+
+  # Overrides for these keys build the Quarantine struct inside the state.
+  @quarantine_keys [
+    :probation,
+    :probing,
+    :probe_strikes,
+    :quarantined,
+    :audit_excluded,
+    :recent_sends
+  ]
 
   setup do
     Sanbase.InMemoryKafka.Producer.clear_state()
@@ -26,6 +38,8 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
   end
 
   defp build_state(overrides \\ []) do
+    {q_overrides, rest} = overrides |> Map.new() |> Map.split(@quarantine_keys)
+
     %{
       active_subs: MapSet.new(),
       slug_map: %{},
@@ -36,9 +50,14 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
       last_message_time: System.system_time(:millisecond),
       healthcheck_failures: 0,
       coalesce_window_ms: 1000,
-      timers: %{}
+      timers: %{},
+      quarantine: struct!(Quarantine, q_overrides)
     }
-    |> Map.merge(Map.new(overrides))
+    |> Map.merge(rest)
+  end
+
+  defp sub_send(coin, ms_ago) do
+    %{coin: coin, slugs: [], sent_at_ms: System.system_time(:millisecond) - ms_ago}
   end
 
   defp side(px, sz), do: %{"px" => to_string(px), "sz" => to_string(sz), "n" => 1}
@@ -434,13 +453,10 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
 
       assert state.slug_map == %{"BTC" => ["bitcoin"], "ETH" => ["ethereum"]}
 
-      queued =
+      methods_by_coin =
         state.pending_sub_queue
         |> :queue.to_list()
-        |> Enum.map(fn {:text, json} -> Jason.decode!(json) end)
-
-      methods_by_coin =
-        Enum.into(queued, %{}, fn %{"method" => m, "subscription" => %{"coin" => c}} -> {c, m} end)
+        |> Enum.into(%{}, fn {method, coin} -> {coin, method} end)
 
       assert methods_by_coin == %{"ETH" => "subscribe", "OLD" => "unsubscribe"}
     end
@@ -474,13 +490,17 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
   end
 
   describe "flush_subs" do
-    test "drains one queued frame per tick via reply" do
-      frame = {:text, Jason.encode!(%{"foo" => 1})}
-      queue = :queue.in(frame, :queue.new())
+    test "drains one queued entry per tick, replying with the built frame" do
+      queue = :queue.in({"subscribe", "BTC"}, :queue.new())
       state = build_state(pending_sub_queue: queue)
 
-      assert {:reply, ^frame, new_state} =
+      assert {:reply, {:text, json}, new_state} =
                WebsocketScraper.handle_info(:flush_subs, state)
+
+      assert Jason.decode!(json) == %{
+               "method" => "subscribe",
+               "subscription" => %{"type" => "bbo", "coin" => "BTC"}
+             }
 
       assert :queue.is_empty(new_state.pending_sub_queue)
     end
@@ -489,15 +509,57 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
       state = build_state()
       assert {:ok, _new_state} = WebsocketScraper.handle_info(:flush_subs, state)
     end
+
+    test "records sent subscribes in the quarantine send log, newest first" do
+      queue =
+        Enum.reduce(
+          [
+            {"subscribe", "A"},
+            {"subscribe", "B"},
+            {"unsubscribe", "SKIP"},
+            {"subscribe", "C"},
+            {"subscribe", "D"},
+            {"subscribe", "E"},
+            {"subscribe", "F"}
+          ],
+          :queue.new(),
+          &:queue.in/2
+        )
+
+      state = build_state(pending_sub_queue: queue, slug_map: %{"A" => ["a-slug"]})
+
+      state =
+        Enum.reduce(1..7, state, fn _, acc ->
+          {:reply, _frame, acc} = WebsocketScraper.handle_info(:flush_subs, acc)
+          acc
+        end)
+
+      recent = state.quarantine.recent_sends
+      assert Enum.map(recent, & &1.coin) == ["F", "E", "D", "C", "B", "A"]
+      assert Enum.all?(recent, &is_integer(&1.sent_at_ms))
+
+      # Slugs resolved from slug_map at send time; unmapped coins get [].
+      assert Enum.map(recent, & &1.slugs) == [[], [], [], [], [], ["a-slug"]]
+    end
+
+    test "the send log stores slugs from slug_map at send time" do
+      queue = :queue.in({"subscribe", "BTC"}, :queue.new())
+
+      state =
+        build_state(pending_sub_queue: queue, slug_map: %{"BTC" => ["bitcoin", "btc-alias"]})
+
+      {:reply, _frame, new_state} = WebsocketScraper.handle_info(:flush_subs, state)
+
+      assert [%{coin: "BTC", slugs: ["bitcoin", "btc-alias"]}] = new_state.quarantine.recent_sends
+    end
   end
 
   describe "flush_subs scheduling" do
     test "draining last frame stops the timer (no re-arm)" do
-      frame = {:text, "x"}
-      queue = :queue.in(frame, :queue.new())
+      queue = :queue.in({"subscribe", "x"}, :queue.new())
       state = build_state(pending_sub_queue: queue, timers: %{flush_subs: make_ref()})
 
-      assert {:reply, ^frame, new_state} =
+      assert {:reply, {:text, _}, new_state} =
                WebsocketScraper.handle_info(:flush_subs, state)
 
       refute Map.has_key?(new_state.timers, :flush_subs)
@@ -505,13 +567,14 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
     end
 
     test "draining when more remain re-arms the timer" do
-      frame_a = {:text, "a"}
-      frame_b = {:text, "b"}
-      queue = :queue.from_list([frame_a, frame_b])
+      queue = :queue.from_list([{"subscribe", "a"}, {"unsubscribe", "b"}])
       state = build_state(pending_sub_queue: queue, timers: %{flush_subs: make_ref()})
 
-      assert {:reply, ^frame_a, new_state} =
+      assert {:reply, {:text, json}, new_state} =
                WebsocketScraper.handle_info(:flush_subs, state)
+
+      assert %{"method" => "subscribe", "subscription" => %{"coin" => "a"}} =
+               Jason.decode!(json)
 
       assert Map.has_key?(new_state.timers, :flush_subs)
       assert :queue.len(new_state.pending_sub_queue) == 1
@@ -589,11 +652,11 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
   describe "handle_disconnect" do
     @describetag capture_log: true
 
-    test "clears in-flight state, resets healthcheck failures, doubles backoff" do
+    test "clears in-flight state, resets healthcheck failures, grows backoff" do
       state =
         build_state(
           active_subs: MapSet.new(["BTC", "ETH"]),
-          pending_sub_queue: :queue.in({:text, "x"}, :queue.new()),
+          pending_sub_queue: :queue.in({"subscribe", "x"}, :queue.new()),
           coalesce_buffer: %{"BTC" => %{coin: "BTC"}},
           last_emitted: %{"BTC" => 1},
           healthcheck_failures: 4,
@@ -612,7 +675,7 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
       assert new_state.prev_unconfirmed == MapSet.new()
     end
 
-    test "short-lived connection keeps doubling the backoff and clears connected_at" do
+    test "short-lived connection keeps growing the backoff and clears connected_at" do
       state =
         build_state(
           connected_at: System.monotonic_time(:millisecond) - 3_000,
@@ -622,35 +685,380 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
       {:reconnect, new_state} =
         WebsocketScraper.handle_disconnect(%{reason: {:remote, :closed}}, state)
 
-      assert new_state.reconnect_backoff_ms == 8
+      assert new_state.reconnect_backoff_ms == 5
       assert new_state.connected_at == nil
     end
   end
 
-  # The stable-reset paths are tested through backoff_plan/3 because
-  # handle_disconnect/2 sleeps its result for real — the reset branch would
-  # block the suite for @reconnect_initial_ms (1s) plus jitter per test.
-  describe "backoff_plan/3" do
-    test "connection that lived past the stable threshold restarts the ladder" do
-      assert {1_000, 2_000} = WebsocketScraper.backoff_plan(16_000, 120_000, 1)
+  describe "probation and probing" do
+    @describetag capture_log: true
+
+    test "disconnect puts unconfirmed subscribes sent within the window on probation" do
+      state =
+        build_state(
+          recent_sends: [sub_send("A", 100), sub_send("B", 300), sub_send("OLD", 10_000)],
+          reconnect_backoff_ms: 1
+        )
+
+      {:reconnect, new_state} = WebsocketScraper.handle_disconnect(%{reason: :test}, state)
+
+      assert new_state.quarantine.probation == ["A", "B"]
     end
 
-    test "short lifetime keeps climbing the ladder" do
-      assert {4_000, 8_000} = WebsocketScraper.backoff_plan(4_000, 3_000, 1)
+    test "confirmed coins (in active_subs) never go on probation" do
+      state =
+        build_state(
+          recent_sends: [sub_send("A", 100), sub_send("B", 300)],
+          active_subs: MapSet.new(["A"]),
+          reconnect_backoff_ms: 1
+        )
+
+      {:reconnect, new_state} = WebsocketScraper.handle_disconnect(%{reason: :test}, state)
+
+      assert new_state.quarantine.probation == ["B"]
     end
 
-    test "failed reconnect attempt (attempt_number > 1) never restarts the ladder" do
-      assert {4_000, 8_000} = WebsocketScraper.backoff_plan(4_000, 120_000, 2)
+    test "probation coins are not re-added and excluded coins never enter" do
+      state =
+        build_state(
+          recent_sends: [sub_send("A", 100), sub_send("Q", 200), sub_send("X", 300)],
+          probation: ["A"],
+          quarantined: %{"Q" => "test reason"},
+          audit_excluded: %{"X" => "audit reason"},
+          reconnect_backoff_ms: 1
+        )
+
+      {:reconnect, new_state} = WebsocketScraper.handle_disconnect(%{reason: :test}, state)
+
+      assert new_state.quarantine.probation == ["A"]
     end
 
-    test "nil lifetime (no live connection was dropped) keeps climbing" do
-      assert {4_000, 8_000} = WebsocketScraper.backoff_plan(4_000, nil, 1)
+    test "failed reconnect attempt (attempt_number > 1) leaves probation untouched" do
+      state =
+        build_state(
+          recent_sends: [sub_send("B", 100)],
+          probation: ["A"],
+          reconnect_backoff_ms: 1
+        )
+
+      {:reconnect, new_state} =
+        WebsocketScraper.handle_disconnect(%{reason: :test, attempt_number: 2}, state)
+
+      assert new_state.quarantine.probation == ["A"]
     end
 
-    test "sleep base plus max jitter never exceeds the 20s ceiling" do
-      {base, next} = WebsocketScraper.backoff_plan(1_000_000, 3_000, 1)
-      assert base + 1_000 <= 20_000
-      assert next + 1_000 <= 20_000
+    test "probe_next starts a probe on a settled connection" do
+      state =
+        build_state(
+          probation: ["X", "Y"],
+          connected_at: System.monotonic_time(:millisecond) - 60_000
+        )
+
+      {:ok, new_state} = WebsocketScraper.handle_info(:probe_next, state)
+
+      assert [%{coin: "X", started_ms: _}] = new_state.quarantine.probing
+      assert :queue.to_list(new_state.pending_sub_queue) == [{"subscribe", "X"}]
+      # Coin stays in probation until its verdict.
+      assert new_state.quarantine.probation == ["X", "Y"]
+      assert Map.has_key?(new_state.timers, :probe_next)
+    end
+
+    test "probe_next does not start a probe while the outbound queue drains or uptime is low" do
+      draining =
+        build_state(
+          probation: ["X"],
+          connected_at: System.monotonic_time(:millisecond) - 60_000,
+          pending_sub_queue: :queue.in({"subscribe", "OTHER"}, :queue.new())
+        )
+
+      {:ok, state1} = WebsocketScraper.handle_info(:probe_next, draining)
+      assert state1.quarantine.probing == []
+
+      young =
+        build_state(
+          probation: ["X"],
+          connected_at: System.monotonic_time(:millisecond) - 1_000
+        )
+
+      {:ok, state2} = WebsocketScraper.handle_info(:probe_next, young)
+      assert state2.quarantine.probing == []
+    end
+
+    test "probe survival with confirmation clears the coin back to normal" do
+      now = System.system_time(:millisecond)
+
+      state =
+        build_state(
+          probation: ["X", "Y"],
+          probing: [%{coin: "X", started_ms: now - 20_000}],
+          probe_strikes: %{"X" => 1},
+          active_subs: MapSet.new(["X"])
+        )
+
+      {:ok, new_state} = WebsocketScraper.handle_info(:probe_next, state)
+
+      assert new_state.quarantine.probing == []
+      assert new_state.quarantine.probation == ["Y"]
+      assert new_state.quarantine.probe_strikes == %{}
+      refute Map.has_key?(new_state.quarantine.quarantined, "X")
+    end
+
+    test "probe survival without confirmation quarantines the silently-ignored coin" do
+      now = System.system_time(:millisecond)
+
+      state =
+        build_state(
+          probation: ["X"],
+          probing: [%{coin: "X", started_ms: now - 20_000}]
+        )
+
+      {:ok, new_state} = WebsocketScraper.handle_info(:probe_next, state)
+
+      assert new_state.quarantine.probing == []
+      assert new_state.quarantine.probation == []
+      assert Map.get(new_state.quarantine.quarantined, "X") =~ "never confirmed"
+    end
+
+    test "crash during probe strikes; second strike convicts and quarantines" do
+      now = System.system_time(:millisecond)
+
+      state =
+        build_state(
+          probation: ["X", "Y"],
+          probing: [%{coin: "X", started_ms: now - 250}],
+          reconnect_backoff_ms: 1
+        )
+
+      {:reconnect, state} = WebsocketScraper.handle_disconnect(%{reason: :test}, state)
+
+      assert state.quarantine.probing == []
+      assert state.quarantine.probe_strikes == %{"X" => 1}
+      # First strike: retried after the other suspects.
+      assert state.quarantine.probation == ["Y", "X"]
+      refute Map.has_key?(state.quarantine.quarantined, "X")
+
+      state = %{
+        state
+        | quarantine: %{
+            state.quarantine
+            | probing: [%{coin: "X", started_ms: System.system_time(:millisecond) - 250}]
+          }
+      }
+
+      {:reconnect, state} = WebsocketScraper.handle_disconnect(%{reason: :test}, state)
+
+      assert Map.get(state.quarantine.quarantined, "X") =~ "probe conviction"
+      assert state.quarantine.probation == ["Y"]
+      assert state.quarantine.probe_strikes == %{}
+    end
+
+    test "crash long after the probe subscribe is not attributed to it" do
+      now = System.system_time(:millisecond)
+
+      state =
+        build_state(
+          probation: ["X"],
+          probing: [%{coin: "X", started_ms: now - 60_000}],
+          reconnect_backoff_ms: 1
+        )
+
+      {:reconnect, new_state} = WebsocketScraper.handle_disconnect(%{reason: :test}, state)
+
+      assert new_state.quarantine.probing == []
+      assert new_state.quarantine.probe_strikes == %{}
+      assert new_state.quarantine.probation == ["X"]
+    end
+
+    test "coin unconfirmed across two reconcile rounds moves to probation instead of re-queueing" do
+      btc = insert(:project, %{name: "Bitcoin", slug: "bitcoin"})
+
+      Sanbase.Project.SourceSlugMapping.create(%{
+        source: "hyperliquid",
+        slug: "BTC",
+        project_id: btc.id
+      })
+
+      state =
+        build_state(
+          prev_unconfirmed: MapSet.new(["BTC"]),
+          connected_at: System.monotonic_time(:millisecond) - 300_000
+        )
+
+      {:ok, new_state} = WebsocketScraper.handle_info(:reconcile_subscriptions, state)
+
+      assert new_state.quarantine.probation == ["BTC"]
+      assert :queue.is_empty(new_state.pending_sub_queue)
+    end
+
+    test "reconcile does not subscribe probation coins but keeps the probing coin subscribed" do
+      btc = insert(:project, %{name: "Bitcoin", slug: "bitcoin"})
+
+      Sanbase.Project.SourceSlugMapping.create(%{
+        source: "hyperliquid",
+        slug: "BTC",
+        project_id: btc.id
+      })
+
+      # On probation, not subscribed -> reconcile must not queue it.
+      state = build_state(probation: ["BTC"])
+      {:ok, new_state} = WebsocketScraper.handle_info(:reconcile_subscriptions, state)
+      assert :queue.is_empty(new_state.pending_sub_queue)
+
+      # Mid-probe and confirmed -> reconcile must not unsubscribe it.
+      state =
+        build_state(
+          probation: ["BTC"],
+          probing: [%{coin: "BTC", started_ms: System.system_time(:millisecond)}],
+          active_subs: MapSet.new(["BTC"])
+        )
+
+      {:ok, new_state} = WebsocketScraper.handle_info(:reconcile_subscriptions, state)
+      assert :queue.is_empty(new_state.pending_sub_queue)
+    end
+
+    test "reconcile defers new bulk subscribes while a probe is in flight" do
+      eth = insert(:project, %{name: "Ethereum", slug: "ethereum"})
+
+      Sanbase.Project.SourceSlugMapping.create(%{
+        source: "hyperliquid",
+        slug: "ETH",
+        project_id: eth.id
+      })
+
+      state =
+        build_state(
+          probation: ["X"],
+          probing: [%{coin: "X", started_ms: System.system_time(:millisecond)}]
+        )
+
+      {:ok, new_state} = WebsocketScraper.handle_info(:reconcile_subscriptions, state)
+
+      # ETH's subscribe waits for the probe verdict; nothing marked pending.
+      assert :queue.is_empty(new_state.pending_sub_queue)
+      assert new_state.prev_unconfirmed == MapSet.new()
+    end
+
+    test "reconcile does not subscribe quarantined coins and unsubscribes active ones" do
+      btc = insert(:project, %{name: "Bitcoin", slug: "bitcoin"})
+
+      Sanbase.Project.SourceSlugMapping.create(%{
+        source: "hyperliquid",
+        slug: "BTC",
+        project_id: btc.id
+      })
+
+      state =
+        build_state(
+          active_subs: MapSet.new(["BTC"]),
+          quarantined: %{"BTC" => "test reason"}
+        )
+
+      {:ok, new_state} = WebsocketScraper.handle_info(:reconcile_subscriptions, state)
+
+      assert :queue.to_list(new_state.pending_sub_queue) == [{"unsubscribe", "BTC"}]
+    end
+
+    test "reconcile never subscribes coins ignored via HYPERLIQUID_IGNORED_COINS" do
+      original = Application.get_env(:sanbase, Quarantine)
+      Application.put_env(:sanbase, Quarantine, ignored_coins: "ANSEM, OTHER")
+
+      on_exit(fn ->
+        if is_nil(original),
+          do: Application.delete_env(:sanbase, Quarantine),
+          else: Application.put_env(:sanbase, Quarantine, original)
+      end)
+
+      ansem = insert(:project, %{name: "Ansem", slug: "sol-the-black-bull"})
+
+      Sanbase.Project.SourceSlugMapping.create(%{
+        source: "hyperliquid",
+        slug: "ANSEM",
+        project_id: ansem.id
+      })
+
+      state = build_state()
+      {:ok, new_state} = WebsocketScraper.handle_info(:reconcile_subscriptions, state)
+
+      assert :queue.is_empty(new_state.pending_sub_queue)
+    end
+  end
+
+  describe "audit flow" do
+    @describetag capture_log: true
+
+    test "audit_result replaces audit_excluded and prunes probation" do
+      state = build_state(probation: ["BAD", "Y"], audit_excluded: %{"OLD" => "gone"})
+
+      result = %{
+        desired: 3,
+        universe: 100,
+        unsupported: ["BAD"],
+        reasons: %{"BAD" => "only a spot token on HL (no perp market)"}
+      }
+
+      {:ok, new_state} = WebsocketScraper.handle_info({:audit_result, result}, state)
+
+      # Replaced, not merged — "OLD" recovered; "BAD" left probation too.
+      assert new_state.quarantine.audit_excluded == %{
+               "BAD" => "only a spot token on HL (no perp market)"
+             }
+
+      assert new_state.quarantine.probation == ["Y"]
+    end
+
+    test "failed audit keeps the previous verdicts" do
+      state = build_state(audit_excluded: %{"BAD" => "reason"})
+
+      {:ok, new_state} =
+        WebsocketScraper.handle_info({:audit_result, {:error, :nxdomain}}, state)
+
+      assert new_state.quarantine.audit_excluded == %{"BAD" => "reason"}
+    end
+
+    test "reconcile respects audit exclusions: no subscribe, unsubscribes active" do
+      btc = insert(:project, %{name: "Bitcoin", slug: "bitcoin"})
+
+      Sanbase.Project.SourceSlugMapping.create(%{
+        source: "hyperliquid",
+        slug: "BTC",
+        project_id: btc.id
+      })
+
+      state = build_state(active_subs: MapSet.new(["BTC"]), audit_excluded: %{"BTC" => "r"})
+      {:ok, new_state} = WebsocketScraper.handle_info(:reconcile_subscriptions, state)
+
+      assert :queue.to_list(new_state.pending_sub_queue) == [{"unsubscribe", "BTC"}]
+    end
+
+    test "connect does not start an audit again within the minimum gap" do
+      recent = System.system_time(:millisecond) - 1_000
+
+      {:ok, new_state} =
+        WebsocketScraper.handle_connect(:fake_conn, build_state(last_audit_at: recent))
+
+      assert new_state.last_audit_at == recent
+      refute_receive {:audit_result, _}, 100
+    end
+
+    test "connect starts an audit when the gap has passed" do
+      with_mock Sanbase.Hyperliquid.Bbo.CoinUniverse,
+        audit: fn -> %{desired: 0, universe: 1, unsupported: [], reasons: %{}} end do
+        stale = System.system_time(:millisecond) - 60_000
+
+        {:ok, new_state} =
+          WebsocketScraper.handle_connect(:fake_conn, build_state(last_audit_at: stale))
+
+        assert new_state.last_audit_at > stale
+        assert_receive {:audit_result, %{reasons: %{}}}, 1_000
+      end
+    end
+
+    test "reconcile no longer triggers audits" do
+      state = build_state()
+      {:ok, new_state} = WebsocketScraper.handle_info(:reconcile_subscriptions, state)
+
+      assert Map.get(new_state, :last_audit_at, 0) == 0
+      refute_receive {:audit_result, _}, 100
     end
   end
 
@@ -660,7 +1068,10 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
         build_state(
           reconnect_backoff_ms: 16_000,
           last_message_time: 0,
-          timers: %{}
+          timers: %{},
+          # Fresh audit — keeps handle_connect from spawning a real audit
+          # task (HTTP + DB) inside the test.
+          last_audit_at: System.system_time(:millisecond)
         )
 
       {:ok, new_state} = WebsocketScraper.handle_connect(:fake_conn, state)
@@ -672,7 +1083,14 @@ defmodule Sanbase.Hyperliquid.Bbo.WebsocketScraperTest do
       assert new_state.last_message_time > 0
       assert [_connected_now] = new_state.connect_times
 
-      for key <- [:ping, :healthcheck, :flush_coalesced, :reconcile_subscriptions] do
+      for key <- [
+            :ping,
+            :healthcheck,
+            :flush_coalesced,
+            :reconcile_subscriptions,
+            :probe_next,
+            :audit
+          ] do
         assert Map.has_key?(new_state.timers, key), "missing #{key} timer"
       end
 

--- a/test/sanbase/hyperliquid/bbo/coin_universe_test.exs
+++ b/test/sanbase/hyperliquid/bbo/coin_universe_test.exs
@@ -1,0 +1,96 @@
+defmodule Sanbase.Hyperliquid.Bbo.CoinUniverseTest do
+  use ExUnit.Case, async: false
+
+  import Mock
+
+  alias Sanbase.Hyperliquid.Bbo.CoinUniverse
+
+  @moduletag capture_log: true
+
+  # Universe: perps BTC + xyz:GOLD; spot pair @107 (base token ANSEM, quote
+  # USDC); ANSEM and USDC exist only as spot tokens.
+  defp mock_universe(_url, opts) do
+    body =
+      case Keyword.fetch!(opts, :json) do
+        %{type: "perpDexs"} ->
+          [nil, %{"name" => "xyz"}]
+
+        %{type: "meta", dex: "xyz"} ->
+          %{"universe" => [%{"name" => "xyz:GOLD"}]}
+
+        %{type: "meta"} ->
+          %{"universe" => [%{"name" => "BTC"}]}
+
+        %{type: "spotMeta"} ->
+          %{
+            "universe" => [%{"name" => "@107", "tokens" => [1, 0]}],
+            "tokens" => [
+              %{"name" => "USDC", "index" => 0},
+              %{"name" => "ANSEM", "index" => 1}
+            ]
+          }
+      end
+
+    {:ok, %Req.Response{status: 200, body: body}}
+  end
+
+  describe "audit/1" do
+    test "flags spot-token-only coins with the pair to map instead" do
+      with_mock Req, post: &mock_universe/2 do
+        result = CoinUniverse.audit(MapSet.new(["BTC", "xyz:GOLD", "@107", "ANSEM", "NOPE"]))
+
+        assert result.unsupported == ["ANSEM", "NOPE"]
+        assert result.reasons["ANSEM"] =~ "only a spot token"
+        assert result.reasons["ANSEM"] =~ "@107"
+        assert result.reasons["NOPE"] == "not in Hyperliquid's universe"
+      end
+    end
+
+    test "perp and spot pair names are subscribable" do
+      with_mock Req, post: &mock_universe/2 do
+        result = CoinUniverse.audit(MapSet.new(["BTC", "xyz:GOLD", "@107"]))
+        assert result.unsupported == []
+        assert result.reasons == %{}
+      end
+    end
+
+    test "spot token with no pair gets the no-pair reason" do
+      with_mock Req, post: &mock_universe/2 do
+        result = CoinUniverse.audit(MapSet.new(["USDC"]))
+        assert result.reasons["USDC"] =~ "no perp market, no spot pair"
+      end
+    end
+
+    test "fetch failure returns an error instead of flagging everything" do
+      with_mock Req, post: fn _url, _opts -> {:error, :nxdomain} end do
+        assert {:error, :nxdomain} = CoinUniverse.audit(MapSet.new(["BTC"]))
+      end
+    end
+  end
+
+  describe "coin_supported?/2" do
+    test "valid perp and spot pair names return :ok" do
+      with_mock Req, post: &mock_universe/2 do
+        assert CoinUniverse.coin_supported?("BTC") == :ok
+        assert CoinUniverse.coin_supported?("xyz:GOLD") == :ok
+        assert CoinUniverse.coin_supported?("@107") == :ok
+      end
+    end
+
+    test "spot-token-only name is unsupported with its pairs as suggestions" do
+      with_mock Req, post: &mock_universe/2 do
+        assert CoinUniverse.coin_supported?("ANSEM") ==
+                 {:unsupported, :spot_token_only, ["@107"]}
+      end
+    end
+
+    test "unknown name is unsupported with jaro suggestions" do
+      with_mock Req, post: &mock_universe/2 do
+        assert {:unsupported, :not_in_universe, suggestions} =
+                 CoinUniverse.coin_supported?("GOLD")
+
+        assert "xyz:GOLD" in suggestions
+      end
+    end
+  end
+end

--- a/test/sanbase/hyperliquid/bbo/quarantine_test.exs
+++ b/test/sanbase/hyperliquid/bbo/quarantine_test.exs
@@ -1,0 +1,207 @@
+defmodule Sanbase.Hyperliquid.Bbo.QuarantineTest do
+  use ExUnit.Case, async: false
+
+  alias Sanbase.Hyperliquid.Bbo.Quarantine
+
+  @moduletag capture_log: true
+
+  setup do
+    original = Application.get_env(:sanbase, Quarantine)
+
+    on_exit(fn ->
+      if is_nil(original),
+        do: Application.delete_env(:sanbase, Quarantine),
+        else: Application.put_env(:sanbase, Quarantine, original)
+    end)
+
+    :ok
+  end
+
+  defp put_ignored(value) do
+    Application.put_env(:sanbase, Quarantine, ignored_coins: value)
+  end
+
+  defp put_config(kv) do
+    Application.put_env(:sanbase, Quarantine, kv)
+  end
+
+  describe "enabled?/0" do
+    test "enabled by default when unset" do
+      Application.delete_env(:sanbase, Quarantine)
+      assert Quarantine.enabled?()
+    end
+
+    test "explicit false or 0 disables" do
+      put_config(enabled?: "false")
+      refute Quarantine.enabled?()
+
+      put_config(enabled?: "0")
+      refute Quarantine.enabled?()
+    end
+
+    test "garbage value falls back to enabled" do
+      put_config(enabled?: "banana")
+      assert Quarantine.enabled?()
+    end
+  end
+
+  describe "disabled workflow" do
+    test "handle_crash, probate and probe_tick are no-ops" do
+      put_config(enabled?: "false", ignored_coins: "")
+      now = 1_000_000
+      sends = [%{coin: "X", sent_at_ms: now - 100}]
+
+      q = %Quarantine{recent_sends: sends}
+      assert Quarantine.handle_crash(q, MapSet.new(), now) == q
+
+      assert Quarantine.probate(Quarantine.new(), ["X"], "why").probation == []
+
+      q = %Quarantine{probation: ["X"]}
+      assert {^q, :noop} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, now)
+    end
+
+    test "audit exclusions and ignored coins still apply when disabled" do
+      put_config(enabled?: "false", ignored_coins: "ANSEM")
+
+      excluded = Quarantine.excluded(%Quarantine{audit_excluded: %{"SPOT" => "r"}})
+
+      assert Map.has_key?(excluded, "ANSEM")
+      assert Map.has_key?(excluded, "SPOT")
+    end
+  end
+
+  describe "ignored_coins/0" do
+    test "parses the comma-separated env value, trimming blanks" do
+      put_ignored(" ANSEM, FOO ,, ")
+
+      assert Quarantine.ignored_coins() == %{
+               "ANSEM" => "ignored via HYPERLIQUID_IGNORED_COINS",
+               "FOO" => "ignored via HYPERLIQUID_IGNORED_COINS"
+             }
+    end
+
+    test "empty or missing config means nothing ignored" do
+      put_ignored("")
+      assert Quarantine.ignored_coins() == %{}
+    end
+  end
+
+  describe "excluded/1" do
+    test "merges env ignores, audit verdicts and convictions" do
+      put_ignored("ANSEM")
+
+      q = %Quarantine{
+        audit_excluded: %{"SPOT" => "spot token only"},
+        quarantined: %{"KILLER" => "probe conviction"}
+      }
+
+      assert Quarantine.excluded(q) == %{
+               "ANSEM" => "ignored via HYPERLIQUID_IGNORED_COINS",
+               "SPOT" => "spot token only",
+               "KILLER" => "probe conviction"
+             }
+    end
+  end
+
+  describe "probe lifecycle" do
+    test "full path: crash -> probation -> pipelined probes -> strikes -> conviction" do
+      put_ignored("")
+      now = 1_000_000
+      sends = [%{coin: "X", sent_at_ms: now - 100}, %{coin: "OK", sent_at_ms: now - 300}]
+
+      # Crash with X and OK unconfirmed: both on probation.
+      q = Quarantine.handle_crash(%Quarantine{recent_sends: sends}, MapSet.new(), now)
+      assert q.probation == ["X", "OK"]
+
+      # Settled connection: probe starts with the head coin.
+      {q, {:subscribe, "X"}} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, now)
+      assert Quarantine.probing_coins(q) == ["X"]
+
+      # Crash 250ms after the probe (the observed kill lag): strike 1,
+      # X re-queued behind OK.
+      q = Quarantine.handle_crash(%{q | recent_sends: []}, MapSet.new(), now + 250)
+      assert q.probation == ["OK", "X"]
+      assert q.probe_strikes == %{"X" => 1}
+      refute Map.has_key?(q.quarantined, "X")
+
+      # Pipelining: X's second probe starts one spacing after OK's, without
+      # waiting for OK's verdict.
+      {q, {:subscribe, "OK"}} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, now + 1_000)
+      {q, :noop} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, now + 1_300)
+
+      {q, {:subscribe, "X"}} =
+        Quarantine.probe_tick(q, MapSet.new(), 60_000, true, now + 1_500)
+
+      assert Quarantine.probing_coins(q) == ["X", "OK"]
+
+      # Crash 250ms after X's probe: only X (age 250 <= strike window) is
+      # struck -> convicted; OK's older probe is not blamed and stays on
+      # probation for a clean re-probe.
+      q = Quarantine.handle_crash(%{q | recent_sends: []}, MapSet.new(), now + 1_750)
+
+      assert Map.get(q.quarantined, "X") =~ "probe conviction"
+      assert q.probation == ["OK"]
+      assert q.probe_strikes == %{}
+
+      # OK re-probes and survives with confirmation: cleared.
+      {q, {:subscribe, "OK"}} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, now + 2_000)
+      {q, :noop} = Quarantine.probe_tick(q, MapSet.new(["OK"]), 60_000, true, now + 3_100)
+
+      assert q.probation == []
+      assert Quarantine.probing_coins(q) == []
+    end
+
+    test "probe that never confirms is quarantined as silently ignored" do
+      put_ignored("")
+      q = %Quarantine{probation: ["X"], probing: [%{coin: "X", started_ms: 0}]}
+
+      {q, :noop} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, 20_000)
+
+      assert q.probation == []
+      assert Map.get(q.quarantined, "X") =~ "never confirmed"
+    end
+
+    test "crash long after the probe is not attributed to it" do
+      put_ignored("")
+      q = %Quarantine{probation: ["X"], probing: [%{coin: "X", started_ms: 0}]}
+
+      q = Quarantine.handle_crash(%{q | recent_sends: []}, MapSet.new(), 60_000)
+
+      assert q.probing == []
+      assert q.probe_strikes == %{}
+      assert q.probation == ["X"]
+    end
+
+    test "no probe starts on a young connection or a draining queue" do
+      put_ignored("")
+      q = %Quarantine{probation: ["X"]}
+
+      assert {^q, :noop} = Quarantine.probe_tick(q, MapSet.new(), 1_000, true, 0)
+      assert {^q, :noop} = Quarantine.probe_tick(q, MapSet.new(), 60_000, false, 0)
+    end
+
+    test "no new probe before the spacing since the newest in-flight one" do
+      put_ignored("")
+      q = %Quarantine{probation: ["A", "B"], probing: [%{coin: "A", started_ms: 1_000}]}
+
+      # 300ms after A's probe: too soon for B.
+      {q, :noop} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, 1_300)
+      # 500ms after: B starts while A still awaits its verdict.
+      {q, {:subscribe, "B"}} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, 1_500)
+
+      assert Quarantine.probing_coins(q) == ["B", "A"]
+    end
+  end
+
+  describe "apply_audit/2" do
+    test "replaces verdicts and prunes probation" do
+      put_ignored("")
+
+      q = %Quarantine{probation: ["BAD", "Y"], audit_excluded: %{"OLD" => "gone"}}
+      q = Quarantine.apply_audit(q, %{"BAD" => "spot token only"})
+
+      assert q.audit_excluded == %{"BAD" => "spot token only"}
+      assert q.probation == ["Y"]
+    end
+  end
+end

--- a/test/sanbase/hyperliquid/bbo/quarantine_test.exs
+++ b/test/sanbase/hyperliquid/bbo/quarantine_test.exs
@@ -130,14 +130,14 @@ defmodule Sanbase.Hyperliquid.Bbo.QuarantineTest do
       {q, :noop} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, now + 1_300)
 
       {q, {:subscribe, "X"}} =
-        Quarantine.probe_tick(q, MapSet.new(), 60_000, true, now + 2_500)
+        Quarantine.probe_tick(q, MapSet.new(), 60_000, true, now + 2_600)
 
       assert Quarantine.probing_coins(q) == ["X", "OK"]
 
       # Crash 250ms after X's probe: only X (age 250 <= strike window) is
-      # struck -> convicted; OK's older probe (age 1750 > strike window) is
+      # struck -> convicted; OK's older probe (age 1850 > strike window) is
       # not blamed and stays on probation for a clean re-probe.
-      q = Quarantine.handle_crash(%{q | recent_sends: []}, MapSet.new(), now + 2_750)
+      q = Quarantine.handle_crash(%{q | recent_sends: []}, MapSet.new(), now + 2_850)
 
       assert Map.get(q.quarantined, "X") =~ "probe conviction"
       assert q.probation == ["OK"]
@@ -202,9 +202,24 @@ defmodule Sanbase.Hyperliquid.Bbo.QuarantineTest do
       # 300ms after A's probe: too soon for B.
       {q, :noop} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, 1_300)
       # A full spacing after: B starts while A still awaits its verdict.
-      {q, {:subscribe, "B"}} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, 2_500)
+      {q, {:subscribe, "B"}} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, 2_600)
 
       assert Quarantine.probing_coins(q) == ["B", "A"]
+    end
+
+    test "a crash at the spacing boundary blames only the newest probe" do
+      put_ignored("")
+      # A at t=0, B at t=1600 (spacing). Crash at t=1600: A age equals spacing
+      # and sits outside the 1500ms strike window; only B is struck.
+      q = %Quarantine{
+        probation: ["A", "B"],
+        probing: [%{coin: "B", started_ms: 1_600}, %{coin: "A", started_ms: 0}]
+      }
+
+      q = Quarantine.handle_crash(%{q | recent_sends: []}, MapSet.new(), 1_600)
+
+      assert q.probe_strikes == %{"B" => 1}
+      assert q.probation == ["A", "B"]
     end
   end
 

--- a/test/sanbase/hyperliquid/bbo/quarantine_test.exs
+++ b/test/sanbase/hyperliquid/bbo/quarantine_test.exs
@@ -130,22 +130,22 @@ defmodule Sanbase.Hyperliquid.Bbo.QuarantineTest do
       {q, :noop} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, now + 1_300)
 
       {q, {:subscribe, "X"}} =
-        Quarantine.probe_tick(q, MapSet.new(), 60_000, true, now + 1_500)
+        Quarantine.probe_tick(q, MapSet.new(), 60_000, true, now + 2_500)
 
       assert Quarantine.probing_coins(q) == ["X", "OK"]
 
       # Crash 250ms after X's probe: only X (age 250 <= strike window) is
-      # struck -> convicted; OK's older probe is not blamed and stays on
-      # probation for a clean re-probe.
-      q = Quarantine.handle_crash(%{q | recent_sends: []}, MapSet.new(), now + 1_750)
+      # struck -> convicted; OK's older probe (age 1750 > strike window) is
+      # not blamed and stays on probation for a clean re-probe.
+      q = Quarantine.handle_crash(%{q | recent_sends: []}, MapSet.new(), now + 2_750)
 
       assert Map.get(q.quarantined, "X") =~ "probe conviction"
       assert q.probation == ["OK"]
       assert q.probe_strikes == %{}
 
       # OK re-probes and survives with confirmation: cleared.
-      {q, {:subscribe, "OK"}} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, now + 2_000)
-      {q, :noop} = Quarantine.probe_tick(q, MapSet.new(["OK"]), 60_000, true, now + 3_100)
+      {q, {:subscribe, "OK"}} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, now + 3_000)
+      {q, :noop} = Quarantine.probe_tick(q, MapSet.new(["OK"]), 60_000, true, now + 5_100)
 
       assert q.probation == []
       assert Quarantine.probing_coins(q) == []
@@ -180,14 +180,29 @@ defmodule Sanbase.Hyperliquid.Bbo.QuarantineTest do
       assert {^q, :noop} = Quarantine.probe_tick(q, MapSet.new(), 60_000, false, 0)
     end
 
+    test "the strike clock restarts when the probe frame is actually sent" do
+      put_ignored("")
+      # Probe queued at t=0; the send only happens at t=1400.
+      q = %Quarantine{probation: ["X"], probing: [%{coin: "X", started_ms: 0}]}
+      q = Quarantine.track_send(q, "X", [], 1_400)
+
+      # Kill lands 300ms after the send (t=1700). Measured from queue time
+      # that is outside the strike window — the send-time restart is what
+      # keeps the kill attributable.
+      q = Quarantine.handle_crash(q, MapSet.new(), 1_700)
+
+      assert q.probe_strikes == %{"X" => 1}
+      assert q.probation == ["X"]
+    end
+
     test "no new probe before the spacing since the newest in-flight one" do
       put_ignored("")
       q = %Quarantine{probation: ["A", "B"], probing: [%{coin: "A", started_ms: 1_000}]}
 
       # 300ms after A's probe: too soon for B.
       {q, :noop} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, 1_300)
-      # 500ms after: B starts while A still awaits its verdict.
-      {q, {:subscribe, "B"}} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, 1_500)
+      # A full spacing after: B starts while A still awaits its verdict.
+      {q, {:subscribe, "B"}} = Quarantine.probe_tick(q, MapSet.new(), 60_000, true, 2_500)
 
       assert Quarantine.probing_coins(q) == ["B", "A"]
     end

--- a/test/sanbase/hyperliquid/bbo/reconnect_test.exs
+++ b/test/sanbase/hyperliquid/bbo/reconnect_test.exs
@@ -1,0 +1,64 @@
+defmodule Sanbase.Hyperliquid.Bbo.ReconnectTest do
+  use ExUnit.Case, async: true
+
+  alias Sanbase.Hyperliquid.Bbo.Reconnect
+
+  # The stable-reset paths are tested here because the scraper's
+  # handle_disconnect/2 sleeps its result for real — the reset branch would
+  # block the suite for the initial backoff (1s) plus jitter per test.
+  describe "plan/3" do
+    test "connection that lived past the stable threshold restarts the ladder" do
+      assert {1_000, 1_100} = Reconnect.plan(16_000, 120_000, 1)
+    end
+
+    test "short lifetime keeps climbing the ladder" do
+      assert {4_000, 4_400} = Reconnect.plan(4_000, 3_000, 1)
+    end
+
+    test "failed reconnect attempt (attempt_number > 1) never restarts the ladder" do
+      assert {4_000, 4_400} = Reconnect.plan(4_000, 120_000, 2)
+    end
+
+    test "nil lifetime (no live connection was dropped) keeps climbing" do
+      assert {4_000, 4_400} = Reconnect.plan(4_000, nil, 1)
+    end
+
+    test "sleep base plus max jitter never exceeds the 20s ceiling" do
+      {base, next} = Reconnect.plan(1_000_000, 3_000, 1)
+      assert base + 1_000 <= 20_000
+      assert next + 1_000 <= 20_000
+    end
+  end
+
+  describe "jitter_ms/1" do
+    test "is positive and bounded by min(base, cap)" do
+      for _ <- 1..50 do
+        assert Reconnect.jitter_ms(100) in 1..100
+        assert Reconnect.jitter_ms(50_000) in 1..1_000
+      end
+    end
+  end
+
+  describe "track_connect/2" do
+    test "prepends now and drops entries older than the rolling minute" do
+      now = 1_000_000
+      times = [now - 30_000, now - 59_999, now - 60_000, now - 90_000]
+
+      assert Reconnect.track_connect(times, now) == [now, now - 30_000, now - 59_999]
+    end
+  end
+
+  describe "describe_cause/1" do
+    test "names the abrupt TCP drop" do
+      assert Reconnect.describe_cause({:remote, :closed}) =~ "without a close frame"
+    end
+
+    test "surfaces close frame code and message" do
+      assert Reconnect.describe_cause({:remote, 1008, "policy"}) =~ "code=1008"
+    end
+
+    test "falls back to inspect for unknown shapes" do
+      assert Reconnect.describe_cause(:weird) == ":weird"
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Some coins crash the Hyperliquid websocket when subscribed (HL drops the whole
TCP connection) or are silently ignored. Before this, every reconnect
re-subscribed the trigger coin and died again, in a loop.

### Quarantine (`Bbo.Quarantine`, new)
- Coins subscribed shortly before a crash go on **probation**; on a settled
  connection they are re-tried one-by-one via pipelined solo **probes**.
- Two strikes (crash attributable to the probe) → **quarantined**; confirmed
  and alive → cleared back to normal. Never-confirmed coins are quarantined as
  silently-ignored.
- Operator escape hatch: `HYPERLIQUID_IGNORED_COINS` env var; workflow toggle
  via `HYPERLIQUID_QUARANTINE_ENABLED`.

### Reconnect policy (`Bbo.Reconnect`, new)
- Gentle backoff ladder (x1.1, capped 20s) with jitter to de-sync instances
  behind one egress IP, plus a rolling connect counter matching HL's
  30 connections/min/IP limit. Only a connection stable for 60s resets the ladder.

### Coin universe audit
- `CoinUniverse.audit` now distinguishes *not in universe* from *spot-token-only*
  (no perp market — bbo can't stream it) and suggests the spot pair names to map
  instead. `SourceSlugMapping` validation surfaces these reasons.

### Misc
- BBO frame parsing extracted into `BboPoint.parse_frame_data/4` (all-or-nothing
  per side, keeps one-sided books).
- Tests for quarantine, reconnect, universe audit, and scraper integration.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a BBO “quarantine” discipline engine with probe/probation and audit-driven exclusions, configurable via environment toggles and ignored coin lists.
  * Improved websocket reconnection with backoff planning, reconnect diagnostics, and safer subscription lifecycle handling.

* **Bug Fixes**
  * Tightened coin universe validation to reject spot-token-only inputs with clear guidance and closest-name suggestions.
  * Hardened BBO frame parsing for one-sided or malformed books, avoiding partial exports.

* **Tests**
  * Updated and expanded coverage for reconnection, quarantine/probing, auditing/validation, and websocket subscribe/flush behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->