### PR TITLE
Improve san staking error handling

### DIFF
--- a/lib/sanbase/accounts/eth_account.ex
+++ b/lib/sanbase/accounts/eth_account.ex
@@ -2,6 +2,7 @@ defmodule Sanbase.Accounts.EthAccount do
   use Ecto.Schema
   import Ecto.Changeset
   import Ecto.Query
+  import Sanbase.Utils.Transform, only: [maybe_apply_function: 2]
 
   alias Sanbase.Repo
   alias Sanbase.SmartContracts.UniswapPair
@@ -99,27 +100,60 @@ defmodule Sanbase.Accounts.EthAccount do
   end
 
   @doc """
-  Fetch wallet staked SAN tokens for given Uniswap pair contract
+  Fetch wallet staked SAN tokens for given Uniswap pair contract.
+
+  A failed contract call is treated as no staked tokens, so this function is
+  suitable only for best-effort read paths, not for persisting data.
   """
   @spec san_staked_address(String.t(), String.t()) :: float()
   def san_staked_address(address, contract) when is_binary(address) and is_binary(contract) do
-    UniswapPair.balance_of(address, contract)
-    |> calculate_san_staked(contract_data_map(contract))
+    case contract_data_map(contract) do
+      {:ok, data_map} ->
+        UniswapPair.balance_of(address, contract)
+        |> calculate_san_staked(data_map)
+
+      {:error, _} ->
+        +0.0
+    end
   end
 
-  def san_staked_addresses(addresses, contract) when is_list(addresses) and is_binary(contract) do
-    data_map = contract_data_map(contract)
+  @doc """
+  Fetch the staked SAN tokens of each address for the given Uniswap pair
+  contract.
 
-    # Batch size of 90 to fixe: "batch limit 100 exceeded (can increase by --rpc.batch.limit)
-    result =
+  The addresses are queried in batches of 90, as the RPC node rejects
+  batches larger than 100 requests. Any failed contract call fails the
+  whole function, so an RPC outage cannot be mistaken for zero balances.
+
+  ## Examples
+
+      iex> EthAccount.san_staked_addresses([addr1, addr2], contract)
+      {:ok, %{addr1 => 150.0, addr2 => 0.0}}
+
+      iex> EthAccount.san_staked_addresses([addr1, addr2], contract)
+      {:error, %Mint.TransportError{reason: :nxdomain}}
+  """
+  @spec san_staked_addresses([String.t()], String.t()) ::
+          {:ok, %{String.t() => float()}} | {:error, any()}
+  def san_staked_addresses(addresses, contract) when is_list(addresses) and is_binary(contract) do
+    with {:ok, data_map} <- contract_data_map(contract) do
       addresses
       |> Enum.chunk_every(90)
-      |> Enum.flat_map(&UniswapPair.balances_of(&1, contract))
+      |> Enum.reduce_while({:ok, []}, fn chunk, {:ok, acc} ->
+        case UniswapPair.balances_of(chunk, contract) do
+          {:ok, balances} -> {:cont, {:ok, [balances | acc]}}
+          {:error, _} = error -> {:halt, error}
+        end
+      end)
+      |> maybe_apply_function(fn balances_chunks ->
+        balances = balances_chunks |> Enum.reverse() |> List.flatten()
 
-    Enum.zip(addresses, result)
-    |> Map.new(fn {addr, [balance]} ->
-      {addr, calculate_san_staked(balance, data_map)}
-    end)
+        Enum.zip(addresses, balances)
+        |> Map.new(fn {addr, balance} ->
+          {addr, calculate_san_staked(balance, data_map)}
+        end)
+      end)
+    end
   end
 
   # Helpers
@@ -129,12 +163,14 @@ defmodule Sanbase.Accounts.EthAccount do
          {reserves0, reserves1} when is_float(reserves0) and is_float(reserves1) <-
            UniswapPair.reserves(contract),
          position when position in [0, 1] <- UniswapPair.get_san_position(contract) do
-      %{
-        total_supply: total_supply,
-        reserves: elem({reserves0, reserves1}, position)
-      }
+      {:ok,
+       %{
+         total_supply: total_supply,
+         reserves: elem({reserves0, reserves1}, position)
+       }}
     else
