### PR TITLE
cryptocompare exporter improvements

### DIFF
--- a/config/scrapers_config.exs
+++ b/config/scrapers_config.exs
@@ -30,6 +30,8 @@ config :sanbase, Oban.Scrapers,
     # Cryptocompare funding rate queues
     cryptocompare_funding_rate_historical_jobs_queue: [limit: 10, paused: true],
     cryptocompare_funding_rate_historical_jobs_pause_resume_queue: 1,
+    # Watchdog that resumes cryptocompare queues stuck in paused state
+    cryptocompare_watchdog_queue: 1,
     # Twitter queues
     twitter_followers_migration_queue: [limit: 25, paused: true]
   ],
@@ -46,7 +48,8 @@ config :sanbase, Oban.Scrapers,
        {"0 * * * *", Sanbase.Cryptocompare.AddHistoricalJobsWorker,
         args: %{"type" => "schedule_historical_open_interest_jobs"}, max_attempts: 10},
        {"0 * * * *", Sanbase.Cryptocompare.AddHistoricalJobsWorker,
-        args: %{"type" => "schedule_historical_funding_rate_jobs"}, max_attempts: 10}
+        args: %{"type" => "schedule_historical_funding_rate_jobs"}, max_attempts: 10},
+       {"*/10 * * * *", Sanbase.Cryptocompare.QueueWatchdogWorker}
      ]}
   ]
 

--- a/config/scrapers_config.exs
+++ b/config/scrapers_config.exs
@@ -41,6 +41,12 @@ config :sanbase, Oban.Scrapers,
     # causes the oban_jobs table (and its GIN indexes) to bloat, leading to
     # progressively higher Postgres CPU usage.
     {Oban.Plugins.Pruner, max_age: 7 * 86_400},
