### PR TITLE
Sync business onboarding mail list

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -26,6 +26,13 @@ config :sanbase, Sanbase.Email.MailjetApi,
   api_business_onboarding_list_id:
     System.get_env("MAILJET_API_BUSINESS_ONBOARDING_LIST_ID", "10331324")
 
+# Launch cutoff for API Business onboarding list reconcile. Subscriptions with
+# inserted_at before this datetime are never backfilled into the Mailjet list.
+# Override with MAILJET_API_BUSINESS_ONBOARDING_SINCE when needed.
+config :sanbase, Sanbase.Email.ApiBusinessOnboardingList,
+  api_business_onboarding_since:
+    System.get_env("MAILJET_API_BUSINESS_ONBOARDING_SINCE", "2026-07-22T00:00:00Z")
+
 config :sanbase, Sanbase.SimpleMailer,
   adapter: Swoosh.Adapters.AmazonSES,
   region: "eu-west-1",

--- a/config/scheduler_config.exs
+++ b/config/scheduler_config.exs
@@ -107,6 +107,10 @@ config :sanbase, Sanbase.Scrapers.Scheduler,
       schedule: "20 * * * *",
       task: {Sanbase.Accounts.User, :sync_subscribed_users_with_changed_email, []}
     ],
+    reconcile_api_business_onboarding_list: [
+      schedule: "15 4 * * *",
+      task: {Sanbase.Email.ApiBusinessOnboardingList, :reconcile, []}
+    ],
     update_all_uniswap_san_staked_users: [
       schedule: "4-59/30 * * * *",
       task: {Sanbase.Accounts.User.UniswapStaking, :update_all_uniswap_san_staked_users, []}

--- a/lib/sanbase/email/api_business_onboarding_list.ex
+++ b/lib/sanbase/email/api_business_onboarding_list.ex
@@ -190,16 +190,23 @@ defmodule Sanbase.Email.ApiBusinessOnboardingList do
   end
 
   defp user_has_eligible_subscription?(user_id) do
-    from(s in Subscription,
-      join: p in assoc(s, :plan),
-      where: s.user_id == ^user_id,
-      where: s.status == :active,
-      where: p.product_id == ^Product.product_api(),
-      where: p.name in ^@business_plan_names or like(p.name, "CUSTOM%"),
-      select: s.id,
-      limit: 1
-    )
-    |> Repo.exists?()
+    case onboarding_since() do
+      nil ->
+        false
+
+      since ->
+        from(s in Subscription,
+          join: p in assoc(s, :plan),
+          where: s.user_id == ^user_id,
+          where: s.status == :active,
+          where: s.inserted_at >= ^since,
+          where: p.product_id == ^Product.product_api(),
+          where: p.name in ^@business_plan_names or like(p.name, "CUSTOM%"),
+          select: s.id,
+          limit: 1
+        )
+        |> Repo.exists?()
+    end
   end
 
   defp business_or_higher_api_plan?(%{product_id: product_id, name: name})
@@ -226,11 +233,11 @@ defmodule Sanbase.Email.ApiBusinessOnboardingList do
 
   defp onboarding_since do
     case Config.module_get(__MODULE__, :api_business_onboarding_since, nil) do
-      %DateTime{} = dt ->
-        dt
-
       %NaiveDateTime{} = ndt ->
-        DateTime.from_naive!(ndt, "Etc/UTC")
+        NaiveDateTime.truncate(ndt, :second)
+
+      %DateTime{} = dt ->
+        DateTime.to_naive(DateTime.truncate(dt, :second))
 
       value when is_binary(value) and value != "" ->
         parse_since(value)
@@ -243,12 +250,12 @@ defmodule Sanbase.Email.ApiBusinessOnboardingList do
   defp parse_since(value) do
     case DateTime.from_iso8601(value) do
       {:ok, dt, _} ->
-        DateTime.truncate(dt, :second)
+        DateTime.to_naive(DateTime.truncate(dt, :second))
 
       {:error, _} ->
         case NaiveDateTime.from_iso8601(value) do
           {:ok, ndt} ->
-            DateTime.from_naive!(ndt, "Etc/UTC") |> DateTime.truncate(:second)
+            NaiveDateTime.truncate(ndt, :second)
 
           {:error, _} ->
             Logger.warning(

--- a/lib/sanbase/email/api_business_onboarding_list.ex
+++ b/lib/sanbase/email/api_business_onboarding_list.ex
@@ -12,7 +12,14 @@ defmodule Sanbase.Email.ApiBusinessOnboardingList do
   so re-running the sync can never resurrect a contact who opted out.
 
   Only `active` subscriptions qualify (Business+ plans are not offered as trials).
+
+  Nightly reconciliation repairs missed billing-event adds for subscriptions
+  created on or after `api_business_onboarding_since` (list launch; defaults to
+  2026-07-22). Historical Business+ customers from before that cutoff are
+  intentionally never backfilled.
   """
+
+  import Ecto.Query
 
   require Logger
 
@@ -20,6 +27,8 @@ defmodule Sanbase.Email.ApiBusinessOnboardingList do
   alias Sanbase.Billing.Product
   alias Sanbase.Billing.Subscription
   alias Sanbase.Email.MailjetApi
+  alias Sanbase.Repo
+  alias Sanbase.Utils.Config
 
   @list_atom :api_business_onboarding
   @business_plan_names ["BUSINESS_PRO", "BUSINESS_MAX"]
@@ -45,6 +54,20 @@ defmodule Sanbase.Email.ApiBusinessOnboardingList do
   def maybe_add(_), do: :ok
 
   @doc """
+  Add the user's current email to the onboarding list when they have any eligible
+  active Business-or-higher API subscription. Used on account email change so the
+  new address is enrolled (add-only; the old Mailjet contact is left as-is).
+  """
+  @spec maybe_add_user(non_neg_integer()) :: :ok | {:error, term()}
+  def maybe_add_user(user_id) when is_integer(user_id) do
+    if user_has_eligible_subscription?(user_id) do
+      add_user_email(user_id)
+    else
+      :ok
+    end
+  end
+
+  @doc """
   Whether a subscription qualifies its owner for the onboarding list: an `active`
   subscription on an API-product Business-or-higher plan.
   """
@@ -53,6 +76,131 @@ defmodule Sanbase.Email.ApiBusinessOnboardingList do
     do: business_or_higher_api_plan?(plan)
 
   def eligible?(_), do: false
+
+  @doc """
+  Distinct emails of users with an eligible subscription inserted on or after the
+  configured launch cutoff. Empty list when the cutoff is not configured.
+  """
+  @spec eligible_user_emails() :: [String.t()]
+  def eligible_user_emails do
+    case onboarding_since() do
+      nil ->
+        []
+
+      since ->
+        business_names = @business_plan_names
+
+        from(s in Subscription,
+          join: p in assoc(s, :plan),
+          join: u in assoc(s, :user),
+          where: s.status == :active,
+          where: s.inserted_at >= ^since,
+          where: p.product_id == ^Product.product_api(),
+          where: p.name in ^business_names or like(p.name, "CUSTOM%"),
+          where: not is_nil(u.email) and u.email != "",
+          distinct: true,
+          select: u.email
+        )
+        |> Repo.all()
+    end
+  end
+
+  @doc """
+  Add-only reconciliation against the Mailjet list.
+
+  Subscribes any post-cutoff eligible emails missing from Mailjet. Logs contacts
+  present in Mailjet but not in the desired set (report only; never removes).
+  """
+  @spec reconcile() ::
+          %{
+            added: non_neg_integer(),
+            missing_emails: [String.t()],
+            extra_count: non_neg_integer()
+          }
+          | {:error, term()}
+  def reconcile do
+    case onboarding_since() do
+      nil ->
+        Logger.info(
+          "[ApiBusinessOnboardingList] Skipping reconcile: api_business_onboarding_since is not configured."
+        )
+
+        %{added: 0, missing_emails: [], extra_count: 0}
+
+      _since ->
+        do_reconcile()
+    end
+  end
+
+  defp do_reconcile do
+    desired = MapSet.new(eligible_user_emails())
+
+    case MailjetApi.client().fetch_list_emails(@list_atom) do
+      {:ok, current_emails} ->
+        current = MapSet.new(current_emails)
+        missing = MapSet.difference(desired, current) |> MapSet.to_list()
+        extras = MapSet.difference(current, desired)
+        extra_count = MapSet.size(extras)
+
+        result =
+          case missing do
+            [] ->
+              :ok
+
+            emails ->
+              MailjetApi.client().subscribe(@list_atom, emails)
+          end
+
+        case result do
+          :ok ->
+            Logger.info(
+              "[ApiBusinessOnboardingList] Reconcile complete. added=#{length(missing)} extra_count=#{extra_count}"
+            )
+
+            if extra_count > 0 do
+              Logger.info(
+                "[ApiBusinessOnboardingList] Mailjet members not in desired set (sample): #{inspect(Enum.take(MapSet.to_list(extras), 20))}"
+              )
+            end
+
+            %{added: length(missing), missing_emails: missing, extra_count: extra_count}
+
+          {:error, reason} = error ->
+            Logger.error(
+              "[ApiBusinessOnboardingList] Reconcile failed while subscribing missing contacts: #{inspect(reason)}"
+            )
+
+            error
+        end
+
+      {:error, :list_not_configured} ->
+        Logger.info(
+          "[ApiBusinessOnboardingList] Skipping reconcile: onboarding list is not configured."
+        )
+
+        %{added: 0, missing_emails: [], extra_count: 0}
+
+      {:error, reason} = error ->
+        Logger.error(
+          "[ApiBusinessOnboardingList] Reconcile failed fetching Mailjet list: #{inspect(reason)}"
+        )
+
+        error
+    end
+  end
+
+  defp user_has_eligible_subscription?(user_id) do
+    from(s in Subscription,
+      join: p in assoc(s, :plan),
+      where: s.user_id == ^user_id,
+      where: s.status == :active,
+      where: p.product_id == ^Product.product_api(),
+      where: p.name in ^@business_plan_names or like(p.name, "CUSTOM%"),
+      select: s.id,
+      limit: 1
+    )
+    |> Repo.exists?()
+  end
 
   defp business_or_higher_api_plan?(%{product_id: product_id, name: name})
        when is_binary(name) do
@@ -73,6 +221,42 @@ defmodule Sanbase.Email.ApiBusinessOnboardingList do
         )
 
         :ok
+    end
+  end
+
+  defp onboarding_since do
+    case Config.module_get(__MODULE__, :api_business_onboarding_since, nil) do
+      %DateTime{} = dt ->
+        dt
+
+      %NaiveDateTime{} = ndt ->
+        DateTime.from_naive!(ndt, "Etc/UTC")
+
+      value when is_binary(value) and value != "" ->
+        parse_since(value)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp parse_since(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, dt, _} ->
+        DateTime.truncate(dt, :second)
+
+      {:error, _} ->
+        case NaiveDateTime.from_iso8601(value) do
+          {:ok, ndt} ->
+            DateTime.from_naive!(ndt, "Etc/UTC") |> DateTime.truncate(:second)
+
+          {:error, _} ->
+            Logger.warning(
+              "[ApiBusinessOnboardingList] Invalid api_business_onboarding_since=#{inspect(value)}; ignoring."
+            )
+
+            nil
+        end
     end
   end
 end

--- a/lib/sanbase/email/mailjet_api.ex
+++ b/lib/sanbase/email/mailjet_api.ex
@@ -12,6 +12,7 @@ defmodule Sanbase.Email.MailjetApi do
   alias Sanbase.Utils.Config
 
   @base_url "https://api.mailjet.com/v3/REST/"
+  @default_fetch_page_limit 1000
   @bi_weekly_list_id -1
   @monthly_newsletter_list_id 61_085
   @mailjet_sanr_list_id 10_321_582
@@ -203,23 +204,13 @@ defmodule Sanbase.Email.MailjetApi do
         {:error, :list_not_configured}
 
       list_id ->
-        url = @base_url <> "contact"
-
-        case Req.get!(url,
-               headers: headers(),
-               params: [ContactsList: list_id, limit: 1000]
-             ) do
-          %{status: 200, body: %{"Data" => data}} ->
-            emails = Enum.map(data, & &1["Email"])
+        case fetch_all_list_emails(list_id, 0, []) do
+          {:ok, emails} ->
             Logger.info("Successfully fetched #{length(emails)} emails from list #{list_atom}")
             {:ok, emails}
 
-          %{status: _status} = response ->
-            Logger.error(
-              "Error fetching emails from Mailjet list #{list_atom}: #{inspect(response)}"
-            )
-
-            {:error, response.body}
+          {:error, _} = error ->
+            error
         end
     end
   rescue
@@ -232,6 +223,58 @@ defmodule Sanbase.Email.MailjetApi do
   end
 
   # private
+
+  defp fetch_all_list_emails(list_id, offset, acc) do
+    page_limit = fetch_page_limit()
+
+    case fetch_list_emails_page(list_id, offset, page_limit) do
+      {:ok, emails} when length(emails) < page_limit ->
+        {:ok, acc ++ emails}
+
+      {:ok, emails} ->
+        fetch_all_list_emails(list_id, offset + page_limit, acc ++ emails)
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp fetch_list_emails_page(list_id, offset, page_limit) do
+    url = @base_url <> "contact"
+
+    opts =
+      [
+        headers: headers(),
+        params: [ContactsList: list_id, Limit: page_limit, Offset: offset]
+      ] ++ req_options()
+
+    case Req.get!(url, opts) do
+      %{status: 200, body: %{"Data" => data}} ->
+        {:ok, Enum.map(data, & &1["Email"])}
+
+      %{status: _status} = response ->
+        Logger.error(
+          "Error fetching emails from Mailjet list id #{list_id}: #{inspect(response)}"
+        )
+
+        {:error, response.body}
+    end
+  end
+
+  defp fetch_page_limit do
+    case Application.get_env(:sanbase, __MODULE__, [])
+         |> Keyword.get(:fetch_list_page_limit, @default_fetch_page_limit) do
+      n when is_integer(n) and n > 0 -> n
+      _ -> @default_fetch_page_limit
+    end
+  end
+
+  defp req_options do
+    case Application.get_env(:sanbase, __MODULE__, []) |> Keyword.get(:req_options, []) do
+      opts when is_list(opts) -> opts
+      _ -> []
+    end
+  end
 
   defp subscribe_unsubscribe(list_atom, email_or_emails, action) do
     case resolve_list_id(list_atom) do

--- a/lib/sanbase/event_bus/user_events_subscriber.ex
+++ b/lib/sanbase/event_bus/user_events_subscriber.ex
@@ -106,6 +106,17 @@ defmodule Sanbase.EventBus.UserEventsSubscriber do
   end
 
   defp handle_event(
+         %{data: %{event_type: :update_email, user_id: user_id}},
+         event_shadow,
+         state
+       ) do
+    Sanbase.Email.ApiBusinessOnboardingList.maybe_add_user(user_id)
+
+    EventBus.mark_as_completed({__MODULE__, event_shadow})
+    state
+  end
+
+  defp handle_event(
          %{data: %{event_type: :subscribe_metric_updates, user_id: user_id}},
          event_shadow,
          state

--- a/lib/sanbase_web/live/admin/api_business_onboarding_live.ex
+++ b/lib/sanbase_web/live/admin/api_business_onboarding_live.ex
@@ -5,10 +5,6 @@ defmodule SanbaseWeb.Admin.ApiBusinessOnboardingLive do
   alias Sanbase.Email.ApiBusinessOnboardingList
   alias Sanbase.Email.MailjetApi
 
-  # Mailjet's contact endpoint returns at most this many rows per request; when we
-  # get exactly this many the real list may be larger and the view is truncated.
-  @page_limit 1000
-
   @impl true
   def mount(_params, _session, socket) do
     socket = assign(socket, :page_title, "API Business Onboarding List")
@@ -38,8 +34,7 @@ defmodule SanbaseWeb.Admin.ApiBusinessOnboardingLive do
            %{
              contacts: %{
                emails: sorted,
-               count: length(sorted),
-               truncated?: length(sorted) >= @page_limit
+               count: length(sorted)
              }
            }}
 
@@ -51,8 +46,6 @@ defmodule SanbaseWeb.Admin.ApiBusinessOnboardingLive do
 
   @impl true
   def render(assigns) do
-    assigns = assign(assigns, :page_limit, @page_limit)
-
     ~H"""
     <div class="flex flex-col w-full px-4 py-6">
       <div class="flex items-center justify-between mb-4">
@@ -76,18 +69,9 @@ defmodule SanbaseWeb.Admin.ApiBusinessOnboardingLive do
           </div>
         </:failed>
 
-        <div :if={contacts.truncated?} class="alert alert-warning mb-3">
-          <span>
-            Showing the first {@page_limit} contacts only - the list is larger and this view
-            is truncated.
-          </span>
-        </div>
-
         <div class="mb-3">
           <span class="text-sm text-base-content/60">
-            {if contacts.truncated?,
-              do: "#{contacts.count}+ contacts",
-              else: "#{contacts.count} contacts"}
+            {contacts.count} contacts
           </span>
         </div>
 

--- a/test/sanbase/email/api_business_onboarding_email_change_test.exs
+++ b/test/sanbase/email/api_business_onboarding_email_change_test.exs
@@ -1,0 +1,54 @@
+defmodule Sanbase.Email.ApiBusinessOnboardingEmailChangeTest do
+  use Sanbase.DataCase, async: false
+
+  import Sanbase.Factory
+  import Mox
+
+  alias Sanbase.Accounts.User
+  alias Sanbase.Email.MockMailjetApi
+  alias Sanbase.EventBus.UserEventsSubscriber
+
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  @list :api_business_onboarding
+
+  setup_all do
+    Sanbase.EventBus.subscribe_subscriber(UserEventsSubscriber)
+
+    on_exit(fn ->
+      Sanbase.EventBus.drain_topics(UserEventsSubscriber.topics(), 10_000)
+      Sanbase.EventBus.unsubscribe_subscriber(UserEventsSubscriber)
+    end)
+  end
+
+  setup do
+    Mox.allow(
+      MockMailjetApi,
+      self(),
+      Process.whereis(UserEventsSubscriber)
+    )
+
+    :ok
+  end
+
+  test "eligible Business+ user changing email is added with the new address" do
+    user = insert(:user, email: "old@example.com")
+    insert(:subscription_business_pro_monthly, user: user)
+
+    expect(MockMailjetApi, :subscribe, fn @list, "new@example.com" -> :ok end)
+
+    assert {:ok, _} = User.Email.update_email(user, "new@example.com")
+
+    :timer.sleep(100)
+  end
+
+  test "non-eligible user changing email is not added to the onboarding list" do
+    user = insert(:user, email: "old@example.com")
+    insert(:subscription_pro, user: user)
+
+    assert {:ok, _} = User.Email.update_email(user, "new@example.com")
+
+    :timer.sleep(100)
+  end
+end

--- a/test/sanbase/email/api_business_onboarding_list_test.exs
+++ b/test/sanbase/email/api_business_onboarding_list_test.exs
@@ -113,7 +113,25 @@ defmodule Sanbase.Email.ApiBusinessOnboardingListTest do
   end
 
   describe "maybe_add_user/1" do
-    test "adds the current email when the user has an eligible subscription" do
+    @since ~N[2025-01-01 00:00:00]
+
+    setup do
+      previous = Application.get_env(:sanbase, ApiBusinessOnboardingList, [])
+
+      Application.put_env(
+        :sanbase,
+        ApiBusinessOnboardingList,
+        Keyword.put(previous, :api_business_onboarding_since, @since)
+      )
+
+      on_exit(fn ->
+        Application.put_env(:sanbase, ApiBusinessOnboardingList, previous)
+      end)
+
+      :ok
+    end
+
+    test "adds the current email when the user has an eligible post-cutoff subscription" do
       user = insert(:user, email: "new@example.com")
       insert(:subscription_business_pro_monthly, user: user)
 
@@ -128,10 +146,21 @@ defmodule Sanbase.Email.ApiBusinessOnboardingListTest do
 
       assert :ok = ApiBusinessOnboardingList.maybe_add_user(user.id)
     end
+
+    test "does not subscribe when the eligible subscription is pre-cutoff" do
+      user = insert(:user, email: "historical@example.com")
+      sub = insert(:subscription_business_pro_monthly, user: user)
+
+      sub
+      |> Ecto.Changeset.change(%{inserted_at: ~N[2020-01-01 00:00:00]})
+      |> Sanbase.Repo.update!()
+
+      assert :ok = ApiBusinessOnboardingList.maybe_add_user(user.id)
+    end
   end
 
   describe "reconcile/0" do
-    @since ~U[2025-01-01 00:00:00Z]
+    @since ~N[2025-01-01 00:00:00]
 
     setup do
       previous = Application.get_env(:sanbase, ApiBusinessOnboardingList, [])

--- a/test/sanbase/email/api_business_onboarding_list_test.exs
+++ b/test/sanbase/email/api_business_onboarding_list_test.exs
@@ -111,4 +111,105 @@ defmodule Sanbase.Email.ApiBusinessOnboardingListTest do
       refute ApiBusinessOnboardingList.eligible?(nil)
     end
   end
+
+  describe "maybe_add_user/1" do
+    test "adds the current email when the user has an eligible subscription" do
+      user = insert(:user, email: "new@example.com")
+      insert(:subscription_business_pro_monthly, user: user)
+
+      expect(MockMailjetApi, :subscribe, fn @list, "new@example.com" -> :ok end)
+
+      assert :ok = ApiBusinessOnboardingList.maybe_add_user(user.id)
+    end
+
+    test "does not subscribe when the user has no eligible subscription" do
+      user = insert(:user, email: "user@example.com")
+      insert(:subscription_pro, user: user)
+
+      assert :ok = ApiBusinessOnboardingList.maybe_add_user(user.id)
+    end
+  end
+
+  describe "reconcile/0" do
+    @since ~U[2025-01-01 00:00:00Z]
+
+    setup do
+      previous = Application.get_env(:sanbase, ApiBusinessOnboardingList, [])
+
+      Application.put_env(
+        :sanbase,
+        ApiBusinessOnboardingList,
+        Keyword.put(previous, :api_business_onboarding_since, @since)
+      )
+
+      on_exit(fn ->
+        Application.put_env(:sanbase, ApiBusinessOnboardingList, previous)
+      end)
+
+      :ok
+    end
+
+    test "adds only missing post-cutoff eligible emails and reports extras" do
+      missing_user = insert(:user, email: "missing@example.com")
+      present_user = insert(:user, email: "present@example.com")
+      old_user = insert(:user, email: "historical@example.com")
+
+      insert(:subscription_business_pro_monthly, user: missing_user)
+      insert(:subscription_business_pro_monthly, user: present_user)
+
+      old_sub = insert(:subscription_business_pro_monthly, user: old_user)
+
+      old_sub
+      |> Ecto.Changeset.change(%{inserted_at: ~N[2020-01-01 00:00:00]})
+      |> Sanbase.Repo.update!()
+
+      expect(MockMailjetApi, :fetch_list_emails, fn @list ->
+        {:ok, ["present@example.com", "stale@example.com"]}
+      end)
+
+      expect(MockMailjetApi, :subscribe, fn @list, emails ->
+        assert Enum.sort(List.wrap(emails)) == ["missing@example.com"]
+        :ok
+      end)
+
+      assert %{
+               added: 1,
+               missing_emails: ["missing@example.com"],
+               extra_count: 1
+             } = ApiBusinessOnboardingList.reconcile()
+    end
+
+    test "is idempotent when Mailjet already has all desired members" do
+      user = insert(:user, email: "present@example.com")
+      insert(:subscription_business_pro_monthly, user: user)
+
+      expect(MockMailjetApi, :fetch_list_emails, fn @list ->
+        {:ok, ["present@example.com"]}
+      end)
+
+      assert %{added: 0, missing_emails: [], extra_count: 0} =
+               ApiBusinessOnboardingList.reconcile()
+    end
+
+    test "skips adds when the launch cutoff is not configured" do
+      Application.put_env(:sanbase, ApiBusinessOnboardingList, [])
+
+      user = insert(:user, email: "biz@example.com")
+      insert(:subscription_business_pro_monthly, user: user)
+
+      assert %{added: 0, missing_emails: [], extra_count: 0} =
+               ApiBusinessOnboardingList.reconcile()
+    end
+
+    test "does not include pre-cutoff eligible subscriptions in desired emails" do
+      user = insert(:user, email: "historical@example.com")
+      sub = insert(:subscription_business_pro_monthly, user: user)
+
+      sub
+      |> Ecto.Changeset.change(%{inserted_at: ~N[2020-01-01 00:00:00]})
+      |> Sanbase.Repo.update!()
+
+      assert ApiBusinessOnboardingList.eligible_user_emails() == []
+    end
+  end
 end

--- a/test/sanbase/email/mailjet_api_fetch_list_emails_test.exs
+++ b/test/sanbase/email/mailjet_api_fetch_list_emails_test.exs
@@ -1,0 +1,84 @@
+defmodule Sanbase.Email.MailjetApiFetchListEmailsTest do
+  use ExUnit.Case, async: false
+
+  alias Sanbase.Email.MailjetApi
+
+  @list :api_business_onboarding
+  @list_id 12_345
+  @stub_name __MODULE__.MailjetStub
+
+  setup do
+    previous_client = Application.get_env(:sanbase, :mailjet_api)
+    previous_mailjet = Application.get_env(:sanbase, MailjetApi, [])
+    previous_mailer = Application.get_env(:sanbase, Sanbase.TemplateMailer, [])
+
+    Application.put_env(:sanbase, :mailjet_api, MailjetApi)
+
+    Application.put_env(
+      :sanbase,
+      MailjetApi,
+      Keyword.merge(previous_mailjet,
+        api_business_onboarding_list_id: @list_id,
+        fetch_list_page_limit: 2,
+        req_options: [plug: {Req.Test, @stub_name}]
+      )
+    )
+
+    Application.put_env(
+      :sanbase,
+      Sanbase.TemplateMailer,
+      Keyword.merge(previous_mailer, api_key: "test_key", secret: "test_secret")
+    )
+
+    on_exit(fn ->
+      Application.put_env(:sanbase, :mailjet_api, previous_client)
+      Application.put_env(:sanbase, MailjetApi, previous_mailjet)
+      Application.put_env(:sanbase, Sanbase.TemplateMailer, previous_mailer)
+    end)
+
+    :ok
+  end
+
+  test "fetch_list_emails/1 paginates with Limit/Offset until a short page" do
+    Req.Test.expect(@stub_name, 3, fn conn ->
+      params = URI.decode_query(conn.query_string)
+      assert params["ContactsList"] == Integer.to_string(@list_id)
+      assert params["Limit"] == "2"
+
+      offset = String.to_integer(params["Offset"])
+
+      data =
+        case offset do
+          0 -> [%{"Email" => "a@example.com"}, %{"Email" => "b@example.com"}]
+          2 -> [%{"Email" => "c@example.com"}, %{"Email" => "d@example.com"}]
+          4 -> [%{"Email" => "e@example.com"}]
+        end
+
+      Req.Test.json(conn, %{"Data" => data})
+    end)
+
+    assert {:ok, emails} = MailjetApi.fetch_list_emails(@list)
+
+    assert emails == [
+             "a@example.com",
+             "b@example.com",
+             "c@example.com",
+             "d@example.com",
+             "e@example.com"
+           ]
+  end
+
+  test "fetch_list_emails/1 returns list_not_configured when list id is unset" do
+    Application.put_env(
+      :sanbase,
+      MailjetApi,
+      Keyword.put(
+        Application.get_env(:sanbase, MailjetApi, []),
+        :api_business_onboarding_list_id,
+        nil
+      )
+    )
+
+    assert {:error, :list_not_configured} = MailjetApi.fetch_list_emails(@list)
+  end
+end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic Mailjet onboarding for eligible API Business-or-higher subscribers.
  * Added nightly reconciliation to backfill eligible contacts and report missing or extra entries.
  * Email changes now trigger onboarding-list updates.
  * Mailjet contact retrieval now supports complete paginated lists.

* **Bug Fixes**
  * Admin contact counts now reflect the full fetched list without truncation warnings.

* **Tests**
  * Added coverage for onboarding eligibility, email changes, reconciliation, and paginated contact retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->