### PR TITLE
improve timeouts

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -128,10 +128,13 @@ config :sanbase, Sanbase.ClickhouseRepo,
   max_overflow: 3,
   scheme: :http
 
+# Same queue budgets as the read-write repo: under pool saturation requests
+# are dropped from the queue fast (with a user-facing timeout message) instead
+# of queueing for minutes past the connection's lifetime. See docs/timeouts.md.
 clickhouse_read_only_opts = [
   adapter: Ecto.Adapters.Postgres,
-  queue_target: 60_000,
-  queue_interval: 60_000,
+  queue_target: 10_000,
+  queue_interval: 30_000,
   timeout: 100_000,
   max_overflow: 3,
   scheme: :http

--- a/config/config.exs
+++ b/config/config.exs
@@ -120,25 +120,23 @@ config :sanbase, Sanbase.EventBus.KafkaExporterSubscriber,
 config :sanbase, Sanbase.ExternalServices.RateLimiting.Server,
   implementation_module: Sanbase.ExternalServices.RateLimiting.WaitServer
 
-config :sanbase, Sanbase.ClickhouseRepo,
+# `:timeout` is one absolute budget for pool wait + query, and it can't
+# interrupt an in-flight recv — hence 85s, not the 102s of headroom above.
+# queue_target/queue_interval are CoDel load shedding, not timeouts.
+# See docs/timeouts.md.
+clickhouse_opts = [
   adapter: Ecto.Adapters.Postgres,
-  queue_target: 10_000,
-  queue_interval: 30_000,
-  timeout: 100_000,
-  max_overflow: 3,
-  scheme: :http
-
-# Same queue budgets as the read-write repo: under pool saturation requests
-# are dropped from the queue fast (with a user-facing timeout message) instead
-# of queueing for minutes past the connection's lifetime. See docs/timeouts.md.
-clickhouse_read_only_opts = [
-  adapter: Ecto.Adapters.Postgres,
-  queue_target: 10_000,
-  queue_interval: 30_000,
-  timeout: 100_000,
+  queue_target: 5_000,
+  queue_interval: 20_000,
+  timeout: 85_000,
   max_overflow: 3,
   scheme: :http
 ]
+
+config :sanbase, Sanbase.ClickhouseRepo, clickhouse_opts
+
+# Per-plan read-only repos share the read-write budgets.
+clickhouse_read_only_opts = clickhouse_opts
 
 config :sanbase, Sanbase.ClickhouseRepo.ReadOnly, clickhouse_read_only_opts
 config :sanbase, Sanbase.ClickhouseRepo.FreeUser, clickhouse_read_only_opts

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -18,8 +18,8 @@ config :sanbase, SanbaseWeb.Endpoint,
     compress: true,
     port: port,
     protocol_options: [
-      # Bump up cowboy2's timeout to 100 seconds
-      idle_timeout: 100_000
+      # Match the prod web idle_timeout (see docs/timeouts.md)
+      idle_timeout: 120_000
     ]
   ],
   url: [host: "localhost"],

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -105,11 +105,8 @@ if config_env() == :prod do
   port = String.to_integer(System.get_env("PORT") || "4000")
   parity_url = System.get_env("PARITY_URL")
 
-  # The timeout chain must be ordered outside-in (see docs/timeouts.md):
-  # web: LB > cowboy idle_timeout (120s) > async resolvers (105s) > CH query (100s)
-  # mcp: cowboy idle_timeout (180s) > Anubis request_timeout (150s) > task work (120s)
-  # MCP tool calls (e.g. combined_trends_tool) can run long due to document
-  # collection + AI summarization.
+  # Outermost layer of the timeout chain (see docs/timeouts.md).
+  # web: cowboy 120s > async 105s > CH 85s. mcp: cowboy 180s > Anubis 150s.
   idle_timeout =
     if System.get_env("CONTAINER_TYPE") == "mcp", do: 180_000, else: 120_000
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -105,11 +105,13 @@ if config_env() == :prod do
   port = String.to_integer(System.get_env("PORT") || "4000")
   parity_url = System.get_env("PARITY_URL")
 
+  # The timeout chain must be ordered outside-in (see docs/timeouts.md):
+  # web: LB > cowboy idle_timeout (120s) > async resolvers (105s) > CH query (100s)
+  # mcp: cowboy idle_timeout (180s) > Anubis request_timeout (150s) > task work (120s)
   # MCP tool calls (e.g. combined_trends_tool) can run long due to document
-  # collection + AI summarization. The timeout chain must be ordered:
-  # Cowboy idle_timeout (180s) > Anubis request_timeout (150s) > task work (120s)
+  # collection + AI summarization.
   idle_timeout =
-    if System.get_env("CONTAINER_TYPE") == "mcp", do: 180_000, else: 100_000
+    if System.get_env("CONTAINER_TYPE") == "mcp", do: 180_000, else: 120_000
 
   config :sanbase, SanbaseWeb.Endpoint,
     url: [host: host, port: port],

--- a/docs/timeouts.md
+++ b/docs/timeouts.md
@@ -1,130 +1,103 @@
 # Request-path timeouts
 
-Every timeout a user request can hit, ordered from the outside in. "Budget"
-is how long that layer allows before it gives up; a request dies at the first
+Every timeout a user request can hit, outside in. A request dies at the first
 layer whose budget it exhausts.
 
-| # | Layer | Budget | Where configured | What happens on timeout |
-|---|-------|--------|------------------|-------------------------|
-| 0 | Load balancer / ingress | **unverified** | infra, outside this repo | client gets 502/504; the BEAM keeps computing |
-| 1 | Cowboy `idle_timeout` | 120s (web), 180s (mcp) | `config/runtime.exs` | connection closed; the BEAM keeps computing |
-| 2 | Absinthe document execution | none | — | no global cap; a query runs as long as its slowest field |
-| 3 | GraphQL cache lock wait | 102s, then **fallback** | `CachexProvider` `@lock_wait_timeout_ms` | waiter logs a warning and computes the value itself, without the lock — no user-facing error (should no longer trigger: the lock holder's work is bounded by the 100s CH budget) |
-| 4 | Absinthe async middleware (`async/1` resolvers) | 105s | `Helpers.Async` `@async_timeout_ms` | `Task.await` exit → **500 internal error** (should no longer trigger: CH gives up first at 100s) |
-| 5 | Dataloader batches | 35s (PG source), 105s (KV/CH source) | per-source `timeout:` in `sanbase_repo.ex` / `sanbase_dataloader.ex` | batch killed; dataloader-backed fields resolve to nil (`:return_nil_on_error`) (should no longer trigger: the wrapped queries give up first) |
-| 6 | Postgres (`Sanbase.Repo`) | queue 5s/10s, query 30s | `config/config.exs` | `DBConnection.ConnectionError` raise |
-| 7 | ClickHouse read-write (`ClickhouseRepo`) | queue 10s/30s, query 100s | `config/config.exs` | rescued → `{:error, message}` (see below) |
-| 8 | ClickHouse read-only per-plan repos | queue 10s/30s, query 100s | `config/config.exs` | rescued → `{:error, message}` |
-| 9 | Generic ConCache locks (`Sanbase.Cache`) | 102s (web), 120s (alerts) | `application.ex`, `alerts.ex` | `GenServer.call` exit → 500 |
-| 10 | External HTTP inside resolvers (Tesla/Hackney, parity) | 25–30s recv | `config/config.exs` | client error tuple, resolver-specific |
+| # | Layer | Budget | Where | On timeout |
+|---|-------|--------|-------|------------|
+| 0 | Load balancer / ingress | **unverified** | infra, not this repo | 502/504; BEAM keeps computing |
+| 1 | Cowboy `idle_timeout` | 120s web, 180s mcp | `config/runtime.exs` | connection closed; BEAM keeps computing |
+| 2 | Absinthe document execution | none | — | no global cap |
+| 3 | GraphQL cache lock wait | 102s, then fallback | `CachexProvider` | waiter recomputes without the lock; no error |
+| 4 | Absinthe async middleware | 105s | `Helpers.Async` | `Task.await` exit → **500** |
+| 5 | Absinthe batch middleware | 5s (library default) | unconfigured, `ico_resolver.ex` | `exit({:timeout, ..})` → **500** |
+| 6 | Dataloader batches | 55s PG, 105s KV/CH | per-source `timeout:` | batch killed; fields → nil |
+| 7 | `RehydratingCache.get/2` | 30s | `rehydrating_cache.ex` | `{:error, :timeout}` |
+| 8 | Postgres | 30s, CoDel 5s/10s | `config/config.exs` | `DBConnection.ConnectionError` → **500** |
+| 9 | ClickHouse (rw + per-plan ro) | 85s, CoDel 5s/20s | `config/config.exs` | rescued → `{:error, message}` |
+| 10 | Generic ConCache locks | 102s, 120s alerts | `cache.ex`, `application.ex`, `alerts.ex` | `GenServer.call` exit → **500** |
+| 11 | External HTTP in resolvers | 25–30s recv | `config/config.exs` | client error tuple |
 
-Deploy-time only: `ConnectionDrainer` waits up to 30s for in-flight requests.
+Chain: `LB (>120s) > cowboy 120s > async 105s > cache lock 102s > CH 85s > PG 30s`.
+MCP: `cowboy 180s > Anubis 150s > task work 120s`.
 
-The web chain is ordered so every inner budget is smaller than the outer one
-that contains it:
+Cache-lock waits sit *above* the CH budget on purpose. Cowboy/async are
+*containment* budgets (outer > inner). A lock wait is a wait on a *peer*: it
+must exceed the peer's budget, or it gives up exactly when the holder is slow.
 
-    LB (verify: must be > 120s) > cowboy 120s > async resolvers 105s
-      > cache-lock wait 102s > CH query 100s > PG query 30s > external HTTP 30s
+## Connection pools
 
-Note the cache-lock waits sit *above* the CH budget on purpose. Containment
-budgets (cowboy, async) bound work they contain, so outer > inner. A lock
-wait instead waits on a *peer's* work: it must exceed the peer's budget
-(CH 100s), otherwise the waiter gives up precisely when the holder is slow —
-and then recomputes a slow value with even less remaining budget.
+- **`:timeout` is one absolute budget for pool wait + query.**
+  `Holder.checkout/3` computes `now + :timeout` before contacting the pool and
+  arms it as an `abs: true` deadline on handover. Queueing eats into the
+  query's time, it does not add to it.
+- **A queued client has no deadline.** `checkout_call/5`'s `receive` has no
+  after-clause and the pool never expires queue entries. CoDel shedding is the
+  only thing that releases a waiter.
+- **`queue_target`/`queue_interval` are CoDel, not timeouts.** `queue_interval`
+  is a sampling window (and the poll period); the pool tracks the *minimum*
+  checkout delay in it and starts shedding only if even that minimum exceeded
+  `queue_target` — a standing queue, not a burst. One fast checkout turns it
+  back off. Shedding drops waiters past `2 * queue_target`, oldest first.
+- **Reaction time**: 10s steady-state; a fully stalled pool needs two poll
+  ticks (~40s CH / ~20s PG) since the first only records the baseline.
+- **Ceiling on raising these**: at `queue_target` 5s a CH request can burn 40s
+  of its 85s queueing, leaving 45s to run. Higher values hand out connections
+  to clients that can no longer use them.
+- **The deadline does not interrupt the driver.** `Ch.Connection.recv_all/3`
+  re-applies `:timeout` to *every* `Mint.HTTP.recv`, so a dribbling response
+  overshoots. That is why CH is 85s and not the full 102s of headroom.
 
-MCP containers have their own chain (long-running AI tool calls):
+## How timeouts surface
 
-    cowboy 180s > Anubis request_timeout 150s > task work 120s
+- **ClickHouse**: rescued in `Sanbase.ClickhouseRepo` → `{:error, "[log_id] msg"}`.
+  `timeout_error?/1` matches four shapes — Mint's bare `"timeout"`,
+  DBConnection's `"timed out because it queued and checked out"` and
+  `"dropped from queue"`, ClickHouse's `(TIMEOUT_EXCEEDED)` — and returns a
+  message telling the user to narrow the query. The match is word-bounded, so
+  identifiers like `timeout_ms` do not count and `TIMEOUT_EXCEEDED` needs its
+  own alternative. Errors can embed the user's SQL, so the echo after
+  `"while processing query:"` is stripped first.
+  Callers passing `propagate_error: true` (the SQL editor) still get the raw
+  error.
+- **Cache lock waits**: no user-facing error; the waiter recomputes. Replaces
+  `"Obtaining cache lock failed because of timeout"` (8.8k Sentry events /
+  157 users since Oct 2024, SANBASE-BACKEND-PROD-8).
+- **Postgres**: still 500s.
+- Dataloader timeouts sit on the **sources**, not the loader —
+  `Dataloader.new(timeout:)` is never read; the run timeout is
+  `max(source timeouts) + 1s`.
+- Modules importing both `Helpers.Async` and `Absinthe.Resolution.Helpers`
+  must `except: [async: 1, async: 2]` on the latter, or the call is ambiguous.
 
-## How timeouts surface to users
+## Open items
 
-- **ClickHouse errors** are rescued in `Sanbase.ClickhouseRepo` and returned
-  as `{:error, "[log_id] message"}`. Timeout-class errors (DBConnection queue
-  drops, query timeouts, ClickHouse `TIMEOUT_EXCEEDED`/`Code: 159`) return a
-  meaningful message telling the user the query ran too long and to request
-  fewer fields/subqueries, narrow the time range or increase the interval —
-  instead of the generic masked message. Everything is still logged in full
-  under the `log_id`.
-- **Cache lock waits** never produce a user-facing error anymore: after 102s
-  the waiter computes the value itself (duplicate work, correct result). Since
-  the wait outlasts the CH budget bounding any live holder, and leaked locks
-  are released instantly by the monitor guard, this fallback should only fire
-  in anomalous states. The old provider raised
-  `"Obtaining cache lock failed because of timeout"` here — 8.8k Sentry
-  events / 157 users since Oct 2024 (SANBASE-BACKEND-PROD-8).
-- **Async resolvers** (`Helpers.Async.async/1`, 9 call sites) get 105s —
-  more than the CH query budget — so a slow CH query surfaces its
-  `{:error, timeout message}` instead of the Task exit becoming a 500.
-- **Dataloader batches** get 105s (KV/CH source) and 35s (Ecto/PG source)
-  for the same reason: the wrapped queries are allowed 100s/30s. The
-  timeouts sit on the *sources* because Dataloader ignores the loader-level
-  `Dataloader.new(timeout:)` option entirely — its run timeout is
-  max(source timeouts) + 1s. The old loader-level 20s was a no-op: the
-  effective budgets were the library defaults, 15s (Ecto) and 30s (KV),
-  silently nil-ing out CH-backed fields while their queries kept running.
-- **Postgres timeouts** still surface as 500s
-  (`DBConnection.ConnectionError`).
+1. **LB budget unverified.** Set ingress read/send timeouts ≥150s so cowboy is
+   the outermost application-visible layer.
+2. **Generic ConCache locks still 500 on timeout.** Porting `CachexProvider`'s
+   recompute-instead-of-raise fallback to `Sanbase.Cache` would close this.
+3. **KV source timeout is per batch.** `Task.async_stream` runs batches in
+   waves, so a request with many CH batches can exceed the 106s loader budget
+   and nil out the whole source. Not reachable at today's batch counts.
+4. **The cache-lock fallback is best-effort for web callers.** 102s + a
+   recompute cannot fit in async 105s. Correct for MCP/background callers;
+   should only fire in anomalous states. If Sentry disagrees, make it
+   budget-aware rather than lowering the wait.
+5. **No per-document budget.** Many independent 85s fields can run for
+   multiples of any single budget. Complexity limits are the lever, not
+   timeouts.
+6. **ClickHouse keeps running after we give up.** No `max_execution_time` is
+   sent, so an abandoned query burns CPU to completion. Setting it ≈85 plus
+   `cancel_http_readonly_queries_on_client_close` on the read-only pools would
+   make the give-up mutual.
+7. **`ConCacheProvider` has no callers** outside its own test. Its
+   `acquire_lock_timeout` fix is inert; delete the module or wire it up.
 
-## Remaining action items and rough edges
+## When touching these
 
-1. **Load balancer budget (#0) is unverified.** The whole chain assumes the
-   LB allows more than cowboy's 120s. Verify the ingress read/send timeouts
-   (nginx ingress: `proxy-read-timeout`/`proxy-send-timeout`, in seconds) and
-   set them to ≥ 150s so cowboy — not the LB — is the outermost
-   application-visible layer. Until verified, a >LB-budget request shows the
-   user a 502/504 while the BEAM finishes work nobody receives.
-2. **Generic ConCache locks (#9) still exit with a 500** when the wait
-   timeout fires. Raising it to 102s (above the CH budget) means it no longer
-   fires for a holder bounded by a single CH query, and ConCache's lock
-   process monitors holders, so a brutally-killed holder releases its lock
-   immediately — no leak. The remaining exposure is a holder that
-   legitimately computes past 102s (e.g. several sequential CH queries under
-   one lock): waiters then exit with a 500 instead of falling back to
-   computing, the way CachexProvider does. Porting that fallback to
-   `Sanbase.Cache` would remove this error class entirely.
-3. **Absinthe has no per-document budget (#2).** A document with many
-   independent 100s fields can, in principle, run for several multiples of
-   any single budget across sequential resolution phases. Cowboy (120s) just
-   closes the connection; the BEAM keeps computing. Complexity limits — not
-   timeouts — are the lever if this becomes a problem in practice.
-
-## History (fixed)
-
-- **Old cache-lock behavior**: the previous provider waited ~52s
-  (30 exponential-backoff attempts) and then raised. Two triggers: a lock
-  holder legitimately computing longer than 52s (CH allows 100s), and leaked
-  locks — a brutally-killed request (client disconnect) skipped `after`, and
-  the old Unlocker janitor only released the lock after 60s, longer than any
-  waiter's 52s budget, so every waiter on a leaked key errored. The new
-  provider releases leaked locks instantly (monitor-based guard), lets
-  waiters return as soon as the cached value lands, and falls back to
-  computing after 60s instead of raising.
-- **CH query 100s == cowboy 100s**: the connection could die at the exact
-  moment the query finished. Web cowboy is now 120s.
-- **Async middleware killed resolvers at 30s** while the CH work they wrap
-  was allowed 100s — the Task exit became a 500 with no meaningful message.
-  Now 105s via `Helpers.Async`.
-- **Dataloader loader-level timeout was a no-op**: `Dataloader.new(timeout:)`
-  is never read by `Dataloader.run/1` — it derives its timeout from the
-  sources. The effective budgets were the library defaults (Ecto 15s, KV
-  30s), both far below the queries they wrap (PG 30s, CH 100s): batches were
-  killed (fields nil'd out) while their queries kept running server-side.
-  Now 35s/105s, configured on the sources where the library actually reads
-  them.
-- **Cache-lock waits (60s) < CH budget (100s)**: waiters gave up on the lock
-  exactly when the holder was slow, then recomputed the same slow value with
-  only ~45s of async budget left — guaranteed dead work, killed at 105s.
-  Both lock waits are now 102s, above the CH budget that bounds any live
-  holder.
-- **Per-plan CH repos queued 60s + 60s** before the 100s query even started —
-  worst case ~220s, far beyond any outer layer. Under pool saturation users
-  waited minutes and still got nothing. Now queue 10s/30s like the
-  read-write repo: overload sheds fast, and queue drops return the
-  user-facing timeout message.
-
-## When touching any of these
-
-Keep the chain ordered: every inner budget should be smaller than the outer
-budget that contains it, with margin for the response to travel out. The
-worst failure mode is an inner layer that outlives the outer one — work whose
-result can never be delivered.
+- Keep the chain ordered, with margin for the response to travel out. The
+  worst failure is an inner layer outliving the outer one.
+- A DB layer's budget is `:timeout` (queue and query share it) — but leave
+  slack, the deadline cannot interrupt a driver blocked in a socket read.
+- Distinguish *containment* budgets (must exceed what they wrap) from *peer
+  waits* (must exceed the peer's own budget).

--- a/docs/timeouts.md
+++ b/docs/timeouts.md
@@ -1,0 +1,130 @@
+# Request-path timeouts
+
+Every timeout a user request can hit, ordered from the outside in. "Budget"
+is how long that layer allows before it gives up; a request dies at the first
+layer whose budget it exhausts.
+
+| # | Layer | Budget | Where configured | What happens on timeout |
+|---|-------|--------|------------------|-------------------------|
+| 0 | Load balancer / ingress | **unverified** | infra, outside this repo | client gets 502/504; the BEAM keeps computing |
+| 1 | Cowboy `idle_timeout` | 120s (web), 180s (mcp) | `config/runtime.exs` | connection closed; the BEAM keeps computing |
+| 2 | Absinthe document execution | none | — | no global cap; a query runs as long as its slowest field |
+| 3 | GraphQL cache lock wait | 102s, then **fallback** | `CachexProvider` `@lock_wait_timeout_ms` | waiter logs a warning and computes the value itself, without the lock — no user-facing error (should no longer trigger: the lock holder's work is bounded by the 100s CH budget) |
+| 4 | Absinthe async middleware (`async/1` resolvers) | 105s | `Helpers.Async` `@async_timeout_ms` | `Task.await` exit → **500 internal error** (should no longer trigger: CH gives up first at 100s) |
+| 5 | Dataloader batches | 35s (PG source), 105s (KV/CH source) | per-source `timeout:` in `sanbase_repo.ex` / `sanbase_dataloader.ex` | batch killed; dataloader-backed fields resolve to nil (`:return_nil_on_error`) (should no longer trigger: the wrapped queries give up first) |
+| 6 | Postgres (`Sanbase.Repo`) | queue 5s/10s, query 30s | `config/config.exs` | `DBConnection.ConnectionError` raise |
+| 7 | ClickHouse read-write (`ClickhouseRepo`) | queue 10s/30s, query 100s | `config/config.exs` | rescued → `{:error, message}` (see below) |
+| 8 | ClickHouse read-only per-plan repos | queue 10s/30s, query 100s | `config/config.exs` | rescued → `{:error, message}` |
+| 9 | Generic ConCache locks (`Sanbase.Cache`) | 102s (web), 120s (alerts) | `application.ex`, `alerts.ex` | `GenServer.call` exit → 500 |
+| 10 | External HTTP inside resolvers (Tesla/Hackney, parity) | 25–30s recv | `config/config.exs` | client error tuple, resolver-specific |
+
+Deploy-time only: `ConnectionDrainer` waits up to 30s for in-flight requests.
+
+The web chain is ordered so every inner budget is smaller than the outer one
+that contains it:
+
+    LB (verify: must be > 120s) > cowboy 120s > async resolvers 105s
+      > cache-lock wait 102s > CH query 100s > PG query 30s > external HTTP 30s
+
+Note the cache-lock waits sit *above* the CH budget on purpose. Containment
+budgets (cowboy, async) bound work they contain, so outer > inner. A lock
+wait instead waits on a *peer's* work: it must exceed the peer's budget
+(CH 100s), otherwise the waiter gives up precisely when the holder is slow —
+and then recomputes a slow value with even less remaining budget.
+
+MCP containers have their own chain (long-running AI tool calls):
+
+    cowboy 180s > Anubis request_timeout 150s > task work 120s
+
+## How timeouts surface to users
+
+- **ClickHouse errors** are rescued in `Sanbase.ClickhouseRepo` and returned
+  as `{:error, "[log_id] message"}`. Timeout-class errors (DBConnection queue
+  drops, query timeouts, ClickHouse `TIMEOUT_EXCEEDED`/`Code: 159`) return a
+  meaningful message telling the user the query ran too long and to request
+  fewer fields/subqueries, narrow the time range or increase the interval —
+  instead of the generic masked message. Everything is still logged in full
+  under the `log_id`.
+- **Cache lock waits** never produce a user-facing error anymore: after 102s
+  the waiter computes the value itself (duplicate work, correct result). Since
+  the wait outlasts the CH budget bounding any live holder, and leaked locks
+  are released instantly by the monitor guard, this fallback should only fire
+  in anomalous states. The old provider raised
+  `"Obtaining cache lock failed because of timeout"` here — 8.8k Sentry
+  events / 157 users since Oct 2024 (SANBASE-BACKEND-PROD-8).
+- **Async resolvers** (`Helpers.Async.async/1`, 9 call sites) get 105s —
+  more than the CH query budget — so a slow CH query surfaces its
+  `{:error, timeout message}` instead of the Task exit becoming a 500.
+- **Dataloader batches** get 105s (KV/CH source) and 35s (Ecto/PG source)
+  for the same reason: the wrapped queries are allowed 100s/30s. The
+  timeouts sit on the *sources* because Dataloader ignores the loader-level
+  `Dataloader.new(timeout:)` option entirely — its run timeout is
+  max(source timeouts) + 1s. The old loader-level 20s was a no-op: the
+  effective budgets were the library defaults, 15s (Ecto) and 30s (KV),
+  silently nil-ing out CH-backed fields while their queries kept running.
+- **Postgres timeouts** still surface as 500s
+  (`DBConnection.ConnectionError`).
+
+## Remaining action items and rough edges
+
+1. **Load balancer budget (#0) is unverified.** The whole chain assumes the
+   LB allows more than cowboy's 120s. Verify the ingress read/send timeouts
+   (nginx ingress: `proxy-read-timeout`/`proxy-send-timeout`, in seconds) and
+   set them to ≥ 150s so cowboy — not the LB — is the outermost
+   application-visible layer. Until verified, a >LB-budget request shows the
+   user a 502/504 while the BEAM finishes work nobody receives.
+2. **Generic ConCache locks (#9) still exit with a 500** when the wait
+   timeout fires. Raising it to 102s (above the CH budget) means it no longer
+   fires for a holder bounded by a single CH query, and ConCache's lock
+   process monitors holders, so a brutally-killed holder releases its lock
+   immediately — no leak. The remaining exposure is a holder that
+   legitimately computes past 102s (e.g. several sequential CH queries under
+   one lock): waiters then exit with a 500 instead of falling back to
+   computing, the way CachexProvider does. Porting that fallback to
+   `Sanbase.Cache` would remove this error class entirely.
+3. **Absinthe has no per-document budget (#2).** A document with many
+   independent 100s fields can, in principle, run for several multiples of
+   any single budget across sequential resolution phases. Cowboy (120s) just
+   closes the connection; the BEAM keeps computing. Complexity limits — not
+   timeouts — are the lever if this becomes a problem in practice.
+
+## History (fixed)
+
+- **Old cache-lock behavior**: the previous provider waited ~52s
+  (30 exponential-backoff attempts) and then raised. Two triggers: a lock
+  holder legitimately computing longer than 52s (CH allows 100s), and leaked
+  locks — a brutally-killed request (client disconnect) skipped `after`, and
+  the old Unlocker janitor only released the lock after 60s, longer than any
+  waiter's 52s budget, so every waiter on a leaked key errored. The new
+  provider releases leaked locks instantly (monitor-based guard), lets
+  waiters return as soon as the cached value lands, and falls back to
+  computing after 60s instead of raising.
+- **CH query 100s == cowboy 100s**: the connection could die at the exact
+  moment the query finished. Web cowboy is now 120s.
+- **Async middleware killed resolvers at 30s** while the CH work they wrap
+  was allowed 100s — the Task exit became a 500 with no meaningful message.
+  Now 105s via `Helpers.Async`.
+- **Dataloader loader-level timeout was a no-op**: `Dataloader.new(timeout:)`
+  is never read by `Dataloader.run/1` — it derives its timeout from the
+  sources. The effective budgets were the library defaults (Ecto 15s, KV
+  30s), both far below the queries they wrap (PG 30s, CH 100s): batches were
+  killed (fields nil'd out) while their queries kept running server-side.
+  Now 35s/105s, configured on the sources where the library actually reads
+  them.
+- **Cache-lock waits (60s) < CH budget (100s)**: waiters gave up on the lock
+  exactly when the holder was slow, then recomputed the same slow value with
+  only ~45s of async budget left — guaranteed dead work, killed at 105s.
+  Both lock waits are now 102s, above the CH budget that bounds any live
+  holder.
+- **Per-plan CH repos queued 60s + 60s** before the 100s query even started —
+  worst case ~220s, far beyond any outer layer. Under pool saturation users
+  waited minutes and still got nothing. Now queue 10s/30s like the
+  read-write repo: overload sheds fast, and queue drops return the
+  user-facing timeout message.
+
+## When touching any of these
+
+Keep the chain ordered: every inner budget should be smaller than the outer
+budget that contains it, with margin for the response to travel out. The
+worst failure mode is an inner layer that outlives the outer one — work whose
+result can never be delivered.

--- a/lib/sanbase/application/application.ex
+++ b/lib/sanbase/application/application.ex
@@ -363,7 +363,11 @@ defmodule Sanbase.Application do
          name: Sanbase.Cache.name(),
          ttl_check_interval: :timer.seconds(30),
          global_ttl: :timer.minutes(5),
-         acquire_lock_timeout: 60_000
+         # Must exceed the ClickHouse query budget (100s) — a waiter that
+         # outlasts the lock holder gets the value instead of exiting with a
+         # timeout while the holder is still legitimately computing.
+         # See docs/timeouts.md.
+         acquire_lock_timeout: 102_000
        ]},
 
       # Start the graphQL in-memory cache

--- a/lib/sanbase/application/application.ex
+++ b/lib/sanbase/application/application.ex
@@ -363,9 +363,7 @@ defmodule Sanbase.Application do
          name: Sanbase.Cache.name(),
          ttl_check_interval: :timer.seconds(30),
          global_ttl: :timer.minutes(5),
-         # Must exceed the ClickHouse query budget (100s) — a waiter that
-         # outlasts the lock holder gets the value instead of exiting with a
-         # timeout while the holder is still legitimately computing.
+         # Must exceed the ClickHouse budget bounding the lock holder (85s).
          # See docs/timeouts.md.
          acquire_lock_timeout: 102_000
        ]},

--- a/lib/sanbase/cache/cache.ex
+++ b/lib/sanbase/cache/cache.ex
@@ -15,7 +15,9 @@ defmodule Sanbase.Cache do
          name: Keyword.fetch!(opts, :name),
          ttl_check_interval: Keyword.get(opts, :ttl_check_interval, :timer.seconds(5)),
          global_ttl: Keyword.get(opts, :global_ttl, :timer.minutes(5)),
-         acquire_lock_timeout: Keyword.get(opts, :acquire_lock_timeout, 60_000)
+         # Above the ClickHouse budget, as in `CachexProvider`: a lock wait
+         # must outlast the work it waits on. See docs/timeouts.md.
+         acquire_lock_timeout: Keyword.get(opts, :acquire_lock_timeout, 102_000)
        ]},
       id: Keyword.fetch!(opts, :id)
     )

--- a/lib/sanbase/clickhouse_repo.ex
+++ b/lib/sanbase/clickhouse_repo.ex
@@ -220,19 +220,29 @@ defmodule Sanbase.ClickhouseRepo do
   @masked_error_message "Cannot execute database query. If issue persists please contact Santiment Support."
 
   @timeout_error_message """
-  The query took too long and was cancelled. An API call that requests many \
+  The query took too long to complete. An API call that requests many \
   fields or subqueries executes many database queries whose runtimes add up — \
   try requesting fewer fields per call, narrowing the from/to range, using a \
   bigger interval, or splitting the call into several smaller ones. If the \
   issue persists please contact Santiment Support.\
   """
 
+  # Mint's bare "timeout", DBConnection's "timed out"/"dropped from queue",
+  # ClickHouse's TIMEOUT_EXCEEDED. See docs/timeouts.md. The word boundaries
+  # keep identifiers like `timeout_ms` from being read as a timeout, which is
+  # why TIMEOUT_EXCEEDED needs an alternative of its own.
+  @timeout_error_regex ~r/\btimed?\s*out\b|\btimeout_exceeded\b|\bdropped\s+from\s+queue\b/i
+
+  # ClickHouse echoes the offending SQL back; drop it so a query containing
+  # "timeout" isn't misclassified.
+  @query_echo_regex ~r/while processing query:/i
+
   @doc false
-  # Timeout-class errors get a meaningful user-facing message instead of the
-  # generic masked one: DBConnection queue/checkout timeouts, query timeouts
-  # and ClickHouse-side TIMEOUT_EXCEEDED all match.
   def timeout_error?(message) when is_binary(message) do
-    message =~ ~r/timed? ?out|TIMEOUT_EXCEEDED|Code: 159|dropped from queue/i
+    message
+    |> String.split(@query_echo_regex, parts: 2)
+    |> hd()
+    |> String.match?(@timeout_error_regex)
   end
 
   def timeout_error?(_), do: false

--- a/lib/sanbase/clickhouse_repo.ex
+++ b/lib/sanbase/clickhouse_repo.ex
@@ -218,6 +218,25 @@ defmodule Sanbase.ClickhouseRepo do
   end
 
   @masked_error_message "Cannot execute database query. If issue persists please contact Santiment Support."
+
+  @timeout_error_message """
+  The query took too long and was cancelled. An API call that requests many \
+  fields or subqueries executes many database queries whose runtimes add up — \
+  try requesting fewer fields per call, narrowing the from/to range, using a \
+  bigger interval, or splitting the call into several smaller ones. If the \
+  issue persists please contact Santiment Support.\
+  """
+
+  @doc false
+  # Timeout-class errors get a meaningful user-facing message instead of the
+  # generic masked one: DBConnection queue/checkout timeouts, query timeouts
+  # and ClickHouse-side TIMEOUT_EXCEEDED all match.
+  def timeout_error?(message) when is_binary(message) do
+    message =~ ~r/timed? ?out|TIMEOUT_EXCEEDED|Code: 159|dropped from queue/i
+  end
+
+  def timeout_error?(_), do: false
+
   defp log_and_return_error_from_exception(
          %{} = exception,
          function_executed,
@@ -247,7 +266,7 @@ defmodule Sanbase.ClickhouseRepo do
       """)
     end
 
-    {:error, "[#{log_id}] #{if propagate_error, do: error_message, else: @masked_error_message}"}
+    {:error, "[#{log_id}] #{user_facing_error_message(error_message, propagate_error)}"}
   end
 
   defp log_and_return_error(error, function_executed, opts) do
@@ -266,7 +285,15 @@ defmodule Sanbase.ClickhouseRepo do
       )
     end
 
-    {:error, "[#{log_id}] #{if propagate_error, do: error_message, else: @masked_error_message}"}
+    {:error, "[#{log_id}] #{user_facing_error_message(error_message, propagate_error)}"}
+  end
+
+  defp user_facing_error_message(error_message, propagate_error) do
+    cond do
+      propagate_error -> error_message
+      timeout_error?(error_message) -> @timeout_error_message
+      true -> @masked_error_message
+    end
   end
 
   # Prefer the ctx explicitly threaded through `opts` (set by the

--- a/lib/sanbase_web/graphql/cache/cachex_provider.ex
+++ b/lib/sanbase_web/graphql/cache/cachex_provider.ex
@@ -49,20 +49,9 @@ defmodule SanbaseWeb.Graphql.CachexProvider do
   @spec max_payload_mb() :: pos_integer()
   def max_payload_mb(), do: @max_payload_mb
 
-  # Lock losers poll the cache waiting for the lock holder's value to land.
-  # The interval starts small so short computations are picked up quickly and
-  # doubles up to a cap so long computations don't cause wake-up churn. After
-  # the timeout the waiter gives up on the lock and computes the value itself
-  # (see lock_or_poll/5) — a duplicate computation, never a user-facing error.
-  #
-  # The timeout must exceed the ClickHouse query budget (100s, config.exs):
-  # a live lock means its holder is still computing, and the holder's work is
-  # bounded by that budget — so a waiter that keeps waiting always gets the
-  # value sooner than it could recompute it. With the timeout below the CH
-  # budget the fallback fired precisely for slow (60-100s) computations,
-  # starting a duplicate that the async-resolver budget (105s) then killed.
-  # Leaked locks don't need the timeout at all — the monitor-based guard
-  # releases them instantly. See docs/timeouts.md.
+  # Lock losers poll for the holder's value with backoff; on timeout they
+  # recompute instead of erroring (see lock_or_poll/5). The wait must outlast
+  # the ClickHouse budget bounding the holder. See docs/timeouts.md.
   @lock_poll_initial_ms 10
   @lock_poll_max_ms 100
   @lock_wait_timeout_ms 102_000
@@ -211,10 +200,11 @@ defmodule SanbaseWeb.Graphql.CachexProvider do
         result
 
       :locked when waited_ms >= @lock_wait_timeout_ms ->
-        # The lock holder is computing for over a minute. Rather than failing
-        # the request (the old provider raised here — the top Sentry error for
-        # years), compute the value ourselves without the lock. A duplicate
-        # computation is strictly better than an error.
+        # The holder outlasted a whole CH query budget, so it's anomalous.
+        # Recompute rather than raise (the old provider raised here — top
+        # Sentry error for years). Web callers are usually cut off before this
+        # lands; it's a best-effort net, correct for MCP/background callers.
+        # See docs/timeouts.md.
         Logger.warning(
           "Cache lock for key #{inspect(true_key)} held longer than " <>
             "#{@lock_wait_timeout_ms}ms — computing without the lock"

--- a/lib/sanbase_web/graphql/cache/cachex_provider.ex
+++ b/lib/sanbase_web/graphql/cache/cachex_provider.ex
@@ -54,9 +54,18 @@ defmodule SanbaseWeb.Graphql.CachexProvider do
   # doubles up to a cap so long computations don't cause wake-up churn. After
   # the timeout the waiter gives up on the lock and computes the value itself
   # (see lock_or_poll/5) — a duplicate computation, never a user-facing error.
+  #
+  # The timeout must exceed the ClickHouse query budget (100s, config.exs):
+  # a live lock means its holder is still computing, and the holder's work is
+  # bounded by that budget — so a waiter that keeps waiting always gets the
+  # value sooner than it could recompute it. With the timeout below the CH
+  # budget the fallback fired precisely for slow (60-100s) computations,
+  # starting a duplicate that the async-resolver budget (105s) then killed.
+  # Leaked locks don't need the timeout at all — the monitor-based guard
+  # releases them instantly. See docs/timeouts.md.
   @lock_poll_initial_ms 10
   @lock_poll_max_ms 100
-  @lock_wait_timeout_ms 60_000
+  @lock_wait_timeout_ms 102_000
 
   @impl SanbaseWeb.Graphql.CacheProvider
   def start_link(opts) do

--- a/lib/sanbase_web/graphql/cache/con_cache_provider.ex
+++ b/lib/sanbase_web/graphql/cache/con_cache_provider.ex
@@ -29,7 +29,9 @@ defmodule SanbaseWeb.Graphql.ConCacheProvider do
       name: Keyword.fetch!(opts, :name),
       ttl_check_interval: Keyword.get(opts, :ttl_check_interval, :timer.seconds(5)),
       global_ttl: Keyword.get(opts, :global_ttl, :timer.minutes(5)),
-      acquire_lock_timeout: Keyword.get(opts, :aquire_lock_timeout, 30_000)
+      # Key was misspelled (`:aquire_lock_timeout`), so caller values were
+      # dropped. See docs/timeouts.md.
+      acquire_lock_timeout: Keyword.get(opts, :acquire_lock_timeout, 102_000)
     ]
   end
 

--- a/lib/sanbase_web/graphql/dataloader/sanbase_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/sanbase_dataloader.ex
@@ -16,12 +16,9 @@ defmodule SanbaseWeb.Graphql.SanbaseDataloader do
   """
   @spec data(Sanbase.RequestContext.t() | nil) :: Dataloader.KV.t()
   def data(request_context \\ nil) do
-    # Timeout must live on the source — Dataloader ignores the loader-level
-    # `Dataloader.new(timeout:)` option and derives its run timeout from
-    # `Source.timeout/1` (`Dataloader.KV` hard-defaults to 30s). Batches here
-    # run ClickHouse queries with a 100s budget (config.exs), +5s margin so
-    # a slow batch returns its data/error instead of being killed while the
-    # query keeps running. See docs/timeouts.md.
+    # Must live on the source — Dataloader ignores `Dataloader.new(timeout:)`.
+    # Outlasts the 85s CH budget these batches run. Note it is *per batch*:
+    # `Task.async_stream` runs them in waves. See docs/timeouts.md.
     Dataloader.KV.new(make_kv_fun(request_context), timeout: :timer.seconds(105))
   end
 

--- a/lib/sanbase_web/graphql/dataloader/sanbase_dataloader.ex
+++ b/lib/sanbase_web/graphql/dataloader/sanbase_dataloader.ex
@@ -16,7 +16,13 @@ defmodule SanbaseWeb.Graphql.SanbaseDataloader do
   """
   @spec data(Sanbase.RequestContext.t() | nil) :: Dataloader.KV.t()
   def data(request_context \\ nil) do
-    Dataloader.KV.new(make_kv_fun(request_context))
+    # Timeout must live on the source — Dataloader ignores the loader-level
+    # `Dataloader.new(timeout:)` option and derives its run timeout from
+    # `Source.timeout/1` (`Dataloader.KV` hard-defaults to 30s). Batches here
+    # run ClickHouse queries with a 100s budget (config.exs), +5s margin so
+    # a slow batch returns its data/error instead of being killed while the
+    # query keeps running. See docs/timeouts.md.
+    Dataloader.KV.new(make_kv_fun(request_context), timeout: :timer.seconds(105))
   end
 
   # `Dataloader.KV` runs each batch in a fresh `Task`. Its callback is

--- a/lib/sanbase_web/graphql/dataloader/sanbase_repo.ex
+++ b/lib/sanbase_web/graphql/dataloader/sanbase_repo.ex
@@ -8,7 +8,11 @@ defmodule SanbaseWeb.Graphql.SanbaseRepo do
 
   @spec data() :: Dataloader.Ecto.t()
   def data() do
-    Dataloader.Ecto.new(Repo, query: &query/2)
+    # Timeout must live on the source — Dataloader ignores the loader-level
+    # `Dataloader.new(timeout:)` option and derives its run timeout from
+    # `Source.timeout/1`. Postgres query budget is 30s (config.exs), +5s
+    # margin so the batch outlives its own query. See docs/timeouts.md.
+    Dataloader.Ecto.new(Repo, query: &query/2, timeout: :timer.seconds(35))
   end
 
   def query(Project, _args) do

--- a/lib/sanbase_web/graphql/dataloader/sanbase_repo.ex
+++ b/lib/sanbase_web/graphql/dataloader/sanbase_repo.ex
@@ -8,11 +8,9 @@ defmodule SanbaseWeb.Graphql.SanbaseRepo do
 
   @spec data() :: Dataloader.Ecto.t()
   def data() do
-    # Timeout must live on the source — Dataloader ignores the loader-level
-    # `Dataloader.new(timeout:)` option and derives its run timeout from
-    # `Source.timeout/1`. Postgres query budget is 30s (config.exs), +5s
-    # margin so the batch outlives its own query. See docs/timeouts.md.
-    Dataloader.Ecto.new(Repo, query: &query/2, timeout: :timer.seconds(35))
+    # Must live on the source — Dataloader ignores `Dataloader.new(timeout:)`.
+    # Outlasts the 30s Postgres budget. See docs/timeouts.md.
+    Dataloader.Ecto.new(Repo, query: &query/2, timeout: :timer.seconds(55))
   end
 
   def query(Project, _args) do

--- a/lib/sanbase_web/graphql/helpers/async.ex
+++ b/lib/sanbase_web/graphql/helpers/async.ex
@@ -5,10 +5,8 @@ defmodule SanbaseWeb.Graphql.Helpers.Async do
   `:test` env just executes the function as if no `async` has been used
   """
 
-  # Task.await budget for async resolvers. Must exceed the ClickHouse query
-  # timeout (100s, config.exs) so a slow query surfaces its {:error, timeout}
-  # message instead of the Task exit crashing the request into a 500.
-  # See docs/timeouts.md for the full chain.
+  # Must exceed the 85s ClickHouse budget so a slow query surfaces
+  # {:error, timeout} instead of a Task exit → 500. See docs/timeouts.md.
   @async_timeout_ms 105_000
 
   defmacro async(func, opts \\ []) do

--- a/lib/sanbase_web/graphql/helpers/async.ex
+++ b/lib/sanbase_web/graphql/helpers/async.ex
@@ -5,12 +5,21 @@ defmodule SanbaseWeb.Graphql.Helpers.Async do
   `:test` env just executes the function as if no `async` has been used
   """
 
-  defmacro async(func) do
-    quote bind_quoted: [func: func] do
+  # Task.await budget for async resolvers. Must exceed the ClickHouse query
+  # timeout (100s, config.exs) so a slow query surfaces its {:error, timeout}
+  # message instead of the Task exit crashing the request into a 500.
+  # See docs/timeouts.md for the full chain.
+  @async_timeout_ms 105_000
+
+  defmacro async(func, opts \\ []) do
+    quote bind_quoted: [func: func, opts: opts, default_timeout_ms: @async_timeout_ms] do
       if Sanbase.Utils.Config.module_get(Sanbase, :env) == :test do
         func.()
       else
-        Absinthe.Resolution.Helpers.async(func)
+        Absinthe.Resolution.Helpers.async(
+          func,
+          Keyword.put_new(opts, :timeout, default_timeout_ms)
+        )
       end
     end
   end

--- a/lib/sanbase_web/graphql/resolvers/project/project_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_resolver.ex
@@ -1,7 +1,7 @@
 defmodule SanbaseWeb.Graphql.Resolvers.ProjectResolver do
   require Logger
 
-  import Absinthe.Resolution.Helpers, except: [async: 1]
+  import Absinthe.Resolution.Helpers, except: [async: 1, async: 2]
   import SanbaseWeb.Graphql.Helpers.Async
 
   alias Sanbase.Project

--- a/lib/sanbase_web/graphql/resolvers/project/project_transfers_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/project/project_transfers_resolver.ex
@@ -2,7 +2,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.ProjectTransfersResolver do
   require Logger
 
   import SanbaseWeb.Graphql.Helpers.Async
-  import Absinthe.Resolution.Helpers, except: [async: 1]
+  import Absinthe.Resolution.Helpers, except: [async: 1, async: 2]
 
   alias Sanbase.Transfers
   alias Sanbase.Project

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -141,10 +141,8 @@ defmodule SanbaseWeb.Graphql.Schema do
   import_types(Graphql.Schema.ChangelogQueries)
 
   def dataloader(request_context \\ nil) do
-    # No `timeout:` here on purpose — Dataloader ignores the loader-level
-    # option and computes its run timeout as max(source timeouts) + 1s.
-    # Timeouts are configured on the sources themselves (SanbaseRepo 35s,
-    # SanbaseDataloader 105s). See docs/timeouts.md.
+    # No `timeout:` — Dataloader ignores it and derives the run timeout as
+    # max(source timeouts) + 1s. Set on the sources. See docs/timeouts.md.
     Dataloader.new(get_policy: :return_nil_on_error)
     |> Dataloader.add_source(SanbaseRepo, SanbaseRepo.data())
     |> Dataloader.add_source(SanbaseDataloader, SanbaseDataloader.data(request_context))

--- a/lib/sanbase_web/graphql/schema.ex
+++ b/lib/sanbase_web/graphql/schema.ex
@@ -141,7 +141,11 @@ defmodule SanbaseWeb.Graphql.Schema do
   import_types(Graphql.Schema.ChangelogQueries)
 
   def dataloader(request_context \\ nil) do
-    Dataloader.new(timeout: :timer.seconds(20), get_policy: :return_nil_on_error)
+    # No `timeout:` here on purpose — Dataloader ignores the loader-level
+    # option and computes its run timeout as max(source timeouts) + 1s.
+    # Timeouts are configured on the sources themselves (SanbaseRepo 35s,
+    # SanbaseDataloader 105s). See docs/timeouts.md.
+    Dataloader.new(get_policy: :return_nil_on_error)
     |> Dataloader.add_source(SanbaseRepo, SanbaseRepo.data())
     |> Dataloader.add_source(SanbaseDataloader, SanbaseDataloader.data(request_context))
   end

--- a/test/sanbase/clickhouse_repo_timeout_error_test.exs
+++ b/test/sanbase/clickhouse_repo_timeout_error_test.exs
@@ -1,0 +1,26 @@
+defmodule Sanbase.ClickhouseRepoTimeoutErrorTest do
+  use ExUnit.Case, async: true
+
+  alias Sanbase.ClickhouseRepo
+
+  test "classifies timeout-class errors" do
+    assert ClickhouseRepo.timeout_error?(
+             "tcp recv (idle): timed out. Client #PID<0.1.0> timed out because it queued"
+           )
+
+    assert ClickhouseRepo.timeout_error?(
+             "connection not available and request was dropped from queue after 2500ms"
+           )
+
+    assert ClickhouseRepo.timeout_error?("Code: 159. DB::Exception: Timeout exceeded")
+    assert ClickhouseRepo.timeout_error?("TIMEOUT_EXCEEDED")
+    assert ClickhouseRepo.timeout_error?("the query timed out")
+  end
+
+  test "does not classify other errors as timeouts" do
+    refute ClickhouseRepo.timeout_error?("Code: 60. DB::Exception: Table does not exist")
+    refute ClickhouseRepo.timeout_error?("syntax error at position 10")
+    refute ClickhouseRepo.timeout_error?(nil)
+    refute ClickhouseRepo.timeout_error?(:some_atom)
+  end
+end

--- a/test/sanbase/clickhouse_repo_timeout_error_test.exs
+++ b/test/sanbase/clickhouse_repo_timeout_error_test.exs
@@ -3,24 +3,74 @@ defmodule Sanbase.ClickhouseRepoTimeoutErrorTest do
 
   alias Sanbase.ClickhouseRepo
 
-  test "classifies timeout-class errors" do
-    assert ClickhouseRepo.timeout_error?(
-             "tcp recv (idle): timed out. Client #PID<0.1.0> timed out because it queued"
-           )
+  describe "timeout-class errors" do
+    test "Ch/Mint recv timeout" do
+      # Mint formats :timeout as exactly this word, so it must match alone.
+      assert ClickhouseRepo.timeout_error?("timeout")
 
-    assert ClickhouseRepo.timeout_error?(
-             "connection not available and request was dropped from queue after 2500ms"
-           )
+      assert ClickhouseRepo.timeout_error?(
+               Exception.message(%Mint.TransportError{reason: :timeout})
+             )
 
-    assert ClickhouseRepo.timeout_error?("Code: 159. DB::Exception: Timeout exceeded")
-    assert ClickhouseRepo.timeout_error?("TIMEOUT_EXCEEDED")
-    assert ClickhouseRepo.timeout_error?("the query timed out")
+      assert ClickhouseRepo.timeout_error?(inspect(%Mint.TransportError{reason: :timeout}))
+      assert ClickhouseRepo.timeout_error?("tcp recv (idle): timed out")
+    end
+
+    test "DBConnection checkout timeout" do
+      assert ClickhouseRepo.timeout_error?(
+               "client #PID<0.1.0> timed out because it queued and checked out " <>
+                 "the connection for longer than 85000ms"
+             )
+    end
+
+    test "DBConnection queue shedding" do
+      assert ClickhouseRepo.timeout_error?(
+               "connection not available and request was dropped from queue after 10000ms"
+             )
+    end
+
+    test "ClickHouse TIMEOUT_EXCEEDED, as transform_error_string/1 rewrites it" do
+      assert ClickhouseRepo.timeout_error?(
+               "(TIMEOUT_EXCEEDED) Timeout exceeded: elapsed 85.1 seconds, maximum: 85 seconds"
+             )
+
+      assert ClickhouseRepo.timeout_error?("Code: 159. DB::Exception: Timeout exceeded")
+
+      # The error code alone, without the prose, is matched on its own.
+      assert ClickhouseRepo.timeout_error?("Code: 159. DB::Exception (TIMEOUT_EXCEEDED)")
+    end
+
+    test "the timeout phrase still counts when the query is echoed after it" do
+      assert ClickhouseRepo.timeout_error?(
+               "(TIMEOUT_EXCEEDED) Timeout exceeded: elapsed 85.1 seconds: " <>
+                 "while processing query: SELECT value FROM intraday_metrics"
+             )
+    end
   end
 
-  test "does not classify other errors as timeouts" do
-    refute ClickhouseRepo.timeout_error?("Code: 60. DB::Exception: Table does not exist")
-    refute ClickhouseRepo.timeout_error?("syntax error at position 10")
-    refute ClickhouseRepo.timeout_error?(nil)
-    refute ClickhouseRepo.timeout_error?(:some_atom)
+  describe "non-timeout errors" do
+    test "ordinary ClickHouse errors" do
+      refute ClickhouseRepo.timeout_error?("Code: 60. DB::Exception: Table does not exist")
+      refute ClickhouseRepo.timeout_error?("(UNKNOWN_TABLE) Table does not exist")
+      refute ClickhouseRepo.timeout_error?("syntax error at position 10")
+    end
+
+    test "a query that merely mentions a timeout is not a timeout" do
+      refute ClickhouseRepo.timeout_error?(
+               "(UNKNOWN_TABLE) Table intraday_metrics does not exist " <>
+                 "while processing query: SELECT timeout_ms FROM intraday_metrics"
+             )
+
+      # An identifier that starts with "timeout" is not the word "timeout" —
+      # the word boundary keeps it out even when it leaks into the error prose.
+      refute ClickhouseRepo.timeout_error?("(UNKNOWN_IDENTIFIER) Missing columns: 'timeout_ms'")
+      refute ClickhouseRepo.timeout_error?("(UNKNOWN_SETTING) Unknown setting receive_timeout_ms")
+    end
+
+    test "non-binary input" do
+      refute ClickhouseRepo.timeout_error?(nil)
+      refute ClickhouseRepo.timeout_error?(:some_atom)
+      refute ClickhouseRepo.timeout_error?(%{message: "timed out"})
+    end
   end
 end


### PR DESCRIPTION
## Changes

Makes the timeout chain ordered end to end, so every layer outlives the one it
waits on and a slow query surfaces as an error message instead of a 500.

- **`docs/timeouts.md`** — new document describing the whole chain, the reasoning
  behind each number, and the known gaps.
- **Web chain**: cowboy `idle_timeout` 120s > `Helpers.Async` 105s > ClickHouse
  85s. `Helpers.Async.async/2` now passes a `:timeout` (it previously inherited
  Absinthe's 30s default), so resolvers get `{:error, timeout}` rather than a
  Task exit. MCP keeps its own chain (cowboy 180s > Anubis 150s).
- **ClickHouse pools**: `timeout` 100s → 85s (it is one absolute budget for pool
  wait + query and cannot interrupt an in-flight recv), `queue_target` 5s /
  `queue_interval` 20s for faster CoDel shedding. Read-only pools now share the
  read-write budgets instead of a 60s queue target.
- **Timeout errors get a real message**: `ClickhouseRepo.timeout_error?/1`
  detects the four shapes a timeout arrives in and returns guidance to narrow
  the query. Non-timeout errors stay masked; `propagate_error: true` callers
  (the SQL editor) still get the raw error. Errors can echo the user's SQL, so
  the echo is stripped before matching.
- **Cache lock waits**: 60s → 102s across `CachexProvider`, `Sanbase.Cache` and
  `ConCacheProvider`, so a waiter never gives up before the ClickHouse query it
  waits on can finish. Also fixes a misspelled `:aquire_lock_timeout` key in
  `ConCacheProvider` that silently dropped caller values.
- **Dataloader**: timeouts moved onto the sources — `Dataloader.new(timeout:)`
  is never read; the run timeout is derived as `max(source timeouts) + 1s`.
  KV (ClickHouse) 105s, Ecto (Postgres) 55s.

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection and handling of database and request timeouts.
  - Users now receive clearer timeout messages while other errors remain appropriately protected.
  - Fixed cache and data-loading timeout behavior to reduce stalled requests and improve recovery.

- **Reliability**
  - Tuned request, connection, caching, and data-fetching time limits for more consistent performance under load.

- **Documentation**
  - Added comprehensive guidance describing timeout behavior across the request lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