+    # Rescue jobs orphaned in the `executing` state by dead pods (e.g. a deploy
+    # kills a pod mid-job): back to available, or discarded when attempts are
+    # exhausted. Lifeline is purely time-based, so rescue_after must exceed the
+    # longest legitimate execution on this instance — AddHistoricalJobsWorker
+    # has a 60m timeout, hence 90m. Runs on the leader, checks once a minute.
+    {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(90)},
     {Oban.Plugins.Cron,
      crontab: [
        {"0 3 * * *", Sanbase.Cryptocompare.AddHistoricalJobsWorker,

--- a/docs/cryptocompare-queue-pause-resume.md
+++ b/docs/cryptocompare-queue-pause-resume.md
@@ -1,0 +1,79 @@
+# Cryptocompare historical queues — pause/resume design
+
+Why the rate-limit pause/resume around the Cryptocompare scrapers
+(`open_interest`, `funding_rate`, `price` historical queues) carries extra
+machinery on top of Oban's built-in `pause_queue/resume_queue`.
+
+## The incident this design comes from
+
+When a Cryptocompare rate limit is hit, the historical queue is paused and a
+single scheduled `PauseResumeWorker` job resumes it later. In production the
+exporters would occasionally stop and never recover until the pod was
+restarted: the queue was paused, and the one resume that should have fired was
+lost. Restarting "fixed" it only because the schedulers resume their queues on
+boot.
+
+## Why Oban's pause/resume is not enough on its own
+
+OSS Oban's pause/resume is an **ephemeral, fire-and-forget signal — not
+managed state**:
+
+1. **No persistence.** The `paused` flag lives in the queue producer process's
+   memory. A producer crash, restart, or deploy resets it to the static config,
+   which for these queues is `paused: true` (they are resumed from code on boot
+   only when the scheduler is enabled). Oban Pro's DynamicQueues persist queue
+   state; OSS does not.
+2. **No delivery guarantee.** `Oban.resume_queue/2` returns `:ok` after handing
+   the signal to the notifier (Postgres LISTEN/NOTIFY). If the listening
+   connection is down at that instant, the signal is silently dropped — no ack,
+   no retry, no replay.
+3. **No "pause for N seconds" primitive.** A timed resume has to be built from
+   something. We use a scheduled Oban job, which is itself losable and raceable.
+4. **Uniqueness discards are silent.** Resume jobs are unique (to avoid a
+   pileup of pending resumes). `Oban.insert/2` reports a uniqueness conflict as
+   a success with `conflict?: true` — without explicit handling, a pause could
+   silently end up with no scheduled resume at all.
+
+## The layers, one per gap
+
+| Gap | Mechanism | Where |
+|---|---|---|
+| Lost resume signal | Resume jobs verify via `Oban.check_queue/2` that the queue actually unpaused; failure returns an error so Oban retries the job (re-sending the signal) | `Handler.resume_and_verify/1` |
+| Silent uniqueness discard | Insert conflicting with an `executing` resume job (which may have already resumed *before* our pause landed) resumes the queue immediately instead of scheduling nothing | `Handler.schedule_resume_job/2` |
+| Producer restart into `paused: true`, or any other unforeseen stuck-pause | Reconciliation loop: cron every 10 minutes resumes any *enabled* queue that is paused without an alive resume job | `QueueWatchdogWorker` |
+| Job rows orphaned in `executing` by dead pods (incl. a resume job itself, which would otherwise look "alive" to the watchdog forever) | `Oban.Plugins.Lifeline` (`rescue_after: 90m`, above the 60m max worker timeout) | `config/scrapers_config.exs` |
+
+Related hardening in the same change: `429` responses are handled through the
+same pause path (they carry the same `X-RateLimit-*` headers as 200s;
+previously they crashed with `CaseClauseError`), and the pause length is the
+reset of the *exhausted* window capped at 1h — the biggest window overall
+(monthly) can be weeks away.
+
+## Invariant and failure bias
+
+Every pause is followed by at least one alive recovery mechanism: a pending
+resume job, an immediate resume, or the next watchdog tick. No code path
+leaves the queue paused with nothing pending.
+
+All ambiguous cases resolve toward **resuming**: a spurious resume costs a few
+extra API calls and, if the limit is still hit, simply re-pauses; a missed
+resume silently stops ingestion. Worst-case recovery: seconds (verify retry),
+≤10 min (watchdog), ≤ ~90 min + one watchdog tick (orphaned executing resume
+job, needs Lifeline first).
+
+## Known limitations
+
+- Verification and the watchdog check the **local** producer only. Fine while
+  the scrapers deployment is a single pod; multiple pods running these queues
+  would need per-node checks.
+- The per-second rate-limit window produces 1s pauses, so pause/resume can
+  churn every few seconds under sustained load. Noisy but harmless; a minimum
+  pause floor would calm it.
+- Oban Pro's Smart Engine (global rate limiting + persisted queue state) would
+  replace essentially all of this machinery — this is the OSS-tier design.
+
+## Debugging
+
+Use `scripts/oban_scrapers_debug.exs` (paste into `bin/sanbase remote` on the
+scrapers pod): `ObanScrapersDebug.report/1` shows queue/producer/cron/resume
+state; `force_resume/1` is the manual override.

--- a/docs/debugging-tips.md
+++ b/docs/debugging-tips.md
@@ -92,3 +92,48 @@ But the Stack Dump of the `application_controller` process has the following:
 ```
 
 From this we now have a clear idea what might be wrong: `pool size must be greater or equal to 1, got 0`
+
+## Debugging stuck Oban scraper queues
+
+The cryptocompare funding rate / open interest / price historical queues run
+on the `:oban_scrapers` instance in the scrapers pod. When one of them appears
+stuck (no new data exported), use `scripts/oban_scrapers_debug.exs`:
+
+```sh
+kubectl exec -it <scrapers-pod> -- bin/sanbase remote
+# then paste the entire contents of scripts/oban_scrapers_debug.exs
+```
+
+```elixir
+ObanScrapersDebug.report()                 # overview + verdict per queue
+ObanScrapersDebug.deep_dive(:funding_rate) # stacktraces of executing jobs, notifier/stager state
+ObanScrapersDebug.watch(:funding_rate)     # one status line per 5s — is it moving?
+ObanScrapersDebug.history(:funding_rate)   # hourly throughput vs rate-limit hits
+ObanScrapersDebug.errors(:funding_rate)    # tally of recent job errors
+ObanScrapersDebug.lag(:funding_rate)       # instruments furthest behind
+```
+
+All of the above are read-only. The full command list is in the script header.
+
+### How these queues get stuck
+
+The queues are defined `paused: true` and resumed at boot by their
+`HistoricalScheduler` when the env flag enables them. On a 429 from the
+Cryptocompare API the handler pauses the queue and schedules a `resume` job
+in the `*_pause_resume_queue`. Known failure modes, all detected by
+`report/0`'s VERDICT section:
+
+- **Paused with no pending resume job** — stuck until manually resumed:
+  `ObanScrapersDebug.force_resume(:funding_rate)`.
+- **Notifier `:isolated`** — pause/resume signals travel over Postgres
+  `pg_notify`; when the LISTEN connection is down the resume job completes but
+  the producer never receives the signal and stays paused. A pod restart
+  re-establishes it.
+- **Orphaned `executing` jobs** — a deploy kills a pod mid-job and the row
+  stays `executing` forever. `Oban.Plugins.Lifeline` (rescue_after: 90m)
+  rescues them automatically; for manual cleanup of ancient orphans use
+  `ObanScrapersDebug.cancel_orphans(:funding_rate, confirm: true)` — cancel,
+  don't retry, old orphans: retrying restarts historical backfill chains.
+- **Everything snoozed** — rate limited; jobs wake on their own, no action.
+- **Stale cron feed** — the hourly `AddHistoricalJobsWorker` insert stopped;
+  cron runs only on the Oban leader node.

--- a/lib/sanbase/cryptocompare/funding_rate/funding_rate_pause_resume_worker.ex
+++ b/lib/sanbase/cryptocompare/funding_rate/funding_rate_pause_resume_worker.ex
@@ -10,15 +10,18 @@ defmodule Sanbase.Cryptocompare.FundingRate.PauseResumeWorker do
 
   require Logger
 
+  alias Sanbase.Cryptocompare.Handler
+  alias Sanbase.Cryptocompare.FundingRate.HistoricalScheduler
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"type" => "resume"}}) do
     Logger.info("[Cryptocompare FundingRate] Resuming historical jobs queue after rate limit.")
-    Sanbase.Cryptocompare.FundingRate.HistoricalScheduler.resume()
+    Handler.resume_and_verify(HistoricalScheduler)
   end
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"type" => "pause"}}) do
     Logger.info("[Cryptocompare FundingRate] Pausing historical jobs queue.")
-    Sanbase.Cryptocompare.FundingRate.HistoricalScheduler.pause()
+    HistoricalScheduler.pause()
   end
 end

--- a/lib/sanbase/cryptocompare/handler.ex
+++ b/lib/sanbase/cryptocompare/handler.ex
@@ -222,7 +222,19 @@ defmodule Sanbase.Cryptocompare.Handler do
   `opts`: pause the module's historical queue, schedule a job that resumes it
   after the (capped) rate limit reset, and return `{:snooze, seconds}` so the
   job that hit the limit is retried after the queue is running again.
+
+  Returns an error when a recovery resume could not be confirmed, so the
+  calling Oban job fails and re-runs the pause/schedule cycle on retry.
+
+  ## Example
+
+      case Handler.handle_rate_limit(http_response, module: __MODULE__) do
+        {:snooze, seconds} -> {:snooze, seconds}
+        {:error, _} = error -> error
+      end
   """
+  @spec handle_rate_limit(HTTPoison.Response.t(), Keyword.t()) ::
+          {:snooze, non_neg_integer()} | {:error, :queue_still_paused}
   def handle_rate_limit(http_response, opts) do
     module = Keyword.fetch!(opts, :module)
 
@@ -232,9 +244,16 @@ defmodule Sanbase.Cryptocompare.Handler do
       |> capped_reset_seconds()
 
     :ok = module.historical_scheduler().pause()
-    :ok = schedule_resume_job(module, rate_limited_seconds)
 
-    {:snooze, rate_limited_seconds}
+    case schedule_resume_job(module, rate_limited_seconds) do
+      :ok ->
+        {:snooze, rate_limited_seconds}
+
+      {:error, _reason} = error ->
+        # The recovery resume was not confirmed. Fail the job so Oban retries
+        # it and re-runs the pause/schedule cycle; the watchdog is the backstop.
+        error
+    end
   end
 
   # States in which an existing resume job is guaranteed to still run in the
@@ -250,8 +269,15 @@ defmodule Sanbase.Cryptocompare.Handler do
   later), but if it conflicts with a job that is currently `executing`, that job
   may have already resumed the queue *before* our pause landed. In that case no
   future resume exists and the queue would stay paused forever, so the queue is
-  resumed immediately; if the rate limit is still hit it will simply pause again.
+  resumed immediately (and verified); if the rate limit is still hit it will
+  simply pause again.
+
+  ## Example
+
+      :ok = Handler.schedule_resume_job(OpenInterest.HistoricalWorker, 60)
   """
+  @spec schedule_resume_job(module(), non_neg_integer()) ::
+          :ok | {:error, :queue_still_paused}
   def schedule_resume_job(module, schedule_in_seconds) do
     data =
       module.pause_resume_worker().new(%{"type" => "resume"}, schedule_in: schedule_in_seconds)
@@ -264,8 +290,7 @@ defmodule Sanbase.Cryptocompare.Handler do
             "Resuming queue immediately to avoid permanent pause."
         )
 
-        module.historical_scheduler().resume()
-        :ok
+        resume_and_verify(module.historical_scheduler())
 
       {:ok, _job} ->
         :ok
@@ -276,8 +301,7 @@ defmodule Sanbase.Cryptocompare.Handler do
             "Resuming queue immediately to avoid permanent pause."
         )
 
-        module.historical_scheduler().resume()
-        :ok
+        resume_and_verify(module.historical_scheduler())
     end
   end
 
@@ -293,7 +317,12 @@ defmodule Sanbase.Cryptocompare.Handler do
 
   Returns `:ok` when the queue is not running on this node — there is no local
   producer to verify in that case.
+
+  ## Example
+
+      :ok = Handler.resume_and_verify(OpenInterest.HistoricalScheduler)
   """
+  @spec resume_and_verify(module()) :: :ok | {:error, :queue_still_paused}
   def resume_and_verify(historical_scheduler) do
     :ok = historical_scheduler.resume()
 

--- a/lib/sanbase/cryptocompare/handler.ex
+++ b/lib/sanbase/cryptocompare/handler.ex
@@ -27,6 +27,7 @@ defmodule Sanbase.Cryptocompare.Handler do
           {:error, HTTPoison.Error.t()}
           | {:error, :first_timestamp_reached}
           | {:error, :service_unavailable}
+          | {:error, String.t()}
           | {:snooze, non_neg_integer()}
           | {:ok, min_timestamp :: non_neg_integer(), data_list :: list()}
   def get_data(url, process_json_response_function, opts)
@@ -52,6 +53,14 @@ defmodule Sanbase.Cryptocompare.Handler do
       {:ok, %{status_code: 503}} ->
         # Service temporarily unavailable
         {:error, :service_unavailable}
+
+      {:ok, %{status_code: 429} = http_response} ->
+        # The 429 responses carry the same X-RateLimit-* headers as the 200
+        # ones, so the reset seconds can be extracted the same way.
+        handle_rate_limit(http_response, opts)
+
+      {:ok, %{status_code: status_code}} ->
+        {:error, "Unexpected status code #{status_code} from the Cryptocompare API"}
 
       {:error, error} ->
         {:error, error}
@@ -82,12 +91,7 @@ defmodule Sanbase.Cryptocompare.Handler do
         |> maybe_remove_known_timestamps(timestamps, opts)
 
       {:error_limited, _info} ->
-        rate_limited_seconds =
-          http_response
-          |> HTTPHeaderUtils.rate_limit_reset_seconds()
-          |> capped_reset_seconds()
-
-        do_handle_rate_limit(rate_limited_seconds, opts)
+        handle_rate_limit(http_response, opts)
     end
   end
 
@@ -202,17 +206,56 @@ defmodule Sanbase.Cryptocompare.Handler do
   defp capped_reset_seconds(seconds) when is_integer(seconds) and seconds >= 0, do: seconds
   defp capped_reset_seconds(_), do: 60
 
-  defp do_handle_rate_limit(rate_limited_seconds, opts) do
+  @doc ~s"""
+  Handle a rate-limited response for the historical worker `module` given in
+  `opts`: pause the module's historical queue, schedule a job that resumes it
+  after the (capped) rate limit reset, and return `{:snooze, seconds}` so the
+  job that hit the limit is retried after the queue is running again.
+  """
+  def handle_rate_limit(http_response, opts) do
     module = Keyword.fetch!(opts, :module)
-    oban_conf_name = module.conf_name()
-    historical_scheduler = module.historical_scheduler()
-    pause_resume_worker = module.pause_resume_worker()
 
-    :ok = historical_scheduler.pause()
+    rate_limited_seconds =
+      http_response
+      |> HTTPHeaderUtils.rate_limit_reset_seconds()
+      |> capped_reset_seconds()
 
-    data = pause_resume_worker.new(%{"type" => "resume"}, schedule_in: rate_limited_seconds)
+    :ok = module.historical_scheduler().pause()
+    :ok = schedule_resume_job(module, rate_limited_seconds)
 
-    case Oban.insert(oban_conf_name, data) do
+    {:snooze, rate_limited_seconds}
+  end
+
+  # States in which an existing resume job is guaranteed to still run in the
+  # future, i.e. after the pause that is being handled right now.
+  @pending_resume_states ~w[available scheduled retryable]
+
+  @doc ~s"""
+  Schedule a `resume` job for the historical queue of the given worker `module`
+  that was just paused.
+
+  The insert can be discarded due to the worker's uniqueness constraint. That is
+  harmless when the conflicting job is still pending (it will resume the queue
+  later), but if it conflicts with a job that is currently `executing`, that job
+  may have already resumed the queue *before* our pause landed. In that case no
+  future resume exists and the queue would stay paused forever, so the queue is
+  resumed immediately; if the rate limit is still hit it will simply pause again.
+  """
+  def schedule_resume_job(module, schedule_in_seconds) do
+    data =
+      module.pause_resume_worker().new(%{"type" => "resume"}, schedule_in: schedule_in_seconds)
+
+    case Oban.insert(module.conf_name(), data) do
+      {:ok, %Oban.Job{conflict?: true, state: state}}
+      when state not in @pending_resume_states ->
+        Logger.warning(
+          "[Cryptocompare] Resume job insert conflicted with a resume job in state #{state}. " <>
+            "Resuming queue immediately to avoid permanent pause."
+        )
+
+        module.historical_scheduler().resume()
+        :ok
+
       {:ok, _job} ->
         :ok
 
@@ -222,9 +265,32 @@ defmodule Sanbase.Cryptocompare.Handler do
             "Resuming queue immediately to avoid permanent pause."
         )
 
-        historical_scheduler.resume()
+        module.historical_scheduler().resume()
+        :ok
     end
+  end
 
-    {:snooze, rate_limited_seconds}
+  # Give the async resume signal time to reach the queue producer before checking.
+  @resume_propagation_ms 1000
+
+  @doc ~s"""
+  Resume the scheduler's queue and verify the resume actually landed.
+
+  The resume signal is delivered asynchronously through the Oban notifier and is
+  silently lost if the notifier connection is down at that moment. Returning an
+  error from here makes the calling Oban job retry, which re-sends the signal.
+
+  Returns `:ok` when the queue is not running on this node — there is no local
+  producer to verify in that case.
+  """
+  def resume_and_verify(historical_scheduler) do
+    :ok = historical_scheduler.resume()
+
+    Process.sleep(@resume_propagation_ms)
+
+    case Oban.check_queue(historical_scheduler.conf_name(), queue: historical_scheduler.queue()) do
+      %{paused: true} -> {:error, :queue_still_paused}
+      _ -> :ok
+    end
   end
 end

--- a/lib/sanbase/cryptocompare/handler.ex
+++ b/lib/sanbase/cryptocompare/handler.ex
@@ -1,4 +1,15 @@
 defmodule Sanbase.Cryptocompare.Handler do
+  @moduledoc ~s"""
+  Shared logic for the Cryptocompare historical scraper workers: fetching data
+  and handling rate limits by pausing/resuming the Oban queues.
+
+  The pause/resume machinery (conflict-aware resume scheduling, post-resume
+  verification, the QueueWatchdogWorker and the Lifeline plugin) exists because
+  OSS Oban's pause/resume is an ephemeral fire-and-forget signal, not managed
+  state. See docs/cryptocompare-queue-pause-resume.md for the full design and
+  the failure modes each layer covers.
+  """
+
   alias Sanbase.Cryptocompare.HTTPHeaderUtils
   alias Sanbase.Cryptocompare.ExporterProgress
   alias Sanbase.Utils.Config

--- a/lib/sanbase/cryptocompare/http_header_utils.ex
+++ b/lib/sanbase/cryptocompare/http_header_utils.ex
@@ -65,16 +65,6 @@ defmodule Sanbase.Cryptocompare.HTTPHeaderUtils do
 
   @default_reset_seconds 60
 
-  def get_biggest_ratelimited_window(resp) do
-    with {_header, value} <- get_header(resp, "X-RateLimit-Reset-All"),
-         [_ | _] = list <- parse_value_list(value) do
-      list |> Enum.max_by(& &1.value) |> Map.get(:value)
-    else
-      # Header missing or unparseable
-      _ -> @default_reset_seconds
-    end
-  end
-
   def rate_limited?(resp) do
     # If any of the rate limit periods has 0 remaining requests
     # it means that the rate limit is reached
@@ -95,10 +85,9 @@ defmodule Sanbase.Cryptocompare.HTTPHeaderUtils do
   takes the one with the longest period (the binding constraint) and returns that
   window's reset time from `X-RateLimit-Reset-All`.
 
-  Unlike `get_biggest_ratelimited_window/1`, which returns the largest reset across
-  *all* windows (e.g. the monthly window, which can be many days away even for a
-  brief per-second burst limit), this returns the reset for the window that is
-  actually exhausted.
+  Note that this deliberately ignores the resets of non-exhausted windows: the
+  largest reset overall (e.g. the monthly window) can be many days away even
+  for a brief per-second burst limit.
 
   Returns `nil` when the response is not rate limited, and falls back to
   `#{@default_reset_seconds}` seconds when the reset header is missing or unparseable.

--- a/lib/sanbase/cryptocompare/open_interest/open_interest_pause_resume_worker.ex
+++ b/lib/sanbase/cryptocompare/open_interest/open_interest_pause_resume_worker.ex
@@ -10,15 +10,18 @@ defmodule Sanbase.Cryptocompare.OpenInterest.PauseResumeWorker do
 
   require Logger
 
+  alias Sanbase.Cryptocompare.Handler
+  alias Sanbase.Cryptocompare.OpenInterest.HistoricalScheduler
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"type" => "resume"}}) do
     Logger.info("[Cryptocompare OpenInterest] Resuming historical jobs queue after rate limit.")
