### PR TITLE
Return proper error when metric is queried with wrong data type

### DIFF
--- a/lib/sanbase/metric/helper.ex
+++ b/lib/sanbase/metric/helper.ex
@@ -44,6 +44,7 @@ defmodule Sanbase.Metric.Helper do
   def implemented_optional_functions(), do: get(:implemented_optional_functions)
   def incomplete_metrics(), do: get(:incomplete_metrics)
   def metric_modules(), do: @modules
+  def metric_to_data_types_map(), do: get(:metric_to_data_types_map)
   def metric_to_module_map(), do: get(:metric_to_module_map)
   def metric_to_modules_map(), do: get(:metric_to_modules_map)
   def metrics(), do: get(:metrics)
@@ -71,6 +72,7 @@ defmodule Sanbase.Metric.Helper do
     {:histogram_metrics_mapset, []},
     {:implemented_optional_functions, []},
     {:incomplete_metrics, []},
+    {:metric_to_data_types_map, []},
     {:metric_to_module_map, []},
     {:metric_to_modules_map, []},
     {:metrics, []},
@@ -200,6 +202,23 @@ defmodule Sanbase.Metric.Helper do
 
   defp compute(:metric_to_module_map, []) do
     build_metric_to_module_map(@modules, :available_metrics)
+  end
+
+  # A metric name can be exposed by multiple modules, in theory with different
+  # data types, so the value is a list of types.
+  defp compute(:metric_to_data_types_map, []) do
+    type_getters = [
+      timeseries: :available_timeseries_metrics,
+      histogram: :available_histogram_metrics,
+      table: :available_table_metrics
+    ]
+
+    for module <- @modules,
+        {data_type, getter_fun} <- type_getters,
+        metric <- apply(module, getter_fun, []),
+        reduce: %{} do
+      acc -> Map.update(acc, metric, [data_type], &Enum.uniq([data_type | &1]))
+    end
   end
 
   defp compute(:metric_to_modules_map, []) do

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -262,21 +262,23 @@ defmodule Sanbase.Metric do
         metric_not_available_error(metric, type: :timeseries)
 
       module when is_atom(module) ->
-        aggregation = Keyword.get(opts, :aggregation, nil)
+        with :ok <- check_metric_data_type(metric, :timeseries) do
+          aggregation = Keyword.get(opts, :aggregation, nil)
 
-        fun = fn ->
-          module.timeseries_data(
-            metric,
-            selector,
-            from,
-            to,
-            interval,
-            opts
-          )
-          |> maybe_round_floats(:timeseries_data)
+          fun = fn ->
+            module.timeseries_data(
+              metric,
+              selector,
+              from,
+              to,
+              interval,
+              opts
+            )
+            |> maybe_round_floats(:timeseries_data)
+          end
+
+          execute_if_aggregation_valid(fun, metric, aggregation)
         end
-
-        execute_if_aggregation_valid(fun, metric, aggregation)
     end
   end
 
@@ -300,23 +302,25 @@ defmodule Sanbase.Metric do
         metric_not_available_error(metric, type: :timeseries)
 
       module when is_atom(module) ->
-        aggregation = Keyword.get(opts, :aggregation, nil)
+        with :ok <- check_metric_data_type(metric, :timeseries) do
+          aggregation = Keyword.get(opts, :aggregation, nil)
 
-        fun = fn ->
-          module.timeseries_data_per_slug(
-            metric,
-            selector,
-            from,
-            to,
-            interval,
-            opts
-          )
-          |> maybe_round_floats(:timeseries_data_per_slug)
+          fun = fn ->
+            module.timeseries_data_per_slug(
+              metric,
+              selector,
+              from,
+              to,
+              interval,
+              opts
+            )
+            |> maybe_round_floats(:timeseries_data_per_slug)
+          end
+
+          execute_if_aggregation_valid(fun, metric, aggregation)
+          |> maybe_sort(:datetime, :asc)
+          |> maybe_apply_function(&sort_data_field_by_slug_asc/1)
         end
-
-        execute_if_aggregation_valid(fun, metric, aggregation)
-        |> maybe_sort(:datetime, :asc)
-        |> maybe_apply_function(&sort_data_field_by_slug_asc/1)
     end
   end
 
