### PR TITLE
Fix the http pool options of ethereumex as it migrated to finch

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -34,9 +34,14 @@ config :tzdata, :autoupdate, :disabled
 
 config :tesla, disable_deprecated_builder_warning: true
 
+# Since ethereumex 0.14 the HTTP client is Finch, not HTTPoison. The
+# :http_options are passed as-is to Finch.request/3, which accepts only
+# [:pool_timeout, :receive_timeout, :request_timeout, :pool_strategy].
+# The connect timeout is a pool (Mint) option, not a per-request one.
 config :ethereumex,
   url: "https://ethereum.santiment.net",
-  http_options: [timeout: 25_000, recv_timeout: 25_000],
+  http_options: [receive_timeout: 25_000],
+  http_pool_options: %{default: [conn_opts: [transport_opts: [timeout: 25_000]]]},
   http_headers: [{"Content-Type", "application/json"}]
 
 config :event_bus,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -163,9 +163,12 @@ if config_env() == :prod do
       ]
     ]
 
+  # See the comment in config/config.exs: the ethereumex HTTP client is Finch,
+  # so the timeouts use the Finch/Mint option names.
   config :ethereumex,
     url: parity_url,
-    http_options: [timeout: 25_000, recv_timeout: 25_000],
+    http_options: [receive_timeout: 25_000],
+    http_pool_options: %{default: [conn_opts: [transport_opts: [timeout: 25_000]]]},
     http_headers: [{"Content-Type", "application/json"}]
 
   git_commit = System.get_env("GIT_COMMIT")

--- a/lib/sanbase/accounts/eth_account.ex
+++ b/lib/sanbase/accounts/eth_account.ex
@@ -131,7 +131,7 @@ defmodule Sanbase.Accounts.EthAccount do
       {:ok, %{addr1 => 150.0, addr2 => 0.0}}
 
       iex> EthAccount.san_staked_addresses([addr1, addr2], contract)
-      {:error, %Mint.TransportError{reason: :nxdomain}}
+      {:error, %Finch.TransportError{reason: :nxdomain}}
   """
   @spec san_staked_addresses([String.t()], String.t()) ::
           {:ok, %{String.t() => float()}} | {:error, any()}

--- a/lib/sanbase/accounts/user/uniswap_staking.ex
+++ b/lib/sanbase/accounts/user/uniswap_staking.ex
@@ -46,7 +46,7 @@ defmodule Sanbase.Accounts.User.UniswapStaking do
       {:ok, {2, nil}}
 
       iex> UniswapStaking.update_all_uniswap_san_staked_users()
-      {:error, %Mint.TransportError{reason: :nxdomain}}
+      {:error, %Finch.TransportError{reason: :nxdomain}}
   """
   @spec update_all_uniswap_san_staked_users() ::
           {:ok, {integer(), nil | [term()]}} | {:error, any()}

--- a/lib/sanbase/smart_contracts/uniswap_pair.ex
+++ b/lib/sanbase/smart_contracts/uniswap_pair.ex
@@ -90,7 +90,7 @@ defmodule Sanbase.SmartContracts.UniswapPair do
       {:ok, [1.0, 2.5]}
 
       iex> UniswapPair.balances_of([addr1, addr2], contract)
