### PR TITLE
Add missing stabilization_period/can_mutate. Tolerate metadata with such missing keys

### DIFF
--- a/lib/sanbase/blockchain_address/metric_adapter.ex
+++ b/lib/sanbase/blockchain_address/metric_adapter.ex
@@ -135,6 +135,8 @@ defmodule Sanbase.BlockchainAddress.MetricAdapter do
        internal_metric: metric,
        has_incomplete_data: has_incomplete_data?(metric),
        min_interval: "5m",
+       stabilization_period: nil,
+       can_mutate: nil,
        default_aggregation: @default_aggregation,
        available_aggregations: @aggregations,
        available_selectors: [:blockchain_address, :slug],

--- a/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/top_holders/metric_adapter.ex
@@ -116,6 +116,7 @@ defmodule Sanbase.Clickhouse.TopHolders.MetricAdapter do
        internal_metric: metric,
        has_incomplete_data: has_incomplete_data?(metric),
        min_interval: "1d",
+       stabilization_period: nil,
        can_mutate: true,
        default_aggregation: @default_aggregation,
        available_aggregations: @aggregations,

--- a/lib/sanbase/clickhouse/uniswap/metric_adapter.ex
+++ b/lib/sanbase/clickhouse/uniswap/metric_adapter.ex
@@ -105,6 +105,12 @@ defmodule Sanbase.Clickhouse.Uniswap.MetricAdapter do
        internal_metric: metric,
        has_incomplete_data: has_incomplete_data?(metric),
        min_interval: "1h",
+       # Computed on the fly from the raw ERC20 transfers of the UNI claim contract.
+       # The other metrics derived from the same transfers ingestion use 12h, here we
+       # double it to be on the safe side, as this one is queried live. The set of
+       # claimers is fixed by the contract, so nothing is recalculated after that.
+       stabilization_period: "24h",
+       can_mutate: false,
        default_aggregation: :sum,
        available_aggregations: @aggregations,
        available_selectors: [:slug],

--- a/lib/sanbase/contract_metric/metric_adapter.ex
+++ b/lib/sanbase/contract_metric/metric_adapter.ex
@@ -116,6 +116,8 @@ defmodule Sanbase.Contract.MetricAdapter do
        internal_metric: metric,
        has_incomplete_data: has_incomplete_data?(metric),
        min_interval: "1m",
+       stabilization_period: nil,
+       can_mutate: nil,
        default_aggregation: :count,
        available_aggregations: @aggregations,
        available_selectors: [:contract_address],

--- a/lib/sanbase/prices/price_pair/metric_adapter.ex
+++ b/lib/sanbase/prices/price_pair/metric_adapter.ex
@@ -96,6 +96,9 @@ defmodule Sanbase.PricePair.MetricAdapter do
        internal_metric: metric,
        has_incomplete_data: has_incomplete_data?(metric),
        min_interval: "1s",
+       # Same source as the Sanbase.Prices.MetricAdapter price metrics
+       stabilization_period: "1h",
+       can_mutate: false,
        default_aggregation: @default_aggregation,
        available_aggregations: @aggregations,
        available_selectors: [:slug],

--- a/lib/sanbase/social_data/metric_adapter.ex
+++ b/lib/sanbase/social_data/metric_adapter.ex
@@ -339,6 +339,8 @@ defmodule Sanbase.SocialData.MetricAdapter do
        internal_metric: metric,
        has_incomplete_data: has_incomplete_data?(metric),
        min_interval: min_interval,
+       stabilization_period: nil,
+       can_mutate: nil,
        default_aggregation: default_aggregation,
        available_aggregations: @aggregations,
        available_selectors: selectors,

--- a/lib/sanbase_web/live/available_metrics/metric_details_live.ex
+++ b/lib/sanbase_web/live/available_metrics/metric_details_live.ex
@@ -142,19 +142,20 @@ defmodule SanbaseWeb.MetricDetailsLive do
         },
         %{
           key: "Stabilization Period",
-          value: metadata.stabilization_period,
+          # Not every metric adapter provides this field, so default to nil instead of raising
+          value: Map.get(metadata, :stabilization_period),
           popover_target: "popover-stabilization-period",
           popover_target_text: get_popover_text(%{key: "Stabilization Period"})
         },
         %{
           key: "Can Mutate",
-          value: metadata.can_mutate,
+          value: Map.get(metadata, :can_mutate),
           popover_target: "popover-can-mutate",
           popover_target_text: get_popover_text(%{key: "Can Mutate"})
         },
         %{
           key: "Docs",
-          value: metadata.docs || [],
+          value: Map.get(metadata, :docs) || [],
           popover_target: "popover-docs",
           popover_target_text: get_popover_text(%{key: "Docs"})
         },

--- a/test/sanbase/metric/metric_metadata_test.exs
+++ b/test/sanbase/metric/metric_metadata_test.exs
@@ -30,4 +30,35 @@ defmodule Sanbase.MetricMetadataTest do
       assert metadata.min_interval in ["1s", "1m", "5m", "15m", "1h", "6h", "8h", "1d", "7d"]
     end
   end
+
+  test "every metadata map has all the keys described by the behaviour" do
+    keys = [
+      :metric,
+      :internal_metric,
+      :min_interval,
+      :status,
+      :default_aggregation,
+      :available_aggregations,
+      :available_selectors,
+      :required_selectors,
+      :data_type,
+      :complexity_weight,
+      :stabilization_period,
+      :has_incomplete_data,
+      :is_label_fqn_metric,
+      :is_timebound,
+      :can_mutate,
+      :is_deprecated,
+      :hard_deprecate_after,
+      :docs
+    ]
+
+    for metric <- Metric.available_metrics() do
+      {:ok, metadata} = Metric.metadata(metric)
+      missing_keys = keys -- Map.keys(metadata)
+
+      assert missing_keys == [],
+             "The metadata of #{metric} is missing the keys: #{inspect(missing_keys)}"
+    end
+  end
 end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metric details now consistently include stabilization period and mutability information.
  * Uniswap metrics show a 24-hour stabilization period and are marked as non-mutable.
  * Price pair metrics are explicitly marked as non-mutable.
* **Improvements**
  * Metric details remain available when optional metadata, such as stabilization periods or documentation links, is missing.
  * Metadata consistency checks help ensure all available metrics provide the expected information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->