@@ -337,20 +341,22 @@ defmodule Sanbase.Metric do
         metric_not_available_error(metric, type: :timeseries)
 
       module when is_atom(module) ->
-        aggregation = Keyword.get(opts, :aggregation, nil)
+        with :ok <- check_metric_data_type(metric, :timeseries) do
+          aggregation = Keyword.get(opts, :aggregation, nil)
 
-        fun = fn ->
-          module.aggregated_timeseries_data(
-            metric,
-            selector,
-            from,
-            to,
-            opts
-          )
-          |> maybe_round_floats(:aggregated_timeseries_data)
+          fun = fn ->
+            module.aggregated_timeseries_data(
+              metric,
+              selector,
+              from,
+              to,
+              opts
+            )
+            |> maybe_round_floats(:aggregated_timeseries_data)
+          end
+
+          execute_if_aggregation_valid(fun, metric, aggregation)
         end
-
-        execute_if_aggregation_valid(fun, metric, aggregation)
     end
   end
 
@@ -461,14 +467,16 @@ defmodule Sanbase.Metric do
         metric_not_available_error(metric, type: :histogram)
 
       module when is_atom(module) ->
-        module.histogram_data(
-          metric,
-          selector,
-          from,
-          to,
-          interval,
-          limit
-        )
+        with :ok <- check_metric_data_type(metric, :histogram) do
+          module.histogram_data(
+            metric,
+            selector,
+            from,
+            to,
+            interval,
+            limit
+          )
+        end
     end
   end
 
@@ -489,19 +497,21 @@ defmodule Sanbase.Metric do
         metric_not_available_error(metric, type: :table)
 
       module when is_atom(module) ->
-        aggregation = Keyword.get(opts, :aggregation, nil)
+        with :ok <- check_metric_data_type(metric, :table) do
+          aggregation = Keyword.get(opts, :aggregation, nil)
 
-        fun = fn ->
-          module.table_data(
-            metric,
-            selector,
-            from,
-            to,
-            opts
-          )
+          fun = fn ->
+            module.table_data(
+              metric,
+              selector,
+              from,
+              to,
+              opts
+            )
+          end
+
+          execute_if_aggregation_valid(fun, metric, aggregation)
         end
-
-        execute_if_aggregation_valid(fun, metric, aggregation)
     end
   end
 
@@ -979,6 +989,34 @@ defmodule Sanbase.Metric do
   def min_plan_map(), do: Helper.min_plan_map()
 
   # Private functions
+
+  # The metric -> module dispatch does not take the metric's data type into
+  # account, so without this check a histogram metric requested as timeseries
+  # (or vice versa) is dispatched to the wrong fetch function and fails deep
+  # in the SQL generation with a hard to understand error.
+  defp check_metric_data_type(metric, expected_type) do
+    case Map.get(Helper.metric_to_data_types_map(), metric) do
+      nil ->
+        # The metric is not part of any data type list. Do not error here,
+        # but let the called module handle it.
+        :ok
+
+      data_types ->
+        if expected_type in data_types do
+          :ok
+        else
+          actual_type = List.first(data_types)
+
+          {:error,
+           "The metric '#{metric}' is a #{actual_type} metric, not a #{expected_type} metric. " <>
+             "Use the #{data_type_fetch_field(actual_type)} field to fetch it."}
+        end
+    end
+  end
+
+  defp data_type_fetch_field(:timeseries), do: "timeseriesData"
+  defp data_type_fetch_field(:histogram), do: "histogramData"
+  defp data_type_fetch_field(:table), do: "tableData"
 
   defp metric_not_available_error(metric, opts \\ [])
 

--- a/test/sanbase/metric/metric_test.exs
+++ b/test/sanbase/metric/metric_test.exs
@@ -111,6 +111,59 @@ defmodule Sanbase.MetricTest do
     end
   end
 
