### PR TITLE
Expand metrics with tag labels

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -78,7 +78,9 @@ config :sanbase, Sanbase.EventBus.KafkaExporterSubscriber,
 
 config :sanbase, Sanbase.EventBus.MetricRegistrySubscriber,
   metric_registry_change_handler:
-    {Sanbase.EventBus.MetricRegistrySubscriber, :on_metric_registry_change_test_env}
+    {Sanbase.EventBus.MetricRegistrySubscriber, :on_metric_registry_change_test_env},
+  metric_tag_change_handler:
+    {Sanbase.EventBus.MetricRegistrySubscriber, :on_metric_tag_change_test_env}
 
 config :sanbase, Sanbase.ExternalServices.RateLimiting.Server,
   implementation_module: Sanbase.ExternalServices.RateLimiting.TestServer

--- a/lib/sanbase/event_bus/event_bus.ex
+++ b/lib/sanbase/event_bus/event_bus.ex
@@ -43,6 +43,7 @@ defmodule Sanbase.EventBus do
     :user_events,
     :watchlist_events,
     :metric_registry_events,
+    :metric_tag_events,
     :vote_events
   ]
 

--- a/lib/sanbase/event_bus/event_validation.ex
+++ b/lib/sanbase/event_bus/event_validation.ex
@@ -267,7 +267,8 @@ defmodule Sanbase.EventBus.EventValidation do
              :bulk_metric_registry_change,
              :create_metric_registry,
              :update_metric_registry,
-             :delete_metric_registry
+             :delete_metric_registry,
+             :metric_tag_change
            ] do
     true
   end

--- a/lib/sanbase/event_bus/metric_registry_subscriber.ex
+++ b/lib/sanbase/event_bus/metric_registry_subscriber.ex
@@ -78,6 +78,19 @@ defmodule Sanbase.EventBus.MetricRegistrySubscriber do
     :ok
   end
 
+  def on_metric_tag_change() do
+    true = Sanbase.Metric.Tag.refresh_stored_terms()
+
+    :ok
+  end
+
+  def on_metric_tag_change_test_env() do
+    # In test env this is the handler in order to avoid Ecto DBConnection
+    # ownership errors
+    Logger.warning("Metric Tag Change event received")
+    :ok
+  end
+
   defp handle_event(
          %{data: %{event_type: event_type, inserts_count: i_count, updates_count: u_count}},
          event_shadow,
@@ -119,6 +132,26 @@ defmodule Sanbase.EventBus.MetricRegistrySubscriber do
       )
 
     :ok = apply(mod, fun, [event_type, metric])
+
+    EventBus.mark_as_completed({__MODULE__, event_shadow})
+    state
+  end
+
+  defp handle_event(
+         %{data: %{event_type: :metric_tag_change}},
+         event_shadow,
+         state
+       ) do
+    Logger.info("Start refreshing stored terms from #{__MODULE__} due to metric tag change")
+
+    {mod, fun} =
+      Config.module_get(
+        __MODULE__,
+        :metric_tag_change_handler,
+        {__MODULE__, :on_metric_tag_change}
+      )
+
+    :ok = apply(mod, fun, [])
 
     EventBus.mark_as_completed({__MODULE__, event_shadow})
     state

--- a/lib/sanbase/event_bus/metric_registry_subscriber.ex
+++ b/lib/sanbase/event_bus/metric_registry_subscriber.ex
@@ -7,7 +7,7 @@ defmodule Sanbase.EventBus.MetricRegistrySubscriber do
 
   require Logger
 
-  def topics(), do: ["metric_registry_events"]
+  def topics(), do: ["metric_registry_events", "metric_tag_events"]
 
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
@@ -80,6 +80,9 @@ defmodule Sanbase.EventBus.MetricRegistrySubscriber do
 
   def on_metric_tag_change() do
     true = Sanbase.Metric.Tag.refresh_stored_terms()
+    # The custom/bundle plan caches resolve their metric sets through the tag
+    # mappings refreshed above.
+    Sanbase.Billing.Plan.CustomPlan.Loader.put_plans_in_persistent_term()
 
     :ok
   end

--- a/lib/sanbase/metric/catalog.ex
+++ b/lib/sanbase/metric/catalog.ex
@@ -1,0 +1,122 @@
+defmodule Sanbase.Metric.Catalog do
+  @moduledoc """
+  Builds a unified "one row per metric" listing of all metrics in the system:
+
+  - Metric Registry rows (`Sanbase.Metric.Registry`). Parametrized (template)
+    metrics are represented as a single entry whose `variants_count` is the
+    number of parameter expansions;
+  - Code-defined metrics coming from adapter modules outside the registry
+    (price, github, social, etc.), deduplicated against the resolved registry
+    metric names so a metric served by the registry is never listed twice.
+
+  Used by the admin dashboards (categorization, tagging) which annotate the
+  entries with their own domain data. Entries are plain maps with no UI or
+  persistence coupling:
+
+      %{
+        metric: "price_usd",
+        human_readable_name: "Price in USD",
+        source_type: "code",                      # or "registry"
+        source_display: "MetricAdapter",          # or "Registry"
+        source_id: nil,                           # or the metric_registry id
+        module: "Sanbase.Price.MetricAdapter",    # nil for registry entries
+        parameters_count: 0,
+        variants_count: 1
+      }
+  """
+
+  alias Sanbase.Metric.Helper
+  alias Sanbase.Metric.Registry
+
+  @doc """
+  Return one entry per metric, sorted by metric name.
+  """
+  @spec all_metrics() :: [map()]
+  def all_metrics() do
+    registry_rows = Registry.all()
+
+    (registry_entries(registry_rows) ++ code_entries(registry_rows))
+    |> Enum.sort_by(& &1.metric, :asc)
+  end
+
+  @doc """
+  Canonical identity of a metric across the registry-vs-code duality.
+
+  Accepts either a catalog entry (`source_type`/`source_id`/`module`/`metric`)
+  or a mapping-style map/struct carrying `metric_registry_id` or
+  `module` + `metric` (e.g. `MetricTagMapping`, `MetricCategoryMapping`).
+  Both shapes produce the same key, so mapping rows can be joined to catalog
+  entries without each consumer restating the dispatch.
+  """
+  @spec entry_key(map() | struct()) :: tuple()
+  def entry_key(%{source_type: "registry", source_id: id}), do: {"registry", id}
+
+  def entry_key(%{source_type: "code", module: module, metric: metric}),
+    do: {"code", module, metric}
+
+  def entry_key(%{metric_registry_id: id}) when is_integer(id), do: {"registry", id}
+
+  def entry_key(%{module: module, metric: metric})
+      when is_binary(module) and is_binary(metric),
+      do: {"code", module, metric}
+
+  @doc """
+  Index mapping rows by their `entry_key/1` for `mappings_for_entry/2` lookups.
+  """
+  @spec index_mappings([map() | struct()]) :: map()
+  def index_mappings(mappings), do: Enum.group_by(mappings, &entry_key/1)
+
+  @doc """
+  All mapping rows belonging to the given catalog entry.
+  """
+  @spec mappings_for_entry(map(), map()) :: [map() | struct()]
+  def mappings_for_entry(entry, mappings_index),
+    do: Map.get(mappings_index, entry_key(entry), [])
+
+  defp registry_entries(registry_rows) do
+    Enum.map(registry_rows, fn registry ->
+      %{
+        metric: registry.metric,
+        human_readable_name: registry.human_readable_name,
+        source_type: "registry",
+        source_display: "Registry",
+        source_id: registry.id,
+        module: nil,
+        parameters_count: length(registry.parameters),
+        variants_count: max(1, length(registry.parameters))
+      }
+    end)
+  end
+
+  defp code_entries(registry_rows) do
+    registry_metrics_mapset =
+      registry_rows
+      |> Registry.resolve()
+      |> Enum.map(& &1.metric)
+      |> MapSet.new()
+
+    Helper.metric_to_module_map()
+    |> Enum.reject(fn {metric, _module} -> metric in registry_metrics_mapset end)
+    |> Enum.map(fn {metric, module} ->
+      {:ok, human_readable_name} = Sanbase.Metric.human_readable_name(metric)
+
+      %{
+        metric: metric,
+        human_readable_name: human_readable_name,
+        source_type: "code",
+        source_display: format_module_name(module),
+        source_id: nil,
+        module: inspect(module),
+        parameters_count: 0,
+        variants_count: 1
+      }
+    end)
+  end
+
+  defp format_module_name(module) do
+    module
+    |> inspect()
+    |> String.split(".")
+    |> List.last()
+  end
+end

--- a/lib/sanbase/metric/category/metric_category_mapping.ex
+++ b/lib/sanbase/metric/category/metric_category_mapping.ex
@@ -63,7 +63,7 @@ defmodule Sanbase.Metric.Category.MetricCategoryMapping do
       :group_id,
       :display_order
     ])
-    |> validate_metric_reference()
+    |> Sanbase.Metric.MetricReference.validate_metric_reference()
     |> validate_length(:module, max: 255)
     |> validate_length(:metric, max: 255)
     |> validate_required([:category_id])
@@ -288,47 +288,6 @@ defmodule Sanbase.Metric.Category.MetricCategoryMapping do
           {:ok, _} -> :ok
           {:error, error} -> Repo.rollback(error)
         end
-    end
-  end
-
-  defp validate_metric_reference(changeset) do
-    metric_registry_id = get_field(changeset, :metric_registry_id)
-    module = get_field(changeset, :module)
-    metric = get_field(changeset, :metric)
-
-    if valid_metric_reference?(metric_registry_id, module, metric) do
-      changeset
-    else
-      add_validation_error(changeset, metric_registry_id, module, metric)
-    end
-  end
-
-  defp valid_metric_reference?(metric_registry_id, module, metric) do
-    # Valid: metric_registry_id is set, module and metric are nil
-    # Valid: metric_registry_id is nil, both module and metric are set
-    is_metric_registry? = not is_nil(metric_registry_id) and is_nil(module) and is_nil(metric)
-    is_module_metric? = is_nil(metric_registry_id) and not is_nil(module) and not is_nil(metric)
-
-    is_metric_registry? or is_module_metric?
-  end
-
-  defp add_validation_error(changeset, metric_registry_id, module, metric) do
-    cond do
-      not is_nil(metric_registry_id) and (not is_nil(module) or not is_nil(metric)) ->
-        add_error(changeset, :metric_registry_id, "cannot be set when module/metric are also set")
-
-      not is_nil(module) and is_nil(metric) ->
-        add_error(changeset, :metric, "must be set when module is set")
-
-      is_nil(module) and not is_nil(metric) ->
-        add_error(changeset, :module, "must be set when metric is set")
-
-      true ->
-        add_error(
-          changeset,
-          :base,
-          "either metric_registry_id or both module and metric must be set"
-        )
     end
   end
 

--- a/lib/sanbase/metric/metric.ex
+++ b/lib/sanbase/metric/metric.ex
@@ -530,6 +530,17 @@ defmodule Sanbase.Metric do
   end
 
   @doc ~s"""
+  Get the list of tag names attached to a given metric.
+
+  Tags are a controlled-vocabulary labeling mechanism used, among other things,
+  to expose a curated subset of metrics on bundle subscription plans.
+  """
+  @spec tags(metric) :: {:ok, [String.t()]}
+  def tags(metric) do
+    {:ok, Sanbase.Metric.Tag.tags_for_metric(metric)}
+  end
+
+  @doc ~s"""
   Get the complexity weight of a metric. This is a multiplier applied to the
   computed complexity. Clickhouse is faster compared to Elasticsearch for fetching
   timeseries data, so it has a smaller weight

--- a/lib/sanbase/metric/metric_reference.ex
+++ b/lib/sanbase/metric/metric_reference.ex
@@ -1,0 +1,54 @@
+defmodule Sanbase.Metric.MetricReference do
+  @moduledoc """
+  Shared changeset validation for mapping tables that reference a metric either
+  by `metric_registry_id` (registry-backed metrics) or by a `module` + `metric`
+  pair (code-defined metrics). Exactly one of the two forms must be set.
+
+  Used by `Sanbase.Metric.Category.MetricCategoryMapping` and
+  `Sanbase.Metric.Tag.MetricTagMapping`.
+  """
+
+  import Ecto.Changeset
+
+  @spec validate_metric_reference(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  def validate_metric_reference(changeset) do
+    metric_registry_id = get_field(changeset, :metric_registry_id)
+    module = get_field(changeset, :module)
+    metric = get_field(changeset, :metric)
+
+    if valid_metric_reference?(metric_registry_id, module, metric) do
+      changeset
+    else
+      add_validation_error(changeset, metric_registry_id, module, metric)
+    end
+  end
+
+  defp valid_metric_reference?(metric_registry_id, module, metric) do
+    # Valid: metric_registry_id is set, module and metric are nil
+    # Valid: metric_registry_id is nil, both module and metric are set
+    is_metric_registry? = not is_nil(metric_registry_id) and is_nil(module) and is_nil(metric)
+    is_module_metric? = is_nil(metric_registry_id) and not is_nil(module) and not is_nil(metric)
+
+    is_metric_registry? or is_module_metric?
+  end
+
+  defp add_validation_error(changeset, metric_registry_id, module, metric) do
+    cond do
+      not is_nil(metric_registry_id) and (not is_nil(module) or not is_nil(metric)) ->
+        add_error(changeset, :metric_registry_id, "cannot be set when module/metric are also set")
+
+      not is_nil(module) and is_nil(metric) ->
+        add_error(changeset, :metric, "must be set when module is set")
+
+      is_nil(module) and not is_nil(metric) ->
+        add_error(changeset, :module, "must be set when metric is set")
+
+      true ->
+        add_error(
+          changeset,
+          :base,
+          "either metric_registry_id or both module and metric must be set"
+        )
+    end
+  end
+end

--- a/lib/sanbase/metric/registry/event_emitter.ex
+++ b/lib/sanbase/metric/registry/event_emitter.ex
@@ -9,6 +9,11 @@ defmodule Sanbase.Metric.Registry.EventEmitter do
     |> notify()
   end
 
+  def handle_event(_, event_type, _args) when event_type in [:metric_tag_change] do
+    %{event_type: event_type}
+    |> notify()
+  end
+
   def handle_event({:ok, map}, event_type, args)
       when event_type in [:bulk_metric_registry_change] do
     %{event_type: event_type}

--- a/lib/sanbase/metric/registry/event_emitter.ex
+++ b/lib/sanbase/metric/registry/event_emitter.ex
@@ -5,7 +5,7 @@ defmodule Sanbase.Metric.Registry.EventEmitter do
   def topic(), do: @topic
 
   def handle_event(_, event_type, _args)
-      when event_type in [:metrics_failed_to_load, :metric_tag_change] do
+      when event_type in [:metrics_failed_to_load] do
     %{event_type: event_type}
     |> notify()
   end

--- a/lib/sanbase/metric/registry/event_emitter.ex
+++ b/lib/sanbase/metric/registry/event_emitter.ex
@@ -4,12 +4,8 @@ defmodule Sanbase.Metric.Registry.EventEmitter do
   @topic :metric_registry_events
   def topic(), do: @topic
 
-  def handle_event(_, event_type, _args) when event_type in [:metrics_failed_to_load] do
-    %{event_type: event_type}
-    |> notify()
-  end
-
-  def handle_event(_, event_type, _args) when event_type in [:metric_tag_change] do
+  def handle_event(_, event_type, _args)
+      when event_type in [:metrics_failed_to_load, :metric_tag_change] do
     %{event_type: event_type}
     |> notify()
   end

--- a/lib/sanbase/metric/registry/registry.ex
+++ b/lib/sanbase/metric/registry/registry.ex
@@ -365,6 +365,10 @@ defmodule Sanbase.Metric.Registry do
     true = Sanbase.Metric.Helper.refresh_stored_terms()
     true = Sanbase.Billing.Plan.StandardAccessChecker.refresh_stored_terms()
     true = Sanbase.Metric.Tag.refresh_stored_terms()
+    # The custom/bundle plan caches resolve their metric sets through the
+    # registry and the tag mappings refreshed above. Returns the list of
+    # plans; it signals failure by raising.
+    Sanbase.Billing.Plan.CustomPlan.Loader.put_plans_in_persistent_term()
 
     :ok
   end

--- a/lib/sanbase/metric/registry/registry.ex
+++ b/lib/sanbase/metric/registry/registry.ex
@@ -364,6 +364,7 @@ defmodule Sanbase.Metric.Registry do
     true = Sanbase.Clickhouse.MetricAdapter.Registry.refresh_stored_terms()
     true = Sanbase.Metric.Helper.refresh_stored_terms()
     true = Sanbase.Billing.Plan.StandardAccessChecker.refresh_stored_terms()
+    true = Sanbase.Metric.Tag.refresh_stored_terms()
 
     :ok
   end

--- a/lib/sanbase/metric/tag.ex
+++ b/lib/sanbase/metric/tag.ex
@@ -107,6 +107,12 @@ defmodule Sanbase.Metric.Tag do
   @spec list_all_mappings() :: [MetricTagMapping.t()]
   def list_all_mappings(), do: MetricTagMapping.list_all()
 
+  @doc """
+  Returns a map of tag id to the number of mappings carrying that tag.
+  """
+  @spec count_mappings_per_tag() :: %{integer() => non_neg_integer()}
+  def count_mappings_per_tag(), do: MetricTagMapping.count_per_tag()
+
   # Access / resolution (delegated to the persistent-term cache)
 
   @doc """

--- a/lib/sanbase/metric/tag.ex
+++ b/lib/sanbase/metric/tag.ex
@@ -1,0 +1,153 @@
+defmodule Sanbase.Metric.Tag do
+  @moduledoc """
+  Context module for metric tags.
+
+  Tags are a controlled-vocabulary labeling mechanism for metrics. A tag can be
+  attached to registry-backed metrics as well as to code-defined metrics that
+  live outside the registry. The primary consumer is the bundle subscription
+  plans, which expose only the metrics carrying a given tag.
+
+  This module is the public API. Persistent-term-cached tag <-> metric name
+  resolution lives in `Sanbase.Metric.Tag.Cache`.
+  """
+
+  alias Sanbase.Metric.Tag.MetricTag
+  alias Sanbase.Metric.Tag.MetricTagMapping
+  alias Sanbase.Metric.Tag.Cache
+  alias Sanbase.Metric.Registry.EventEmitter
+
+  # Tag operations
+
+  @doc """
+  Creates a new metric tag.
+  """
+  @spec create_tag(map()) :: {:ok, MetricTag.t()} | {:error, Ecto.Changeset.t()}
+  def create_tag(attrs) do
+    MetricTag.create(attrs) |> emit_on_change()
+  end
+
+  @doc """
+  Updates a metric tag.
+  """
+  @spec update_tag(MetricTag.t(), map()) :: {:ok, MetricTag.t()} | {:error, Ecto.Changeset.t()}
+  def update_tag(%MetricTag{} = tag, attrs) do
+    MetricTag.update(tag, attrs) |> emit_on_change()
+  end
+
+  @doc """
+  Deletes a metric tag (and, via the FK, its mappings).
+  """
+  @spec delete_tag(MetricTag.t()) :: {:ok, MetricTag.t()} | {:error, Ecto.Changeset.t()}
+  def delete_tag(%MetricTag{} = tag) do
+    MetricTag.delete(tag) |> emit_on_change()
+  end
+
+  @doc """
+  Gets a metric tag by ID.
+  """
+  @spec get_tag(integer()) :: {:ok, MetricTag.t()} | {:error, String.t()}
+  def get_tag(id) do
+    case MetricTag.get(id) do
+      %MetricTag{} = tag -> {:ok, tag}
+      nil -> {:error, "Metric tag with id #{id} does not exist"}
+    end
+  end
+
+  @doc """
+  Gets a metric tag by name.
+  """
+  @spec get_tag_by_name(String.t()) :: MetricTag.t() | nil
+  def get_tag_by_name(name), do: MetricTag.get_by_name(name)
+
+  @doc """
+  Lists all metric tags ordered by name.
+  """
+  @spec list_tags() :: [MetricTag.t()]
+  def list_tags(), do: MetricTag.list_all()
+
+  # Mapping operations
+
+  @doc """
+  Gets a metric tag mapping by ID.
+  """
+  @spec get_mapping(integer()) :: {:ok, MetricTagMapping.t()} | {:error, String.t()}
+  def get_mapping(id) do
+    case MetricTagMapping.get(id) do
+      %MetricTagMapping{} = mapping -> {:ok, mapping}
+      nil -> {:error, "Metric tag mapping with id #{id} does not exist"}
+    end
+  end
+
+  @doc """
+  Creates a new metric tag mapping.
+  """
+  @spec create_mapping(map()) :: {:ok, MetricTagMapping.t()} | {:error, Ecto.Changeset.t()}
+  def create_mapping(attrs) do
+    MetricTagMapping.create(attrs) |> emit_on_change()
+  end
+
+  @doc """
+  Deletes a metric tag mapping.
+  """
+  @spec delete_mapping(MetricTagMapping.t()) ::
+          {:ok, MetricTagMapping.t()} | {:error, Ecto.Changeset.t()}
+  def delete_mapping(%MetricTagMapping{} = mapping) do
+    MetricTagMapping.delete(mapping) |> emit_on_change()
+  end
+
+  @doc """
+  Lists all mappings for a given tag id.
+  """
+  @spec list_mappings_by_tag(integer()) :: [MetricTagMapping.t()]
+  def list_mappings_by_tag(tag_id), do: MetricTagMapping.get_by_tag_id(tag_id)
+
+  @doc """
+  Lists all metric tag mappings.
+  """
+  @spec list_all_mappings() :: [MetricTagMapping.t()]
+  def list_all_mappings(), do: MetricTagMapping.list_all()
+
+  # Access / resolution (delegated to the persistent-term cache)
+
+  @doc """
+  Returns the `MapSet` of concrete metric names carrying the given tag.
+  """
+  @spec metrics_for_tag(String.t()) :: MapSet.t()
+  def metrics_for_tag(tag_name), do: Cache.metrics_for_tag(tag_name)
+
+  @doc """
+  Returns the `MapSet` union of concrete metric names carrying any of the given tags.
+  """
+  @spec metrics_for_tags([String.t()]) :: MapSet.t()
+  def metrics_for_tags(tag_names), do: Cache.metrics_for_tags(tag_names)
+
+  @doc """
+  Returns the list of tag names attached to the given metric.
+  """
+  @spec tags_for_metric(String.t()) :: [String.t()]
+  def tags_for_metric(metric), do: Cache.tags_for_metric(metric)
+
+  @doc """
+  Refreshes the persistent-term caches that depend on tags. Also refreshes the
+  custom/bundle plan caches, since a bundle plan's resolved metric set depends
+  on the tag -> metric mapping.
+  """
+  @spec refresh_stored_terms() :: true
+  def refresh_stored_terms() do
+    true = Cache.refresh_stored_terms()
+    # Side-effecting: repopulates the bundle/custom-plan persistent_term caches,
+    # whose resolved metric sets depend on the tag -> metric mapping. Returns a
+    # list, not a status; it signals failure by raising.
+    Sanbase.Billing.Plan.CustomPlan.Loader.put_plans_in_persistent_term()
+    true
+  end
+
+  # Private
+
+  defp emit_on_change({:ok, _} = result) do
+    EventEmitter.emit_event(result, :metric_tag_change, %{})
+    result
+  end
+
+  defp emit_on_change({:error, _} = result), do: result
+end