-      _ -> %{total_supply: 0.0, reserves: 0.0}
+      {:error, _} = error -> error
+      unexpected -> {:error, {:invalid_contract_data, unexpected}}
     end
   end
 

--- a/lib/sanbase/accounts/user/uniswap_staking.ex
+++ b/lib/sanbase/accounts/user/uniswap_staking.ex
@@ -32,6 +32,17 @@ defmodule Sanbase.Accounts.User.UniswapStaking do
   @doc """
   Fetch all users with conncted wallets, fetch their total staked
   SAN tokens and update.
+
+  If fetching the staked tokens fails, the update is aborted and the
+  currently stored records are left untouched.
+
+  ## Examples
+
+      iex> UniswapStaking.update_all_uniswap_san_staked_users()
+      {:ok, {2, nil}}
+
+      iex> UniswapStaking.update_all_uniswap_san_staked_users()
+      {:error, %Mint.TransportError{reason: :nxdomain}}
   """
   @spec update_all_uniswap_san_staked_users() ::
           {:ok, {integer(), nil | [term()]}} | {:error, any()}
@@ -40,22 +51,35 @@ defmodule Sanbase.Accounts.User.UniswapStaking do
     naive_now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
 
     users = User.fetch_all_users_with_eth_account()
-    users_staked_map = fetch_uniswap_san_staked(users)
 
-    users_san_staked =
-      users
-      |> Enum.map(fn user ->
-        san_staked = user_san_staked_amount(user, users_staked_map)
+    case fetch_uniswap_san_staked(users) do
+      {:ok, users_staked_map} ->
+        users_san_staked =
+          users
+          |> Enum.map(fn user ->
+            san_staked = user_san_staked_amount(user, users_staked_map)
 
-        %{
-          user_id: user.id,
-          san_staked: san_staked,
-          inserted_at: naive_now,
-          updated_at: naive_now
-        }
-      end)
-      |> Enum.filter(&(&1.san_staked > 0.0))
+            %{
+              user_id: user.id,
+              san_staked: san_staked,
+              inserted_at: naive_now,
+              updated_at: naive_now
+            }
+          end)
+          |> Enum.filter(&(&1.san_staked > 0.0))
 
+        store_uniswap_san_staked_users(users_san_staked)
+
+      {:error, reason} ->
+        Logger.error(
+          "Finished update_all_uniswap_san_staked_users error, could not fetch staked balances: #{inspect(reason)}"
+        )
+
+        {:error, reason}
+    end
+  end
+
+  defp store_uniswap_san_staked_users(users_san_staked) do
     Repo.transaction(fn ->
       Repo.delete_all(__MODULE__)
 
@@ -100,8 +124,15 @@ defmodule Sanbase.Accounts.User.UniswapStaking do
       Enum.flat_map(users, fn user -> Enum.map(user.eth_accounts, fn acc -> acc.address end) end)
 
     UniswapPair.all_pair_contracts()
-    |> Enum.map(&EthAccount.san_staked_addresses(addresses, &1))
-    |> Enum.reduce(%{}, &Map.merge(&1, &2, fn _k, v1, v2 -> v1 + v2 end))
+    |> Enum.reduce_while({:ok, %{}}, fn contract, {:ok, acc} ->
+      case EthAccount.san_staked_addresses(addresses, contract) do
+        {:ok, staked_map} ->
+          {:cont, {:ok, Map.merge(acc, staked_map, fn _k, v1, v2 -> v1 + v2 end)}}
+
+        {:error, _} = error ->
+          {:halt, error}
+      end
+    end)
   end
 
   defp calc_uniswap_san_staked_user(user) do

--- a/lib/sanbase/accounts/user/uniswap_staking.ex
+++ b/lib/sanbase/accounts/user/uniswap_staking.ex
@@ -1,4 +1,8 @@
 defmodule Sanbase.Accounts.User.UniswapStaking do
+  defmodule UpdateError do
+    defexception [:message]
+  end
+
   use Ecto.Schema
   import Ecto.Changeset
 
@@ -75,8 +79,25 @@ defmodule Sanbase.Accounts.User.UniswapStaking do
           "Finished update_all_uniswap_san_staked_users error, could not fetch staked balances: #{inspect(reason)}"
         )
 
+        report_update_error(reason)
+
         {:error, reason}
     end