-    Sanbase.Cryptocompare.OpenInterest.HistoricalScheduler.resume()
+    Handler.resume_and_verify(HistoricalScheduler)
   end
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"type" => "pause"}}) do
     Logger.info("[Cryptocompare OpenInterest] Pausing historical jobs queue.")
-    Sanbase.Cryptocompare.OpenInterest.HistoricalScheduler.pause()
+    HistoricalScheduler.pause()
   end
 end

--- a/lib/sanbase/cryptocompare/price/price_historical_worker.ex
+++ b/lib/sanbase/cryptocompare/price/price_historical_worker.ex
@@ -31,9 +31,19 @@ defmodule Sanbase.Cryptocompare.Price.HistoricalWorker do
   def queue(), do: :cryptocompare_historical_jobs_queue
   def conf_name(), do: @oban_conf_name
 
+  @doc ~s"""
+  The Oban worker that pauses/resumes this worker's queue after rate limits.
+  Part of the callbacks `Sanbase.Cryptocompare.Handler` uses via `module:`.
+  """
+  @spec pause_resume_worker() :: module()
   def pause_resume_worker(),
     do: Sanbase.Cryptocompare.Price.PauseResumeWorker
 
+  @doc ~s"""
+  The GenServer that owns pause/resume/enabled? for this worker's queue.
+  Part of the callbacks `Sanbase.Cryptocompare.Handler` uses via `module:`.
+  """
+  @spec historical_scheduler() :: module()
   def historical_scheduler(),
     do: Sanbase.Cryptocompare.Price.HistoricalScheduler
 
@@ -123,6 +133,22 @@ defmodule Sanbase.Cryptocompare.Price.HistoricalWorker do
     assets
   end
 
+  @doc ~s"""
+  Fetch one day of minute OHLCV data for the pair from the Cryptocompare
+  min-api.
+
+  Returns:
+  - `{:ok, ohlcv_list}` on success
+  - `{:snooze, seconds}` when rate limited — the queue is paused and a resume
+    job is scheduled via `Sanbase.Cryptocompare.Handler.handle_rate_limit/2`
+  - `:snooze` when the API returns a JSON error payload instead of CSV
+  - `{:error, reason}` on HTTP errors or unexpected status codes
+
+  ## Example
+
+      get_data("BTC", "USD", "2024-01-01")
+      #=> {:ok, [%{time: 1704067200, open: ..., high: ..., ...} | _]}
+  """
   @spec get_data(String.t(), String.t(), String.t()) ::
           {:ok, any} | {:snooze, non_neg_integer()} | :snooze | {:error, any}
   def get_data(base_asset, quote_asset, date) do

--- a/lib/sanbase/cryptocompare/price/price_historical_worker.ex
+++ b/lib/sanbase/cryptocompare/price/price_historical_worker.ex
@@ -19,6 +19,7 @@ defmodule Sanbase.Cryptocompare.Price.HistoricalWorker do
     max_attempts: 20,
     unique: [period: 7 * 86_400]
 
+  alias Sanbase.Cryptocompare.Handler
   alias Sanbase.Cryptocompare.HTTPHeaderUtils
 
   require Logger
@@ -29,6 +30,12 @@ defmodule Sanbase.Cryptocompare.Price.HistoricalWorker do
 
   def queue(), do: :cryptocompare_historical_jobs_queue
   def conf_name(), do: @oban_conf_name
+
+  def pause_resume_worker(),
+    do: Sanbase.Cryptocompare.Price.PauseResumeWorker
+
+  def historical_scheduler(),
+    do: Sanbase.Cryptocompare.Price.HistoricalScheduler
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: args, attempt: attempt}) do
@@ -116,7 +123,8 @@ defmodule Sanbase.Cryptocompare.Price.HistoricalWorker do
     assets
   end
 
-  @spec get_data(String.t(), String.t(), String.t()) :: {:error, HTTPoison.Error.t()} | {:ok, any}
+  @spec get_data(String.t(), String.t(), String.t()) ::
+          {:ok, any} | {:snooze, non_neg_integer()} | :snooze | {:error, any}
   def get_data(base_asset, quote_asset, date) do
     query_params = [
       fsym: base_asset,
@@ -132,37 +140,18 @@ defmodule Sanbase.Cryptocompare.Price.HistoricalWorker do
     case HTTPoison.get(url, headers, recv_timeout: 15_000) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body} = resp} ->
         case HTTPHeaderUtils.rate_limited?(resp) do
-          false ->
-            csv_to_ohlcv_list(body)
-
-          {:error_limited, _} ->
-            Sanbase.Cryptocompare.Price.HistoricalScheduler.pause()
-            reset_after_seconds = HTTPHeaderUtils.get_biggest_ratelimited_window(resp)
-            enqueue_resume_worker(reset_after_seconds)
-            {:snooze, reset_after_seconds}
+          false -> csv_to_ohlcv_list(body)
+          {:error_limited, _} -> Handler.handle_rate_limit(resp, module: __MODULE__)
         end
+
+      {:ok, %HTTPoison.Response{status_code: 429} = resp} ->
+        Handler.handle_rate_limit(resp, module: __MODULE__)
+
+      {:ok, %HTTPoison.Response{status_code: status_code}} ->
+        {:error, "Unexpected status code #{status_code} from the Cryptocompare API"}
 
       {:error, error} ->
         {:error, error}
-    end
-  end
-
-  defp enqueue_resume_worker(reset_after_seconds) do
-    data =
-      %{"type" => "resume"}
-      |> Sanbase.Cryptocompare.Price.PauseResumeWorker.new(schedule_in: reset_after_seconds)
-
-    case Oban.insert(@oban_conf_name, data) do
-      {:ok, _job} ->
-        :ok
-
-      {:error, reason} ->
-        Logger.error(
-          "[Cryptocompare Historical] Failed to enqueue PauseResumeWorker: #{inspect(reason)}. " <>
-            "Resuming queue immediately to avoid permanent pause."
-        )
-
-        Sanbase.Cryptocompare.Price.HistoricalScheduler.resume()
     end
   end
 

--- a/lib/sanbase/cryptocompare/price/price_pause_resume_worker.ex
+++ b/lib/sanbase/cryptocompare/price/price_pause_resume_worker.ex
@@ -10,15 +10,18 @@ defmodule Sanbase.Cryptocompare.Price.PauseResumeWorker do
 
   require Logger
 
+  alias Sanbase.Cryptocompare.Handler
+  alias Sanbase.Cryptocompare.Price.HistoricalScheduler
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"type" => "resume"}}) do
     Logger.info("[Cryptocompare Price] Resuming historical jobs queue after rate limit.")
-    Sanbase.Cryptocompare.Price.HistoricalScheduler.resume()
+    Handler.resume_and_verify(HistoricalScheduler)
   end
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"type" => "pause"}}) do
     Logger.info("[Cryptocompare Price] Pausing historical jobs queue.")
-    Sanbase.Cryptocompare.Price.HistoricalScheduler.pause()
+    HistoricalScheduler.pause()
   end
 end

--- a/lib/sanbase/cryptocompare/queue_watchdog_worker.ex
+++ b/lib/sanbase/cryptocompare/queue_watchdog_worker.ex
@@ -16,6 +16,8 @@ defmodule Sanbase.Cryptocompare.QueueWatchdogWorker do
   Any of these leaves the queue paused forever and the exporter silently stops
   until the pod is restarted. This worker runs periodically via Oban cron and
   resumes any enabled queue that is paused without a pending resume job.