--- a/lib/sanbase/metric/tag.ex
+++ b/lib/sanbase/metric/tag.ex
@@ -11,10 +11,19 @@ defmodule Sanbase.Metric.Tag do
   resolution lives in `Sanbase.Metric.Tag.Cache`.
   """
 
+  alias Sanbase.Repo
   alias Sanbase.Metric.Tag.MetricTag
   alias Sanbase.Metric.Tag.MetricTagMapping
   alias Sanbase.Metric.Tag.Cache
-  alias Sanbase.Metric.Registry.EventEmitter
+  alias Sanbase.Metric.Tag.EventEmitter
+
+  @vocabulary_tags [
+    %{name: "basic", description: "Metrics exposed on the Basic bundle plan"},
+    %{name: "development_data", description: "Development activity metrics"},
+    %{name: "market_data", description: "Price and market metrics"},
+    %{name: "social_data", description: "Social volume and sentiment metrics"},
+    %{name: "onchain_data", description: "Onchain and blockchain metrics"}
+  ]
 
   # Tag operations
 
@@ -64,6 +73,25 @@ defmodule Sanbase.Metric.Tag do
   """
   @spec list_tags() :: [MetricTag.t()]
   def list_tags(), do: MetricTag.list_all()
+
+  @doc """
+  Idempotently inserts the seed vocabulary tags.
+
+  Production databases get these from the migration that created the
+  `metric_tags` table. Databases created by loading `structure.sql` (like the
+  test database) contain no data, so the seeds must be applied separately.
+  """
+  @spec seed_vocabulary_tags() :: :ok
+  def seed_vocabulary_tags() do
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    entries =
+      Enum.map(@vocabulary_tags, &Map.merge(&1, %{inserted_at: now, updated_at: now}))
+
+    Repo.insert_all(MetricTag, entries, on_conflict: :nothing, conflict_target: :name)
+
+    :ok
+  end
 
   # Mapping operations
 
@@ -134,18 +162,17 @@ defmodule Sanbase.Metric.Tag do
   def tags_for_metric(metric), do: Cache.tags_for_metric(metric)
 
   @doc """
-  Refreshes the persistent-term caches that depend on tags. Also refreshes the
-  custom/bundle plan caches, since a bundle plan's resolved metric set depends
-  on the tag -> metric mapping.
+  Refreshes the persistent-term tag -> metric caches.
+
+  Callers reacting to tag or registry changes must also refresh the caches
+  that are derived from tags — the custom/bundle plan caches
+  (`Sanbase.Billing.Plan.CustomPlan.Loader`) — see
+  `Sanbase.Metric.Registry.refresh_stored_terms/0` and
+  `Sanbase.EventBus.MetricRegistrySubscriber.on_metric_tag_change/0`.
   """
   @spec refresh_stored_terms() :: true
   def refresh_stored_terms() do
-    true = Cache.refresh_stored_terms()
-    # Side-effecting: repopulates the bundle/custom-plan persistent_term caches,
-    # whose resolved metric sets depend on the tag -> metric mapping. Returns a
-    # list, not a status; it signals failure by raising.
-    Sanbase.Billing.Plan.CustomPlan.Loader.put_plans_in_persistent_term()
-    true
+    Cache.refresh_stored_terms()
   end
 
   # Private

--- a/lib/sanbase/metric/tag/cache.ex
+++ b/lib/sanbase/metric/tag/cache.ex
@@ -45,34 +45,42 @@ defmodule Sanbase.Metric.Tag.Cache do
   end
 
   @doc """
-  Recomputes and stores all cached maps in `:persistent_term`.
+  Recomputes the cached maps and stores them in `:persistent_term`.
 
-  The metric -> tags map is derived from the tag -> metrics map computed in the
-  same call, so the two stored terms are always consistent with each other.
+  Both maps are derived from a single computation and published as one
+  persistent-term value, so readers always observe a mutually consistent
+  snapshot. Event-driven refreshes are serialized by the event bus subscriber
+  process (`Sanbase.EventBus.MetricRegistrySubscriber`), which processes
+  `metric_tag_change` events one at a time.
   """
   @spec refresh_stored_terms() :: true
   def refresh_stored_terms() do
     Logger.info("Refreshing stored terms in #{inspect(__MODULE__)}")
 
     tag_to_metrics_map = compute_tag_to_metrics_map()
-    :persistent_term.put(key(:tag_to_metrics_map), tag_to_metrics_map)
-    :persistent_term.put(key(:metric_to_tags_map), invert_tag_to_metrics_map(tag_to_metrics_map))
+
+    snapshot = %{
+      tag_to_metrics_map: tag_to_metrics_map,
+      metric_to_tags_map: invert_tag_to_metrics_map(tag_to_metrics_map)
+    }
+
+    :persistent_term.put(key(), snapshot)
 
     true
   end
 
   # Private
 
-  defp key(fun), do: {__MODULE__, fun}
+  defp key(), do: {__MODULE__, :snapshot}
 
   defp get(map_name) do
-    case :persistent_term.get(key(map_name), :undefined) do
+    case :persistent_term.get(key(), :undefined) do
       :undefined ->
         refresh_stored_terms()
-        :persistent_term.get(key(map_name))
+        Map.fetch!(:persistent_term.get(key()), map_name)
 
-      data ->
-        data
+      snapshot ->
+        Map.fetch!(snapshot, map_name)
     end
   end
 

--- a/lib/sanbase/metric/tag/cache.ex
+++ b/lib/sanbase/metric/tag/cache.ex
@@ -1,0 +1,114 @@
+defmodule Sanbase.Metric.Tag.Cache do
+  @moduledoc """
+  Persistent-term-backed view of which concrete metric names carry each tag, and
+  the inverse (metric name -> tag names).
+
+  Registry-backed mappings are expanded through `Registry.resolve_safe/1`, so
+  template parameters and aliases are covered automatically — tagging a single
+  registry row transparently tags every concrete metric name it resolves to.
+  Module/metric mappings are already concrete names.
+
+  The computation fails closed: if the database is unavailable the maps resolve
+  to empty, so a bundle plan temporarily sees zero tag-derived metrics rather
+  than accidentally granting access.
+  """
+
+  require Logger
+
+  alias Sanbase.Metric.Registry
+  alias Sanbase.Metric.Tag.MetricTagMapping
+
+  @functions [:tag_to_metrics_map, :metric_to_tags_map]
+
+  @doc """
+  Returns the `MapSet` of concrete metric names carrying the given tag.
+  """
+  @spec metrics_for_tag(String.t()) :: MapSet.t()
+  def metrics_for_tag(tag_name) when is_binary(tag_name) do
+    Map.get(get(:tag_to_metrics_map), tag_name, MapSet.new())
+  end
+
+  @doc """
+  Returns the `MapSet` union of concrete metric names carrying any of the given tags.
+  """
+  @spec metrics_for_tags([String.t()]) :: MapSet.t()
+  def metrics_for_tags(tag_names) when is_list(tag_names) do
+    Enum.reduce(tag_names, MapSet.new(), fn tag_name, acc ->
+      MapSet.union(acc, metrics_for_tag(tag_name))
+    end)
+  end
+
+  @doc """
+  Returns the list of tag names attached to the given metric.
+  """
+  @spec tags_for_metric(String.t()) :: [String.t()]
+  def tags_for_metric(metric) when is_binary(metric) do
+    Map.get(get(:metric_to_tags_map), metric, [])
+  end
+
+  @doc """
+  Recomputes and stores all cached maps in `:persistent_term`.
+  """
+  @spec refresh_stored_terms() :: true
+  def refresh_stored_terms() do
+    Logger.info("Refreshing stored terms in #{inspect(__MODULE__)}")
+    Enum.each(@functions, fn fun -> :persistent_term.put(key(fun), compute(fun)) end)
+    true
+  end
+
+  # Private
+
+  defp key(fun), do: {__MODULE__, fun}
+
+  defp get(fun) do
+    case :persistent_term.get(key(fun), :undefined) do
+      :undefined ->
+        data = compute(fun)
+        :persistent_term.put(key(fun), data)
+        data
+
+      data ->
+        data
+    end
+  end
+
+  defp compute(:tag_to_metrics_map) do
+    MetricTagMapping.list_all()
+    |> Enum.group_by(& &1.tag.name)
+    |> Map.new(fn {tag_name, mappings} ->
+      metric_names =
+        mappings
+        |> Enum.flat_map(&resolve_mapping_metric_names/1)
+        |> MapSet.new()
+
+      {tag_name, metric_names}
+    end)
+  rescue
+    e ->
+      Logger.error(
+        "[#{inspect(__MODULE__)}] Failed to compute tag_to_metrics_map: #{Exception.message(e)}"
+      )
+
+      %{}
+  end
+
+  defp compute(:metric_to_tags_map) do
+    get(:tag_to_metrics_map)
+    |> Enum.flat_map(fn {tag_name, metric_names} ->
+      Enum.map(metric_names, fn metric -> {metric, tag_name} end)
+    end)
+    |> Enum.group_by(fn {metric, _tag} -> metric end, fn {_metric, tag} -> tag end)
+  end
+
+  defp resolve_mapping_metric_names(%MetricTagMapping{metric_registry: %Registry{} = registry}) do
+    {resolved, _errors} = Registry.resolve_safe([registry])
+    Enum.map(resolved, & &1.metric)
+  end
+
+  defp resolve_mapping_metric_names(%MetricTagMapping{module: module, metric: metric})
+       when is_binary(module) and is_binary(metric) do
+    [metric]
+  end
+
+  defp resolve_mapping_metric_names(_), do: []
+end

--- a/lib/sanbase/metric/tag/cache.ex
+++ b/lib/sanbase/metric/tag/cache.ex
@@ -18,8 +18,6 @@ defmodule Sanbase.Metric.Tag.Cache do
   alias Sanbase.Metric.Registry
   alias Sanbase.Metric.Tag.MetricTagMapping
 
-  @functions [:tag_to_metrics_map, :metric_to_tags_map]
-
   @doc """
   Returns the `MapSet` of concrete metric names carrying the given tag.
   """
@@ -48,11 +46,18 @@ defmodule Sanbase.Metric.Tag.Cache do
 
   @doc """
   Recomputes and stores all cached maps in `:persistent_term`.
+
+  The metric -> tags map is derived from the tag -> metrics map computed in the
+  same call, so the two stored terms are always consistent with each other.
   """
   @spec refresh_stored_terms() :: true
   def refresh_stored_terms() do
     Logger.info("Refreshing stored terms in #{inspect(__MODULE__)}")
-    Enum.each(@functions, fn fun -> :persistent_term.put(key(fun), compute(fun)) end)
+
+    tag_to_metrics_map = compute_tag_to_metrics_map()
+    :persistent_term.put(key(:tag_to_metrics_map), tag_to_metrics_map)
+    :persistent_term.put(key(:metric_to_tags_map), invert_tag_to_metrics_map(tag_to_metrics_map))
+
     true
   end
 
@@ -60,25 +65,27 @@ defmodule Sanbase.Metric.Tag.Cache do
 
   defp key(fun), do: {__MODULE__, fun}
 
-  defp get(fun) do
-    case :persistent_term.get(key(fun), :undefined) do
+  defp get(map_name) do
+    case :persistent_term.get(key(map_name), :undefined) do
       :undefined ->
-        data = compute(fun)
-        :persistent_term.put(key(fun), data)
-        data
+        refresh_stored_terms()
+        :persistent_term.get(key(map_name))
 
       data ->
         data
     end
   end
 
