### PR TITLE
Improve errors when sanqueries query failes to compute

### DIFF
--- a/lib/sanbase/queries/refresh/refresh.ex
+++ b/lib/sanbase/queries/refresh/refresh.ex
@@ -50,9 +50,13 @@ defmodule Sanbase.Queries.Refresh do
   end
 
   def refresh_query(query_id, user_id, opts) do
-    {:ok, query} = Sanbase.Queries.get_query(query_id, user_id)
-    user = Sanbase.Accounts.get_user!(user_id)
-    refresh_query(query, user, opts)
+    # Return an error tuple instead of raising a MatchError/Ecto.NoResultsError, so
+    # the caller (RefreshWorker) can annotate it with the query_id/user_id and
+    # decide whether the job is worth retrying.
+    with {:ok, query} <- Sanbase.Queries.get_query(query_id, user_id),
+         {:ok, user} <- Sanbase.Accounts.get_user(user_id) do
+      refresh_query(query, user, opts)
+    end
   end
 
   def refresh_all_dashboard_queries(dashboard_id) do

--- a/lib/sanbase/queries/refresh/worker.ex
+++ b/lib/sanbase/queries/refresh/worker.ex
@@ -3,6 +3,8 @@ defmodule Sanbase.Queries.RefreshWorker do
     queue: :refresh_queries,
     max_attempts: 3
 
+  require Logger
+
   alias Sanbase.Queries.Refresh
 
   @oban_conf_name :oban_web
@@ -10,14 +12,40 @@ defmodule Sanbase.Queries.RefreshWorker do
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"user_id" => user_id, "query_id" => query_id}} = job) do
+    # Make the query_id/user_id searchable Sentry tags in case the job fails
+    Sanbase.Sentry.ObanTags.put_job_context(job)
+
     # Schedule a new job to refresh the query on the first attempt
     scheduled_job = if job.attempt == 1, do: schedule_next_refresh(job), else: nil
 
     Refresh.refresh_query(query_id, user_id)
+    |> handle_result(job, query_id, user_id)
     |> maybe_remove_scheduled_job(scheduled_job)
   end
 
   # private
+
+  # Attach the identifiers of the offending query to the error before it is
+  # returned to Oban. The error tuple returned from here is what ends up in the
+  # Oban.PerformError message that is reported to Sentry, so the query can be
+  # located in postgres (`SELECT * FROM queries WHERE id = <query_id>`) directly
+  # from the error title, without inspecting the job args.
+  defp handle_result({:error, error}, %Oban.Job{} = job, query_id, user_id) do
+    error_str = error_to_string(error)
+
+    Logger.warning(
+      "[Queries.RefreshWorker] Failed to refresh query_id=#{query_id} user_id=#{user_id} " <>
+        "(oban_job_id=#{job.id}, attempt=#{job.attempt}/#{job.max_attempts}): #{error_str}"
+    )
+
+    {:error, "Failed to refresh query_id=#{query_id} user_id=#{user_id}. Reason: #{error_str}"}
+  end
+
+  defp handle_result(result, _job, _query_id, _user_id), do: result
+
+  defp error_to_string(error) when is_binary(error), do: error
+  defp error_to_string(%{__exception__: true} = error), do: Exception.message(error)
+  defp error_to_string(error), do: inspect(error)
 
   defp schedule_next_refresh(%Oban.Job{args: args}) do
     next_refresh_in_seconds = args["next_refresh_in_seconds"] || @one_day
@@ -48,7 +76,13 @@ defmodule Sanbase.Queries.RefreshWorker do
       "(ACCESS_DENIED)",
       "(UNKNOWN_TABLE)",
       "(MEMORY_LIMIT_EXCEEDED)",
-      "(AMBIGUOUS_COLUMN_NAME)"
+      "(AMBIGUOUS_COLUMN_NAME)",
+      # The query or its owner is gone - there is nothing left to refresh, so the
+      # daily chain must not be prolonged. Errors that the owner can still fix
+      # (a {{key}} template without a matching parameter, for example) are kept
+      # retryable on purpose, so the auto-refresh resumes on its own once fixed.
+      "Query does not exist or you don't have access to it.",
+      "Cannot fetch the user with id"
     ]
 
     has_non_retryable_error? =

