### PR TITLE
Fix formatter crash: use integer truncate in dev logger config

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -39,9 +39,12 @@ config :sanbase, SanbaseWeb.Endpoint,
     ]
   ]
 
+# truncate must be an integer, not :infinity — Logger.Formatter passes it verbatim
+# as :chars_limit to Erlang report callbacks, and io_lib only accepts an integer
+# or :unlimited there, so :infinity makes every OTP report crash the formatter
 config :logger,
   level: :debug,
-  truncate: :infinity
+  truncate: 1_000_000
 
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$time][$level][$metadata] $message\n"


### PR DESCRIPTION
Logger.Formatter passes :truncate verbatim as :chars_limit to Erlang
report callbacks, and io_lib rejects :infinity, so every OTP report
crashed the formatter and removed log handlers.

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