-  defp compute(:tag_to_metrics_map) do
-    MetricTagMapping.list_all()
+  defp compute_tag_to_metrics_map() do
+    mappings = MetricTagMapping.list_all()
+    resolved_names_by_registry_id = batch_resolve_registries(mappings)
+
+    mappings
     |> Enum.group_by(& &1.tag.name)
     |> Map.new(fn {tag_name, mappings} ->
       metric_names =
         mappings
-        |> Enum.flat_map(&resolve_mapping_metric_names/1)
+        |> Enum.flat_map(&mapping_metric_names(&1, resolved_names_by_registry_id))
         |> MapSet.new()
 
       {tag_name, metric_names}
@@ -92,23 +99,36 @@ defmodule Sanbase.Metric.Tag.Cache do
       %{}
   end
 
-  defp compute(:metric_to_tags_map) do
-    get(:tag_to_metrics_map)
+  defp invert_tag_to_metrics_map(tag_to_metrics_map) do
+    tag_to_metrics_map
     |> Enum.flat_map(fn {tag_name, metric_names} ->
       Enum.map(metric_names, fn metric -> {metric, tag_name} end)
     end)
     |> Enum.group_by(fn {metric, _tag} -> metric end, fn {_metric, tag} -> tag end)
   end
 
-  defp resolve_mapping_metric_names(%MetricTagMapping{metric_registry: %Registry{} = registry}) do
-    {resolved, _errors} = Registry.resolve_safe([registry])
-    Enum.map(resolved, & &1.metric)
+  defp batch_resolve_registries(mappings) do
+    registries =
+      for %MetricTagMapping{metric_registry: %Registry{} = registry} <- mappings,
+          uniq: true,
+          do: registry
+
+    {resolved, _errors} = Registry.resolve_safe(registries)
+
+    Enum.group_by(resolved, & &1.id, & &1.metric)
   end
 
-  defp resolve_mapping_metric_names(%MetricTagMapping{module: module, metric: metric})
+  defp mapping_metric_names(
+         %MetricTagMapping{metric_registry: %Registry{} = registry},
+         resolved_names_by_registry_id
+       ) do
+    Map.get(resolved_names_by_registry_id, registry.id, [])
+  end
+
+  defp mapping_metric_names(%MetricTagMapping{module: module, metric: metric}, _resolved)
        when is_binary(module) and is_binary(metric) do
     [metric]
   end
 
-  defp resolve_mapping_metric_names(_), do: []
+  defp mapping_metric_names(_, _resolved), do: []
 end

--- a/lib/sanbase/metric/tag/event_emitter.ex
+++ b/lib/sanbase/metric/tag/event_emitter.ex
@@ -1,0 +1,20 @@
+defmodule Sanbase.Metric.Tag.EventEmitter do
+  use Sanbase.EventBus.EventEmitter
+
+  @topic :metric_tag_events
+  def topic(), do: @topic
+
+  def handle_event({:ok, _}, :metric_tag_change = event_type, _args) do
+    %{event_type: event_type}
+    |> notify()
+  end
+
+  def handle_event({:error, _}, _event_type, _args) do
+    :ok
+  end
+
+  defp notify(data) do
+    Sanbase.EventBus.notify(%{topic: @topic, data: data})
+    :ok
+  end
+end

--- a/lib/sanbase/metric/tag/metric_tag.ex
+++ b/lib/sanbase/metric/tag/metric_tag.ex
@@ -1,0 +1,111 @@
+defmodule Sanbase.Metric.Tag.MetricTag do
+  @moduledoc """
+  Schema for metric tags.
+
+  A tag is a controlled-vocabulary label that can be attached to metrics
+  (both registry-backed and code-defined ones via `MetricTagMapping`). Tags
+  are the mechanism used to expose a curated subset of metrics on bundle
+  subscription plans.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+  import Ecto.Query
+
+  alias Sanbase.Repo
+  alias Sanbase.Metric.Tag.MetricTagMapping
+
+  @type t :: %__MODULE__{
+          id: integer(),
+          name: String.t(),
+          description: String.t() | nil,
+          mappings: [MetricTagMapping.t()],
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "metric_tags" do
+    field(:name, :string)
+    field(:description, :string)
+
+    has_many(:mappings, MetricTagMapping, foreign_key: :tag_id)
+
+    timestamps()
+  end
+
+  @doc """
+  Creates a changeset for a metric tag.
+  """
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(%__MODULE__{} = tag, attrs) do
+    tag
+    |> cast(attrs, [:name, :description])
+    |> validate_required([:name])
+    |> validate_length(:name, min: 1, max: 255)
+    |> validate_length(:description, max: 2000)
+    |> unique_constraint(:name)
+  end
+
+  @doc """
+  Creates a new metric tag.
+  """
+  @spec create(map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def create(attrs) do
+    %__MODULE__{}
+    |> changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a metric tag.
+  """
+  @spec update(t(), map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def update(%__MODULE__{} = tag, attrs) do
+    tag
+    |> changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a metric tag. The associated mappings are removed by the
+  `on_delete: :delete_all` foreign key.
+  """
+  @spec delete(t()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def delete(%__MODULE__{} = tag) do
+    Repo.delete(tag)
+  end
+
+  @doc """
+  Gets a metric tag by ID.
+  """
+  @spec get(integer()) :: t() | nil
+  def get(id) when is_integer(id) do
+    Repo.get(__MODULE__, id)
+  end
+
+  @doc """
+  Gets a metric tag by name.
+  """
+  @spec get_by_name(String.t()) :: t() | nil
+  def get_by_name(name) when is_binary(name) do
+    Repo.get_by(__MODULE__, name: name)
+  end
+
+  @doc """
+  Lists all metric tags ordered by name.
+  """
+  @spec list_all() :: [t()]
+  def list_all() do
+    query = from(t in __MODULE__, order_by: [asc: t.name])
+    Repo.all(query)
+  end
+
+  @doc """
+  Lists all tag names.
+  """
+  @spec list_names() :: [String.t()]
+  def list_names() do
+    query = from(t in __MODULE__, order_by: [asc: t.name], select: t.name)
+    Repo.all(query)
+  end
+end

--- a/lib/sanbase/metric/tag/metric_tag.ex
+++ b/lib/sanbase/metric/tag/metric_tag.ex
@@ -99,13 +99,4 @@ defmodule Sanbase.Metric.Tag.MetricTag do
     query = from(t in __MODULE__, order_by: [asc: t.name])
     Repo.all(query)
   end
-
-  @doc """
-  Lists all tag names.
-  """
-  @spec list_names() :: [String.t()]
-  def list_names() do
-    query = from(t in __MODULE__, order_by: [asc: t.name], select: t.name)
-    Repo.all(query)
-  end
 end

--- a/lib/sanbase/metric/tag/metric_tag_mapping.ex
+++ b/lib/sanbase/metric/tag/metric_tag_mapping.ex
@@ -47,7 +47,7 @@ defmodule Sanbase.Metric.Tag.MetricTagMapping do
   def changeset(%__MODULE__{} = mapping, attrs) do
     mapping
     |> cast(attrs, [:metric_registry_id, :module, :metric, :tag_id])
-    |> validate_metric_reference()
+    |> Sanbase.Metric.MetricReference.validate_metric_reference()
     |> validate_length(:module, max: 255)
     |> validate_length(:metric, max: 255)
     |> validate_required([:tag_id])
@@ -124,6 +124,16 @@ defmodule Sanbase.Metric.Tag.MetricTagMapping do
   end
 
   @doc """
+  Returns a map of tag id to the number of mappings carrying that tag.
+  """
+  @spec count_per_tag() :: %{integer() => non_neg_integer()}
+  def count_per_tag() do
+    from(m in __MODULE__, group_by: m.tag_id, select: {m.tag_id, count(m.id)})
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  @doc """
   Creates a mapping by metric registry id.
   """
   @spec create_by_metric_registry_id(integer(), integer()) ::
@@ -141,48 +151,5 @@ defmodule Sanbase.Metric.Tag.MetricTagMapping do
   def create_by_module_and_metric(module, metric, tag_id)
       when is_binary(module) and is_binary(metric) and is_integer(tag_id) do
     create(%{module: module, metric: metric, tag_id: tag_id})
-  end
-
-  # Private functions
-
-  defp validate_metric_reference(changeset) do
-    metric_registry_id = get_field(changeset, :metric_registry_id)
-    module = get_field(changeset, :module)
-    metric = get_field(changeset, :metric)
-
-    if valid_metric_reference?(metric_registry_id, module, metric) do
-      changeset
-    else
-      add_validation_error(changeset, metric_registry_id, module, metric)
-    end
-  end
-
-  defp valid_metric_reference?(metric_registry_id, module, metric) do
-    # Valid: metric_registry_id is set, module and metric are nil
-    # Valid: metric_registry_id is nil, both module and metric are set
-    is_metric_registry? = not is_nil(metric_registry_id) and is_nil(module) and is_nil(metric)
-    is_module_metric? = is_nil(metric_registry_id) and not is_nil(module) and not is_nil(metric)
-
-    is_metric_registry? or is_module_metric?
-  end
-
-  defp add_validation_error(changeset, metric_registry_id, module, metric) do
-    cond do
-      not is_nil(metric_registry_id) and (not is_nil(module) or not is_nil(metric)) ->
-        add_error(changeset, :metric_registry_id, "cannot be set when module/metric are also set")
-
-      not is_nil(module) and is_nil(metric) ->
-        add_error(changeset, :metric, "must be set when module is set")
-
-      is_nil(module) and not is_nil(metric) ->
-        add_error(changeset, :module, "must be set when metric is set")
-
-      true ->
-        add_error(
-          changeset,
-          :base,
-          "either metric_registry_id or both module and metric must be set"
-        )
-    end
   end
 end

--- a/lib/sanbase/metric/tag/metric_tag_mapping.ex
+++ b/lib/sanbase/metric/tag/metric_tag_mapping.ex
@@ -132,24 +132,4 @@ defmodule Sanbase.Metric.Tag.MetricTagMapping do
     |> Repo.all()
     |> Map.new()
   end
-
-  @doc """
-  Creates a mapping by metric registry id.
-  """
-  @spec create_by_metric_registry_id(integer(), integer()) ::
-          {:ok, t()} | {:error, Ecto.Changeset.t()}
-  def create_by_metric_registry_id(metric_registry_id, tag_id)
-      when is_integer(metric_registry_id) and is_integer(tag_id) do
-    create(%{metric_registry_id: metric_registry_id, tag_id: tag_id})
-  end
-
-  @doc """
-  Creates a mapping by module and metric.
-  """
-  @spec create_by_module_and_metric(String.t(), String.t(), integer()) ::
-          {:ok, t()} | {:error, Ecto.Changeset.t()}
-  def create_by_module_and_metric(module, metric, tag_id)
-      when is_binary(module) and is_binary(metric) and is_integer(tag_id) do
-    create(%{module: module, metric: metric, tag_id: tag_id})
-  end
 end

--- a/lib/sanbase/metric/tag/metric_tag_mapping.ex
+++ b/lib/sanbase/metric/tag/metric_tag_mapping.ex
@@ -1,0 +1,188 @@
+defmodule Sanbase.Metric.Tag.MetricTagMapping do
+  @moduledoc """
+  Schema mapping metrics to tags.
+
+  A mapping references a metric either by `metric_registry_id` (registry-backed
+  metrics) or by a `module`/`metric` string pair (code-defined metrics that live
+  outside the registry, e.g. `price_usd`, github/social metrics). A DB check
+  constraint enforces that exactly one of the two identifiers is set.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+  import Ecto.Query
+
+  alias Sanbase.Repo
+  alias Sanbase.Metric.Registry
+  alias Sanbase.Metric.Tag.MetricTag
+
+  @type t :: %__MODULE__{
+          id: integer(),
+          metric_registry_id: integer() | nil,
+          metric_registry: Registry.t() | nil,
+          module: String.t() | nil,
+          metric: String.t() | nil,
+          tag: MetricTag.t(),
+          tag_id: integer(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "metric_tag_mappings" do
+    # Either module/metric is set and metric_registry is nil, or vice versa.
+    # There is a DB constraint check for that as well.
+    field(:module, :string)
+    field(:metric, :string)
+
+    belongs_to(:metric_registry, Registry, foreign_key: :metric_registry_id)
+    belongs_to(:tag, MetricTag, foreign_key: :tag_id)
+
+    timestamps()
+  end
+
+  @doc """
+  Creates a changeset for a metric tag mapping.
+  """
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(%__MODULE__{} = mapping, attrs) do
+    mapping
+    |> cast(attrs, [:metric_registry_id, :module, :metric, :tag_id])
+    |> validate_metric_reference()
+    |> validate_length(:module, max: 255)
+    |> validate_length(:metric, max: 255)
+    |> validate_required([:tag_id])
+    |> foreign_key_constraint(:tag_id)
+    |> foreign_key_constraint(:metric_registry_id)
+    # The unique constraints don't apply when the field is nil.
+    # Either metric_registry_id or module/metric is set.
+    |> unique_constraint([:metric_registry_id, :tag_id],
+      name: :metric_tag_mappings_metric_registry_id_tag_id_index
+    )
+    |> unique_constraint([:module, :metric, :tag_id],
+      name: :metric_tag_mappings_module_metric_tag_id_index
+    )
+  end
+
+  @doc """
+  Creates a new metric tag mapping.
+  """
+  @spec create(map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def create(attrs) do
+    %__MODULE__{}
+    |> changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Deletes a metric tag mapping.
+  """
+  @spec delete(t()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def delete(%__MODULE__{} = mapping) do
+    Repo.delete(mapping)
+  end
+
+  @doc """
+  Gets a metric tag mapping by ID.
+  """
+  @spec get(integer()) :: t() | nil
+  def get(id) when is_integer(id) do
+    query =
+      from(m in __MODULE__,
+        where: m.id == ^id,
+        preload: [:tag, :metric_registry]
+      )
+
+    Repo.one(query)
+  end
+
+  @doc """
+  Gets all mappings for a given tag id.
+  """
+  @spec get_by_tag_id(integer()) :: [t()]
+  def get_by_tag_id(tag_id) when is_integer(tag_id) do
+    query =
+      from(m in __MODULE__,
+        where: m.tag_id == ^tag_id,
+        preload: [:tag, :metric_registry],
+        order_by: [asc: m.id]
+      )
+
+    Repo.all(query)
+  end
+
+  @doc """
+  Lists all metric tag mappings with their related data.
+  """
+  @spec list_all() :: [t()]
+  def list_all() do
+    query =
+      from(m in __MODULE__,
+        preload: [:tag, :metric_registry]
+      )
+
+    Repo.all(query)
+  end
+
+  @doc """
+  Creates a mapping by metric registry id.
+  """
+  @spec create_by_metric_registry_id(integer(), integer()) ::
+          {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def create_by_metric_registry_id(metric_registry_id, tag_id)
+      when is_integer(metric_registry_id) and is_integer(tag_id) do
+    create(%{metric_registry_id: metric_registry_id, tag_id: tag_id})
+  end
+
+  @doc """
+  Creates a mapping by module and metric.
+  """
+  @spec create_by_module_and_metric(String.t(), String.t(), integer()) ::
+          {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def create_by_module_and_metric(module, metric, tag_id)
+      when is_binary(module) and is_binary(metric) and is_integer(tag_id) do
+    create(%{module: module, metric: metric, tag_id: tag_id})
+  end
+
+  # Private functions
+
+  defp validate_metric_reference(changeset) do
+    metric_registry_id = get_field(changeset, :metric_registry_id)
+    module = get_field(changeset, :module)
+    metric = get_field(changeset, :metric)
+
+    if valid_metric_reference?(metric_registry_id, module, metric) do
+      changeset
+    else
+      add_validation_error(changeset, metric_registry_id, module, metric)
+    end
+  end
+
+  defp valid_metric_reference?(metric_registry_id, module, metric) do
+    # Valid: metric_registry_id is set, module and metric are nil
+    # Valid: metric_registry_id is nil, both module and metric are set
+    is_metric_registry? = not is_nil(metric_registry_id) and is_nil(module) and is_nil(metric)
+    is_module_metric? = is_nil(metric_registry_id) and not is_nil(module) and not is_nil(metric)
+
+    is_metric_registry? or is_module_metric?
+  end
+
+  defp add_validation_error(changeset, metric_registry_id, module, metric) do
+    cond do
+      not is_nil(metric_registry_id) and (not is_nil(module) or not is_nil(metric)) ->
+        add_error(changeset, :metric_registry_id, "cannot be set when module/metric are also set")
+
+      not is_nil(module) and is_nil(metric) ->
+        add_error(changeset, :metric, "must be set when module is set")
+
+      is_nil(module) and not is_nil(metric) ->
+        add_error(changeset, :module, "must be set when metric is set")
+
+      true ->
+        add_error(
+          changeset,
+          :base,
+          "either metric_registry_id or both module and metric must be set"
+        )
+    end
+  end
+end

--- a/lib/sanbase_web/components/admin/admin_shared_components.ex
+++ b/lib/sanbase_web/components/admin/admin_shared_components.ex
@@ -12,6 +12,7 @@ defmodule SanbaseWeb.AdminSharedComponents do
   - Date displays (created/updated)
   """
   use Phoenix.Component
+  use SanbaseWeb, :verified_routes
 
   alias SanbaseWeb.CoreComponents
 
@@ -282,6 +283,60 @@ defmodule SanbaseWeb.AdminSharedComponents do
         <span class="text-base-content/70 text-sm">{@updated_duration} ago</span>
       </div>
     </div>
+    """
+  end
+
+  @doc """
+  Badge for a metric catalog entry's source: a link to the registry record for
+  registry-backed metrics, a plain badge for code-defined ones.
+  """
+  attr :source_type, :string, required: true
+  attr :source_display, :string, required: true
+  attr :source_id, :integer, default: nil
+
+  def metric_source_badge(assigns) do
+    ~H"""
+    <span :if={@source_type == "registry"} class="badge badge-sm badge-info badge-soft">
+      <.link navigate={~p"/admin/metric_registry/show/#{@source_id}"}>
+        {@source_display}
+      </.link>
+    </span>
+    <span :if={@source_type == "code"} class="badge badge-sm badge-secondary badge-soft">
+      {@source_display}
+    </span>
+    """
+  end
+
+  @doc """
+  The search + source filter inputs shared by the metric catalog admin pages
+  (categorization, tagging). Meant to be rendered inside a `simple_form` with
+  `phx-change="filter"`; page-specific filter selects stay in the page.
+  """
+  attr :search_query, :string, required: true
+  attr :filter_source, :string, required: true
+
+  def metric_catalog_filter_inputs(assigns) do
+    ~H"""
+    <CoreComponents.input
+      type="text"
+      name="search"
+      value={@search_query}
+      label="Search metrics"
+      placeholder="Type metric name..."
+      phx-debounce="300"
+    />
+
+    <CoreComponents.input
+      type="select"
+      name="source"
+      value={@filter_source}
+      label="Source"
+      options={[
+        {"All Sources", "all"},
+        {"Registry", "registry"},
+        {"Code Module", "code"}
+      ]}
+    />
     """
   end
 end

--- a/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
@@ -204,6 +204,9 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   def get_human_readable_name(_root, _args, %{source: %{metric: metric}}),
     do: Metric.human_readable_name(metric)
 
+  def get_tags(_root, _args, %{source: %{metric: metric}}),
+    do: Metric.tags(metric)
+
   def get_metadata(%{}, _args, %{source: %{metric: metric, version: version}} = resolution) do
     %{
       context: %{

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -395,6 +395,15 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     end
 
     @desc ~s"""
+    The list of tags (labels) attached to the metric. Tags are a
+    controlled-vocabulary labeling mechanism used, among other things, to expose
+    a curated subset of metrics on bundle subscription plans.
+    """
+    field :tags, non_null(list_of(non_null(:string))) do
+      cache_resolve(&MetricResolver.get_tags/3, ttl: 120)
+    end
+
+    @desc ~s"""
     List of slugs which can be provided to the `timeseriesDataJson` (and co.)
     field to fetch the metric.
     """

--- a/lib/sanbase_web/live/admin_live_helpers.ex
+++ b/lib/sanbase_web/live/admin_live_helpers.ex
@@ -99,6 +99,7 @@ defmodule SanbaseWeb.AdminLiveHelpers do
   Filters metric maps (with `:metric` and `:human_readable_name` keys) by a
   case-insensitive query matching either field. An empty query is a no-op.
   """
+  @spec filter_by_search([map()], String.t()) :: [map()]
   def filter_by_search(metrics, ""), do: metrics
 
   def filter_by_search(metrics, query) do
@@ -114,6 +115,7 @@ defmodule SanbaseWeb.AdminLiveHelpers do
   @doc """
   Filters metric maps by `:source_type` ("registry"/"code"). "all" is a no-op.
   """
+  @spec filter_by_source([map()], String.t()) :: [map()]
   def filter_by_source(metrics, "all"), do: metrics
   def filter_by_source(metrics, source), do: Enum.filter(metrics, &(&1.source_type == source))
 
@@ -122,9 +124,12 @@ defmodule SanbaseWeb.AdminLiveHelpers do
   The 4-arity version also skips values equal to the given default, keeping
   URLs free of parameters that match the initial filter state.
   """
+  @spec maybe_add_param(map(), String.t(), term()) :: map()
   def maybe_add_param(params, _key, ""), do: params
   def maybe_add_param(params, key, value), do: Map.put(params, key, value)
 
+  @spec maybe_add_param(map(), String.t(), term(), term()) :: map()
+  def maybe_add_param(params, _key, "", _default), do: params
   def maybe_add_param(params, _key, value, default) when value == default, do: params
   def maybe_add_param(params, key, value, _default), do: Map.put(params, key, value)
 end

--- a/lib/sanbase_web/live/admin_live_helpers.ex
+++ b/lib/sanbase_web/live/admin_live_helpers.ex
@@ -7,6 +7,8 @@ defmodule SanbaseWeb.AdminLiveHelpers do
   - In-memory row updates by ID
   - Changeset error flash messages
   - Integer parsing with defaults
+  - Filtering metric catalog entries (see `Sanbase.Metric.Catalog`)
+  - Building URL query params from filter values
   """
 
   import Phoenix.LiveView, only: [put_flash: 3]
@@ -92,4 +94,37 @@ defmodule SanbaseWeb.AdminLiveHelpers do
       :error -> default
     end
   end
+
+  @doc """
+  Filters metric maps (with `:metric` and `:human_readable_name` keys) by a
+  case-insensitive query matching either field. An empty query is a no-op.
+  """
+  def filter_by_search(metrics, ""), do: metrics
+
+  def filter_by_search(metrics, query) do
+    query_lower = String.downcase(query)
+
+    Enum.filter(metrics, fn metric ->
+      String.contains?(String.downcase(metric.metric), query_lower) ||
+        (metric.human_readable_name &&
+           String.contains?(String.downcase(metric.human_readable_name), query_lower))
+    end)
+  end
+
+  @doc """
+  Filters metric maps by `:source_type` ("registry"/"code"). "all" is a no-op.
+  """
+  def filter_by_source(metrics, "all"), do: metrics
+  def filter_by_source(metrics, source), do: Enum.filter(metrics, &(&1.source_type == source))
+
+  @doc """
+  Puts `key => value` into a URL query params map, skipping empty values.
+  The 4-arity version also skips values equal to the given default, keeping
+  URLs free of parameters that match the initial filter state.
+  """
+  def maybe_add_param(params, _key, ""), do: params
+  def maybe_add_param(params, key, value), do: Map.put(params, key, value)
+
+  def maybe_add_param(params, _key, value, default) when value == default, do: params
+  def maybe_add_param(params, key, value, _default), do: Map.put(params, key, value)
 end

--- a/lib/sanbase_web/live/metric_registry/categorization_live/categorization.ex
+++ b/lib/sanbase_web/live/metric_registry/categorization_live/categorization.ex
@@ -13,18 +13,7 @@ defmodule SanbaseWeb.CategorizationLive.Index do
   def mount(_params, _session, socket) do
     {:ok,
      socket
-     |> assign(
-       page_title: "Metric Categorization",
-       metrics: [],
-       filtered_metrics: [],
-       search_query: "",
-       filter_source: "all",
-       filter_status: "all",
-       filter_ui_metadata: "all",
-       filter_sanbase_display: "all",
-       selected_category_id: nil,
-       loading: true
-     )
+     |> assign(page_title: "Metric Categorization")
      |> load_data()}
   end
 
@@ -79,16 +68,7 @@ defmodule SanbaseWeb.CategorizationLive.Index do
 
       <.metrics_stats metrics={@metrics} filtered_metrics={@filtered_metrics} />
 
-      <.metrics_table
-        :if={!@loading}
-        filtered_metrics={@filtered_metrics}
-        categories_colors={@categories_colors}
-      />
-
-      <div :if={@loading} class="flex justify-center items-center py-12">
-        <span class="loading loading-spinner loading-lg text-primary"></span>
-        <p class="ml-4 text-base-content/70">Loading metrics...</p>
-      </div>
+      <.metrics_table filtered_metrics={@filtered_metrics} categories_colors={@categories_colors} />
     </div>
     """
   end
@@ -133,25 +113,9 @@ defmodule SanbaseWeb.CategorizationLive.Index do
     <div class="card bg-base-100 border border-base-300 shadow p-4 my-4">
       <.simple_form for={%{}} as={:filters} phx-change="filter">
         <div class="flex flex-col sm:flex-row sm:flex-wrap gap-4">
-          <.input
-            type="text"
-            name="search"
-            value={@search_query}
-            label="Search metrics"
-            placeholder="Type metric name..."
-            phx-debounce="300"
-          />
-
-          <.input
-            type="select"
-            name="source"
-            value={@filter_source}
-            label="Source"
-            options={[
-              {"All Sources", "all"},
-              {"Registry", "registry"},
-              {"Code Module", "code"}
-            ]}
+          <AdminSharedComponents.metric_catalog_filter_inputs
+            search_query={@search_query}
+            filter_source={@filter_source}
           />
 
           <.input
@@ -352,15 +316,11 @@ defmodule SanbaseWeb.CategorizationLive.Index do
         </div>
       </td>
       <td>
-        <span :if={@metric.source_type == "registry"} class="badge badge-sm badge-info badge-soft">
-          <.link navigate={~p"/admin/metric_registry/show/#{@metric.source_id}"}>
-            {@metric.source_display}
-          </.link>
-        </span>
-
-        <span :if={@metric.source_type == "code"} class="badge badge-sm badge-secondary badge-soft">
-          {@metric.source_display}
-        </span>
+        <AdminSharedComponents.metric_source_badge
+          source_type={@metric.source_type}
+          source_display={@metric.source_display}
+          source_id={@metric.source_id}
+        />
       </td>
       <td>
         <div :if={@metric.category_name} class="text-sm">
@@ -501,26 +461,15 @@ defmodule SanbaseWeb.CategorizationLive.Index do
       ui_metadata_list
       |> Enum.group_by(& &1.metric_category_mapping_id)
 
-    multi_category_registry_ids =
-      mappings
-      |> Enum.reject(&is_nil(&1.metric_registry_id))
-      |> Enum.group_by(& &1.metric_registry_id)
-      |> Enum.filter(fn {_id, mapping_list} -> length(mapping_list) > 1 end)
-      |> Enum.map(fn {id, _} -> id end)
-      |> MapSet.new()
-
-    multi_category_module_metrics =
-      mappings
-      |> Enum.reject(&(is_nil(&1.module) || &1.module == "__none__"))
-      |> Enum.group_by(&{&1.module, &1.metric})
-      |> Enum.filter(fn {_key, mapping_list} -> length(mapping_list) > 1 end)
-      |> Enum.map(fn {key, _} -> key end)
-      |> MapSet.new()
-
     mappings_index =
       mappings
       |> Enum.filter(&(&1.metric_registry_id || (&1.module && &1.metric)))
       |> Catalog.index_mappings()
+
+    multi_category_keys =
+      mappings_index
+      |> Enum.filter(fn {_key, mapping_list} -> length(mapping_list) > 1 end)
+      |> MapSet.new(fn {key, _} -> key end)
 
     all_metrics =
       Catalog.all_metrics()
@@ -528,7 +477,7 @@ defmodule SanbaseWeb.CategorizationLive.Index do
         mappings = Catalog.mappings_for_entry(entry, mappings_index)
 
         is_multi_category? =
-          multi_category?(entry, multi_category_registry_ids, multi_category_module_metrics)
+          MapSet.member?(multi_category_keys, Catalog.entry_key(entry))
 
         case mappings do
           [] ->
@@ -575,16 +524,9 @@ defmodule SanbaseWeb.CategorizationLive.Index do
     |> assign(
       metrics: all_metrics,
       categories: categories,
-      categories_colors: categories_colors,
-      loading: false
+      categories_colors: categories_colors
     )
   end
-
-  defp multi_category?(%{source_type: "registry"} = entry, registry_ids, _module_metrics),
-    do: MapSet.member?(registry_ids, entry.source_id)
-
-  defp multi_category?(%{source_type: "code"} = entry, _registry_ids, module_metrics),
-    do: MapSet.member?(module_metrics, {entry.module, entry.metric})
 
   defp annotate_with_categorization(entry, mapping, ui_metadata_by_mapping_id, is_multi_category?) do
     ui_metadata_list = mapping && Map.get(ui_metadata_by_mapping_id, mapping.id, [])
@@ -594,7 +536,7 @@ defmodule SanbaseWeb.CategorizationLive.Index do
 
     all_variants_have_ui_metadata? =
       case entry do
-        %{source_type: "code"} -> true
+        %{source_type: "code"} -> has_ui_metadata?
         %{parameters_count: 0} -> has_ui_metadata?
         %{parameters_count: count} -> has_ui_metadata? and length(ui_metadata_list) == count
       end

--- a/lib/sanbase_web/live/metric_registry/categorization_live/categorization.ex
+++ b/lib/sanbase_web/live/metric_registry/categorization_live/categorization.ex
@@ -1,10 +1,12 @@
 defmodule SanbaseWeb.CategorizationLive.Index do
   use SanbaseWeb, :live_view
 
+  import SanbaseWeb.AdminLiveHelpers,
+    only: [filter_by_search: 2, filter_by_source: 2, maybe_add_param: 3, maybe_add_param: 4]
+
+  alias Sanbase.Metric.Catalog
   alias Sanbase.Metric.Category
   alias Sanbase.Metric.Category.MetricCategoryMapping
-  alias Sanbase.Metric.Registry
-  alias Sanbase.Metric.Helper
   alias SanbaseWeb.AdminSharedComponents
 
   @impl true
@@ -515,31 +517,42 @@ defmodule SanbaseWeb.CategorizationLive.Index do
       |> Enum.map(fn {key, _} -> key end)
       |> MapSet.new()
 
-    mappings_by_registry_id =
+    mappings_index =
       mappings
-      |> Enum.filter(& &1.metric_registry_id)
-      |> Enum.group_by(& &1.metric_registry_id)
+      |> Enum.filter(&(&1.metric_registry_id || (&1.module && &1.metric)))
+      |> Catalog.index_mappings()
 
-    mappings_by_module_metric =
-      mappings
-      |> Enum.filter(&(&1.module && &1.metric))
-      |> Enum.group_by(&{&1.module, &1.metric})
+    all_metrics =
+      Catalog.all_metrics()
+      |> Enum.flat_map(fn entry ->
+        mappings = Catalog.mappings_for_entry(entry, mappings_index)
 
-    registry_metrics =
-      get_registry_metrics(
-        mappings_by_registry_id,
-        ui_metadata_by_mapping_id,
-        multi_category_registry_ids
-      )
+        is_multi_category? =
+          multi_category?(entry, multi_category_registry_ids, multi_category_module_metrics)
 
-    code_metrics =
-      get_code_metrics(
-        mappings_by_module_metric,
-        ui_metadata_by_mapping_id,
-        multi_category_module_metrics
-      )
+        case mappings do
+          [] ->
+            [
+              annotate_with_categorization(
+                entry,
+                nil,
+                ui_metadata_by_mapping_id,
+                is_multi_category?
+              )
+            ]
 
-    all_metrics = registry_metrics ++ code_metrics
+          mappings ->
+            Enum.map(
+              mappings,
+              &annotate_with_categorization(
+                entry,
+                &1,
+                ui_metadata_by_mapping_id,
+                is_multi_category?
+              )
+            )
+        end
+      end)
 
     all_metrics =
       Enum.sort_by(
@@ -567,65 +580,26 @@ defmodule SanbaseWeb.CategorizationLive.Index do
     )
   end
 
-  defp get_registry_metrics(
-         mappings_by_registry_id,
-         ui_metadata_by_mapping_id,
-         multi_category_registry_ids
-       ) do
-    Registry.all()
-    |> Enum.flat_map(fn registry ->
-      mappings = Map.get(mappings_by_registry_id, registry.id, [])
-      is_multi_category? = MapSet.member?(multi_category_registry_ids, registry.id)
+  defp multi_category?(%{source_type: "registry"} = entry, registry_ids, _module_metrics),
+    do: MapSet.member?(registry_ids, entry.source_id)
 
-      case mappings do
-        [] ->
-          [
-            build_registry_metric_map(
-              registry,
-              nil,
-              ui_metadata_by_mapping_id,
-              is_multi_category?
-            )
-          ]
+  defp multi_category?(%{source_type: "code"} = entry, _registry_ids, module_metrics),
+    do: MapSet.member?(module_metrics, {entry.module, entry.metric})
 
-        mappings ->
-          Enum.map(mappings, fn mapping ->
-            build_registry_metric_map(
-              registry,
-              mapping,
-              ui_metadata_by_mapping_id,
-              is_multi_category?
-            )
-          end)
-      end
-    end)
-  end
-
-  defp build_registry_metric_map(
-         registry,
-         mapping,
-         ui_metadata_by_mapping_id,
-         is_multi_category?
-       ) do
+  defp annotate_with_categorization(entry, mapping, ui_metadata_by_mapping_id, is_multi_category?) do
     ui_metadata_list = mapping && Map.get(ui_metadata_by_mapping_id, mapping.id, [])
 
     has_ui_metadata? = ui_metadata_list != [] && ui_metadata_list != nil
     show_on_sanbase? = has_ui_metadata? && Enum.any?(ui_metadata_list, & &1.show_on_sanbase)
 
     all_variants_have_ui_metadata? =
-      if registry.parameters == [] do
-        has_ui_metadata?
-      else
-        has_ui_metadata? and length(ui_metadata_list) == length(registry.parameters)
+      case entry do
+        %{source_type: "code"} -> true
+        %{parameters_count: 0} -> has_ui_metadata?
+        %{parameters_count: count} -> has_ui_metadata? and length(ui_metadata_list) == count
       end
 
-    %{
-      metric: registry.metric,
-      human_readable_name: registry.human_readable_name,
-      source_type: "registry",
-      source_display: "Registry",
-      source_id: registry.id,
-      module: nil,
+    Map.merge(entry, %{
       mapping: mapping,
       mapping_id: mapping && mapping.id,
       category_id: mapping && mapping.category_id,
@@ -639,96 +613,8 @@ defmodule SanbaseWeb.CategorizationLive.Index do
       has_ui_metadata?: has_ui_metadata?,
       all_variants_have_ui_metadata?: all_variants_have_ui_metadata?,
       show_on_sanbase?: show_on_sanbase?,
-      variants_count: max(1, length(registry.parameters)),
       is_multi_category?: is_multi_category?
-    }
-  end
-
-  defp get_code_metrics(
-         mappings_by_module_metric,
-         ui_metadata_by_mapping_id,
-         multi_category_module_metrics
-       ) do
-    registry_metrics_mapset =
-      Registry.all()
-      |> Registry.resolve()
-      |> Enum.map(& &1.metric)
-      |> MapSet.new()
-
-    metric_to_module_map = Helper.metric_to_module_map()
-
-    metric_to_module_map
-    |> Enum.reject(fn {metric, _module} -> metric in registry_metrics_mapset end)
-    |> Enum.flat_map(fn {metric, module} ->
-      module_str = inspect(module)
-      mappings = Map.get(mappings_by_module_metric, {module_str, metric}, [])
-      is_multi_category? = MapSet.member?(multi_category_module_metrics, {module_str, metric})
-
-      case mappings do
-        [] ->
-          [
-            build_code_metric_map(
-              metric,
-              module,
-              module_str,
-              nil,
-              ui_metadata_by_mapping_id,
-              is_multi_category?
-            )
-          ]
-
-        mappings ->
-          Enum.map(mappings, fn mapping ->
-            build_code_metric_map(
-              metric,
-              module,
-              module_str,
-              mapping,
-              ui_metadata_by_mapping_id,
-              is_multi_category?
-            )
-          end)
-      end
-    end)
-  end
-
-  defp build_code_metric_map(
-         metric,
-         module,
-         module_str,
-         mapping,
-         ui_metadata_by_mapping_id,
-         is_multi_category?
-       ) do
-    ui_metadata_list = mapping && Map.get(ui_metadata_by_mapping_id, mapping.id, [])
-    {:ok, human_readable_name} = Sanbase.Metric.human_readable_name(metric)
-
-    has_ui_metadata? = ui_metadata_list != [] && ui_metadata_list != nil
-    show_on_sanbase? = has_ui_metadata? && Enum.any?(ui_metadata_list, & &1.show_on_sanbase)
-
-    %{
-      metric: metric,
-      human_readable_name: human_readable_name,
-      source_type: "code",
-      source_display: format_module_name(module),
-      source_id: nil,
-      module: module_str,
-      mapping: mapping,
-      mapping_id: mapping && mapping.id,
-      category_id: mapping && mapping.category_id,
-      category_name: mapping && mapping.category && mapping.category.name,
-      category_display_order: mapping && mapping.category && mapping.category.display_order,
-      group_id: mapping && mapping.group_id,
-      group_name: mapping && mapping.group && mapping.group.name,
-      group_display_order: (mapping && mapping.group && mapping.group.display_order) || -1,
-      display_order: mapping && mapping.display_order,
-      categorized?: not is_nil(mapping),
-      has_ui_metadata?: has_ui_metadata?,
-      all_variants_have_ui_metadata?: true,
-      show_on_sanbase?: show_on_sanbase?,
-      variants_count: 1,
-      is_multi_category?: is_multi_category?
-    }
+    })
   end
 
   defp apply_filters(socket) do
@@ -753,21 +639,6 @@ defmodule SanbaseWeb.CategorizationLive.Index do
 
     assign(socket, filtered_metrics: filtered_metrics)
   end
-
-  defp filter_by_search(metrics, ""), do: metrics
-
-  defp filter_by_search(metrics, query) do
-    query_lower = String.downcase(query)
-
-    Enum.filter(metrics, fn metric ->
-      String.contains?(String.downcase(metric.metric), query_lower) ||
-        (metric.human_readable_name &&
-           String.contains?(String.downcase(metric.human_readable_name), query_lower))
-    end)
-  end
-
-  defp filter_by_source(metrics, "all"), do: metrics
-  defp filter_by_source(metrics, source), do: Enum.filter(metrics, &(&1.source_type == source))
 
   defp filter_by_status(metrics, "all"), do: metrics
 
@@ -815,13 +686,6 @@ defmodule SanbaseWeb.CategorizationLive.Index do
   defp filter_by_sanbase_display(metrics, "hidden"),
     do: Enum.filter(metrics, &(not &1.show_on_sanbase?))
 
-  defp format_module_name(module) do
-    module
-    |> inspect()
-    |> String.split(".")
-    |> List.last()
-  end
-
   defp build_new_params(metric) do
     params = %{}
 
@@ -836,10 +700,4 @@ defmodule SanbaseWeb.CategorizationLive.Index do
 
     params
   end
-
-  defp maybe_add_param(params, _key, ""), do: params
-  defp maybe_add_param(params, key, value), do: Map.put(params, key, value)
-
-  defp maybe_add_param(params, _key, value, default) when value == default, do: params
-  defp maybe_add_param(params, key, value, _default), do: Map.put(params, key, value)
 end

--- a/lib/sanbase_web/live/metric_registry/metric_registry_index_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_registry_index_live.ex
@@ -523,6 +523,11 @@ defmodule SanbaseWeb.MetricRegistryIndexLive do
           text="UI Display Order"
           href={~p"/admin/metric_registry/display_order"}
         />
+        <AdminSharedComponents.nav_button
+          icon="hero-tag"
+          text="Tags"
+          href={~p"/admin/metric_registry/tags"}
+        />
       </div>
     </div>
     """

--- a/lib/sanbase_web/live/metric_registry/tag_live/form.ex
+++ b/lib/sanbase_web/live/metric_registry/tag_live/form.ex
@@ -1,0 +1,103 @@
+defmodule SanbaseWeb.TagLive.Form do
+  use SanbaseWeb, :live_view
+
+  import SanbaseWeb.AdminLiveHelpers, only: [format_errors: 1]
+
+  alias Sanbase.Metric.Tag
+  alias Sanbase.Metric.Tag.MetricTag
+  alias SanbaseWeb.AdminSharedComponents
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :new, _params) do
+    socket
+    |> assign(
+      page_title: "Create New Tag",
+      tag: %MetricTag{},
+      action: :new
+    )
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}) do
+    id = String.to_integer(id)
+
+    case Tag.get_tag(id) do
+      {:ok, tag} ->
+        socket
+        |> assign(
+          page_title: "Edit Tag",
+          tag: tag,
+          action: :edit
+        )
+
+      {:error, _} ->
+        socket
+        |> put_flash(:error, "Tag not found")
+        |> push_navigate(to: ~p"/admin/metric_registry/tags/manage")
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="flex flex-col justify-center w-full">
+      <div class="text-base-content text-2xl mb-4">
+        {if @action == :new, do: "Create New Tag", else: "Edit Tag"}
+      </div>
+
+      <div class="my-4">
+        <AdminSharedComponents.nav_button
+          text="Back to Tags"
+          href={~p"/admin/metric_registry/tags/manage"}
+          icon="hero-arrow-uturn-left"
+        />
+      </div>
+
+      <.simple_form for={%{}} as={:tag} phx-submit="save">
+        <.input type="text" name="name" value={@tag.name} label="Tag Name" />
+        <.input
+          type="textarea"
+          name="description"
+          value={@tag.description}
+          label="Description"
+        />
+
+        <.button type="submit">Save</.button>
+      </.simple_form>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("save", %{"name" => name} = params, socket) do
+    attrs = %{name: name, description: Map.get(params, "description")}
+
+    result =
+      case socket.assigns.action do
+        :new -> Tag.create_tag(attrs)
+        :edit -> Tag.update_tag(socket.assigns.tag, attrs)
+      end
+
+    case result do
+      {:ok, _tag} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Tag saved successfully")
+         |> push_navigate(to: ~p"/admin/metric_registry/tags/manage")}
+
+      {:error, changeset} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, format_errors(changeset))
+         |> assign(tag: %{socket.assigns.tag | name: name, description: attrs.description})}
+    end
+  end
+end