+  describe "data type mismatch" do
+    test "cannot fetch a histogram metric as timeseries", %{project: project} do
+      assert {:error, error} =
+               Metric.timeseries_data("age_distribution", %{slug: project.slug}, @from, @to, "1d")
+
+      assert error =~
+               "The metric 'age_distribution' is a histogram metric, not a timeseries metric. " <>
+                 "Use the histogramData field to fetch it."
+    end
+
+    test "cannot fetch a histogram metric as timeseries per slug", %{project: project} do
+      assert {:error, error} =
+               Metric.timeseries_data_per_slug(
+                 "price_histogram",
+                 %{slug: project.slug},
+                 @from,
+                 @to,
+                 "1d"
+               )
+
+      assert error =~
+               "The metric 'price_histogram' is a histogram metric, not a timeseries metric."
+    end
+
+    test "cannot fetch a histogram metric as aggregated timeseries", %{project: project} do
+      assert {:error, error} =
+               Metric.aggregated_timeseries_data(
+                 "spent_coins_cost",
+                 %{slug: project.slug},
+                 @from,
+                 @to
+               )
+
+      assert error =~
+               "The metric 'spent_coins_cost' is a histogram metric, not a timeseries metric."
+    end
+
+    test "cannot fetch a timeseries metric as histogram", %{project: project} do
+      assert {:error, error} =
+               Metric.histogram_data(
+                 "daily_active_addresses",
+                 %{slug: project.slug},
+                 @from,
+                 @to,
+                 "1d"
+               )
+
+      assert error =~
+               "The metric 'daily_active_addresses' is a timeseries metric, not a histogram metric. " <>
+                 "Use the timeseriesData field to fetch it."
+    end
+  end
+
   describe "available_non_crypto_asset_slugs/2" do
     test "unknown metric returns an error even when no non-crypto assets exist" do
       assert {:error, error} = Metric.available_non_crypto_asset_slugs("unknown_metric_xyz")

--- a/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_timeseries_data_test.exs
@@ -436,6 +436,29 @@ defmodule SanbaseWeb.Graphql.ApiMetricTimeseriesDataTest do
     end
   end
 
+  @tag capture_log: true
+  test "returns error when fetching a histogram metric as timeseries", context do
+    %{conn: conn, slug: slug, from: from, to: to, interval: interval} = context
+
+    # Regression test: this used to reach the timeseries SQL generation and
+    # crash with a FunctionClauseError instead of returning an error
+    %{"errors" => [%{"message" => error_message}]} =
+      get_timeseries_metric_json(
+        conn,
+        "age_distribution",
+        %{slug: slug},
+        from,
+        to,
+        interval,
+        :last,
+        nil
+      )
+
+    assert error_message =~
+             "The metric 'age_distribution' is a histogram metric, not a timeseries metric. " <>
+               "Use the histogramData field to fetch it."
+  end
+
   test "returns error when slug is not given", context do
     %{conn: conn, from: from, to: to, interval: interval} = context
     aggregation = :avg


### PR DESCRIPTION
## Changes

This is also fixing an exception caused by a histogram metric reaching the timeseries data SQL query generator where it confuses it by having 2 tables.

Return proper error message when a wrong data type is queried for a metric.
For example if `histogramData` is queried for `price_usd` or `timeseriesDataJson` is queried for `all_spent_coins`.
Before we got `Internal server error`, but  now a proper error message is returned:
```graphql
{
  getMetric(metric: "price_usd") {
    histogramData(
      slug: "ethereum"
      from: "utc_now-90d"
      to: "utc_now-80d"
      limit: 20
    ) {
      labels
      values {
        ... on FloatList {
          data
        }
      }
    }
  }
}
```
```json
{
  "data": {
    "getMetric": {
      "histogramData": null
    }
  },
  "errors": [
    {
      "message": "[e56c73bf-0151-4223-957b-9237c1ff07ac] Can't fetch price_usd for project with slug ethereum, Reason: \"The metric 'price_usd' is a timeseries metric, not a histogram metric. Use the timeseriesData field to fetch it.\"",
      "path": [
        "getMetric",
        "histogramData"
      ],
      "locations": [
        {
          "line": 3,
          "column": 5
        }
      ]
    }
  ]
}
```
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added metric data-type mapping to identify whether metrics are available as timeseries, histogram, or table data.

- **Bug Fixes**
  - Added validation to prevent fetching metrics through an incompatible data type.
  - GraphQL requests now return clear guidance to use the correct field instead of failing unexpectedly.

- **Tests**
  - Added coverage for mismatched metric types across metric APIs and GraphQL requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->