+  end
+
+  # The Logger.error alone does not reach Sentry, as capturing of log
+  # messages is not enabled. Raise and rescue a dedicated exception so
+  # Sentry gets a real exception event with a stacktrace and a broken
+  # RPC node does not degrade the staking updates silently.
+  defp report_update_error(reason) do
+    raise UpdateError,
+      message: "Failed to fetch Uniswap SAN staked balances, update aborted: #{inspect(reason)}"
+  rescue
+    e ->
+      Sentry.capture_exception(e,
+        stacktrace: __STACKTRACE__,
+        extra: %{reason: inspect(reason)}
+      )
   end
 
   defp store_uniswap_san_staked_users(users_san_staked) do

--- a/lib/sanbase/smart_contracts/uniswap_pair.ex
+++ b/lib/sanbase/smart_contracts/uniswap_pair.ex
@@ -2,6 +2,8 @@ defmodule Sanbase.SmartContracts.UniswapPair do
   import Sanbase.SmartContracts.Utils,
     only: [call_contract: 4, call_contract_batch: 5, format_address: 1, format_number: 2]
 
+  import Sanbase.Utils.Transform, only: [maybe_apply_function: 2]
+
   @type address :: String.t()
 
   @bac_san_pair_contract "0x0D88ba937A8492AE235519334Da954EbA73625dF"
@@ -54,12 +56,12 @@ defmodule Sanbase.SmartContracts.UniswapPair do
     end
   end
 
-  @spec total_supply(address) :: float()
+  @spec total_supply(address) :: float() | {:error, any()}
   def total_supply(contract) do
     call_contract(contract, "totalSupply()", [], [{:uint, 256}])
     |> case do
       [total_supply] -> format_number(total_supply, @decimals)
-      {:error, _} -> +0.0
+      {:error, _} = error -> error
     end
   end
 
@@ -74,6 +76,23 @@ defmodule Sanbase.SmartContracts.UniswapPair do
     end
   end
 
+  @doc ~s"""
+  Fetch the balances of a list of addresses for the given pair contract
+  in a single batched RPC call.
+
+  Returns the balances in the same order as the given addresses. A single
+  failed request in the batch fails the whole call, as the result would no
+  longer correspond 1:1 to the addresses list.
+
+  ## Examples
+
+      iex> UniswapPair.balances_of([addr1, addr2], contract)
+      {:ok, [1.0, 2.5]}
+
+      iex> UniswapPair.balances_of([addr1, addr2], contract)
+      {:error, %Mint.TransportError{reason: :nxdomain}}
+  """
+  @spec balances_of([address], address) :: {:ok, [float()]} | {:error, any()}
   def balances_of(addresses, contract) do
     addresses_args = Enum.map(addresses, &format_address/1) |> Enum.map(&List.wrap/1)
     # balanceOf has 2 optional parameters - block number and opts. In case of
@@ -82,8 +101,20 @@ defmodule Sanbase.SmartContracts.UniswapPair do
     # to "latest", then it is populated by a keyword list and fails.
     opts = [transform_args_list_fun: fn list -> list ++ ["latest"] end]
 
-    call_contract_batch(contract, "balanceOf(address)", addresses_args, [{:uint, 256}], opts)
-    |> Enum.map(fn [balance] -> [format_number(balance, @decimals)] end)
+    with results when is_list(results) <-
+           call_contract_batch(
+             contract,
+             "balanceOf(address)",
+             addresses_args,
+             [{:uint, 256}],
+             opts
+           ) do
+      Enum.reduce_while(results, {:ok, []}, fn
+        [balance], {:ok, acc} -> {:cont, {:ok, [format_number(balance, @decimals) | acc]}}
+        {:error, _} = error, _acc -> {:halt, error}
+      end)
+      |> maybe_apply_function(&Enum.reverse/1)
+    end
   end
 
   @spec get_san_position(address) :: 0 | 1 | {:error, any()}