--- a/lib/sanbase_web/live/metric_registry/tag_live/form.ex
+++ b/lib/sanbase_web/live/metric_registry/tag_live/form.ex
@@ -97,7 +97,7 @@ defmodule SanbaseWeb.TagLive.Form do
         {:noreply,
          socket
          |> put_flash(:error, format_errors(changeset))
-         |> assign(tag: %{socket.assigns.tag | name: name, description: attrs.description})}
+         |> assign(tag: struct(socket.assigns.tag, attrs))}
     end
   end
 end

--- a/lib/sanbase_web/live/metric_registry/tag_live/form.ex
+++ b/lib/sanbase_web/live/metric_registry/tag_live/form.ex
@@ -22,23 +22,23 @@ defmodule SanbaseWeb.TagLive.Form do
     |> assign(
       page_title: "Create New Tag",
       tag: %MetricTag{},
+      form: to_form(MetricTag.changeset(%MetricTag{}, %{}), as: :tag),
       action: :new
     )
   end
 
   defp apply_action(socket, :edit, %{"id" => id}) do
-    id = String.to_integer(id)
-
-    case Tag.get_tag(id) do
-      {:ok, tag} ->
-        socket
-        |> assign(
-          page_title: "Edit Tag",
-          tag: tag,
-          action: :edit
-        )
-
-      {:error, _} ->
+    with {id, ""} <- Integer.parse(id),
+         {:ok, tag} <- Tag.get_tag(id) do
+      socket
+      |> assign(
+        page_title: "Edit Tag",
+        tag: tag,
+        form: to_form(MetricTag.changeset(tag, %{}), as: :tag),
+        action: :edit
+      )
+    else
+      _ ->
         socket
         |> put_flash(:error, "Tag not found")
         |> push_navigate(to: ~p"/admin/metric_registry/tags/manage")
@@ -61,14 +61,9 @@ defmodule SanbaseWeb.TagLive.Form do
         />
       </div>
 
-      <.simple_form for={%{}} as={:tag} phx-submit="save">
-        <.input type="text" name="name" value={@tag.name} label="Tag Name" />
-        <.input
-          type="textarea"
-          name="description"
-          value={@tag.description}
-          label="Description"
-        />
+      <.simple_form for={@form} phx-submit="save">
+        <.input type="text" field={@form[:name]} label="Tag Name" />
+        <.input type="textarea" field={@form[:description]} label="Description" />
 
         <.button type="submit">Save</.button>
       </.simple_form>
@@ -77,13 +72,11 @@ defmodule SanbaseWeb.TagLive.Form do
   end
 
   @impl true
-  def handle_event("save", %{"name" => name} = params, socket) do
-    attrs = %{name: name, description: Map.get(params, "description")}
-
+  def handle_event("save", %{"tag" => params}, socket) do
     result =
       case socket.assigns.action do
-        :new -> Tag.create_tag(attrs)
-        :edit -> Tag.update_tag(socket.assigns.tag, attrs)
+        :new -> Tag.create_tag(params)
+        :edit -> Tag.update_tag(socket.assigns.tag, params)
       end
 
     case result do
@@ -97,7 +90,7 @@ defmodule SanbaseWeb.TagLive.Form do
         {:noreply,
          socket
          |> put_flash(:error, format_errors(changeset))
-         |> assign(tag: struct(socket.assigns.tag, attrs))}
+         |> assign(form: to_form(changeset, as: :tag))}
     end
   end
 end

--- a/lib/sanbase_web/live/metric_registry/tag_live/index.ex
+++ b/lib/sanbase_web/live/metric_registry/tag_live/index.ex
@@ -1,9 +1,11 @@
 defmodule SanbaseWeb.TagLive.Index do
   use SanbaseWeb, :live_view
 
+  import SanbaseWeb.AdminLiveHelpers,
+    only: [filter_by_search: 2, filter_by_source: 2, maybe_add_param: 3, maybe_add_param: 4]
+
+  alias Sanbase.Metric.Catalog
   alias Sanbase.Metric.Tag
-  alias Sanbase.Metric.Registry
-  alias Sanbase.Metric.Helper
   alias SanbaseWeb.AdminSharedComponents
 
   @impl true
@@ -19,9 +21,11 @@ defmodule SanbaseWeb.TagLive.Index do
        filter_source: "all",
        filter_status: "all",
        filter_tag: "all",
+       recently_changed: MapSet.new(),
        loading: true
      )
-     |> load_data()}
+     |> load_catalog()
+     |> refresh_tag_annotations()}
   end
 
   @impl true