--- a/lib/sanbase/sentry/oban_tags.ex
+++ b/lib/sanbase/sentry/oban_tags.ex
@@ -1,0 +1,37 @@
+defmodule Sanbase.Sentry.ObanTags do
+  @moduledoc ~s"""
+  Promote the interesting Oban job args to Sentry tags.
+
+  The Sentry Oban integration puts the whole `job.args` map into the event's
+  `extra` data. `extra` is not searchable and is not part of the tag breakdown of
+  an issue, so when hundreds of events are grouped under a single issue there is no
+  way to tell *which* entities are failing without opening the events one by one.
+
+  The args listed in `@args_to_tags` are promoted to Sentry tags. This makes them
+  searchable (`oban_query_id:667`) and lists all the affected ids in the tag
+  breakdown of the issue.
+
+  Call `put_job_context/1` in the beginning of `perform/1`. The Sentry context is
+  stored in the process dictionary and Oban runs the job and emits the
+  `[:oban, :job, :exception]` telemetry event (the one the Sentry integration
+  hooks into) in the same process, so the tags end up in the reported event.
+  """
+
+  # The args that identify a row in postgres. Keep the list short - every tag is
+  # indexed by Sentry and high-cardinality tags are not free.
+  @args_to_tags ["query_id", "dashboard_id", "user_id"]
+
+  @spec put_job_context(Oban.Job.t() | map()) :: :ok
+  def put_job_context(job) do
+    job |> from_job() |> Sentry.Context.set_tags_context()
+  end
+
+  @spec from_job(Oban.Job.t() | map()) :: map()
+  def from_job(%{args: args}) when is_map(args) do
+    for key <- @args_to_tags, value = Map.get(args, key), into: %{} do
+      {:"oban_#{key}", to_string(value)}
+    end
+  end
+
+  def from_job(_job), do: %{}
+end

--- a/lib/sanbase/template_engine/template_engine.ex
+++ b/lib/sanbase/template_engine/template_engine.ex
@@ -252,8 +252,13 @@ defmodule Sanbase.TemplateEngine do
         {:ok, {sql, args}}
 
       _ ->
-        missing_keys = Enum.map(errors, & &1.key) |> Enum.join(", ")
-        params_keys = Map.keys(params)
+        # Sort and dedup the keys so the error message is deterministic. The same
+        # broken query must always produce the same error string, otherwise the
+        # error grouping in Sentry/logs is fragmented.
+        missing_keys =
+          errors |> Enum.map(& &1.key) |> Enum.uniq() |> Enum.sort() |> Enum.join(", ")
+
+        params_keys = params |> Map.keys() |> Enum.sort()
         params_keys = if params_keys == [], do: "none", else: Enum.join(params_keys, ", ")
 
         error_str =

--- a/test/sanbase/queries/refresh_worker_test.exs
+++ b/test/sanbase/queries/refresh_worker_test.exs
@@ -1,0 +1,53 @@
+defmodule Sanbase.Queries.RefreshWorkerTest do
+  use Sanbase.DataCase, async: false
+
+  import Sanbase.Factory
+
+  alias Sanbase.Queries
+  alias Sanbase.Queries.RefreshWorker
+
+  test "the error identifies the offending query" do
+    user = insert(:user)
+
+    {:ok, query} =
+      Queries.create_query(
+        %{
+          sql_query_text: "SELECT * FROM metrics WHERE slug = {{asset1}}",
+          sql_query_parameters: %{}
+        },
+        user.id
+      )
+
+    job = %Oban.Job{
+      id: 1,
+      attempt: 2,
+      max_attempts: 3,
+      args: %{"query_id" => query.id, "user_id" => user.id}
+    }
+
+    assert {:error, error} = RefreshWorker.perform(job)
+
+    assert error =~ "Failed to refresh query_id=#{query.id} user_id=#{user.id}"
+    assert error =~ "Template keys missing from the parameters: {{asset1}}"
+
+    assert %{tags: tags} = Sentry.Context.get_all()
+    assert tags[:oban_query_id] == to_string(query.id)
+    assert tags[:oban_user_id] == to_string(user.id)
+  end
+
+  test "missing query does not raise, the error identifies the query id" do
+    user = insert(:user)
+
+    job = %Oban.Job{
+      id: 1,
+      attempt: 2,
+      max_attempts: 3,
+      args: %{"query_id" => 0, "user_id" => user.id}
+    }
+
+    assert {:error, error} = RefreshWorker.perform(job)
+
+    assert error =~ "Failed to refresh query_id=0 user_id=#{user.id}"
+    assert error =~ "Query does not exist or you don't have access to it."
+  end
+end