-      {:error, %Mint.TransportError{reason: :nxdomain}}
+      {:error, %Finch.TransportError{reason: :nxdomain}}
   """
   @spec balances_of([address], address) :: {:ok, [float()]} | {:error, any()}
   def balances_of(addresses, contract) do

--- a/test/sanbase/smart_contracts/eth_node_client_test.exs
+++ b/test/sanbase/smart_contracts/eth_node_client_test.exs
@@ -1,0 +1,117 @@
+defmodule Sanbase.SmartContracts.EthNodeClientTest do
+  @moduledoc ~s"""
+  Exercise the ethereumex HTTP client against a local JSON-RPC server.
+
+  The tests do not pass any http options themselves, they rely on the ones from
+  the app config, so an option name that the HTTP client does not accept fails
+  here instead of only on stage/prod.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Sanbase.SmartContracts.EthNodeClientTest.RpcServer
+  alias Sanbase.SmartContracts.Utils
+
+  @contract "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
+  @address "0x0000000000000000000000000000000000000abc"
+
+  setup do
+    start_supervised!(
+      {Plug.Cowboy, scheme: :http, plug: RpcServer, options: [port: 0, ref: RpcServer.ref()]}
+    )
+
+    original_url = Application.get_env(:ethereumex, :url)
+    Application.put_env(:ethereumex, :url, "http://127.0.0.1:#{:ranch.get_port(RpcServer.ref())}")
+
+    on_exit(fn ->
+      Application.put_env(:ethereumex, :url, original_url)
+      RpcServer.clear_response()
+    end)
+
+    :ok
+  end
+
+  test "eth_call reaches the node and the response is decoded" do
+    RpcServer.set_response(%{"result" => uint256(1_000_000)})
+
+    assert Utils.call_contract(@contract, "totalSupply()", [], [{:uint, 256}]) == [1_000_000]
+  end
+
+  test "batched eth_call reaches the node and the responses are decoded" do
+    RpcServer.set_response(%{"result" => uint256(150)})
+
+    address = Utils.format_address(@address)
+
+    result =
+      Utils.call_contract_batch(
+        @contract,
+        "balanceOf(address)",
+        [[address], [address]],
+        [{:uint, 256}],
+        transform_args_list_fun: fn list -> list ++ ["latest"] end
+      )
+
+    assert result == [[150], [150]]
+  end
+
+  test "a JSON-RPC error is returned as an error tuple" do
+    RpcServer.set_response(%{"error" => %{"code" => -32_000, "message" => "execution reverted"}})
+
+    assert {:error, %{"message" => "execution reverted"}} =
+             Utils.call_contract(@contract, "totalSupply()", [], [{:uint, 256}])
+  end
+
+  test "an unreachable node is returned as an error tuple, not raised" do
+    Application.put_env(:ethereumex, :url, "http://127.0.0.1:1")
+
+    assert {:error, %Finch.TransportError{reason: :econnrefused}} =
+             Utils.call_contract(@contract, "totalSupply()", [], [{:uint, 256}])
+  end
+
+  defp uint256(value) do
+    "0x" <> (value |> Integer.to_string(16) |> String.downcase() |> String.pad_leading(64, "0"))
+  end
+end
+
+defmodule Sanbase.SmartContracts.EthNodeClientTest.RpcServer do
+  @moduledoc ~s"""
+  Minimal Ethereum JSON-RPC server. The response returned for every request is
+  set per test via `set_response/1`. The `id` of each request is echoed back, as
+  ethereumex matches batch responses to requests by it.
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  @key {__MODULE__, :response}
+
+  def ref(), do: __MODULE__.HTTP
+
+  def set_response(response), do: :persistent_term.put(@key, response)
+
+  def clear_response(), do: :persistent_term.erase(@key)
+
+  @impl Plug
+  def init(opts), do: opts
+
+  @impl Plug
+  def call(conn, _opts) do
+    {:ok, body, conn} = read_body(conn)
+    response = :persistent_term.get(@key)
+
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(200, Jason.encode!(response_body(Jason.decode!(body), response)))
+  end
+
+  defp response_body(payload, response) when is_list(payload) do
+    Enum.map(payload, fn %{"id" => id} -> response_body_for_id(response, id) end)
+  end
+
+  defp response_body(%{"id" => id}, response), do: response_body_for_id(response, id)
+
+  defp response_body_for_id(response, id) do
+    Map.merge(%{"jsonrpc" => "2.0", "id" => id}, response)
+  end
+end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Ethereum node connection timeout handling for more consistent request behavior.
  - Standardized transport error reporting when an Ethereum node is unreachable.

- **Documentation**
  - Updated examples to reflect the current error format returned by Ethereum requests.

- **Tests**
  - Added coverage for successful, batched, and failed Ethereum JSON-RPC requests, including unreachable-node scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->