+
+  See docs/cryptocompare-queue-pause-resume.md for the full design rationale.
   """
   use Oban.Worker, queue: :cryptocompare_watchdog_queue, max_attempts: 3
 

--- a/lib/sanbase/cryptocompare/queue_watchdog_worker.ex
+++ b/lib/sanbase/cryptocompare/queue_watchdog_worker.ex
@@ -1,0 +1,83 @@
+defmodule Sanbase.Cryptocompare.QueueWatchdogWorker do
+  @moduledoc ~s"""
+  Self-healing watchdog for the Cryptocompare historical scraper queues.
+
+  When a rate limit is hit, the historical queue is paused and a single
+  scheduled `resume` job is responsible for resuming it. That single-shot
+  resume can be lost:
+
+  - the resume signal is delivered via the Oban notifier and is dropped if the
+    notifier connection is down at that moment;
+  - a queue producer that crashes is restarted with the config state, which is
+    `paused: true`;
+  - the resume job insert can be discarded by the uniqueness constraint in a
+    narrow race with an executing resume job.
+
+  Any of these leaves the queue paused forever and the exporter silently stops
+  until the pod is restarted. This worker runs periodically via Oban cron and
+  resumes any enabled queue that is paused without a pending resume job.
+  """
+  use Oban.Worker, queue: :cryptocompare_watchdog_queue, max_attempts: 3
+
+  import Ecto.Query
+
+  require Logger
+
+  # The historical workers expose historical_scheduler/0 and
+  # pause_resume_worker/0 — the same callbacks Handler.handle_rate_limit/2 uses.
+  @historical_workers [
+    Sanbase.Cryptocompare.Price.HistoricalWorker,
+    Sanbase.Cryptocompare.OpenInterest.HistoricalWorker,
+    Sanbase.Cryptocompare.FundingRate.HistoricalWorker
+  ]
+
+  # A resume job in any of these states either will run or is running right
+  # now, so the watchdog does not need to interfere.
+  @resume_job_alive_states ~w[available scheduled executing retryable]
+
+  @impl Oban.Worker
+  def perform(_job) do
+    Enum.each(@historical_workers, &resume_if_stuck/1)
+    :ok
+  end
+
+  defp resume_if_stuck(historical_worker) do
+    scheduler = historical_worker.historical_scheduler()
+
+    # The queues start paused and are resumed on boot only when enabled, so a
+    # paused queue of a disabled scheduler is intentional and must stay paused.
+    with true <- scheduler.enabled?(),
+         %{paused: true} <- Oban.check_queue(scheduler.conf_name(), queue: scheduler.queue()),
+         false <-
+           pending_resume_job_exists?(
+             scheduler.conf_name(),
+             historical_worker.pause_resume_worker()
+           ) do
+      Logger.warning(
+        "[Cryptocompare Watchdog] Queue #{scheduler.queue()} is paused and has no " <>
+          "pending resume job. Resuming it."
+      )
+
+      scheduler.resume()
+    else
+      _ -> :ok
+    end
+  end
+
+  @doc false
+  def pending_resume_job_exists?(oban_conf_name, pause_resume_worker) do
+    worker_name = Oban.Worker.to_string(pause_resume_worker)
+
+    query =
+      from(j in Oban.Job,
+        where:
+          j.worker == ^worker_name and
+            j.state in ^@resume_job_alive_states and
+            fragment("?->>'type' = 'resume'", j.args)
+      )
+
+    # Oban.Repo injects the instance's repo and prefix — on prod the oban_jobs
+    # table lives in the sanbase2 schema, not in public.
+    oban_conf_name |> Oban.config() |> Oban.Repo.exists?(query)
+  end
+end

--- a/lib/sanbase/cryptocompare/queue_watchdog_worker.ex
+++ b/lib/sanbase/cryptocompare/queue_watchdog_worker.ex
@@ -25,6 +25,8 @@ defmodule Sanbase.Cryptocompare.QueueWatchdogWorker do
 
   require Logger
 
+  alias Sanbase.Cryptocompare.Handler
+
   # The historical workers expose historical_scheduler/0 and
   # pause_resume_worker/0 — the same callbacks Handler.handle_rate_limit/2 uses.
   @historical_workers [
@@ -39,8 +41,20 @@ defmodule Sanbase.Cryptocompare.QueueWatchdogWorker do
 
   @impl Oban.Worker
   def perform(_job) do
-    Enum.each(@historical_workers, &resume_if_stuck/1)
-    :ok
+    unconfirmed =
+      @historical_workers
+      |> Enum.map(&resume_if_stuck/1)
+      |> Enum.reject(&(&1 == :ok))
+
+    case unconfirmed do
+      [] ->
+        :ok
+
+      _ ->
+        # Fail the job so Oban retries it (and the next cron tick is another
+        # chance anyway).
+        {:error, :queue_resume_not_confirmed}
+    end
   end
 
   defp resume_if_stuck(historical_worker) do
@@ -60,13 +74,27 @@ defmodule Sanbase.Cryptocompare.QueueWatchdogWorker do
           "pending resume job. Resuming it."
       )
 
-      scheduler.resume()
+      Handler.resume_and_verify(scheduler)
     else
       _ -> :ok
     end
   end
 
-  @doc false
+  @doc ~s"""
+  Check whether a `resume` job of the given pause/resume worker exists in a
+  state in which it either will run or is running right now.
+
+  Used by the watchdog to avoid interfering with an in-flight recovery.
+
+  ## Example
+
+      QueueWatchdogWorker.pending_resume_job_exists?(
+        :oban_scrapers,
+        Sanbase.Cryptocompare.OpenInterest.PauseResumeWorker
+      )
+      #=> false
+  """
+  @spec pending_resume_job_exists?(atom(), module()) :: boolean()
   def pending_resume_job_exists?(oban_conf_name, pause_resume_worker) do
     worker_name = Oban.Worker.to_string(pause_resume_worker)
 

--- a/scripts/oban_scrapers_debug.exs
+++ b/scripts/oban_scrapers_debug.exs
@@ -103,9 +103,9 @@ defmodule ObanScrapersDebug do
     """)
 
     if d.executing != [] do
-      IO.puts("    executing (oldest first, max 15):")
+      IO.puts("    executing (#{length(d.executing)} total, oldest first, max 15 shown):")
 
-      Enum.each(d.executing, fn j ->
+      Enum.each(Enum.take(d.executing, 15), fn j ->
         mark = if j in d.orphans, do: "  <-- ORPHAN (dead node)", else: ""
 
         IO.puts(
@@ -216,9 +216,24 @@ defmodule ObanScrapersDebug do
         do: " #{recent} are <7d old and BLOCK unique re-inserts of the same market/instrument.",
         else: " All older than the 7d unique window, so they block nothing — just zombie rows."
 
-    "#{length(orphans)} ORPHANED executing job(s) (no Lifeline plugin -> never rescued)." <>
+    lifeline_note =
+      case lifeline_rescue_after_ms() do
+        nil -> " (no Lifeline plugin -> never rescued)"
+        ms -> " (Lifeline rescues them ~#{div(ms, 60_000)}m after attempted_at)"
+      end
+
+    "#{length(orphans)} ORPHANED executing job(s)#{lifeline_note}." <>
       unique_note <>
       " Fix: ObanScrapersDebug.cancel_orphans(:#{metric}, confirm: true) (or retry_orphans)."
+  end
+
+  defp lifeline_rescue_after_ms() do
+    Oban.config(@conf_name).plugins
+    |> Enum.find_value(fn
+      {Oban.Plugins.Lifeline, opts} -> Keyword.get(opts, :rescue_after, :timer.minutes(60))
+      Oban.Plugins.Lifeline -> :timer.minutes(60)
+      _ -> nil
+    end)
   end
 
   defp check_flow(%{main_meta: nil}), do: nil
@@ -400,7 +415,10 @@ defmodule ObanScrapersDebug do
   end
 
   defp pad_count(counts, state, width \\ 5) do
-    counts |> Map.get(state, empty_row()) |> Map.get(:count) |> to_string()
+    counts
+    |> Map.get(state, empty_row())
+    |> Map.get(:count)
+    |> to_string()
     |> String.pad_leading(width)
   end
 
@@ -536,7 +554,10 @@ defmodule ObanScrapersDebug do
 
     Enum.each(rows, fn {key, max_ts, updated_at} ->
       newest = DateTime.from_unix!(max_ts)
-      IO.puts("  #{String.pad_trailing(key, 45)} data up to #{newest} (row updated #{rel(updated_at)})")
+
+      IO.puts(
+        "  #{String.pad_trailing(key, 45)} data up to #{newest} (row updated #{rel(updated_at)})"
+      )
     end)
 
     :ok
@@ -702,7 +723,12 @@ defmodule ObanScrapersDebug do
           fragment("?[1] != ?", j.attempted_by, ^conf.node) and
           j.id not in ^running_ids,
       order_by: [asc: j.attempted_at],
-      select: %{id: j.id, attempted_at: j.attempted_at, attempted_by: j.attempted_by, args: j.args}
+      select: %{
+        id: j.id,
+        attempted_at: j.attempted_at,
+        attempted_by: j.attempted_by,
+        args: j.args
+      }
     )
   end
 
@@ -713,7 +739,9 @@ defmodule ObanScrapersDebug do
   defp with_conf(fun) do
     case safe(fn -> Oban.config(@conf_name) end, nil) do
       nil ->
-        IO.puts("!! #{inspect(@conf_name)} not running on this node — attach to the scrapers pod.")
+        IO.puts(
+          "!! #{inspect(@conf_name)} not running on this node — attach to the scrapers pod."
+        )
 
       conf ->
         fun.(conf)
@@ -746,14 +774,21 @@ defmodule ObanScrapersDebug do
     ) || {0, nil, nil}
   end
 
+  # Fetch enough rows that saturation checks (vs the producer limit, up to 25)
+  # and orphan counts stay accurate; only the first 15 are displayed.
   defp executing_jobs(conf, queue) do
     Oban.Repo.all(
       conf,
       from(j in Oban.Job,
         where: j.queue == ^to_string(queue) and j.state == "executing",
         order_by: [asc: j.attempted_at],
-        limit: 15,
-        select: %{id: j.id, attempted_at: j.attempted_at, attempted_by: j.attempted_by, args: j.args}
+        limit: 200,
+        select: %{
+          id: j.id,
+          attempted_at: j.attempted_at,
+          attempted_by: j.attempted_by,
+          args: j.args
+        }
       )
     )
   end
@@ -783,7 +818,13 @@ defmodule ObanScrapersDebug do
         where: j.queue == ^to_string(pr_queue),
         order_by: [desc: j.id],
         limit: 5,
-        select: %{id: j.id, state: j.state, args: j.args, scheduled_at: j.scheduled_at, completed_at: j.completed_at}
+        select: %{
+          id: j.id,
+          state: j.state,
+          args: j.args,
+          scheduled_at: j.scheduled_at,
+          completed_at: j.completed_at
+        }
       )
     )
   end