@@ -236,10 +240,18 @@ defmodule SanbaseWeb.TagLive.Index do
     assigns = assign(assigns, available_tags: available_tags)
 
     ~H"""
-    <tr class="hover:bg-base-200">
+    <tr class={[
+      "hover:bg-base-200 transition-colors duration-700",
+      @metric.recently_changed? && "bg-info/10"
+    ]}>
       <td class="max-w-[360px] break-words">
         <div class="flex flex-col">
-          <div class="text-sm font-medium">{@metric.metric}</div>
+          <div class="flex items-center gap-2">
+            <div class="text-sm font-medium">{@metric.metric}</div>
+            <span :if={@metric.recently_changed?} class="badge badge-xs badge-info badge-soft">
+              changed
+            </span>
+          </div>
           <div class="text-xs text-base-content/60">{@metric.human_readable_name}</div>
           <div :if={@metric.variants_count >= 2} class="text-xs text-secondary">
             ({@metric.variants_count} variants)
@@ -261,15 +273,12 @@ defmodule SanbaseWeb.TagLive.Index do
           Not tagged
         </div>
         <div class="flex flex-wrap gap-1">
-          <span
-            :for={tag <- @metric.tags}
-            class="badge badge-sm badge-primary badge-soft gap-1"
-          >
+          <span :for={tag <- @metric.tags} class="badge badge-sm badge-secondary gap-1">
             {tag.tag_name}
             <button
               phx-click="remove_tag"
               phx-value-mapping_id={tag.mapping_id}
-              class="hover:text-error"
+              class="cursor-pointer hover:text-error"
               data-confirm={"Remove tag '#{tag.tag_name}' from #{@metric.metric}?"}
               aria-label="Remove tag"
             >
@@ -287,7 +296,7 @@ defmodule SanbaseWeb.TagLive.Index do
             phx-value-registry_id={@metric.source_id}
             phx-value-module={@metric.module}
             phx-value-metric={@metric.metric}
-            class="badge badge-sm badge-ghost hover:badge-primary hover:badge-soft"
+            class="badge badge-sm badge-secondary badge-soft cursor-pointer transition-colors hover:bg-secondary! hover:text-secondary-content!"
           >
             + {tag.name}
           </button>
@@ -309,7 +318,12 @@ defmodule SanbaseWeb.TagLive.Index do
       |> maybe_add_param("status", params["status"] || "all", "all")
       |> maybe_add_param("tag", params["tag"] || "all", "all")
 
-    {:noreply, push_patch(socket, to: ~p"/admin/metric_registry/tags?#{query_params}")}
+    # Changing the filters is a deliberate view change - drop the rows kept
+    # visible only because they were recently tagged/untagged.
+    {:noreply,
+     socket
+     |> assign(recently_changed: MapSet.new())
+     |> push_patch(to: ~p"/admin/metric_registry/tags?#{query_params}")}
   end
 
   def handle_event("add_tag", params, socket) do
@@ -326,8 +340,12 @@ defmodule SanbaseWeb.TagLive.Index do
       end
 
     case Tag.create_mapping(attrs) do
-      {:ok, _} ->
-        {:noreply, socket |> load_data() |> apply_filters()}
+      {:ok, mapping} ->
+        {:noreply,
+         socket
+         |> mark_recently_changed(mapping)
+         |> refresh_tag_annotations()
+         |> apply_filters()}
 
       {:error, _} ->
         {:noreply, put_flash(socket, :error, "Failed to add tag (it may already be assigned)")}
@@ -340,80 +358,36 @@ defmodule SanbaseWeb.TagLive.Index do
     case Tag.get_mapping(id) do
       {:ok, mapping} ->
         Tag.delete_mapping(mapping)
-        {:noreply, socket |> load_data() |> apply_filters()}
+
+        {:noreply,
+         socket
+         |> mark_recently_changed(mapping)
+         |> refresh_tag_annotations()
+         |> apply_filters()}
 
       {:error, _} ->
         {:noreply, put_flash(socket, :error, "Mapping not found")}
     end
   end
 
-  defp load_data(socket) do
+  # The catalog itself (registry rows + code metrics) does not change when tags
+  # are (un)assigned, so it is loaded once on mount. Tag events only need
+  # refresh_tag_annotations/1.
+  defp load_catalog(socket) do
+    assign(socket, catalog: Catalog.all_metrics(), loading: false)
+  end
+
+  defp refresh_tag_annotations(socket) do
     tags = Tag.list_tags()
-    mappings = Tag.list_all_mappings()
+    mappings_index = Tag.list_all_mappings() |> Catalog.index_mappings()
 
-    mappings_by_registry_id =
-      mappings
-      |> Enum.filter(& &1.metric_registry_id)
-      |> Enum.group_by(& &1.metric_registry_id)
+    metrics =
+      Enum.map(socket.assigns.catalog, fn entry ->
+        mappings = Catalog.mappings_for_entry(entry, mappings_index)
+        Map.merge(entry, %{tags: mappings_to_tags(mappings), tagged?: mappings != []})
+      end)
 
-    mappings_by_module_metric =
-      mappings
-      |> Enum.filter(&(&1.module && &1.metric))
-      |> Enum.group_by(&{&1.module, &1.metric})
-
-    registry_metrics = get_registry_metrics(mappings_by_registry_id)
-    code_metrics = get_code_metrics(mappings_by_module_metric)
-
-    all_metrics = Enum.sort_by(registry_metrics ++ code_metrics, & &1.metric, :asc)
-
-    assign(socket, metrics: all_metrics, tags: tags, loading: false)
-  end
-
-  defp get_registry_metrics(mappings_by_registry_id) do
-    Registry.all()
-    |> Enum.map(fn registry ->
-      mappings = Map.get(mappings_by_registry_id, registry.id, [])
-
-      %{
-        metric: registry.metric,
-        human_readable_name: registry.human_readable_name,
-        source_type: "registry",
-        source_display: "Registry",
-        source_id: registry.id,
-        module: nil,
-        tags: mappings_to_tags(mappings),
-        tagged?: mappings != [],
-        variants_count: max(1, length(registry.parameters))
-      }
-    end)
-  end
-
-  defp get_code_metrics(mappings_by_module_metric) do
-    registry_metrics_mapset =
-      Registry.all()
-      |> Registry.resolve()
-      |> Enum.map(& &1.metric)
-      |> MapSet.new()
-
-    Helper.metric_to_module_map()
-    |> Enum.reject(fn {metric, _module} -> metric in registry_metrics_mapset end)
-    |> Enum.map(fn {metric, module} ->
-      module_str = inspect(module)
-      mappings = Map.get(mappings_by_module_metric, {module_str, metric}, [])
-      {:ok, human_readable_name} = Sanbase.Metric.human_readable_name(metric)
-
-      %{
-        metric: metric,
-        human_readable_name: human_readable_name,
-        source_type: "code",
-        source_display: format_module_name(module),
-        source_id: nil,
-        module: module_str,
-        tags: mappings_to_tags(mappings),
-        tagged?: mappings != [],
-        variants_count: 1
-      }
-    end)
+    assign(socket, metrics: metrics, tags: tags)
   end
 
   defp mappings_to_tags(mappings) do
@@ -430,33 +404,42 @@ defmodule SanbaseWeb.TagLive.Index do
       search_query: search_query,
       filter_source: filter_source,
       filter_status: filter_status,
-      filter_tag: filter_tag
+      filter_tag: filter_tag,
+      recently_changed: recently_changed
     } = socket.assigns
 
-    filtered_metrics =
+    matching_keys =
       metrics
       |> filter_by_search(search_query)
       |> filter_by_source(filter_source)
       |> filter_by_status(filter_status)
       |> filter_by_tag(filter_tag)
+      |> MapSet.new(&Catalog.entry_key/1)
+
+    # Rows that were just tagged/untagged stay visible (highlighted) even when
+    # they no longer match the filters, so an accidental change can be undone
+    # in place. They are dropped once the filters change.
+    filtered_metrics =
+      metrics
+      |> Enum.filter(fn metric ->
+        key = Catalog.entry_key(metric)
+        MapSet.member?(matching_keys, key) or MapSet.member?(recently_changed, key)
+      end)
+      |> Enum.map(fn metric ->
+        Map.put(
+          metric,
+          :recently_changed?,
+          MapSet.member?(recently_changed, Catalog.entry_key(metric))
+        )
+      end)
 
     assign(socket, filtered_metrics: filtered_metrics)
   end
 
-  defp filter_by_search(metrics, ""), do: metrics
-
-  defp filter_by_search(metrics, query) do
-    query_lower = String.downcase(query)
-
-    Enum.filter(metrics, fn metric ->
-      String.contains?(String.downcase(metric.metric), query_lower) ||
-        (metric.human_readable_name &&
-           String.contains?(String.downcase(metric.human_readable_name), query_lower))
-    end)
+  defp mark_recently_changed(socket, mapping) do
+    key = Catalog.entry_key(mapping)
+    assign(socket, recently_changed: MapSet.put(socket.assigns.recently_changed, key))
   end
-
-  defp filter_by_source(metrics, "all"), do: metrics
-  defp filter_by_source(metrics, source), do: Enum.filter(metrics, &(&1.source_type == source))
 
   defp filter_by_status(metrics, "all"), do: metrics
   defp filter_by_status(metrics, "tagged"), do: Enum.filter(metrics, & &1.tagged?)
@@ -469,17 +452,4 @@ defmodule SanbaseWeb.TagLive.Index do
     tag_id = String.to_integer(tag_id)
     Enum.filter(metrics, fn m -> Enum.any?(m.tags, &(&1.tag_id == tag_id)) end)
   end
-
-  defp format_module_name(module) do
-    module
-    |> inspect()
-    |> String.split(".")
-    |> List.last()
-  end
-
-  defp maybe_add_param(params, _key, ""), do: params
-  defp maybe_add_param(params, key, value), do: Map.put(params, key, value)
-
-  defp maybe_add_param(params, _key, value, default) when value == default, do: params
-  defp maybe_add_param(params, key, value, _default), do: Map.put(params, key, value)
 end

--- a/lib/sanbase_web/live/metric_registry/tag_live/index.ex
+++ b/lib/sanbase_web/live/metric_registry/tag_live/index.ex
@@ -1,0 +1,485 @@
+defmodule SanbaseWeb.TagLive.Index do
+  use SanbaseWeb, :live_view
+
+  alias Sanbase.Metric.Tag
+  alias Sanbase.Metric.Registry
+  alias Sanbase.Metric.Helper
+  alias SanbaseWeb.AdminSharedComponents
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(
+       page_title: "Metric Tagging",
+       metrics: [],
+       filtered_metrics: [],
+       tags: [],
+       search_query: "",
+       filter_source: "all",
+       filter_status: "all",
+       filter_tag: "all",
+       loading: true
+     )
+     |> load_data()}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply,
+     socket
+     |> assign(
+       search_query: params["search"] || "",
+       filter_source: params["source"] || "all",
+       filter_status: params["status"] || "all",
+       filter_tag: params["tag"] || "all"
+     )
+     |> apply_filters()}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="flex flex-col justify-center w-full">
+      <div class="text-2xl mb-4">
+        Metric Tagging
+      </div>
+
+      <.navigation />
+
+      <div class="text-base-content/70 whitespace-pre-line" phx-no-curly-interpolation>
+        Attach tags (labels) to metrics. Tags are used, among other things, to expose a curated subset of metrics on bundle subscription plans.
+        A metric can carry multiple tags. Parametrized metrics like `mvrv_usd_{{timebound}}` are shown as a single row; a tag applies to all their variants.
+      </div>
+
+      <.filters
+        search_query={@search_query}
+        filter_source={@filter_source}
+        filter_status={@filter_status}
+        filter_tag={@filter_tag}
+        tags={@tags}
+      />
+
+      <.metrics_stats metrics={@metrics} filtered_metrics={@filtered_metrics} />
+
+      <.metrics_table :if={!@loading} filtered_metrics={@filtered_metrics} tags={@tags} />
+
+      <div :if={@loading} class="flex justify-center items-center py-12">
+        <span class="loading loading-spinner loading-lg text-primary"></span>
+        <p class="ml-4 text-base-content/70">Loading metrics...</p>
+      </div>
+    </div>
+    """
+  end
+
+  def navigation(assigns) do
+    ~H"""
+    <div class="my-4 flex flex-row space-x-2">
+      <AdminSharedComponents.nav_button
+        text="Back to Metric Registry"
+        href={~p"/admin/metric_registry"}
+        icon="hero-home"
+      />
+      <AdminSharedComponents.nav_button
+        text="Manage Tags"
+        href={~p"/admin/metric_registry/tags/manage"}
+        icon="hero-tag"
+      />
+    </div>
+    """
+  end
+
+  attr :search_query, :string, required: true
+  attr :filter_source, :string, required: true
+  attr :filter_status, :string, required: true
+  attr :filter_tag, :string, required: true
+  attr :tags, :list, required: true
+
+  def filters(assigns) do
+    ~H"""
+    <div class="card bg-base-100 border border-base-300 shadow p-4 my-4">
+      <.simple_form for={%{}} as={:filters} phx-change="filter">
+        <div class="flex flex-col sm:flex-row sm:flex-wrap gap-4">
+          <.input
+            type="text"
+            name="search"
+            value={@search_query}
+            label="Search metrics"
+            placeholder="Type metric name..."
+            phx-debounce="300"
+          />
+
+          <.input
+            type="select"
+            name="source"
+            value={@filter_source}
+            label="Source"
+            options={[
+              {"All Sources", "all"},
+              {"Registry", "registry"},
+              {"Code Module", "code"}
+            ]}
+          />
+
+          <.input
+            type="select"
+            name="status"
+            value={@filter_status}
+            label="Status"
+            options={[
+              {"All", "all"},
+              {"Tagged", "tagged"},
+              {"Not Tagged", "not_tagged"}
+            ]}
+          />
+
+          <.input
+            type="select"
+            name="tag"
+            value={@filter_tag}
+            label="Tag"
+            options={[
+              {"All Tags", "all"},
+              {"Not Tagged", "none"}
+              | Enum.map(@tags, fn t -> {t.name, t.id} end)
+            ]}
+          />
+        </div>
+      </.simple_form>
+    </div>
+    """
+  end
+
+  attr :metrics, :list, required: true
+  attr :filtered_metrics, :list, required: true
+
+  def metrics_stats(assigns) do
+    metrics_count = length(assigns.metrics)
+    variants_count = Enum.sum_by(assigns.metrics, & &1.variants_count)
+
+    filtered_count = length(assigns.filtered_metrics)
+    filtered_variants_count = Enum.sum_by(assigns.filtered_metrics, & &1.variants_count)
+
+    tagged_count = Enum.count(assigns.filtered_metrics, & &1.tagged?)
+    not_tagged_count = filtered_count - tagged_count
+
+    assigns =
+      assign(assigns,
+        metrics_count: metrics_count,
+        variants_count: variants_count,
+        filtered_count: filtered_count,
+        filtered_variants_count: filtered_variants_count,
+        tagged_count: tagged_count,
+        not_tagged_count: not_tagged_count
+      )
+
+    ~H"""
+    <div class="flex flex-row flex-wrap gap-4 my-2">
+      <.stat label="Metrics (filtered / total)" value={"#{@filtered_count} / #{@metrics_count}"} />
+      <.stat
+        label="Variants (filtered / total)"
+        value={"#{@filtered_variants_count} / #{@variants_count}"}
+      />
+      <.stat label="Tagged" value={@tagged_count} />
+      <.stat label="Not tagged" value={@not_tagged_count} />
+    </div>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :value, :any, required: true
+
+  def stat(assigns) do
+    ~H"""
+    <div class="rounded-box border border-base-300 px-4 py-2">
+      <div class="text-xs text-base-content/60">{@label}</div>
+      <div class="text-lg font-semibold">{@value}</div>
+    </div>
+    """
+  end
+
+  attr :filtered_metrics, :list, required: true
+  attr :tags, :list, required: true
+
+  def metrics_table(assigns) do
+    ~H"""
+    <div class="rounded-box border border-base-300 overflow-hidden">
+      <div class="overflow-x-auto">
+        <table class="table table-sm">
+          <thead>
+            <tr>
+              <th>Metric</th>
+              <th>Source</th>
+              <th>Tags</th>
+              <th>Add tag</th>
+            </tr>
+          </thead>
+          <tbody>
+            <.metric_row :for={metric <- @filtered_metrics} metric={metric} tags={@tags} />
+          </tbody>
+        </table>
+      </div>
+
+      <div :if={@filtered_metrics == []} class="px-6 py-12 text-center text-base-content/50">
+        No metrics found matching your filters.
+      </div>
+    </div>
+    """
+  end
+
+  attr :metric, :map, required: true
+  attr :tags, :list, required: true
+
+  def metric_row(assigns) do
+    assigned_tag_ids = MapSet.new(assigns.metric.tags, & &1.tag_id)
+    available_tags = Enum.reject(assigns.tags, &MapSet.member?(assigned_tag_ids, &1.id))
+    assigns = assign(assigns, available_tags: available_tags)
+
+    ~H"""
+    <tr class="hover:bg-base-200">
+      <td class="max-w-[360px] break-words">
+        <div class="flex flex-col">
+          <div class="text-sm font-medium">{@metric.metric}</div>
+          <div class="text-xs text-base-content/60">{@metric.human_readable_name}</div>
+          <div :if={@metric.variants_count >= 2} class="text-xs text-secondary">
+            ({@metric.variants_count} variants)
+          </div>
+        </div>
+      </td>
+      <td>
+        <span :if={@metric.source_type == "registry"} class="badge badge-sm badge-info badge-soft">
+          <.link navigate={~p"/admin/metric_registry/show/#{@metric.source_id}"}>
+            {@metric.source_display}
+          </.link>
+        </span>
+        <span :if={@metric.source_type == "code"} class="badge badge-sm badge-secondary badge-soft">
+          {@metric.source_display}
+        </span>
+      </td>
+      <td class="max-w-[320px]">
+        <div :if={@metric.tags == []} class="text-sm text-base-content/40 italic">
+          Not tagged
+        </div>
+        <div class="flex flex-wrap gap-1">
+          <span
+            :for={tag <- @metric.tags}
+            class="badge badge-sm badge-primary badge-soft gap-1"
+          >
+            {tag.tag_name}
+            <button
+              phx-click="remove_tag"
+              phx-value-mapping_id={tag.mapping_id}
+              class="hover:text-error"
+              data-confirm={"Remove tag '#{tag.tag_name}' from #{@metric.metric}?"}
+              aria-label="Remove tag"
+            >
+              <.icon name="hero-x-mark" class="size-3" />
+            </button>
+          </span>
+        </div>
+      </td>
+      <td>
+        <div class="flex flex-wrap gap-1">
+          <button
+            :for={tag <- @available_tags}
+            phx-click="add_tag"
+            phx-value-tag_id={tag.id}
+            phx-value-registry_id={@metric.source_id}
+            phx-value-module={@metric.module}
+            phx-value-metric={@metric.metric}
+            class="badge badge-sm badge-ghost hover:badge-primary hover:badge-soft"
+          >
+            + {tag.name}
+          </button>
+          <span :if={@available_tags == []} class="text-xs text-base-content/40 italic">
+            All tags assigned
+          </span>
+        </div>
+      </td>
+    </tr>
+    """
+  end
+
+  @impl true
+  def handle_event("filter", params, socket) do
+    query_params =
+      %{}
+      |> maybe_add_param("search", params["search"] || "")
+      |> maybe_add_param("source", params["source"] || "all", "all")
+      |> maybe_add_param("status", params["status"] || "all", "all")
+      |> maybe_add_param("tag", params["tag"] || "all", "all")
+
+    {:noreply, push_patch(socket, to: ~p"/admin/metric_registry/tags?#{query_params}")}
+  end
+
+  def handle_event("add_tag", params, socket) do
+    %{"tag_id" => tag_id} = params
+    tag_id = String.to_integer(tag_id)
+
+    attrs =
+      case params["registry_id"] do
+        registry_id when is_binary(registry_id) and registry_id != "" ->
+          %{tag_id: tag_id, metric_registry_id: String.to_integer(registry_id)}
+
+        _ ->
+          %{tag_id: tag_id, module: params["module"], metric: params["metric"]}
+      end
+
+    case Tag.create_mapping(attrs) do
+      {:ok, _} ->
+        {:noreply, socket |> load_data() |> apply_filters()}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Failed to add tag (it may already be assigned)")}
+    end
+  end
+
+  def handle_event("remove_tag", %{"mapping_id" => id}, socket) do
+    id = String.to_integer(id)
+
+    case Tag.get_mapping(id) do
+      {:ok, mapping} ->
+        Tag.delete_mapping(mapping)
+        {:noreply, socket |> load_data() |> apply_filters()}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Mapping not found")}
+    end
+  end
+
+  defp load_data(socket) do
+    tags = Tag.list_tags()
+    mappings = Tag.list_all_mappings()
+
+    mappings_by_registry_id =
+      mappings
+      |> Enum.filter(& &1.metric_registry_id)
+      |> Enum.group_by(& &1.metric_registry_id)
+
+    mappings_by_module_metric =
+      mappings
+      |> Enum.filter(&(&1.module && &1.metric))
+      |> Enum.group_by(&{&1.module, &1.metric})
+
+    registry_metrics = get_registry_metrics(mappings_by_registry_id)
+    code_metrics = get_code_metrics(mappings_by_module_metric)
+
+    all_metrics = Enum.sort_by(registry_metrics ++ code_metrics, & &1.metric, :asc)
+
+    assign(socket, metrics: all_metrics, tags: tags, loading: false)
+  end
+
+  defp get_registry_metrics(mappings_by_registry_id) do
+    Registry.all()
+    |> Enum.map(fn registry ->
+      mappings = Map.get(mappings_by_registry_id, registry.id, [])
+
+      %{
+        metric: registry.metric,
+        human_readable_name: registry.human_readable_name,
+        source_type: "registry",
+        source_display: "Registry",
+        source_id: registry.id,
+        module: nil,
+        tags: mappings_to_tags(mappings),
+        tagged?: mappings != [],
+        variants_count: max(1, length(registry.parameters))
+      }
+    end)
+  end
+
+  defp get_code_metrics(mappings_by_module_metric) do
+    registry_metrics_mapset =
+      Registry.all()
+      |> Registry.resolve()
+      |> Enum.map(& &1.metric)
+      |> MapSet.new()
+
+    Helper.metric_to_module_map()
+    |> Enum.reject(fn {metric, _module} -> metric in registry_metrics_mapset end)
+    |> Enum.map(fn {metric, module} ->
+      module_str = inspect(module)
+      mappings = Map.get(mappings_by_module_metric, {module_str, metric}, [])
+      {:ok, human_readable_name} = Sanbase.Metric.human_readable_name(metric)
+
+      %{
+        metric: metric,
+        human_readable_name: human_readable_name,
+        source_type: "code",
+        source_display: format_module_name(module),
+        source_id: nil,
+        module: module_str,
+        tags: mappings_to_tags(mappings),
+        tagged?: mappings != [],
+        variants_count: 1
+      }
+    end)
+  end
+
+  defp mappings_to_tags(mappings) do
+    mappings
+    |> Enum.map(fn mapping ->
+      %{tag_id: mapping.tag_id, tag_name: mapping.tag.name, mapping_id: mapping.id}
+    end)
+    |> Enum.sort_by(& &1.tag_name)
+  end
+
+  defp apply_filters(socket) do
+    %{
+      metrics: metrics,
+      search_query: search_query,
+      filter_source: filter_source,
+      filter_status: filter_status,
+      filter_tag: filter_tag
+    } = socket.assigns
+
+    filtered_metrics =
+      metrics
+      |> filter_by_search(search_query)
+      |> filter_by_source(filter_source)
+      |> filter_by_status(filter_status)
+      |> filter_by_tag(filter_tag)
+
+    assign(socket, filtered_metrics: filtered_metrics)
+  end
+
+  defp filter_by_search(metrics, ""), do: metrics
+
+  defp filter_by_search(metrics, query) do
+    query_lower = String.downcase(query)
+
+    Enum.filter(metrics, fn metric ->
+      String.contains?(String.downcase(metric.metric), query_lower) ||
+        (metric.human_readable_name &&
+           String.contains?(String.downcase(metric.human_readable_name), query_lower))
+    end)
+  end
+
+  defp filter_by_source(metrics, "all"), do: metrics
+  defp filter_by_source(metrics, source), do: Enum.filter(metrics, &(&1.source_type == source))
+
+  defp filter_by_status(metrics, "all"), do: metrics
+  defp filter_by_status(metrics, "tagged"), do: Enum.filter(metrics, & &1.tagged?)
+  defp filter_by_status(metrics, "not_tagged"), do: Enum.filter(metrics, &(not &1.tagged?))
+
+  defp filter_by_tag(metrics, "all"), do: metrics
+  defp filter_by_tag(metrics, "none"), do: Enum.filter(metrics, &(&1.tags == []))
+
+  defp filter_by_tag(metrics, tag_id) when is_binary(tag_id) do
+    tag_id = String.to_integer(tag_id)
+    Enum.filter(metrics, fn m -> Enum.any?(m.tags, &(&1.tag_id == tag_id)) end)
+  end
+
+  defp format_module_name(module) do
+    module
+    |> inspect()
+    |> String.split(".")
+    |> List.last()
+  end
+
+  defp maybe_add_param(params, _key, ""), do: params
+  defp maybe_add_param(params, key, value), do: Map.put(params, key, value)
+
+  defp maybe_add_param(params, _key, value, default) when value == default, do: params
+  defp maybe_add_param(params, key, value, _default), do: Map.put(params, key, value)
+end

--- a/lib/sanbase_web/live/metric_registry/tag_live/index.ex
+++ b/lib/sanbase_web/live/metric_registry/tag_live/index.ex
@@ -14,15 +14,7 @@ defmodule SanbaseWeb.TagLive.Index do
      socket
      |> assign(
        page_title: "Metric Tagging",
-       metrics: [],
-       filtered_metrics: [],
-       tags: [],
-       search_query: "",
-       filter_source: "all",
-       filter_status: "all",
-       filter_tag: "all",
-       recently_changed: MapSet.new(),
-       loading: true
+       recently_changed: MapSet.new()
      )
      |> load_catalog()
      |> refresh_tag_annotations()}
@@ -66,12 +58,7 @@ defmodule SanbaseWeb.TagLive.Index do
 
       <.metrics_stats metrics={@metrics} filtered_metrics={@filtered_metrics} />
 
-      <.metrics_table :if={!@loading} filtered_metrics={@filtered_metrics} tags={@tags} />
-
-      <div :if={@loading} class="flex justify-center items-center py-12">
-        <span class="loading loading-spinner loading-lg text-primary"></span>
-        <p class="ml-4 text-base-content/70">Loading metrics...</p>
-      </div>
+      <.metrics_table filtered_metrics={@filtered_metrics} />
     </div>
     """
   end