--- a/test/sanbase/accounts/user/uniswap_staking_test.exs
+++ b/test/sanbase/accounts/user/uniswap_staking_test.exs
@@ -1,0 +1,135 @@
+defmodule Sanbase.Accounts.User.UniswapStakingTest do
+  use Sanbase.DataCase, async: false
+
+  import Sanbase.Factory
+  import ExUnit.CaptureLog
+
+  alias Sanbase.Accounts.EthAccount
+  alias Sanbase.Accounts.User.UniswapStaking
+  alias Sanbase.Repo
+  alias Sanbase.SmartContracts.UniswapPair
+
+  setup do
+    user = insert(:user)
+    address = "0x9024d48cc7be15343dfd76ef051fa5264cfbf7a9"
+    {:ok, _} = EthAccount.create(user.id, address)
+
+    %{user: user, address: address}
+  end
+
+  describe "update_all_uniswap_san_staked_users/0" do
+    test "stores the staked amount when all contract calls succeed", %{user: user} do
+      Sanbase.Mock.prepare_mock2(&UniswapPair.balances_of/2, {:ok, [2.0]})
+      |> Sanbase.Mock.prepare_mock2(&UniswapPair.total_supply/1, 10.0)
+      |> Sanbase.Mock.prepare_mock2(&UniswapPair.reserves/1, {5.0, 3.0})
+      |> Sanbase.Mock.prepare_mock2(&UniswapPair.get_san_position/1, 0)
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        assert {:ok, {1, _}} = UniswapStaking.update_all_uniswap_san_staked_users()
+
+        assert [%UniswapStaking{user_id: user_id, san_staked: san_staked}] =
+                 UniswapStaking.fetch_all_uniswap_staked_users()
+
+        assert user_id == user.id
+        # 2 pair contracts, each contributing 2.0 / 10.0 * 5.0 = 1.0
+        assert san_staked == 2.0
+      end)
+    end
+
+    test "does not wipe existing data when a contract metadata call fails", %{user: user} do
+      %UniswapStaking{}
+      |> UniswapStaking.changeset(%{san_staked: 5.0})
+      |> Ecto.Changeset.put_change(:user_id, user.id)
+      |> Repo.insert!()
+
+      error = {:error, %Mint.TransportError{reason: :nxdomain}}
+
+      Sanbase.Mock.prepare_mock2(&UniswapPair.balances_of/2, {:ok, [2.0]})
+      |> Sanbase.Mock.prepare_mock2(&UniswapPair.total_supply/1, error)
+      |> Sanbase.Mock.prepare_mock2(&UniswapPair.reserves/1, {5.0, 3.0})
+      |> Sanbase.Mock.prepare_mock2(&UniswapPair.get_san_position/1, 0)
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        capture_log(fn ->
+          assert {:error, %Mint.TransportError{reason: :nxdomain}} =
+                   UniswapStaking.update_all_uniswap_san_staked_users()
+        end)
+
+        assert [%UniswapStaking{san_staked: 5.0}] =
+                 UniswapStaking.fetch_all_uniswap_staked_users()
+      end)
+    end
+
+    test "does not wipe existing data when the RPC node is unreachable", %{user: user} do
+      %UniswapStaking{}
+      |> UniswapStaking.changeset(%{san_staked: 5.0})
+      |> Ecto.Changeset.put_change(:user_id, user.id)
+      |> Repo.insert!()
+
+      error = {:error, %Mint.TransportError{reason: :nxdomain}}
+
+      Sanbase.Mock.prepare_mock2(&UniswapPair.balances_of/2, error)
+      |> Sanbase.Mock.prepare_mock2(&UniswapPair.total_supply/1, 10.0)
+      |> Sanbase.Mock.prepare_mock2(&UniswapPair.reserves/1, {5.0, 3.0})
+      |> Sanbase.Mock.prepare_mock2(&UniswapPair.get_san_position/1, 0)
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        capture_log(fn ->
+          assert {:error, %Mint.TransportError{reason: :nxdomain}} =
+                   UniswapStaking.update_all_uniswap_san_staked_users()
+        end)
+
+        assert [%UniswapStaking{san_staked: 5.0}] =
+                 UniswapStaking.fetch_all_uniswap_staked_users()
+      end)
+    end
+  end
+
+  describe "UniswapPair.balances_of/2" do
+    setup do
+      %{
+        addresses: [
+          "0x9024d48cc7be15343dfd76ef051fa5264cfbf7a9",
+          "0x4efb548a2cb8f0af7c591cef21053f6875b5d38f"
+        ],
+        contract: UniswapPair.san_eth_pair_contract()
+      }
+    end
+
+    test "returns the balances on success", %{addresses: addresses, contract: contract} do
+      batch_result = [[1_000_000_000_000_000_000], [2_500_000_000_000_000_000]]
+
+      Sanbase.Mock.prepare_mock2(
+        &Sanbase.SmartContracts.Utils.call_contract_batch/5,
+        batch_result
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        assert {:ok, [1.0, 2.5]} = UniswapPair.balances_of(addresses, contract)
+      end)
+    end
+
+    test "returns the error when the whole batch request fails", %{
+      addresses: addresses,
+      contract: contract
+    } do
+      error = {:error, %Mint.TransportError{reason: :nxdomain}}
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.SmartContracts.Utils.call_contract_batch/5, error)
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        assert ^error = UniswapPair.balances_of(addresses, contract)
+      end)
+    end
+
+    test "returns the error when a single request in the batch fails", %{
+      addresses: addresses,
+      contract: contract
+    } do
+      batch_result = [[1_000_000_000_000_000_000], {:error, :empty_response}]
+
+      Sanbase.Mock.prepare_mock2(
+        &Sanbase.SmartContracts.Utils.call_contract_batch/5,
+        batch_result
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        assert {:error, :empty_response} = UniswapPair.balances_of(addresses, contract)
+      end)
+    end
+  end
+end