--- a/scripts/oban_scrapers_debug.exs
+++ b/scripts/oban_scrapers_debug.exs
@@ -1,0 +1,948 @@
+# Oban scrapers queue debugger — cryptocompare funding rate / open interest / price.
+#
+# Diagnoses stuck historical scraper queues: paused without a pending resume,
+# rate limited (snoozed), saturated, orphaned `executing` rows from dead pods,
+# isolated notifier (pause/resume signals lost), dead cron feed.
+#
+# Usage on prod:
+#   1. Attach to the SCRAPERS pod (the only pod running :oban_scrapers with queues):
+#        kubectl exec -it <scrapers-pod> -- bin/sanbase remote
+#   2. Paste this entire file into the iex prompt.
+#
+# READ-ONLY commands:
+#   ObanScrapersDebug.report()                 # funding_rate + open_interest overview
+#   ObanScrapersDebug.report(:all)             # + price
+#   ObanScrapersDebug.deep_dive(:funding_rate) # live processes: stacktraces of executing
+#                                              # jobs, stager/sonar/peer, hackney pool
+#   ObanScrapersDebug.watch(:funding_rate)     # 1 line / 5s: is the queue moving?
+#   ObanScrapersDebug.history(:funding_rate)   # completions & rate-limit hits per hour
+#   ObanScrapersDebug.errors(:funding_rate)    # tally of recent job errors
+#   ObanScrapersDebug.lag(:funding_rate)       # stalest instruments (exporter progress)
+#   ObanScrapersDebug.orphans(:funding_rate)   # executing rows left by dead nodes
+#   ObanScrapersDebug.job(4175570)             # dump one job row
+#   ObanScrapersDebug.processes()              # all Oban processes + mailboxes
+#
+# MUTATING commands (explicit, never called by the read-only ones):
+#   ObanScrapersDebug.force_resume(:funding_rate)
+#   ObanScrapersDebug.cancel_orphans(:funding_rate, confirm: true)  # stale work -> cancelled
+#   ObanScrapersDebug.retry_orphans(:funding_rate, confirm: true)   # re-run the work
+#   Without `confirm: true` both only print what they would touch.
+
+defmodule ObanScrapersDebug do
+  import Ecto.Query
+
+  @conf_name :oban_scrapers
+  @add_jobs_worker "Sanbase.Cryptocompare.AddHistoricalJobsWorker"
+  @pending_states ["available", "scheduled", "executing", "retryable"]
+  # Orphan = executing row attempted by another node, older than 2x the 5m worker timeout.
+  @orphan_age_sec 600
+
+  @metrics %{
+    funding_rate: %{
+      queue: :cryptocompare_funding_rate_historical_jobs_queue,
+      pause_resume_queue: :cryptocompare_funding_rate_historical_jobs_pause_resume_queue,
+      scheduler: Sanbase.Cryptocompare.FundingRate.HistoricalScheduler,
+      cron_type: "schedule_historical_funding_rate_jobs",
+      cron_stale_after_sec: 2 * 3600
+    },
+    open_interest: %{
+      queue: :cryptocompare_open_interest_historical_jobs_queue,
+      pause_resume_queue: :cryptocompare_open_interest_historical_jobs_pause_resume_queue,
+      scheduler: Sanbase.Cryptocompare.OpenInterest.HistoricalScheduler,
+      cron_type: "schedule_historical_open_interest_jobs",
+      cron_stale_after_sec: 2 * 3600
+    },
+    price: %{
+      queue: :cryptocompare_historical_jobs_queue,
+      pause_resume_queue: :cryptocompare_historical_jobs_pause_resume_queue,
+      scheduler: Sanbase.Cryptocompare.Price.HistoricalScheduler,
+      cron_type: "schedule_historical_price_jobs",
+      cron_stale_after_sec: 26 * 3600
+    }
+  }
+
+  # ======================================================================
+  # Overview report
+  # ======================================================================
+
+  def report(metrics \\ [:funding_rate, :open_interest])
+  def report(:all), do: report(Map.keys(@metrics))
+  def report(metric) when is_atom(metric), do: report([metric])
+
+  def report(metrics) when is_list(metrics) do
+    with_conf(fn conf ->
+      notifier = safe(fn -> Oban.Notifier.status(@conf_name) end, :unknown)
+      leader = safe(fn -> Oban.Peer.leader?(@conf_name) end, :unknown)
+
+      isolated_note =
+        if notifier == :isolated,
+          do: "  <-- !! pg_notify down: pause/resume signals are LOST",
+          else: ""
+
+      IO.puts("""
+
+      ==== OBAN SCRAPERS @ #{DateTime.utc_now() |> DateTime.truncate(:second)} ====
+      node: #{node()}  oban node: #{conf.node}  prefix: #{inspect(conf.prefix)}
+      notifier: #{inspect(notifier)}#{isolated_note}
+      leader?: #{inspect(leader)} (Cron/Pruner/Stager run on leader)  connected: #{inspect(Node.list())}
+      """)
+
+      Enum.each(metrics, &print_metric(conf, &1))
+    end)
+  end
+
+  defp print_metric(conf, metric) do
+    m = Map.fetch!(@metrics, metric)
+    d = collect(conf, m)
+
+    IO.puts("""
+    ---- #{String.upcase(to_string(metric))} (#{m.queue}) ----
+    producer main : #{fmt_producer(d.main_meta)}
+    producer p/r  : #{fmt_producer(d.pr_meta)}
+    #{fmt_counts(d)}  last job completed: #{rel(d.last_completed)}
+    """)
+
+    if d.executing != [] do
+      IO.puts("    executing (oldest first, max 15):")
+
+      Enum.each(d.executing, fn j ->
+        mark = if j in d.orphans, do: "  <-- ORPHAN (dead node)", else: ""
+
+        IO.puts(
+          "      id=#{j.id} started=#{rel(j.attempted_at)} node=#{Enum.at(j.attempted_by || [], 0)} " <>
+            "#{j.args["market"] || "?"}/#{j.args["instrument"] || "?"}#{mark}"
+        )
+      end)
+    end
+
+    IO.puts("    pause/resume queue (last 5):")
+    if d.pr_history == [], do: IO.puts("      (empty)")
+
+    Enum.each(d.pr_history, fn j ->
+      IO.puts(
+        "      id=#{j.id} #{j.args["type"]} #{j.state} scheduled=#{rel(j.scheduled_at)} " <>
+          "completed=#{rel(j.completed_at)}"
+      )
+    end)
+
+    IO.puts("    cron feed (#{m.cron_type}, last 3):")
+    if d.cron_jobs == [], do: IO.puts("      none in last 7d")
+
+    Enum.each(d.cron_jobs, fn j ->
+      IO.puts("      id=#{j.id} #{j.state} inserted=#{rel(j.inserted_at)}")
+    end)
+
+    IO.puts("    VERDICT")
+    Enum.each(verdict(metric, m, d), &IO.puts("      * " <> &1))
+    IO.puts("")
+  end
+
+  defp collect(conf, m) do
+    executing = executing_jobs(conf, m.queue)
+
+    %{
+      main_meta: producer_meta(m.queue),
+      pr_meta: producer_meta(m.pause_resume_queue),
+      counts: state_counts(conf, m.queue),
+      snoozed: snoozed_info(conf, m.queue),
+      executing: executing,
+      orphans: Enum.filter(executing, &orphan?(&1, conf.node)),
+      pending_resumes: pending_resumes(conf, m.pause_resume_queue),
+      pr_history: pr_history(conf, m.pause_resume_queue),
+      last_completed: last_completed_at(conf, m.queue),
+      cron_jobs: cron_feed(conf, m.cron_type)
+    }
+  end
+
+  # ======================================================================
+  # Verdict — every check returns nil or a message; non-nils are printed.
+  # ======================================================================
+
+  defp verdict(metric, m, d) do
+    checks = [
+      check_producer(metric, d),
+      check_pr_producer(d),
+      check_orphans(metric, d),
+      check_flow(d),
+      check_cron(m, d),
+      check_heartbeat(d)
+    ]
+
+    case Enum.reject(checks, &is_nil/1) do
+      [] -> ["Looks healthy."]
+      lines -> lines
+    end
+  end
+
+  defp check_producer(metric, %{main_meta: nil}) do
+    "main producer NOT RUNNING on this node — wrong pod, or the queue supervisor crashed" <>
+      " (metric: #{metric})"
+  end
+
+  defp check_producer(metric, %{main_meta: %{paused: true}, pending_resumes: []}) do
+    "PAUSED with NO pending resume -> stuck until manual resume: " <>
+      "ObanScrapersDebug.force_resume(:#{metric})"
+  end
+
+  defp check_producer(_metric, %{main_meta: %{paused: true}, pending_resumes: [j | _]}) do
+    overdue? = DateTime.diff(DateTime.utc_now(), j.scheduled_at, :second) > 60
+
+    if overdue? do
+      "PAUSED, resume job id=#{j.id} OVERDUE (due #{rel(j.scheduled_at)}, state=#{j.state}). " <>
+        "Suspects: pause_resume producer down/paused, notifier :isolated, stager stuck."
+    else
+      "PAUSED, rate limited. Resume job id=#{j.id} due #{rel(j.scheduled_at)} — normal flow."
+    end
+  end
+
+  defp check_producer(_metric, _d), do: nil
+
+  defp check_pr_producer(%{pr_meta: %{paused: true}}),
+    do: "!! pause_resume queue PAUSED — resume jobs can never run (paused via Oban.Web?)"
+
+  defp check_pr_producer(%{pr_meta: nil}),
+    do: "!! pause_resume producer not running on this node"
+
+  defp check_pr_producer(_d), do: nil
+
+  defp check_orphans(_metric, %{orphans: []}), do: nil
+
+  defp check_orphans(metric, %{orphans: orphans}) do
+    week_ago = DateTime.add(DateTime.utc_now(), -7 * 86_400, :second)
+    recent = Enum.count(orphans, &(DateTime.compare(&1.attempted_at, week_ago) == :gt))
+
+    unique_note =
+      if recent > 0,
+        do: " #{recent} are <7d old and BLOCK unique re-inserts of the same market/instrument.",
+        else: " All older than the 7d unique window, so they block nothing — just zombie rows."
+
+    "#{length(orphans)} ORPHANED executing job(s) (no Lifeline plugin -> never rescued)." <>
+      unique_note <>
+      " Fix: ObanScrapersDebug.cancel_orphans(:#{metric}, confirm: true) (or retry_orphans)."
+  end
+
+  defp check_flow(%{main_meta: nil}), do: nil
+  defp check_flow(%{main_meta: %{paused: true}}), do: nil
+
+  defp check_flow(d) do
+    %{count: available, min_sched: oldest_avail} = Map.get(d.counts, "available", empty_row())
+    %{count: scheduled, min_sched: next_sched} = Map.get(d.counts, "scheduled", empty_row())
+    {snoozed, snoozed_min, _} = d.snoozed
+    live = length(d.executing) - length(d.orphans)
+    limit = d.main_meta.limit
+
+    cond do
+      live >= limit ->
+        oldest = List.first(d.executing)
+
+        "SATURATED: all #{limit} slots busy, oldest since #{rel(oldest.attempted_at)}. " <>
+          "Persistent saturation = slow/hanging HTTP (worker timeout 5m). Try deep_dive/1."
+
+      available == 0 and live == 0 and snoozed > 0 ->
+        "IDLE, all work SNOOZED (rate limited). Next due #{rel(snoozed_min)} — wakes on its own."
+
+      available == 0 and live == 0 and scheduled > 0 ->
+        "IDLE: #{scheduled} scheduled, next due #{rel(next_sched)}."
+
+      available == 0 and live == 0 ->
+        "EMPTY: no pending jobs. If cron feed below is stale, the hourly scheduler is dead."
+
+      available > 0 and live == 0 and stale?(oldest_avail, 120) ->
+        "!! #{available} jobs AVAILABLE but nothing executing — producer not dispatching. " <>
+          "Check heartbeat/notifier; deep_dive/1 for the producer process."
+
+      true ->
+        nil
+    end
+  end
+
+  defp check_cron(_m, %{cron_jobs: []}), do: "CRON FEED EMPTY: no #{@add_jobs_worker} in 7d."
+
+  defp check_cron(m, %{cron_jobs: [j | _]}) do
+    if stale?(j.inserted_at, m.cron_stale_after_sec) do
+      "CRON FEED STALE: last insert #{rel(j.inserted_at)}. Cron runs on the Oban leader — " <>
+        "check leader? in the header."
+    end
+  end
+
+  defp check_heartbeat(%{main_meta: %{updated_at: at}}) do
+    if stale?(at, 60) do
+      "!! producer heartbeat stale (#{rel(at)}) — producer wedged? Consider a pod restart."
+    end
+  end
+
+  defp check_heartbeat(_d), do: nil
+
+  # ======================================================================
+  # deep_dive — live BEAM processes (read-only)
+  # ======================================================================
+
+  @doc """
+  What the DB cannot show: stacktraces of the processes executing jobs right
+  now (see exactly where a job hangs — HTTP recv, Kafka, DB checkout),
+  stager mode (:local = notifier down, polling fallback), sonar/peer state,
+  hackney HTTP pool saturation. `busy=false` on a job process means it burned
+  ~no reductions over 500ms, i.e. genuinely blocked, not slowly working.
+  """
+  def deep_dive(metric) do
+    %{queue: queue} = Map.fetch!(@metrics, metric)
+    IO.puts("\n== DEEP DIVE #{metric} (#{queue}) — this node only ==\n")
+
+    for {label, role, keys} <- [
+          {"stager", Oban.Stager, [:mode, :interval, :limit]},
+          {"sonar ", Oban.Sonar, [:status, :interval]},
+          {"peer  ", Oban.Peer, [:leader?, :interval]}
+        ] do
+      case get_role_state(role) do
+        {:ok, state} -> IO.puts("  #{label}: #{inspect(Map.take(state, keys), limit: 10)}")
+        {:error, why} -> IO.puts("  #{label}: unavailable (#{inspect(why)})")
+      end
+    end
+
+    case producer_pid(queue) do
+      nil ->
+        IO.puts("\n  producer: NOT FOUND on this node")
+
+      pid ->
+        info = Process.info(pid, [:message_queue_len, :status])
+
+        IO.puts(
+          "\n  producer #{inspect(pid)} status=#{info[:status]} mailbox=#{info[:message_queue_len]}"
+        )
+    end
+
+    print_stacktraces(queue)
+    print_hackney()
+    :ok
+  end
+
+  defp print_stacktraces(queue) do
+    tasks = foreman_children(queue)
+    jobs = running_jobs_by_pid(queue)
+    IO.puts("\n  #{length(tasks)} live job process(es):")
+
+    before = Map.new(tasks, &{&1, Process.info(&1, :reductions)})
+    if tasks != [], do: Process.sleep(500)
+
+    Enum.each(tasks, fn pid ->
+      case Process.info(pid, [:current_stacktrace, :status, :reductions]) do
+        nil ->
+          IO.puts("    #{inspect(pid)} exited during inspection")
+
+        info ->
+          {:reductions, red0} = before[pid] || {:reductions, info[:reductions]}
+          busy? = info[:reductions] - red0 > 1_000
+
+          job_desc =
+            case jobs[pid] do
+              {id, args} -> "job=#{id} #{args["market"] || "?"}/#{args["instrument"] || "?"}"
+              nil -> "job=?"
+            end
+
+          IO.puts("    #{inspect(pid)} #{job_desc} status=#{info[:status]} busy=#{busy?}")
+
+          info[:current_stacktrace]
+          |> Enum.take(6)
+          |> Enum.each(fn {mod, fun, arity, loc} ->
+            line = if loc[:line], do: ":#{loc[:line]}", else: ""
+            IO.puts("        #{inspect(mod)}.#{fun}/#{arity} #{loc[:file]}#{line}")
+          end)
+      end
+    end)
+  end
+
+  defp print_hackney() do
+    stats = safe(fn -> :hackney_pool.get_stats(:default) end, nil)
+
+    case stats do
+      nil ->
+        IO.puts("\n  hackney :default pool: no stats")
+
+      stats ->
+        IO.puts(
+          "\n  hackney :default pool: in_use=#{stats[:in_use_count]} free=#{stats[:free_count]} " <>
+            "waiting=#{stats[:queue_count]} max=#{stats[:max]}" <>
+            if(stats[:queue_count] > 0, do: "  <-- !! pool exhausted", else: "")
+        )
+    end
+  end
+
+  # ======================================================================
+  # watch — is the queue moving right now?
+  # ======================================================================
+
+  @doc "Print one status line every 5s for `seconds` (default 30, max 600). Read-only."
+  def watch(metric, seconds \\ 30) do
+    %{queue: queue} = Map.fetch!(@metrics, metric)
+    seconds = min(seconds, 600)
+    IO.puts("time     | paused | avail | exec | sched | retry | completed since start")
+
+    with_conf(fn conf ->
+      base = completed_count(conf, queue)
+
+      for _ <- 1..max(div(seconds, 5), 1) do
+        c = state_counts(conf, queue)
+        paused = match?(%{paused: true}, producer_meta(queue))
+        done = completed_count(conf, queue) - base
+        t = Time.utc_now() |> Time.truncate(:second)
+
+        IO.puts(
+          "#{t} | #{String.pad_leading(to_string(paused), 6)} | " <>
+            "#{pad_count(c, "available")} | #{pad_count(c, "executing", 4)} | " <>
+            "#{pad_count(c, "scheduled")} | #{pad_count(c, "retryable")} | +#{done}"
+        )
+
+        Process.sleep(5_000)
+      end
+
+      :ok
+    end)
+  end
+
+  defp pad_count(counts, state, width \\ 5) do
+    counts |> Map.get(state, empty_row()) |> Map.get(:count) |> to_string()
+    |> String.pad_leading(width)
+  end
+
+  # ======================================================================
+  # history — hourly throughput vs rate-limit hits
+  # ======================================================================
+
+  @doc """
+  Per-hour completed jobs and rate-limit hits (inserts into the pause_resume
+  queue) for the last `hours`. A gap in completions + a resume insert at the
+  same hour = the queue was paused by the rate limiter there.
+  """
+  def history(metric, hours \\ 24) do
+    %{queue: queue, pause_resume_queue: pr_queue} = Map.fetch!(@metrics, metric)
+
+    with_conf(fn conf ->
+      completed = per_hour(conf, queue, :completed_at, "completed", hours)
+      limited = per_hour(conf, pr_queue, :inserted_at, nil, hours)
+
+      IO.puts("hour (UTC)        | completed | rate-limit hits")
+
+      hours_range(hours)
+      |> Enum.each(fn hour ->
+        c = Map.get(completed, hour, 0)
+        l = Map.get(limited, hour, 0)
+        bar = String.duplicate("#", min(40, div(c, 25)))
+        lim = if l > 0, do: " #{l} !!", else: ""
+
+        IO.puts("#{hour} | #{String.pad_leading(to_string(c), 9)} |#{lim} #{bar}")
+      end)
+
+      :ok
+    end)
+  end
+
+  defp per_hour(conf, queue, ts_field, state, hours) do
+    query =
+      from(j in Oban.Job,
+        where: j.queue == ^to_string(queue) and field(j, ^ts_field) > ago(^hours, "hour"),
+        group_by: fragment("date_trunc('hour', ?)", field(j, ^ts_field)),
+        select: {fragment("date_trunc('hour', ?)", field(j, ^ts_field)), count(j.id)}
+      )
+
+    query = if state, do: where(query, [j], j.state == ^state), else: query
+
+    Oban.Repo.all(conf, query)
+    |> Map.new(fn {hour, count} -> {fmt_hour(hour), count} end)
+  end
+
+  defp hours_range(hours) do
+    now = DateTime.utc_now()
+    for h <- hours..0//-1, do: fmt_hour(DateTime.add(now, -h * 3600, :second))
+  end
+
+  defp fmt_hour(%{year: y, month: mo, day: d, hour: h}) do
+    :io_lib.format("~4..0B-~2..0B-~2..0B ~2..0B:00", [y, mo, d, h]) |> to_string()
+  end
+
+  # ======================================================================
+  # errors — what is actually failing
+  # ======================================================================
+
+  @doc "Tally the last error message of the most recent `limit` failed jobs."
+  def errors(metric, limit \\ 200) do
+    %{queue: queue} = Map.fetch!(@metrics, metric)
+
+    with_conf(fn conf ->
+      rows =
+        Oban.Repo.all(
+          conf,
+          from(j in Oban.Job,
+            where: j.queue == ^to_string(queue) and fragment("cardinality(?) > 0", j.errors),
+            order_by: [desc: j.id],
+            limit: ^limit,
+            select: %{state: j.state, errors: j.errors}
+          )
+        )
+
+      IO.puts("#{length(rows)} recent jobs with errors. Last-error tally:")
+
+      rows
+      |> Enum.map(fn j ->
+        msg =
+          case List.last(j.errors || []) do
+            %{"error" => err} -> err |> String.split("\n") |> hd() |> String.slice(0, 90)
+            other -> inspect(other) |> String.slice(0, 90)
+          end
+
+        {msg, j.state}
+      end)
+      |> Enum.frequencies()
+      |> Enum.sort_by(fn {_k, count} -> -count end)
+      |> Enum.take(15)
+      |> Enum.each(fn {{msg, state}, count} ->
+        IO.puts("  #{String.pad_leading(to_string(count), 5)}x [#{state}] #{msg}")
+      end)
+
+      :ok
+    end)
+  end
+
+  # ======================================================================
+  # lag — which instruments stopped progressing (exporter progress table)
+  # ======================================================================
+
+  @doc """
+  The `n` instruments whose newest exported data point (max_timestamp) is the
+  oldest — i.e. the ones falling behind. Uses cryptocompare_exporter_progress
+  via Sanbase.Repo (regular table, no oban prefix).
+  """
+  def lag(metric, n \\ 15) do
+    %{queue: queue} = Map.fetch!(@metrics, metric)
+
+    rows =
+      Sanbase.Repo.all(
+        from(e in Sanbase.Cryptocompare.ExporterProgress,
+          where: e.queue == ^to_string(queue),
+          order_by: [asc: e.max_timestamp],
+          limit: ^n,
+          select: {e.key, e.max_timestamp, e.updated_at}
+        )
+      )
+
+    total =
+      Sanbase.Repo.one(
+        from(e in Sanbase.Cryptocompare.ExporterProgress,
+          where: e.queue == ^to_string(queue),
+          select: count(e.id)
+        )
+      )
+
+    IO.puts("#{total} tracked instruments. #{n} furthest behind (newest data point):")
+
+    Enum.each(rows, fn {key, max_ts, updated_at} ->
+      newest = DateTime.from_unix!(max_ts)
+      IO.puts("  #{String.pad_trailing(key, 45)} data up to #{newest} (row updated #{rel(updated_at)})")
+    end)
+
+    :ok
+  end
+
+  # ======================================================================
+  # Single job + process listing
+  # ======================================================================
+
+  @doc "Dump one oban job row."
+  def job(id) do
+    with_conf(fn conf ->
+      Oban.Repo.one(conf, from(j in Oban.Job, where: j.id == ^id))
+      |> IO.inspect(pretty: true, limit: :infinity)
+
+      :ok
+    end)
+  end
+
+  @doc "Every process Oban registered for this instance + mailbox/status."
+  def processes() do
+    entries =
+      Registry.select(Oban.Registry, [{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
+      |> Enum.filter(fn {key, _pid} ->
+        key == @conf_name or (is_tuple(key) and elem(key, 0) == @conf_name)
+      end)
+      |> Enum.sort_by(fn {key, _} -> inspect(key) end)
+
+    IO.puts("#{length(entries)} processes for #{inspect(@conf_name)}:")
+
+    Enum.each(entries, fn {key, pid} ->
+      role = if is_tuple(key), do: elem(key, 1), else: :supervisor
+
+      case Process.info(pid, [:message_queue_len, :status, :memory]) do
+        nil ->
+          IO.puts("  #{inspect(role)} #{inspect(pid)} DEAD")
+
+        info ->
+          mark = if info[:message_queue_len] > 100, do: "  <-- !! mailbox backing up", else: ""
+
+          IO.puts(
+            "  #{String.pad_trailing(inspect(role), 60)} status=#{info[:status]} " <>
+              "mailbox=#{info[:message_queue_len]} mem=#{div(info[:memory], 1024)}KiB#{mark}"
+          )
+      end
+    end)
+
+    :ok
+  end
+
+  # ======================================================================
+  # Mutating helpers — explicit only
+  # ======================================================================
+
+  @doc "Resume the main queue, then verify the producer actually unpaused."
+  def force_resume(metric) do
+    %{queue: queue, scheduler: scheduler} = Map.fetch!(@metrics, metric)
+    IO.puts("#{inspect(scheduler)}.resume() -> #{inspect(scheduler.resume())}")
+    Process.sleep(1_000)
+
+    case producer_meta(queue) do
+      %{paused: false} ->
+        IO.puts("OK — producer unpaused")
+
+      %{paused: true} ->
+        IO.puts("""
+        !! STILL paused. Resume travels over the notifier (pg_notify) — if
+           Oban.Notifier.status(#{inspect(@conf_name)}) is :isolated the signal was lost;
+           a pod restart re-establishes the LISTEN connection (queue starts paused
+           and the scheduler resumes it on boot when the env flag is enabled).
+        """)
+
+      nil ->
+        IO.puts("!! no local producer — wrong pod?")
+    end
+  end
+
+  @doc "List orphaned executing rows (attempted by another node, older than #{@orphan_age_sec}s)."
+  def orphans(metric) do
+    %{queue: queue} = Map.fetch!(@metrics, metric)
+
+    with_conf(fn conf ->
+      list = Oban.Repo.all(conf, orphans_query(conf, queue))
+      IO.puts("#{length(list)} orphan(s) on #{queue}:")
+
+      Enum.each(list, fn j ->
+        IO.puts(
+          "  id=#{j.id} started=#{rel(j.attempted_at)} node=#{Enum.at(j.attempted_by, 0)} " <>
+            "#{j.args["market"] || "?"}/#{j.args["instrument"] || "?"}"
+        )
+      end)
+
+      list
+    end)
+  end
+
+  @doc """
+  Cancel orphaned executing rows (-> cancelled, pruned by Pruner after 7d).
+  Right choice for ancient orphans: the work is stale, don't re-run it.
+  Dry run unless `confirm: true`. Verify the node is truly dead first
+  (`Node.list()` in the report header / kubectl) — the query only excludes
+  THIS node, not other live scraper pods.
+  """
+  def cancel_orphans(metric, opts \\ []) do
+    act_on_orphans(metric, opts, fn _conf, query ->
+      Oban.cancel_all_jobs(@conf_name, query)
+    end)
+  end
+
+  @doc """
+  Move orphaned executing rows back to available so they re-run. Right choice
+  for RECENT orphans (a deploy killed a pod mid-job and the work still
+  matters). Careful with ancient ones: jobs with schedule_next_job=true will
+  restart historical backfill chains and eat the rate limit.
+  Dry run unless `confirm: true`.
+  """
+  def retry_orphans(metric, opts \\ []) do
+    act_on_orphans(metric, opts, fn conf, query ->
+      Oban.Repo.update_all(conf, query, set: [state: "available"])
+    end)
+  end
+
+  defp act_on_orphans(metric, opts, fun) do
+    list = orphans(metric)
+    %{queue: queue} = Map.fetch!(@metrics, metric)
+
+    cond do
+      list == [] ->
+        :ok
+
+      Keyword.get(opts, :confirm, false) ->
+        with_conf(fn conf ->
+          ids = Enum.map(list, & &1.id)
+          query = from(j in Oban.Job, where: j.id in ^ids and j.state == "executing")
+
+          n =
+            case fun.(conf, query) do
+              {:ok, n} when is_integer(n) -> n
+              {n, _} when is_integer(n) -> n
+            end
+
+          IO.puts("Affected #{n} job(s) on #{queue}.")
+        end)
+
+      true ->
+        IO.puts("Dry run. Re-run with `confirm: true` to apply.")
+    end
+  end
+
+  defp orphans_query(conf, queue) do
+    cutoff = DateTime.add(DateTime.utc_now(), -@orphan_age_sec, :second)
+
+    running_ids =
+      case producer_meta(queue) do
+        %{running: ids} -> ids
+        _ -> []
+      end
+
+    from(j in Oban.Job,
+      where:
+        j.queue == ^to_string(queue) and j.state == "executing" and
+          j.attempted_at < ^cutoff and
+          fragment("?[1] != ?", j.attempted_by, ^conf.node) and
+          j.id not in ^running_ids,
+      order_by: [asc: j.attempted_at],
+      select: %{id: j.id, attempted_at: j.attempted_at, attempted_by: j.attempted_by, args: j.args}
+    )
+  end
+
+  # ======================================================================
+  # Data fetchers (read-only)
+  # ======================================================================
+
+  defp with_conf(fun) do
+    case safe(fn -> Oban.config(@conf_name) end, nil) do
+      nil ->
+        IO.puts("!! #{inspect(@conf_name)} not running on this node — attach to the scrapers pod.")
+
+      conf ->
+        fun.(conf)
+    end
+  end
+
+  defp producer_meta(queue), do: safe(fn -> Oban.check_queue(@conf_name, queue: queue) end, nil)
+
+  defp state_counts(conf, queue) do
+    Oban.Repo.all(
+      conf,
+      from(j in Oban.Job,
+        where: j.queue == ^to_string(queue),
+        group_by: j.state,
+        select: {j.state, %{count: count(j.id), min_sched: min(j.scheduled_at)}}
+      )
+    )
+    |> Map.new()
+  end
+
+  # Snoozed = scheduled with attempt > 0: ran at least once, put back by the
+  # rate limiter's {:snooze, seconds}.
+  defp snoozed_info(conf, queue) do
+    Oban.Repo.one(
+      conf,
+      from(j in Oban.Job,
+        where: j.queue == ^to_string(queue) and j.state == "scheduled" and j.attempt > 0,
+        select: {count(j.id), min(j.scheduled_at), max(j.scheduled_at)}
+      )
+    ) || {0, nil, nil}
+  end
+
+  defp executing_jobs(conf, queue) do
+    Oban.Repo.all(
+      conf,
+      from(j in Oban.Job,
+        where: j.queue == ^to_string(queue) and j.state == "executing",
+        order_by: [asc: j.attempted_at],
+        limit: 15,
+        select: %{id: j.id, attempted_at: j.attempted_at, attempted_by: j.attempted_by, args: j.args}
+      )
+    )
+  end
+
+  defp orphan?(job, conf_node) do
+    Enum.at(job.attempted_by || [], 0) != conf_node and stale?(job.attempted_at, @orphan_age_sec)
+  end
+
+  defp pending_resumes(conf, pr_queue) do
+    Oban.Repo.all(
+      conf,
+      from(j in Oban.Job,
+        where:
+          j.queue == ^to_string(pr_queue) and j.state in ^@pending_states and
+            fragment("?->>'type' = 'resume'", j.args),
+        order_by: [asc: j.scheduled_at],
+        limit: 5,
+        select: %{id: j.id, state: j.state, scheduled_at: j.scheduled_at}
+      )
+    )
+  end
+
+  defp pr_history(conf, pr_queue) do
+    Oban.Repo.all(
+      conf,
+      from(j in Oban.Job,
+        where: j.queue == ^to_string(pr_queue),
+        order_by: [desc: j.id],
+        limit: 5,
+        select: %{id: j.id, state: j.state, args: j.args, scheduled_at: j.scheduled_at, completed_at: j.completed_at}
+      )
+    )
+  end
+
+  defp last_completed_at(conf, queue) do
+    Oban.Repo.one(
+      conf,
+      from(j in Oban.Job,
+        where: j.queue == ^to_string(queue) and j.state == "completed",
+        order_by: [desc: j.id],
+        limit: 1,
+        select: j.completed_at
+      )
+    )
+  end
+
+  defp completed_count(conf, queue) do
+    Oban.Repo.one(
+      conf,
+      from(j in Oban.Job,
+        where: j.queue == ^to_string(queue) and j.state == "completed",
+        select: count(j.id)
+      )
+    )
+  end
+
+  defp cron_feed(conf, cron_type) do
+    Oban.Repo.all(
+      conf,
+      from(j in Oban.Job,
+        where: j.worker == ^@add_jobs_worker and fragment("?->>'type' = ?", j.args, ^cron_type),
+        order_by: [desc: j.id],
+        limit: 3,
+        select: %{id: j.id, state: j.state, inserted_at: j.inserted_at}
+      )
+    )
+  end
+
+  # ======================================================================
+  # BEAM process helpers
+  # ======================================================================
+
+  defp whereis_role(role), do: safe(fn -> Oban.Registry.whereis(@conf_name, role) end, nil)
+
+  defp producer_pid(queue),
+    do: whereis_role({:producer, to_string(queue)}) || whereis_role({:producer, queue})
+
+  defp foreman_children(queue) do
+    case whereis_role({:foreman, to_string(queue)}) || whereis_role({:foreman, queue}) do
+      nil -> []
+      pid -> safe(fn -> Task.Supervisor.children(pid) end, [])
+    end
+  end
+
+  defp get_role_state(role) do
+    case whereis_role(role) do
+      nil -> {:error, :not_found}
+      pid -> safe_get_state(pid)
+    end
+  end
+
+  # Best effort: the producer's running map shape is an internal detail.
+  defp running_jobs_by_pid(queue) do
+    with pid when is_pid(pid) <- producer_pid(queue),
+         {:ok, state} <- safe_get_state(pid) do
+      (Map.get(state, :running) || %{})
+      |> Enum.reduce(%{}, fn
+        {_ref, {pid, %{job: %{id: id, args: args}}}}, acc -> Map.put(acc, pid, {id, args})
+        _, acc -> acc
+      end)
+    else
+      _ -> %{}
+    end
+  end
+
+  defp safe_get_state(pid) do
+    {:ok, :sys.get_state(pid, 2_000) |> to_plain_map()}
+  rescue
+    error -> {:error, error}
+  catch
+    :exit, reason -> {:error, reason}
+  end
+
+  defp to_plain_map(%_{} = struct), do: Map.from_struct(struct)
+  defp to_plain_map(map) when is_map(map), do: map
+  defp to_plain_map(other), do: %{value: other}
+
+  defp safe(fun, default) do
+    fun.()
+  rescue
+    _ -> default
+  catch
+    :exit, _ -> default
+  end
+
+  # ======================================================================
+  # Formatting
+  # ======================================================================
+
+  defp fmt_producer(nil), do: "NOT RUNNING on this node"
+
+  defp fmt_producer(meta) do
+    "paused=#{meta.paused} limit=#{meta.limit} executing_now=#{length(meta.running)} " <>
+      "heartbeat=#{rel(meta.updated_at)}"
+  end
+
+  defp fmt_counts(d) do
+    {snoozed, snoozed_min, _} = d.snoozed
+
+    line =
+      ~w[available executing scheduled retryable completed cancelled discarded]
+      |> Enum.map(fn state ->
+        "#{state}=#{Map.get(d.counts, state, empty_row()).count}"
+      end)
+      |> Enum.join(" ")
+
+    extras =
+      [
+        avail_extra(d.counts["available"]),
+        sched_extra(d.counts["scheduled"]),
+        if(snoozed > 0, do: "snoozed=#{snoozed} next due #{rel(snoozed_min)}")
+      ]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join("; ")
+
+    "    counts: #{line}" <> if(extras == "", do: "", else: "\n    #{extras}")
+  end
+
+  defp avail_extra(%{count: c, min_sched: min_s}) when c > 0, do: "oldest available #{rel(min_s)}"
+  defp avail_extra(_), do: nil
+
+  defp sched_extra(%{count: c, min_sched: min_s}) when c > 0, do: "next scheduled #{rel(min_s)}"
+  defp sched_extra(_), do: nil
+
+  defp empty_row(), do: %{count: 0, min_sched: nil}
+
+  defp stale?(nil, _sec), do: false
+  defp stale?(dt, sec), do: DateTime.diff(DateTime.utc_now(), to_dt(dt), :second) > sec
+
+  defp rel(nil), do: "n/a"
+
+  defp rel(dt) do
+    diff = DateTime.diff(DateTime.utc_now(), to_dt(dt), :second)
+    if diff >= 0, do: "#{dur(diff)} ago", else: "in #{dur(-diff)}"
+  end
+
+  defp to_dt(%DateTime{} = dt), do: dt
+  defp to_dt(%NaiveDateTime{} = ndt), do: DateTime.from_naive!(ndt, "Etc/UTC")
+
+  defp dur(s) when s < 60, do: "#{s}s"
+  defp dur(s) when s < 3600, do: "#{div(s, 60)}m #{rem(s, 60)}s"
+  defp dur(s) when s < 86_400, do: "#{div(s, 3600)}h #{rem(s, 3600) |> div(60)}m"
+  defp dur(s), do: "#{div(s, 86_400)}d #{rem(s, 86_400) |> div(3600)}h"
+end
+
+IO.puts("""
+ObanScrapersDebug loaded.
+
+Read-only : report/0,1  deep_dive/1  watch/1,2  history/1,2  errors/1,2
+            lag/1,2  orphans/1  job/1  processes/0
+Mutating  : force_resume/1  cancel_orphans/2  retry_orphans/2  (need confirm: true)
+""")

--- a/test/sanbase/cryptocompare/http_header_utils_test.exs
+++ b/test/sanbase/cryptocompare/http_header_utils_test.exs
@@ -27,13 +27,11 @@ defmodule Sanbase.Cryptocompare.HTTPHeaderUtilsTest do
 
     test "waits for the exhausted short window, not the longest overall window" do
       # only the per-second window is exhausted -> wait 1s (its reset), not the
-      # ~14 day monthly reset that get_biggest_ratelimited_window/1 would return.
+      # ~14 day monthly reset, which is the biggest reset value in the header.
       remaining =
         "100, 0;window=1, 50;window=60, 1000;window=3600, 5000;window=86400, 99999;window=2592000"
 
       assert HTTPHeaderUtils.rate_limit_reset_seconds(resp(remaining, @reset)) == 1
-      # contrast with the pre-existing function that ignores which window is exhausted
-      assert HTTPHeaderUtils.get_biggest_ratelimited_window(resp(remaining, @reset)) == 1_200_000
     end
 
     test "uses the reset of the exhausted window" do
@@ -72,18 +70,11 @@ defmodule Sanbase.Cryptocompare.HTTPHeaderUtilsTest do
       assert HTTPHeaderUtils.rate_limited?(resp) == false
     end
 
-    test "get_biggest_ratelimited_window/1 falls back to 60s when the Reset-All header is missing" do
+    test "rate_limit_reset_seconds/1 falls back to 60s when the Reset-All header is unparseable" do
       remaining =
         "100, 0;window=1, 50;window=60, 1000;window=3600, 5000;window=86400, 99999;window=2592000"
 
-      assert HTTPHeaderUtils.get_biggest_ratelimited_window(resp(remaining, nil)) == 60
-    end
-
-    test "get_biggest_ratelimited_window/1 falls back to 60s when the Reset-All header is unparseable" do
-      remaining =
-        "100, 0;window=1, 50;window=60, 1000;window=3600, 5000;window=86400, 99999;window=2592000"
-
-      assert HTTPHeaderUtils.get_biggest_ratelimited_window(resp(remaining, "garbage")) == 60
+      assert HTTPHeaderUtils.rate_limit_reset_seconds(resp(remaining, "garbage")) == 60
     end
   end
 end

--- a/test/sanbase/cryptocompare/queue_pause_resume_test.exs
+++ b/test/sanbase/cryptocompare/queue_pause_resume_test.exs
@@ -1,0 +1,85 @@
+defmodule Sanbase.Cryptocompare.QueuePauseResumeTest do
+  use Sanbase.DataCase
+  use Oban.Testing, repo: Sanbase.Repo
+
+  import Ecto.Query
+  import ExUnit.CaptureLog
+
+  alias Sanbase.Cryptocompare.Handler
+  alias Sanbase.Cryptocompare.OpenInterest
+  alias Sanbase.Cryptocompare.QueueWatchdogWorker
+
+  @conf_name :oban_scrapers
+
+  describe "Handler.schedule_resume_job/2" do
+    test "schedules a resume job" do
+      assert :ok = Handler.schedule_resume_job(OpenInterest.HistoricalWorker, 60)
+
+      assert [job] = all_enqueued(worker: OpenInterest.PauseResumeWorker)
+      assert job.args == %{"type" => "resume"}
+      assert job.state == "scheduled"
+    end
+
+    test "a pending resume job absorbs the duplicate insert" do
+      :ok = Handler.schedule_resume_job(OpenInterest.HistoricalWorker, 60)
+      :ok = Handler.schedule_resume_job(OpenInterest.HistoricalWorker, 60)
+
+      # The second insert conflicts with the scheduled job, which will still
+      # run in the future, so no new job and no immediate resume are needed.
+      assert [_job] = all_enqueued(worker: OpenInterest.PauseResumeWorker)
+    end
+
+    test "conflict with an executing resume job triggers an immediate resume" do
+      :ok = Handler.schedule_resume_job(OpenInterest.HistoricalWorker, 60)
+
+      # Simulate the poison race: the pending resume job is currently executing,
+      # so it may have already resumed the queue before the new pause landed.
+      from(j in Oban.Job,
+        where: j.worker == "Sanbase.Cryptocompare.OpenInterest.PauseResumeWorker"
+      )
+      |> Sanbase.Repo.update_all(set: [state: "executing"])
+
+      log =
+        capture_log(fn ->
+          assert :ok = Handler.schedule_resume_job(OpenInterest.HistoricalWorker, 60)
+        end)
+
+      assert log =~ "Resume job insert conflicted with a resume job in state executing"
+      assert log =~ "Resuming queue immediately"
+    end
+  end
+
+  describe "QueueWatchdogWorker" do
+    test "perform/1 returns :ok" do
+      assert :ok = perform_job(QueueWatchdogWorker, %{})
+    end
+
+    test "pending_resume_job_exists?/2 sees only pending resume jobs" do
+      refute QueueWatchdogWorker.pending_resume_job_exists?(
+               @conf_name,
+               OpenInterest.PauseResumeWorker
+             )
+
+      {:ok, _} =
+        Oban.insert(
+          @conf_name,
+          OpenInterest.PauseResumeWorker.new(%{"type" => "resume"}, schedule_in: 60)
+        )
+
+      assert QueueWatchdogWorker.pending_resume_job_exists?(
+               @conf_name,
+               OpenInterest.PauseResumeWorker
+             )
+
+      from(j in Oban.Job,
+        where: j.worker == "Sanbase.Cryptocompare.OpenInterest.PauseResumeWorker"
+      )
+      |> Sanbase.Repo.update_all(set: [state: "completed"])
+
+      refute QueueWatchdogWorker.pending_resume_job_exists?(
+               @conf_name,
+               OpenInterest.PauseResumeWorker
+             )
+    end
+  end
+end


### PR DESCRIPTION
## Changes

### Problem

The open interest / funding rate / price historical exporters would silently stop and never recover until the `sanbase-scrapers` pod was killed. Root cause: when a rate limit is hit, the queue is paused and a **single scheduled resume job** is responsible for resuming it. That single-shot resume can be lost in several ways:

- the resume signal travels through the Oban notifier and is dropped if the connection is down at that moment;
- a crashed queue producer restarts with the config state, which is `paused: true`;
- the resume-job insert is silently discarded by the uniqueness constraint when it races an *executing* resume job that already resumed the queue before the new pause landed.

Any of these leaves the queue paused forever. Sentry timelines confirmed the pattern: exporter activity stops after a rate-limit pause and only returns after a pod restart (the schedulers resume their queues on boot).

### Fixes (defense in depth)

| Layer | Change |
|---|---|
| 429 handling | `429` responses previously crashed with `CaseClauseError` (372 events). They carry the same `X-RateLimit-*` headers as 200s, so they now go through the same pause path. Unknown status codes return an error instead of crashing. |
| Resume scheduling | On insert conflict with an *executing* resume job, resume the queue immediately instead of silently scheduling nothing (`Handler.schedule_resume_job/2`). |
| Resume verification | Resume jobs verify via `Oban.check_queue` that the queue actually unpaused; a lost signal becomes a normal Oban retry (`Handler.resume_and_verify/1`). |
| Watchdog | New `QueueWatchdogWorker` (cron `*/10`): resumes any *enabled* queue that is paused without a pending resume job. Catches producer restarts and anything else. |
| Price queue | The pause used the biggest reset window (monthly — up to ~1 month of silence). Now capped at 1h and routed through the shared `Handler.handle_rate_limit/2` path via the same module callbacks OI/FR use. |
| Orphaned jobs | `Oban.Plugins.Lifeline` (90m `rescue_after`, above the 60m max worker timeout) rescues `executing` jobs orphaned by pods killed mid-job. |

### Ops tooling

`scripts/oban_scrapers_debug.exs` — an `ObanScrapersDebug` module pasted into `bin/sanbase remote` on the scrapers pod for live diagnosis of stuck queues: `report/1`, `deep_dive/1` (stacktraces of executing jobs, stager/sonar/peer, hackney pool), `watch/2`, `history/2`, `errors/2`, `lag/2`, `orphans/1`, `processes/0`. Mutating commands (`force_resume/1`, `cancel_orphans/2`, `retry_orphans/2`) are explicit and require `confirm: true`.

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for stalled historical data queues.
  * Improved handling of rate limits, including safer pause and resume behavior.
  * Added scheduled monitoring to detect and restore stuck queues.
  * Added diagnostic tools for investigating queue health and job failures.

* **Bug Fixes**
  * Improved recovery of interrupted jobs and clearer handling of unexpected responses.

* **Documentation**
  * Added troubleshooting guidance for stalled scraper queues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->