--- a/test/sanbase/sentry/oban_tags_test.exs
+++ b/test/sanbase/sentry/oban_tags_test.exs
@@ -1,0 +1,30 @@
+defmodule Sanbase.Sentry.ObanTagsTest do
+  use ExUnit.Case, async: true
+
+  alias Sanbase.Sentry.ObanTags
+
+  test "promotes the known entity ids to tags" do
+    job = %{args: %{"query_id" => 667, "user_id" => 3207, "next_refresh_in_seconds" => 86_400}}
+
+    assert ObanTags.from_job(job) == %{oban_query_id: "667", oban_user_id: "3207"}
+  end
+
+  test "ignores the args that are not in the allowlist" do
+    job = %{args: %{"slug" => "bitcoin"}}
+
+    assert ObanTags.from_job(job) == %{}
+  end
+
+  test "handles jobs without args" do
+    assert ObanTags.from_job(%{}) == %{}
+    assert ObanTags.from_job(%{args: nil}) == %{}
+  end
+
+  test "put_job_context/1 stores the tags in the Sentry context" do
+    job = %{args: %{"query_id" => 667, "user_id" => 3207}}
+
+    assert :ok = ObanTags.put_job_context(job)
+
+    assert %{tags: %{oban_query_id: "667", oban_user_id: "3207"}} = Sentry.Context.get_all()
+  end
+end

--- a/test/sanbase/template_engine/template_engine_test.exs
+++ b/test/sanbase/template_engine/template_engine_test.exs
@@ -175,7 +175,8 @@ defmodule Sanbase.TemplateEngineTest do
       assert error_msg =~
                "One or more of the {{<key>}} templates in the query text do not correspond to any of the parameters."
 
-      assert error_msg =~ "Template keys missing from the parameters: {{d}}, {{c}}"
+      # The missing keys are sorted and deduplicated so the message is deterministic
+      assert error_msg =~ "Template keys missing from the parameters: {{c}}, {{d}}"
       assert error_msg =~ "Parameters' keys defined: a, b"
     end
 


### PR DESCRIPTION
## Changes

When a SanQueries auto-refresh job failed, the Sentry issue said nothing about
*which* query failed — `job.args` lands in the event's `extra`, which is not
searchable and not part of an issue's tag breakdown. A deleted query or user was
worse: `refresh_query/3` matched `{:ok, query}` and called `get_user!/1`, so the
job died with a bare `MatchError`/`Ecto.NoResultsError` and the next day's job,
already scheduled, kept the dead chain alive forever.

- `Sanbase.Queries.Refresh.refresh_query/3` returns `{:error, reason}` instead of
  raising when the query or its owner is gone.
- `RefreshWorker` annotates the error with `query_id`/`user_id` before returning
  it to Oban, so the `Oban.PerformError` message names the row to look up in
  postgres, and logs a warning with the job id and attempt.
- New `Sanbase.Sentry.ObanTags` promotes `query_id`/`dashboard_id`/`user_id` from
  the job args to Sentry tags, making them searchable (`oban_query_id:667`) and
  visible in the issue's tag breakdown.
- "Query does not exist" / "Cannot fetch the user" are treated as non-retryable,
  so the daily refresh chain is cancelled instead of prolonged. Errors the owner
  can still fix (e.g. a `{{key}}` with no matching parameter) stay retryable on
  purpose.
- `TemplateEngine` missing-key error now dedups and sorts the keys, so the same
  broken query always produces the same string and groups as one issue.
<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->