--- a/test/sanbase/accounts/user/uniswap_staking_test.exs
+++ b/test/sanbase/accounts/user/uniswap_staking_test.exs
@@ -47,6 +47,7 @@ defmodule Sanbase.Accounts.User.UniswapStakingTest do
       |> Sanbase.Mock.prepare_mock2(&UniswapPair.total_supply/1, error)
       |> Sanbase.Mock.prepare_mock2(&UniswapPair.reserves/1, {5.0, 3.0})
       |> Sanbase.Mock.prepare_mock2(&UniswapPair.get_san_position/1, 0)
+      |> prepare_sentry_exception_mock(self())
       |> Sanbase.Mock.run_with_mocks(fn ->
         capture_log(fn ->
           assert {:error, %Mint.TransportError{reason: :nxdomain}} =
@@ -55,6 +56,9 @@ defmodule Sanbase.Accounts.User.UniswapStakingTest do
 
         assert [%UniswapStaking{san_staked: 5.0}] =
                  UniswapStaking.fetch_all_uniswap_staked_users()
+
+        assert_receive {:sentry_exception, %UniswapStaking.UpdateError{message: message}}
+        assert message =~ ":nxdomain"
       end)
     end
 
@@ -70,6 +74,7 @@ defmodule Sanbase.Accounts.User.UniswapStakingTest do
       |> Sanbase.Mock.prepare_mock2(&UniswapPair.total_supply/1, 10.0)
       |> Sanbase.Mock.prepare_mock2(&UniswapPair.reserves/1, {5.0, 3.0})
       |> Sanbase.Mock.prepare_mock2(&UniswapPair.get_san_position/1, 0)
+      |> prepare_sentry_exception_mock(self())
       |> Sanbase.Mock.run_with_mocks(fn ->
         capture_log(fn ->
           assert {:error, %Mint.TransportError{reason: :nxdomain}} =
@@ -78,8 +83,18 @@ defmodule Sanbase.Accounts.User.UniswapStakingTest do
 
         assert [%UniswapStaking{san_staked: 5.0}] =
                  UniswapStaking.fetch_all_uniswap_staked_users()
+
+        assert_receive {:sentry_exception, %UniswapStaking.UpdateError{message: message}}
+        assert message =~ ":nxdomain"
       end)
     end
+  end
+
+  defp prepare_sentry_exception_mock(mock_state, test_pid) do
+    Sanbase.Mock.prepare_mock(mock_state, Sentry, :capture_exception, fn exception, _opts ->
+      send(test_pid, {:sentry_exception, exception})
+      {:ok, "mocked"}
+    end)
   end
 
   describe "UniswapPair.balances_of/2" do


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving Uniswap staking balances by processing results in manageable batches and halting on the first failure.
  * Errors from staking/balance lookups are now propagated instead of being treated as zero, and update failures no longer silently ignore issues.
  * Existing staking records are preserved when an update cannot be completed.
* **New Features**
  * Added clearer failure handling for Uniswap staking updates, including dedicated error reporting.
* **Tests**
  * Added tests covering success, batch failure, individual element failure, and ensuring stored data remains unchanged after errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->