@@ -104,25 +91,9 @@ defmodule SanbaseWeb.TagLive.Index do
     <div class="card bg-base-100 border border-base-300 shadow p-4 my-4">
       <.simple_form for={%{}} as={:filters} phx-change="filter">
         <div class="flex flex-col sm:flex-row sm:flex-wrap gap-4">
-          <.input
-            type="text"
-            name="search"
-            value={@search_query}
-            label="Search metrics"
-            placeholder="Type metric name..."
-            phx-debounce="300"
-          />
-
-          <.input
-            type="select"
-            name="source"
-            value={@filter_source}
-            label="Source"
-            options={[
-              {"All Sources", "all"},
-              {"Registry", "registry"},
-              {"Code Module", "code"}
-            ]}
+          <AdminSharedComponents.metric_catalog_filter_inputs
+            search_query={@search_query}
+            filter_source={@filter_source}
           />
 
           <.input
@@ -203,7 +174,6 @@ defmodule SanbaseWeb.TagLive.Index do
   end
 
   attr :filtered_metrics, :list, required: true
-  attr :tags, :list, required: true
 
   def metrics_table(assigns) do
     ~H"""
@@ -219,7 +189,7 @@ defmodule SanbaseWeb.TagLive.Index do
             </tr>
           </thead>
           <tbody>
-            <.metric_row :for={metric <- @filtered_metrics} metric={metric} tags={@tags} />
+            <.metric_row :for={metric <- @filtered_metrics} metric={metric} />
           </tbody>
         </table>
       </div>
@@ -232,13 +202,8 @@ defmodule SanbaseWeb.TagLive.Index do
   end
 
   attr :metric, :map, required: true
-  attr :tags, :list, required: true
 
   def metric_row(assigns) do
-    assigned_tag_ids = MapSet.new(assigns.metric.tags, & &1.tag_id)
-    available_tags = Enum.reject(assigns.tags, &MapSet.member?(assigned_tag_ids, &1.id))
-    assigns = assign(assigns, available_tags: available_tags)
-
     ~H"""
     <tr class={[
       "hover:bg-base-200 transition-colors duration-700",
@@ -259,14 +224,11 @@ defmodule SanbaseWeb.TagLive.Index do
         </div>
       </td>
       <td>
-        <span :if={@metric.source_type == "registry"} class="badge badge-sm badge-info badge-soft">
-          <.link navigate={~p"/admin/metric_registry/show/#{@metric.source_id}"}>
-            {@metric.source_display}
-          </.link>
-        </span>
-        <span :if={@metric.source_type == "code"} class="badge badge-sm badge-secondary badge-soft">
-          {@metric.source_display}
-        </span>
+        <AdminSharedComponents.metric_source_badge
+          source_type={@metric.source_type}
+          source_display={@metric.source_display}
+          source_id={@metric.source_id}
+        />
       </td>
       <td class="max-w-[320px]">
         <div :if={@metric.tags == []} class="text-sm text-base-content/40 italic">
@@ -290,7 +252,7 @@ defmodule SanbaseWeb.TagLive.Index do
       <td>
         <div class="flex flex-wrap gap-1">
           <button
-            :for={tag <- @available_tags}
+            :for={tag <- @metric.available_tags}
             phx-click="add_tag"
             phx-value-tag_id={tag.id}
             phx-value-registry_id={@metric.source_id}
@@ -300,7 +262,7 @@ defmodule SanbaseWeb.TagLive.Index do
           >
             + {tag.name}
           </button>
-          <span :if={@available_tags == []} class="text-xs text-base-content/40 italic">
+          <span :if={@metric.available_tags == []} class="text-xs text-base-content/40 italic">
             All tags assigned
           </span>
         </div>
@@ -374,7 +336,7 @@ defmodule SanbaseWeb.TagLive.Index do
   # are (un)assigned, so it is loaded once on mount. Tag events only need
   # refresh_tag_annotations/1.
   defp load_catalog(socket) do
-    assign(socket, catalog: Catalog.all_metrics(), loading: false)
+    assign(socket, catalog: Catalog.all_metrics())
   end
 
   defp refresh_tag_annotations(socket) do
@@ -383,8 +345,16 @@ defmodule SanbaseWeb.TagLive.Index do
 
     metrics =
       Enum.map(socket.assigns.catalog, fn entry ->
-        mappings = Catalog.mappings_for_entry(entry, mappings_index)
-        Map.merge(entry, %{tags: mappings_to_tags(mappings), tagged?: mappings != []})
+        metric_tags =
+          Catalog.mappings_for_entry(entry, mappings_index) |> mappings_to_tags()
+
+        assigned_tag_ids = MapSet.new(metric_tags, & &1.tag_id)
+
+        Map.merge(entry, %{
+          tags: metric_tags,
+          tagged?: metric_tags != [],
+          available_tags: Enum.reject(tags, &MapSet.member?(assigned_tag_ids, &1.id))
+        })
       end)
 
     assign(socket, metrics: metrics, tags: tags)
@@ -420,17 +390,14 @@ defmodule SanbaseWeb.TagLive.Index do
     # they no longer match the filters, so an accidental change can be undone
     # in place. They are dropped once the filters change.
     filtered_metrics =
-      metrics
-      |> Enum.filter(fn metric ->
+      Enum.flat_map(metrics, fn metric ->
         key = Catalog.entry_key(metric)
-        MapSet.member?(matching_keys, key) or MapSet.member?(recently_changed, key)
-      end)
-      |> Enum.map(fn metric ->
-        Map.put(
-          metric,
-          :recently_changed?,
-          MapSet.member?(recently_changed, Catalog.entry_key(metric))
-        )
+
+        cond do
+          MapSet.member?(recently_changed, key) -> [Map.put(metric, :recently_changed?, true)]
+          MapSet.member?(matching_keys, key) -> [Map.put(metric, :recently_changed?, false)]
+          true -> []
+        end
       end)
 
     assign(socket, filtered_metrics: filtered_metrics)

--- a/lib/sanbase_web/live/metric_registry/tag_live/tag_index.ex
+++ b/lib/sanbase_web/live/metric_registry/tag_live/tag_index.ex
@@ -13,12 +13,7 @@ defmodule SanbaseWeb.TagLive.TagIndex do
   end
 
   defp load_data(socket) do
-    tags = Tag.list_tags()
-
-    counts =
-      Enum.into(tags, %{}, fn tag -> {tag.id, length(Tag.list_mappings_by_tag(tag.id))} end)
-
-    assign(socket, tags: tags, counts: counts)
+    assign(socket, tags: Tag.list_tags(), counts: Tag.count_mappings_per_tag())
   end
 
   @impl true
@@ -43,7 +38,9 @@ defmodule SanbaseWeb.TagLive.TagIndex do
           </thead>
           <tbody>
             <tr :for={tag <- @tags} class="hover:bg-base-200">
-              <td class="font-medium">{tag.name}</td>
+              <td>
+                <span class="badge badge-sm badge-secondary">{tag.name}</span>
+              </td>
               <td class="text-base-content/60">{tag.description}</td>
               <td class="text-center">{Map.get(@counts, tag.id, 0)}</td>
               <td>

--- a/lib/sanbase_web/live/metric_registry/tag_live/tag_index.ex
+++ b/lib/sanbase_web/live/metric_registry/tag_live/tag_index.ex
@@ -1,0 +1,113 @@
+defmodule SanbaseWeb.TagLive.TagIndex do
+  use SanbaseWeb, :live_view
+
+  alias Sanbase.Metric.Tag
+  alias SanbaseWeb.AdminSharedComponents
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(page_title: "Manage Tags")
+     |> load_data()}
+  end
+
+  defp load_data(socket) do
+    tags = Tag.list_tags()
+
+    counts =
+      Enum.into(tags, %{}, fn tag -> {tag.id, length(Tag.list_mappings_by_tag(tag.id))} end)
+
+    assign(socket, tags: tags, counts: counts)
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="flex flex-col justify-center w-full">
+      <div class="text-2xl mb-4">
+        Manage Tags
+      </div>
+
+      <.navigation />
+
+      <div class="rounded-box border border-base-300 overflow-hidden">
+        <table class="table table-sm">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Description</th>
+              <th class="text-center">Metrics assigned</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={tag <- @tags} class="hover:bg-base-200">
+              <td class="font-medium">{tag.name}</td>
+              <td class="text-base-content/60">{tag.description}</td>
+              <td class="text-center">{Map.get(@counts, tag.id, 0)}</td>
+              <td>
+                <div class="flex space-x-2">
+                  <.link
+                    navigate={~p"/admin/metric_registry/tags/edit/#{tag.id}"}
+                    class="link link-primary"
+                  >
+                    Edit
+                  </.link>
+                  <button
+                    phx-click="delete"
+                    phx-value-id={tag.id}
+                    class="link link-error"
+                    data-confirm="Delete this tag? This also removes all its metric assignments."
+                  >
+                    Delete
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div :if={@tags == []} class="px-6 py-12 text-center text-base-content/50">
+          No tags yet.
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  def navigation(assigns) do
+    ~H"""
+    <div class="my-4 flex flex-row space-x-2">
+      <AdminSharedComponents.nav_button
+        text="Back to Tagging Dashboard"
+        href={~p"/admin/metric_registry/tags"}
+        icon="hero-arrow-uturn-left"
+      />
+      <AdminSharedComponents.nav_button
+        text="Create New Tag"
+        href={~p"/admin/metric_registry/tags/new"}
+        icon="hero-plus"
+      />
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    id = String.to_integer(id)
+
+    case Tag.get_tag(id) do
+      {:ok, tag} ->
+        Tag.delete_tag(tag)
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "Tag deleted successfully")
+         |> load_data()}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Tag not found")}
+    end
+  end
+end

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -167,6 +167,10 @@ defmodule SanbaseWeb.Router do
         live("/groups", GroupLive.Index)
         live("/groups/new", GroupLive.Form, :new)
         live("/groups/edit/:id", GroupLive.Form, :edit)
+        live("/tags", TagLive.Index)
+        live("/tags/manage", TagLive.TagIndex)
+        live("/tags/new", TagLive.Form, :new)
+        live("/tags/edit/:id", TagLive.Form, :edit)
         live("/changelog", MetricChangelogLive)
 
         live("/categorization", CategorizationLive.Index)

--- a/priv/repo/migrations/20260709120000_add_metric_tags_tables.exs
+++ b/priv/repo/migrations/20260709120000_add_metric_tags_tables.exs
@@ -1,0 +1,85 @@
+defmodule Sanbase.Repo.Migrations.AddMetricTagsTables do
+  use Ecto.Migration
+
+  @tags [
+    {"basic", "Metrics exposed on the Basic bundle plan"},
+    {"development_data", "Development activity metrics"},
+    {"market_data", "Price and market metrics"},
+    {"social_data", "Social volume and sentiment metrics"},
+    {"onchain_data", "Onchain and blockchain metrics"}
+  ]
+
+  def change do
+    create table(:metric_tags) do
+      add(:name, :string, null: false)
+      add(:description, :text)
+
+      timestamps()
+    end
+
+    create(unique_index(:metric_tags, [:name]))
+
+    create table(:metric_tag_mappings) do
+      # There's a check constraint that allows either metric_registry_id to be set
+      # or module/metric, but not both.
+      add(:metric_registry_id, references(:metric_registry, on_delete: :delete_all))
+      add(:module, :string)
+      add(:metric, :string)
+
+      add(:tag_id, references(:metric_tags, on_delete: :delete_all), null: false)
+
+      timestamps()
+    end
+
+    create(index(:metric_tag_mappings, [:tag_id]))
+
+    # Either metric_registry_id is set and module/metric are NULL,
+    # or metric_registry_id is NULL and module/metric are both not NULL.
+    create(
+      constraint(:metric_tag_mappings, :only_one_metric_identifier,
+        check: """
+        (metric_registry_id IS NOT NULL AND module IS NULL AND metric IS NULL)
+        OR
+        (metric_registry_id IS NULL AND module IS NOT NULL AND metric IS NOT NULL)
+        """
+      )
+    )
+
+    # A registry-backed metric can carry many tags, but not the same tag twice.
+    create(
+      index(:metric_tag_mappings, [:metric_registry_id, :tag_id],
+        unique: true,
+        where: "metric_registry_id IS NOT NULL"
+      )
+    )
+
+    # A module/metric pair can carry many tags, but not the same tag twice.
+    create(
+      index(:metric_tag_mappings, [:module, :metric, :tag_id],
+        unique: true,
+        where: "module IS NOT NULL AND metric IS NOT NULL"
+      )
+    )
+
+    seed_tags()
+  end
+
+  defp seed_tags() do
+    values =
+      @tags
+      |> Enum.map_join(",\n", fn {name, description} ->
+        "('#{name}', '#{description}', NOW(), NOW())"
+      end)
+
+    execute(
+      """
+      INSERT INTO metric_tags (name, description, inserted_at, updated_at) VALUES
+      #{values}
+      ON CONFLICT (name) DO NOTHING
+      """,
+      """
+      DELETE FROM metric_tags WHERE name IN (#{Enum.map_join(@tags, ",", fn {name, _} -> "'#{name}'" end)})
+      """
+    )
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2935,7 +2935,8 @@ CREATE TABLE public.non_crypto_assets (
     hidden_reason text,
     metadata jsonb DEFAULT '{}'::jsonb,
     inserted_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    CONSTRAINT valid_asset_type CHECK (((asset_type)::text = ANY ((ARRAY['stock'::character varying, 'commodity'::character varying, 'index'::character varying, 'forex'::character varying, 'fund'::character varying, 'bond'::character varying, 'other'::character varying])::text[])))
 );
 
 

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -4,8 +4,8 @@
 
 \restrict ceqVK0DMuO2zoA4LQREjud7ms9ZRZ5kWQaf0GzzlrvFcsgf91OCiDidiVhAPYLm
 
--- Dumped from database version 17.10 (Homebrew)
--- Dumped by pg_dump version 17.10 (Homebrew)
+-- Dumped from database version 17.9 (Homebrew)
+-- Dumped by pg_dump version 17.9 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -2711,6 +2711,73 @@ ALTER SEQUENCE public.metric_registry_sync_runs_id_seq OWNED BY public.metric_re
 
 
 --
+-- Name: metric_tag_mappings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.metric_tag_mappings (
+    id bigint NOT NULL,
+    metric_registry_id bigint,
+    module character varying(255),
+    metric character varying(255),
+    tag_id bigint NOT NULL,
+    inserted_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    CONSTRAINT only_one_metric_identifier CHECK ((((metric_registry_id IS NOT NULL) AND (module IS NULL) AND (metric IS NULL)) OR ((metric_registry_id IS NULL) AND (module IS NOT NULL) AND (metric IS NOT NULL))))
+);
+
+
+--
+-- Name: metric_tag_mappings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.metric_tag_mappings_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: metric_tag_mappings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.metric_tag_mappings_id_seq OWNED BY public.metric_tag_mappings.id;
+
+
+--
+-- Name: metric_tags; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.metric_tags (
+    id bigint NOT NULL,
+    name character varying(255) NOT NULL,
+    description text,
+    inserted_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: metric_tags_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.metric_tags_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: metric_tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.metric_tags_id_seq OWNED BY public.metric_tags.id;
+
+
+--
 -- Name: metric_ui_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2868,8 +2935,7 @@ CREATE TABLE public.non_crypto_assets (
     hidden_reason text,
     metadata jsonb DEFAULT '{}'::jsonb,
     inserted_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    CONSTRAINT valid_asset_type CHECK (((asset_type)::text = ANY ((ARRAY['stock'::character varying, 'commodity'::character varying, 'index'::character varying, 'forex'::character varying, 'fund'::character varying, 'bond'::character varying, 'other'::character varying])::text[])))
+    updated_at timestamp without time zone NOT NULL
 );
 
 
@@ -6514,6 +6580,20 @@ ALTER TABLE ONLY public.metric_registry_sync_runs ALTER COLUMN id SET DEFAULT ne
 
 
 --
+-- Name: metric_tag_mappings id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.metric_tag_mappings ALTER COLUMN id SET DEFAULT nextval('public.metric_tag_mappings_id_seq'::regclass);
+
+
+--
+-- Name: metric_tags id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.metric_tags ALTER COLUMN id SET DEFAULT nextval('public.metric_tags_id_seq'::regclass);
+
+
+--
 -- Name: metric_ui_metadata id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7681,6 +7761,22 @@ ALTER TABLE ONLY public.metric_registry
 
 ALTER TABLE ONLY public.metric_registry_sync_runs
     ADD CONSTRAINT metric_registry_sync_runs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: metric_tag_mappings metric_tag_mappings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.metric_tag_mappings
+    ADD CONSTRAINT metric_tag_mappings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: metric_tags metric_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.metric_tags
+    ADD CONSTRAINT metric_tags_pkey PRIMARY KEY (id);
 
 
 --
@@ -9271,6 +9367,34 @@ CREATE UNIQUE INDEX metric_registry_composite_unique_index ON public.metric_regi
 --
 
 CREATE UNIQUE INDEX metric_registry_sync_runs_uuid_sync_type_index ON public.metric_registry_sync_runs USING btree (uuid, sync_type);
+
+
+--
+-- Name: metric_tag_mappings_metric_registry_id_tag_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX metric_tag_mappings_metric_registry_id_tag_id_index ON public.metric_tag_mappings USING btree (metric_registry_id, tag_id) WHERE (metric_registry_id IS NOT NULL);
+
+
+--
+-- Name: metric_tag_mappings_module_metric_tag_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX metric_tag_mappings_module_metric_tag_id_index ON public.metric_tag_mappings USING btree (module, metric, tag_id) WHERE ((module IS NOT NULL) AND (metric IS NOT NULL));
+
+
+--
+-- Name: metric_tag_mappings_tag_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX metric_tag_mappings_tag_id_index ON public.metric_tag_mappings USING btree (tag_id);
+
+
+--
+-- Name: metric_tags_name_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX metric_tags_name_index ON public.metric_tags USING btree (name);
 
 
 --
@@ -10898,6 +11022,22 @@ ALTER TABLE ONLY public.metric_registry_changelog
 
 
 --
+-- Name: metric_tag_mappings metric_tag_mappings_metric_registry_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.metric_tag_mappings
+    ADD CONSTRAINT metric_tag_mappings_metric_registry_id_fkey FOREIGN KEY (metric_registry_id) REFERENCES public.metric_registry(id) ON DELETE CASCADE;
+
+
+--
+-- Name: metric_tag_mappings metric_tag_mappings_tag_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.metric_tag_mappings
+    ADD CONSTRAINT metric_tag_mappings_tag_id_fkey FOREIGN KEY (tag_id) REFERENCES public.metric_tags(id) ON DELETE CASCADE;
+
+
+--
 -- Name: metric_ui_metadata metric_ui_metadata_metric_category_mapping_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -12396,4 +12536,5 @@ INSERT INTO public."schema_migrations" (version) VALUES (20260610120000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260610120100);
 INSERT INTO public."schema_migrations" (version) VALUES (20260610170000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260612130000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260709120000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260720115000);

--- a/test/sanbase/metric/catalog_test.exs
+++ b/test/sanbase/metric/catalog_test.exs
@@ -1,0 +1,57 @@
+defmodule Sanbase.Metric.CatalogTest do
+  use Sanbase.DataCase, async: false
+
+  import Sanbase.MetricRegistryHelpers, only: [create_registry_metric: 1]
+
+  alias Sanbase.Metric.Catalog
+
+  test "includes code metrics not present in the registry" do
+    entry = Catalog.all_metrics() |> Enum.find(&(&1.metric == "price_usd"))
+
+    assert %{
+             source_type: "code",
+             source_display: "MetricAdapter",
+             source_id: nil,
+             module: "Sanbase.Price.MetricAdapter",
+             parameters_count: 0,
+             variants_count: 1
+           } = entry
+  end
+
+  test "registry template metrics appear once with variants count from parameters" do
+    registry =
+      create_registry_metric(%{
+        metric: "catalog_tpl_{{param}}",
+        internal_metric: "catalog_tpl_internal_{{param}}",
+        human_readable_name: "Catalog Tpl {{param}}",
+        parameters: [%{"param" => "aaa"}, %{"param" => "bbb"}]
+      })
+
+    assert [entry] = Catalog.all_metrics() |> Enum.filter(&(&1.metric == "catalog_tpl_{{param}}"))
+
+    assert entry.source_type == "registry"
+    assert entry.source_display == "Registry"
+    assert entry.source_id == registry.id
+    assert entry.module == nil
+    assert entry.parameters_count == 2
+    assert entry.variants_count == 2
+
+    # The expansions are covered by the template entry, not listed separately
+    metrics = Catalog.all_metrics() |> Enum.map(& &1.metric)
+    refute "catalog_tpl_aaa" in metrics
+    refute "catalog_tpl_bbb" in metrics
+  end
+
+  test "code metrics covered by a registry row are not duplicated" do
+    registry = create_registry_metric(%{metric: "price_usd"})
+
+    assert [entry] = Catalog.all_metrics() |> Enum.filter(&(&1.metric == "price_usd"))
+    assert entry.source_type == "registry"
+    assert entry.source_id == registry.id
+  end
+
+  test "entries are sorted by metric name" do
+    metrics = Catalog.all_metrics() |> Enum.map(& &1.metric)
+    assert metrics == Enum.sort(metrics)
+  end
+end

--- a/test/sanbase/metric/tag_cache_test.exs
+++ b/test/sanbase/metric/tag_cache_test.exs
@@ -1,24 +1,10 @@
 defmodule Sanbase.Metric.Tag.CacheTest do
   use Sanbase.DataCase, async: false
 
+  import Sanbase.MetricRegistryHelpers, only: [create_registry_metric: 1]
+
   alias Sanbase.Metric.Tag
   alias Sanbase.Metric.Tag.Cache
-
-  defp create_registry_metric(attrs) do
-    defaults = %{
-      internal_metric: Map.fetch!(attrs, :metric) <> "_internal",
-      human_readable_name: "Human name",
-      min_interval: "5m",
-      tables: [%{name: "daily_metrics_v2"}],
-      default_aggregation: "avg",
-      access: "free",
-      has_incomplete_data: false,
-      data_type: "timeseries"
-    }
-
-    {:ok, registry} = Sanbase.Metric.Registry.create(Map.merge(defaults, attrs))
-    registry
-  end
 
   test "module/metric mapping resolves to the concrete metric name" do
     {:ok, tag} = Tag.create_tag(%{name: "cache_module_tag"})

--- a/test/sanbase/metric/tag_cache_test.exs
+++ b/test/sanbase/metric/tag_cache_test.exs
@@ -1,0 +1,110 @@
+defmodule Sanbase.Metric.Tag.CacheTest do
+  use Sanbase.DataCase, async: false
+
+  alias Sanbase.Metric.Tag
+  alias Sanbase.Metric.Tag.Cache
+
+  defp create_registry_metric(attrs) do
+    defaults = %{
+      internal_metric: Map.fetch!(attrs, :metric) <> "_internal",
+      human_readable_name: "Human name",
+      min_interval: "5m",
+      tables: [%{name: "daily_metrics_v2"}],
+      default_aggregation: "avg",
+      access: "free",
+      has_incomplete_data: false,
+      data_type: "timeseries"
+    }
+
+    {:ok, registry} = Sanbase.Metric.Registry.create(Map.merge(defaults, attrs))
+    registry
+  end
+
+  test "module/metric mapping resolves to the concrete metric name" do
+    {:ok, tag} = Tag.create_tag(%{name: "cache_module_tag"})
+
+    {:ok, _} =
+      Tag.create_mapping(%{
+        tag_id: tag.id,
+        module: "Sanbase.Price.MetricAdapter",
+        metric: "price_usd"
+      })
+
+    Cache.refresh_stored_terms()
+
+    assert MapSet.member?(Cache.metrics_for_tag("cache_module_tag"), "price_usd")
+    assert Cache.tags_for_metric("price_usd") == ["cache_module_tag"]
+  end
+
+  test "registry-backed mapping resolves to the metric name and its aliases" do
+    registry =
+      create_registry_metric(%{
+        metric: "cache_aliased_metric",
+        aliases: [%{name: "cache_aliased_metric_alias"}]
+      })
+
+    {:ok, tag} = Tag.create_tag(%{name: "cache_alias_tag"})
+    {:ok, _} = Tag.create_mapping(%{tag_id: tag.id, metric_registry_id: registry.id})
+
+    Cache.refresh_stored_terms()
+
+    metrics = Cache.metrics_for_tag("cache_alias_tag")
+    assert MapSet.member?(metrics, "cache_aliased_metric")
+    assert MapSet.member?(metrics, "cache_aliased_metric_alias")
+  end
+
+  test "registry template mapping resolves to all parameter expansions" do
+    registry =
+      create_registry_metric(%{
+        metric: "cache_tpl_{{param}}",
+        internal_metric: "cache_tpl_internal_{{param}}",
+        human_readable_name: "Cache Tpl {{param}}",
+        parameters: [%{"param" => "aaa"}, %{"param" => "bbb"}]
+      })
+
+    assert registry.is_template
+
+    {:ok, tag} = Tag.create_tag(%{name: "cache_tpl_tag"})
+    {:ok, _} = Tag.create_mapping(%{tag_id: tag.id, metric_registry_id: registry.id})
+
+    Cache.refresh_stored_terms()
+
+    metrics = Cache.metrics_for_tag("cache_tpl_tag")
+    assert MapSet.member?(metrics, "cache_tpl_aaa")
+    assert MapSet.member?(metrics, "cache_tpl_bbb")
+  end
+
+  test "metrics_for_tags/1 returns the union of the given tags" do
+    {:ok, tag_a} = Tag.create_tag(%{name: "union_a"})
+    {:ok, tag_b} = Tag.create_tag(%{name: "union_b"})
+
+    {:ok, _} =
+      Tag.create_mapping(%{tag_id: tag_a.id, module: "M", metric: "metric_a"})
+
+    {:ok, _} =
+      Tag.create_mapping(%{tag_id: tag_b.id, module: "M", metric: "metric_b"})
+
+    Cache.refresh_stored_terms()
+
+    union = Cache.metrics_for_tags(["union_a", "union_b"])
+    assert MapSet.member?(union, "metric_a")
+    assert MapSet.member?(union, "metric_b")
+  end
+
+  test "refresh picks up newly created mappings" do
+    {:ok, tag} = Tag.create_tag(%{name: "refresh_tag"})
+
+    Cache.refresh_stored_terms()
+    assert MapSet.size(Cache.metrics_for_tag("refresh_tag")) == 0
+
+    {:ok, _} = Tag.create_mapping(%{tag_id: tag.id, module: "M", metric: "late_metric"})
+    Cache.refresh_stored_terms()
+
+    assert MapSet.member?(Cache.metrics_for_tag("refresh_tag"), "late_metric")
+  end
+
+  test "unknown tag returns an empty set" do
+    Cache.refresh_stored_terms()
+    assert Cache.metrics_for_tag("does_not_exist") == MapSet.new()
+  end
+end

--- a/test/sanbase/metric/tag_event_test.exs
+++ b/test/sanbase/metric/tag_event_test.exs
@@ -1,0 +1,133 @@
+defmodule Sanbase.Metric.TagEventTest do
+  use Sanbase.DataCase, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Sanbase.Metric.Tag
+  alias Sanbase.EventBus.MetricRegistrySubscriber
+
+  @receiver :tag_event_test_receiver
+
+  defmodule Forwarder do
+    @moduledoc """
+    Test subscriber that forwards every event on the subscribed topics to the
+    test process, so tests can assert on the emitted event payloads.
+    """
+
+    def process({_topic, _id} = event_shadow) do
+      event = EventBus.fetch_event(event_shadow)
+
+      case Process.whereis(:tag_event_test_receiver) do
+        nil -> :ok
+        pid -> send(pid, {:tag_event, event.data})
+      end
+
+      EventBus.mark_as_completed({__MODULE__, event_shadow})
+      :ok
+    end
+  end
+
+  setup_all do
+    # In test env MetricRegistrySubscriber is in the disabled_subscribers list,
+    # so it must be subscribed explicitly to test the topic -> subscriber ->
+    # handler dispatch. Same pattern as KafkaExporterSubscriberTest.
+    EventBus.subscribe({Forwarder, ["metric_tag_events"]})
+    Sanbase.EventBus.subscribe_subscriber(MetricRegistrySubscriber)
+    # EventBus.subscribe/1 is a cast; give it time to be established
+    Process.sleep(200)
+
+    on_exit(fn ->
+      Sanbase.EventBus.drain_topics(["metric_tag_events"], 10_000)
+      EventBus.unsubscribe(Forwarder)
+      Sanbase.EventBus.unsubscribe_subscriber(MetricRegistrySubscriber)
+    end)
+
+    :ok
+  end
+
+  setup do
+    Process.register(self(), @receiver)
+    :ok
+  end
+
+  describe "wiring" do
+    test "the metric_tag_events topic is registered at boot" do
+      assert :metric_tag_events in EventBus.topics()
+    end
+
+    test "MetricRegistrySubscriber subscribes to the metric_tag_events topic" do
+      assert "metric_tag_events" in MetricRegistrySubscriber.topics()
+    end
+
+    test "the tag event emitter emits on the metric_tag_events topic" do
+      assert Sanbase.Metric.Tag.EventEmitter.topic() == :metric_tag_events
+    end
+
+    test "metric_tag_change is a valid event type" do
+      assert Sanbase.EventBus.EventValidation.valid?(%{event_type: :metric_tag_change})
+    end
+  end
+
+  describe "event emission" do
+    test "every tag and mapping mutation emits a metric_tag_change event" do
+      {:ok, tag} = Tag.create_tag(%{name: "emit_test_tag"})
+      assert_receive {:tag_event, %{event_type: :metric_tag_change}}, 1000
+
+      {:ok, tag} = Tag.update_tag(tag, %{description: "updated"})
+      assert_receive {:tag_event, %{event_type: :metric_tag_change}}, 1000
+
+      {:ok, mapping} = Tag.create_mapping(%{tag_id: tag.id, module: "M", metric: "emit_metric"})
+      assert_receive {:tag_event, %{event_type: :metric_tag_change}}, 1000
+
+      {:ok, _} = Tag.delete_mapping(mapping)
+      assert_receive {:tag_event, %{event_type: :metric_tag_change}}, 1000
+
+      {:ok, _} = Tag.delete_tag(tag)
+      assert_receive {:tag_event, %{event_type: :metric_tag_change}}, 1000
+
+      refute_receive {:tag_event, _}, 100
+    end
+
+    test "failed mutations do not emit events" do
+      {:ok, _} = Tag.create_tag(%{name: "emit_dup_tag"})
+      assert_receive {:tag_event, %{event_type: :metric_tag_change}}, 1000
+
+      assert {:error, _} = Tag.create_tag(%{name: "emit_dup_tag"})
+      refute_receive {:tag_event, _}, 100
+    end
+  end
+
+  describe "event processing" do
+    test "the subscriber dispatches metric_tag_change to the configured handler" do
+      # In test env the configured handler is on_metric_tag_change_test_env/0,
+      # which logs instead of refreshing caches (to avoid Ecto sandbox
+      # ownership errors in the subscriber process).
+      log =
+        capture_log(fn ->
+          {:ok, _} = Tag.create_tag(%{name: "process_test_tag"})
+          # The emitter's maybe_wait/2 returns only after all subscribers have
+          # marked the event as completed, so the handler has already run here.
+          Logger.flush()
+        end)
+
+      assert log =~ "Metric Tag Change event received"
+    end
+
+    test "on_metric_tag_change/0 (the prod handler) refreshes the tag caches" do
+      {:ok, tag} = Tag.create_tag(%{name: "prod_handler_tag"})
+
+      # Pin a snapshot computed before the mapping exists. Without this the
+      # lazy cache-miss refresh would make the assertions below pass even if
+      # the handler refreshed nothing.
+      true = Tag.refresh_stored_terms()
+
+      {:ok, _} = Tag.create_mapping(%{tag_id: tag.id, module: "M", metric: "prod_handler_metric"})
+      assert Tag.tags_for_metric("prod_handler_metric") == []
+
+      assert :ok = MetricRegistrySubscriber.on_metric_tag_change()
+
+      assert Tag.tags_for_metric("prod_handler_metric") == ["prod_handler_tag"]
+      assert MapSet.member?(Tag.metrics_for_tag("prod_handler_tag"), "prod_handler_metric")
+    end
+  end
+end

--- a/test/sanbase/metric/tag_test.exs
+++ b/test/sanbase/metric/tag_test.exs
@@ -1,24 +1,9 @@
 defmodule Sanbase.Metric.TagTest do
   use Sanbase.DataCase, async: false
 
+  import Sanbase.MetricRegistryHelpers, only: [create_registry_metric: 1]
+
   alias Sanbase.Metric.Tag
-
-  defp create_registry_metric(metric) do
-    {:ok, registry} =
-      Sanbase.Metric.Registry.create(%{
-        metric: metric,
-        internal_metric: metric <> "_internal",
-        human_readable_name: "Human name for #{metric}",
-        min_interval: "5m",
-        tables: [%{name: "daily_metrics_v2"}],
-        default_aggregation: "avg",
-        access: "free",
-        has_incomplete_data: false,
-        data_type: "timeseries"
-      })
-
-    registry
-  end
 
   describe "tag CRUD" do
     test "create, get, update and delete a tag" do

--- a/test/sanbase/metric/tag_test.exs
+++ b/test/sanbase/metric/tag_test.exs
@@ -1,0 +1,146 @@
+defmodule Sanbase.Metric.TagTest do
+  use Sanbase.DataCase, async: false
+
+  alias Sanbase.Metric.Tag
+
+  defp create_registry_metric(metric) do
+    {:ok, registry} =
+      Sanbase.Metric.Registry.create(%{
+        metric: metric,
+        internal_metric: metric <> "_internal",
+        human_readable_name: "Human name for #{metric}",
+        min_interval: "5m",
+        tables: [%{name: "daily_metrics_v2"}],
+        default_aggregation: "avg",
+        access: "free",
+        has_incomplete_data: false,
+        data_type: "timeseries"
+      })
+
+    registry
+  end
+
+  describe "tag CRUD" do
+    test "create, get, update and delete a tag" do
+      assert {:ok, tag} = Tag.create_tag(%{name: "my_tag", description: "desc"})
+      assert tag.name == "my_tag"
+      assert tag.description == "desc"
+
+      assert {:ok, ^tag} = Tag.get_tag(tag.id)
+      assert %{name: "my_tag"} = Tag.get_tag_by_name("my_tag")
+
+      assert {:ok, updated} = Tag.update_tag(tag, %{description: "new desc"})
+      assert updated.description == "new desc"
+
+      assert {:ok, _} = Tag.delete_tag(updated)
+      assert {:error, _} = Tag.get_tag(tag.id)
+    end
+
+    test "tag name must be unique" do
+      assert {:ok, _} = Tag.create_tag(%{name: "dup_tag"})
+      assert {:error, changeset} = Tag.create_tag(%{name: "dup_tag"})
+      assert "has already been taken" in errors_on(changeset).name
+    end
+
+    test "name is required" do
+      assert {:error, changeset} = Tag.create_tag(%{description: "no name"})
+      assert "can't be blank" in errors_on(changeset).name
+    end
+
+    test "seeded vocabulary tags exist" do
+      names = Tag.list_tags() |> Enum.map(& &1.name)
+
+      for expected <- ~w(basic development_data market_data social_data onchain_data) do
+        assert expected in names
+      end
+    end
+  end
+
+  describe "mapping constraints" do
+    setup do
+      {:ok, tag} = Tag.create_tag(%{name: "constraint_tag"})
+      %{tag: tag}
+    end
+
+    test "rejects a mapping with neither identifier", %{tag: tag} do
+      assert {:error, changeset} = Tag.create_mapping(%{tag_id: tag.id})
+      refute changeset.valid?
+    end
+
+    test "rejects a mapping with both identifiers", %{tag: tag} do
+      registry = create_registry_metric("both_ids_metric")
+
+      assert {:error, changeset} =
+               Tag.create_mapping(%{
+                 tag_id: tag.id,
+                 metric_registry_id: registry.id,
+                 module: "Some.Module",
+                 metric: "some_metric"
+               })
+
+      refute changeset.valid?
+    end
+
+    test "accepts a registry-backed mapping", %{tag: tag} do
+      registry = create_registry_metric("registry_backed_metric")
+
+      assert {:ok, mapping} =
+               Tag.create_mapping(%{tag_id: tag.id, metric_registry_id: registry.id})
+
+      assert mapping.metric_registry_id == registry.id
+    end
+
+    test "accepts a module/metric mapping", %{tag: tag} do
+      assert {:ok, mapping} =
+               Tag.create_mapping(%{
+                 tag_id: tag.id,
+                 module: "Sanbase.Price.MetricAdapter",
+                 metric: "price_usd"
+               })
+
+      assert mapping.metric == "price_usd"
+    end
+
+    test "rejects the same (registry metric, tag) pair twice", %{tag: tag} do
+      registry = create_registry_metric("dup_registry_metric")
+
+      assert {:ok, _} = Tag.create_mapping(%{tag_id: tag.id, metric_registry_id: registry.id})
+
+      assert {:error, changeset} =
+               Tag.create_mapping(%{tag_id: tag.id, metric_registry_id: registry.id})
+
+      refute changeset.valid?
+    end
+
+    test "rejects the same (module/metric, tag) pair twice", %{tag: tag} do
+      attrs = %{tag_id: tag.id, module: "Sanbase.Price.MetricAdapter", metric: "price_usd"}
+
+      assert {:ok, _} = Tag.create_mapping(attrs)
+      assert {:error, changeset} = Tag.create_mapping(attrs)
+      refute changeset.valid?
+    end
+  end
+
+  describe "multiple tags per metric" do
+    test "a single metric can carry more than one tag" do
+      {:ok, tag_a} = Tag.create_tag(%{name: "multi_a"})
+      {:ok, tag_b} = Tag.create_tag(%{name: "multi_b"})
+
+      attrs_a = %{tag_id: tag_a.id, module: "Sanbase.Price.MetricAdapter", metric: "price_usd"}
+      attrs_b = %{tag_id: tag_b.id, module: "Sanbase.Price.MetricAdapter", metric: "price_usd"}
+
+      assert {:ok, _} = Tag.create_mapping(attrs_a)
+      assert {:ok, _} = Tag.create_mapping(attrs_b)
+
+      Tag.refresh_stored_terms()
+
+      assert Enum.sort(Tag.tags_for_metric("price_usd")) == ["multi_a", "multi_b"]
+    end
+  end
+
+  describe "refresh_stored_terms/0" do
+    test "returns true" do
+      assert Tag.refresh_stored_terms() == true
+    end
+  end
+end

--- a/test/sanbase_web/live/metric_registry/categorization_live_test.exs
+++ b/test/sanbase_web/live/metric_registry/categorization_live_test.exs
@@ -2,18 +2,9 @@ defmodule SanbaseWeb.CategorizationLiveTest do
   use SanbaseWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
-  import Sanbase.Factory
 
   setup do
-    user = insert(:user)
-    metric_registry_role = insert(:role_metric_registry_owner)
-    admin_role = insert(:role_admin_panel_viewer)
-    Sanbase.Accounts.UserRole.create(user.id, metric_registry_role.id)
-    Sanbase.Accounts.UserRole.create(user.id, admin_role.id)
-    {:ok, jwt_tokens} = SanbaseWeb.Guardian.get_jwt_tokens(user)
-    conn = Plug.Test.init_test_session(build_conn(), jwt_tokens)
-
-    {:ok, conn: conn}
+    {:ok, conn: Sanbase.MetricRegistryHelpers.metric_registry_admin_conn()}
   end
 
   test "renders the metrics table", %{conn: conn} do

--- a/test/sanbase_web/live/metric_registry/categorization_live_test.exs
+++ b/test/sanbase_web/live/metric_registry/categorization_live_test.exs
@@ -1,0 +1,36 @@
+defmodule SanbaseWeb.CategorizationLiveTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Sanbase.Factory
+
+  setup do
+    user = insert(:user)
+    metric_registry_role = insert(:role_metric_registry_owner)
+    admin_role = insert(:role_admin_panel_viewer)
+    Sanbase.Accounts.UserRole.create(user.id, metric_registry_role.id)
+    Sanbase.Accounts.UserRole.create(user.id, admin_role.id)
+    {:ok, jwt_tokens} = SanbaseWeb.Guardian.get_jwt_tokens(user)
+    conn = Plug.Test.init_test_session(build_conn(), jwt_tokens)
+
+    {:ok, conn: conn}
+  end
+
+  test "renders the metrics table", %{conn: conn} do
+    {:ok, _view, html} = live(conn, "/admin/metric_registry/categorization")
+
+    assert html =~ "Metric Categorization"
+    assert html =~ "price_usd"
+  end
+
+  test "filters by not-categorized status", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/admin/metric_registry/categorization")
+
+    html =
+      view
+      |> element("form[phx-change=\"filter\"]")
+      |> render_change(%{"status" => "not_categorized"})
+
+    assert html =~ "price_usd"
+  end
+end

--- a/test/sanbase_web/live/metric_registry/categorization_live_test.exs
+++ b/test/sanbase_web/live/metric_registry/categorization_live_test.exs
@@ -17,20 +17,19 @@ defmodule SanbaseWeb.CategorizationLiveTest do
   end
 
   test "renders the metrics table", %{conn: conn} do
-    {:ok, _view, html} = live(conn, "/admin/metric_registry/categorization")
+    {:ok, view, _html} = live(conn, "/admin/metric_registry/categorization")
 
-    assert html =~ "Metric Categorization"
-    assert html =~ "price_usd"
+    assert has_element?(view, "div", "Metric Categorization")
+    assert has_element?(view, "td div", "price_usd")
   end
 
   test "filters by not-categorized status", %{conn: conn} do
     {:ok, view, _html} = live(conn, "/admin/metric_registry/categorization")
 
-    html =
-      view
-      |> element("form[phx-change=\"filter\"]")
-      |> render_change(%{"status" => "not_categorized"})
+    view
+    |> element("form[phx-change=\"filter\"]")
+    |> render_change(%{"status" => "not_categorized"})
 
-    assert html =~ "price_usd"
+    assert has_element?(view, "td div", "price_usd")
   end
 end

--- a/test/sanbase_web/live/metric_registry/tag_live_test.exs
+++ b/test/sanbase_web/live/metric_registry/tag_live_test.exs
@@ -59,6 +59,38 @@ defmodule SanbaseWeb.TagLiveTest do
 
       assert html =~ "price_usd"
     end
+
+    test "tagged row stays visible and highlighted under the not_tagged filter", %{
+      conn: conn,
+      tag: tag
+    } do
+      {:ok, view, _html} = live(conn, "/admin/metric_registry/tags")
+
+      view
+      |> element("form[phx-change=\"filter\"]")
+      |> render_change(%{"status" => "not_tagged"})
+
+      # Tagging the metric makes it stop matching the filter, but the row is
+      # kept visible and marked as changed so the action can be undone in place
+      html =
+        view
+        |> element(
+          ~s|button[phx-click="add_tag"][phx-value-metric="price_usd"][phx-value-tag_id="#{tag.id}"]|
+        )
+        |> render_click()
+
+      assert html =~ ~s|phx-value-metric="price_usd"|
+      assert html =~ "changed"
+      assert html =~ "bg-info/10"
+
+      # Changing the filters drops the pinned row
+      html =
+        view
+        |> element("form[phx-change=\"filter\"]")
+        |> render_change(%{"status" => "not_tagged", "search" => "price"})
+
+      refute html =~ ~s|phx-value-metric="price_usd"|
+    end
   end
 
   describe "manage tags page" do

--- a/test/sanbase_web/live/metric_registry/tag_live_test.exs
+++ b/test/sanbase_web/live/metric_registry/tag_live_test.exs
@@ -1,0 +1,82 @@
+defmodule SanbaseWeb.TagLiveTest do
+  use SanbaseWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Sanbase.Factory
+
+  alias Sanbase.Metric.Tag
+
+  setup do
+    user = insert(:user)
+    metric_registry_role = insert(:role_metric_registry_owner)
+    admin_role = insert(:role_admin_panel_viewer)
+    Sanbase.Accounts.UserRole.create(user.id, metric_registry_role.id)
+    Sanbase.Accounts.UserRole.create(user.id, admin_role.id)
+    {:ok, jwt_tokens} = SanbaseWeb.Guardian.get_jwt_tokens(user)
+    conn = Plug.Test.init_test_session(build_conn(), jwt_tokens)
+
+    {:ok, tag} = Tag.create_tag(%{name: "basic_test_tag", description: "tag for tests"})
+
+    {:ok, conn: conn, tag: tag}
+  end
+
+  describe "tagging dashboard" do
+    test "renders the metrics table", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/admin/metric_registry/tags")
+
+      assert html =~ "Metric Tagging"
+      assert html =~ "price_usd"
+      assert html =~ "basic_test_tag"
+    end
+
+    test "adding and removing a tag on a code metric", %{conn: conn, tag: tag} do
+      {:ok, view, _html} = live(conn, "/admin/metric_registry/tags")
+
+      view
+      |> element(
+        ~s|button[phx-click="add_tag"][phx-value-metric="price_usd"][phx-value-tag_id="#{tag.id}"]|
+      )
+      |> render_click()
+
+      assert Enum.any?(Tag.list_mappings_by_tag(tag.id), &(&1.metric == "price_usd"))
+
+      mapping = Tag.list_mappings_by_tag(tag.id) |> Enum.find(&(&1.metric == "price_usd"))
+
+      view
+      |> element(~s|button[phx-click="remove_tag"][phx-value-mapping_id="#{mapping.id}"]|)
+      |> render_click()
+
+      refute Enum.any?(Tag.list_mappings_by_tag(tag.id), &(&1.metric == "price_usd"))
+    end
+
+    test "filters by not-tagged status", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/admin/metric_registry/tags")
+
+      html =
+        view
+        |> element("form[phx-change=\"filter\"]")
+        |> render_change(%{"status" => "not_tagged"})
+
+      assert html =~ "price_usd"
+    end
+  end
+
+  describe "manage tags page" do
+    test "lists tags", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/admin/metric_registry/tags/manage")
+
+      assert html =~ "Manage Tags"
+      assert html =~ "basic_test_tag"
+    end
+
+    test "deletes a tag", %{conn: conn, tag: tag} do
+      {:ok, view, _html} = live(conn, "/admin/metric_registry/tags/manage")
+
+      view
+      |> element(~s|button[phx-click="delete"][phx-value-id="#{tag.id}"]|)
+      |> render_click()
+
+      assert {:error, _} = Tag.get_tag(tag.id)
+    end
+  end
+end

--- a/test/sanbase_web/live/metric_registry/tag_live_test.exs
+++ b/test/sanbase_web/live/metric_registry/tag_live_test.exs
@@ -2,18 +2,11 @@ defmodule SanbaseWeb.TagLiveTest do
   use SanbaseWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
-  import Sanbase.Factory
 
   alias Sanbase.Metric.Tag
 
   setup do
-    user = insert(:user)
-    metric_registry_role = insert(:role_metric_registry_owner)
-    admin_role = insert(:role_admin_panel_viewer)
-    Sanbase.Accounts.UserRole.create(user.id, metric_registry_role.id)
-    Sanbase.Accounts.UserRole.create(user.id, admin_role.id)
-    {:ok, jwt_tokens} = SanbaseWeb.Guardian.get_jwt_tokens(user)
-    conn = Plug.Test.init_test_session(build_conn(), jwt_tokens)
+    conn = Sanbase.MetricRegistryHelpers.metric_registry_admin_conn()
 
     {:ok, tag} = Tag.create_tag(%{name: "basic_test_tag", description: "tag for tests"})
 

--- a/test/sanbase_web/live/metric_registry/tag_live_test.exs
+++ b/test/sanbase_web/live/metric_registry/tag_live_test.exs
@@ -22,11 +22,11 @@ defmodule SanbaseWeb.TagLiveTest do
 
   describe "tagging dashboard" do
     test "renders the metrics table", %{conn: conn} do
-      {:ok, _view, html} = live(conn, "/admin/metric_registry/tags")
+      {:ok, view, _html} = live(conn, "/admin/metric_registry/tags")
 
-      assert html =~ "Metric Tagging"
-      assert html =~ "price_usd"
-      assert html =~ "basic_test_tag"
+      assert has_element?(view, "div", "Metric Tagging")
+      assert has_element?(view, "td div", "price_usd")
+      assert has_element?(view, ~s|button[phx-click="add_tag"]|, "basic_test_tag")
     end
 
     test "adding and removing a tag on a code metric", %{conn: conn, tag: tag} do
@@ -52,12 +52,11 @@ defmodule SanbaseWeb.TagLiveTest do
     test "filters by not-tagged status", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/admin/metric_registry/tags")
 
-      html =
-        view
-        |> element("form[phx-change=\"filter\"]")
-        |> render_change(%{"status" => "not_tagged"})
+      view
+      |> element("form[phx-change=\"filter\"]")
+      |> render_change(%{"status" => "not_tagged"})
 
-      assert html =~ "price_usd"
+      assert has_element?(view, "td div", "price_usd")
     end
 
     test "tagged row stays visible and highlighted under the not_tagged filter", %{
@@ -72,33 +71,32 @@ defmodule SanbaseWeb.TagLiveTest do
 
       # Tagging the metric makes it stop matching the filter, but the row is
       # kept visible and marked as changed so the action can be undone in place
-      html =
-        view
-        |> element(
-          ~s|button[phx-click="add_tag"][phx-value-metric="price_usd"][phx-value-tag_id="#{tag.id}"]|
-        )
-        |> render_click()
+      view
+      |> element(
+        ~s|button[phx-click="add_tag"][phx-value-metric="price_usd"][phx-value-tag_id="#{tag.id}"]|
+      )
+      |> render_click()
 
-      assert html =~ ~s|phx-value-metric="price_usd"|
-      assert html =~ "changed"
-      assert html =~ "bg-info/10"
+      assert has_element?(view, "td div", "price_usd")
+      assert has_element?(view, "span.badge", "changed")
+      assert has_element?(view, ~s|tr[class*="bg-info/10"]|)
 
       # Changing the filters drops the pinned row
-      html =
-        view
-        |> element("form[phx-change=\"filter\"]")
-        |> render_change(%{"status" => "not_tagged", "search" => "price"})
+      view
+      |> element("form[phx-change=\"filter\"]")
+      |> render_change(%{"status" => "not_tagged", "search" => "price"})
 
-      refute html =~ ~s|phx-value-metric="price_usd"|
+      refute has_element?(view, ~s|tr[class*="bg-info/10"]|)
+      refute has_element?(view, "span.badge", "changed")
     end
   end
 
   describe "manage tags page" do
     test "lists tags", %{conn: conn} do
-      {:ok, _view, html} = live(conn, "/admin/metric_registry/tags/manage")
+      {:ok, view, _html} = live(conn, "/admin/metric_registry/tags/manage")
 
-      assert html =~ "Manage Tags"
-      assert html =~ "basic_test_tag"
+      assert has_element?(view, "div", "Manage Tags")
+      assert has_element?(view, "td span.badge", "basic_test_tag")
     end
 
     test "deletes a tag", %{conn: conn, tag: tag} do

--- a/test/support/metric_registry_helpers.ex
+++ b/test/support/metric_registry_helpers.ex
@@ -1,7 +1,24 @@
 defmodule Sanbase.MetricRegistryHelpers do
   @moduledoc """
-  Test helpers for creating metric registry rows.
+  Test helpers for the metric registry admin tests: creating registry rows and
+  building an authenticated admin conn.
   """
+
+  @doc """
+  Returns a conn authenticated as a user carrying the metric registry owner and
+  admin panel viewer roles, ready for `live/2` calls against the metric
+  registry admin pages.
+  """
+  def metric_registry_admin_conn() do
+    user = Sanbase.Factory.insert(:user)
+    metric_registry_role = Sanbase.Factory.insert(:role_metric_registry_owner)
+    admin_role = Sanbase.Factory.insert(:role_admin_panel_viewer)
+    Sanbase.Accounts.UserRole.create(user.id, metric_registry_role.id)
+    Sanbase.Accounts.UserRole.create(user.id, admin_role.id)
+    {:ok, jwt_tokens} = SanbaseWeb.Guardian.get_jwt_tokens(user)
+
+    Plug.Test.init_test_session(Phoenix.ConnTest.build_conn(), jwt_tokens)
+  end
 
   @doc """
   Creates a metric registry row. Accepts a metric name or an attrs map with a

--- a/test/support/metric_registry_helpers.ex
+++ b/test/support/metric_registry_helpers.ex
@@ -1,0 +1,29 @@
+defmodule Sanbase.MetricRegistryHelpers do
+  @moduledoc """
+  Test helpers for creating metric registry rows.
+  """
+
+  @doc """
+  Creates a metric registry row. Accepts a metric name or an attrs map with a
+  required `:metric` key; any other attrs override the defaults.
+  """
+  def create_registry_metric(metric) when is_binary(metric) do
+    create_registry_metric(%{metric: metric})
+  end
+
+  def create_registry_metric(attrs) when is_map(attrs) do
+    defaults = %{
+      internal_metric: Map.fetch!(attrs, :metric) <> "_internal",
+      human_readable_name: "Human name",
+      min_interval: "5m",
+      tables: [%{name: "daily_metrics_v2"}],
+      default_aggregation: "avg",
+      access: "free",
+      has_incomplete_data: false,
+      data_type: "timeseries"
+    }
+
+    {:ok, registry} = Sanbase.Metric.Registry.create(Map.merge(defaults, attrs))
+    registry
+  end
+end

--- a/test/test_seeds.exs
+++ b/test/test_seeds.exs
@@ -7,3 +7,7 @@ IO.puts("Populating the Metric Registry...")
 IO.puts(
   "Finished populating the Metric Registry. Inserted #{length(metrics)} metrics. Summary: #{inspect(summary)}"
 )
+
+IO.puts("Seeding metric vocabulary tags...")
+
+:ok = Sanbase.Metric.Tag.seed_vocabulary_tags()


### PR DESCRIPTION
## Changes

### What

Introduces **metric tags**: named labels (`basic`, `advanced`, whatever we may need) attachable to any metric — both Metric Registry rows and code-defined metrics. Primary consumer is bundle subscription plans, which expose only metrics carrying a given tag.

### How

- New `metric_tags` and `metric_tag_mappings` tables. A mapping points at a metric via `metric_registry_id` **or** a `module`+`metric` pair — exactly one, DB-enforced. Seeded with 5 initial tags.
- `Sanbase.Metric.Tag` — public API for tag/mapping CRUD and tag↔metric resolution. Mutations emit `metric_tag_change`, which refreshes the tag cache and the bundle-plan caches.
- `Sanbase.Metric.Tag.Cache` — persistent-term maps for tag↔metric lookups. Registry-backed mappings expand via `Registry.resolve_safe/1`, so tagging one template row covers all its variants. Fails closed on DB errors.
- GraphQL: `tags` field on metric metadata.
- Extracted `Sanbase.Metric.Catalog` (unified registry + code-defined metric listing) and `Sanbase.Metric.MetricReference` (shared XOR-reference validation); categorization admin refactored onto both.
- Admin UI: `/tags` to assign tags to metrics, `/tags/manage` for tag CRUD.


<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added metric tagging: create/edit/delete tags and assign/remove tags on metrics (via mapping management).
  * Added admin tagging pages (dashboard + manage tags) with search/source/status/tag filtering.
  * Exposed metric tags in GraphQL metric metadata.
  * Introduced a unified metric catalog powering admin metric views.

* **Bug Fixes**
  * Tag and mapping changes now automatically refresh cached tag/metric data.
  * Improved validation for tag-to-metric mapping references to prevent invalid configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->