### PR TITLE
Add status to metric_display_order

### DIFF
--- a/lib/sanbase/metric/ui_metadata/display_order.ex
+++ b/lib/sanbase/metric/ui_metadata/display_order.ex
@@ -13,6 +13,7 @@ defmodule Sanbase.Metric.UIMetadata.DisplayOrder do
   @allowed_chart_styles ["filledLine", "greenRedBar", "bar", "line", "area", "reference"]
   @allowed_unit_formats ["", "usd", "percent"]
   @allowed_metric_types ["metric", "query"]
+  @allowed_statuses [:live, :hidden, :under_maintenance]
 
   @type t :: %__MODULE__{
           id: integer(),
@@ -32,6 +33,7 @@ defmodule Sanbase.Metric.UIMetadata.DisplayOrder do
           description: String.t(),
           args: map(),
           type: String.t(),
+          status: atom(),
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
         }
@@ -47,6 +49,7 @@ defmodule Sanbase.Metric.UIMetadata.DisplayOrder do
     field(:description, :string)
     field(:args, :map, default: %{})
     field(:type, :string, default: "metric")
+    field(:status, Ecto.Enum, values: @allowed_statuses, default: :live)
 
     field(:display_order, :integer)
 
@@ -78,7 +81,8 @@ defmodule Sanbase.Metric.UIMetadata.DisplayOrder do
       :unit,
       :description,
       :args,
-      :type
+      :type,
+      :status
     ])
     |> validate_required([:display_order, :category_id])
     |> validate_inclusion(:source_type, ["registry", "code"])
@@ -145,7 +149,8 @@ defmodule Sanbase.Metric.UIMetadata.DisplayOrder do
             unit: Keyword.get(opts, :unit, base_metric.unit),
             description: Keyword.get(opts, :description, base_metric.description),
             args: new_args,
-            type: base_metric.type
+            type: base_metric.type,
+            status: Keyword.get(opts, :status, base_metric.status)
           }
 
           create(variant_attrs)
@@ -231,28 +236,44 @@ defmodule Sanbase.Metric.UIMetadata.DisplayOrder do
   @doc """
   Increment the display_order of a record by its ID.
   """
+  @spec increment_display_order(integer()) ::
+          {:ok, t()} | {:error, Ecto.Changeset.t() | String.t()}
   def increment_display_order(id) when is_integer(id) do
-    case by_id(id) do
-      nil ->
-        {:error, "Record not found"}
-
-      record ->
-        updated_attrs = %{display_order: record.display_order + 1}
-        do_update(record, updated_attrs)
-    end
+    update_by_id(id, fn record -> %{display_order: record.display_order + 1} end)
   end
 
   @doc """
   Decrement the display_order of a record by its ID.
   """
+  @spec decrement_display_order(integer()) ::
+          {:ok, t()} | {:error, Ecto.Changeset.t() | String.t()}
   def decrement_display_order(id) when is_integer(id) do
-    case by_id(id) do
-      nil ->
-        {:error, "Record not found"}
+    update_by_id(id, fn record -> %{display_order: record.display_order - 1} end)
+  end
 
-      record ->
-        updated_attrs = %{display_order: record.display_order - 1}
-        do_update(record, updated_attrs)
+  @doc """
+  Update the status of a record by its ID.
+  The status does not affect which records are returned by the API — it is
+  returned as a field so the consumer can decide how to display the metric.
+
+  Allowed statuses: #{inspect(@allowed_statuses)}
+
+  ## Examples
+
+      iex> {:ok, %DisplayOrder{status: :hidden}} = DisplayOrder.update_status(record.id, :hidden)
+      iex> DisplayOrder.update_status(-1, :live)
+      {:error, "Record not found"}
+  """
+  @spec update_status(integer(), atom() | String.t()) ::
+          {:ok, t()} | {:error, Ecto.Changeset.t() | String.t()}
+  def update_status(id, status) when is_integer(id) do
+    update_by_id(id, fn _record -> %{status: status} end)
+  end
+
+  defp update_by_id(id, attrs_fun) when is_integer(id) do
+    case Repo.get(__MODULE__, id) do
+      nil -> {:error, "Record not found"}
+      record -> do_update(record, attrs_fun.(record))
     end
   end
 
@@ -290,7 +311,8 @@ defmodule Sanbase.Metric.UIMetadata.DisplayOrder do
   @doc """
   Get all metric display order entries ordered by category, group, and display_order.
   """
-  def all_ordered do
+  @spec all_ordered() :: [t()]
+  def all_ordered() do
     categories = Category.all_ordered()
 
     category_order_map =
@@ -393,7 +415,8 @@ defmodule Sanbase.Metric.UIMetadata.DisplayOrder do
   Get the ordered list of all metrics with their metadata.
   This combines data from both the metric registry and the display order table.
   """
-  def get_ordered_metrics do
+  @spec get_ordered_metrics() :: %{metrics: [map()], categories: [map()]}
+  def get_ordered_metrics() do
     ordered_metrics = all_ordered()
 
     categories = Category.all_ordered()
@@ -434,6 +457,7 @@ defmodule Sanbase.Metric.UIMetadata.DisplayOrder do
           metric_registry_id: display_order.metric_registry_id,
           args: display_order.args || %{},
           is_new: is_new?(display_order.inserted_at),
+          status: display_order.status,
           display_order: display_order.display_order,
           inserted_at: display_order.inserted_at,
           updated_at: display_order.updated_at,
@@ -565,6 +589,19 @@ defmodule Sanbase.Metric.UIMetadata.DisplayOrder do
   """
   def get_available_metric_types do
     @allowed_metric_types
+  end
+
+  @doc """
+  Get all available statuses.
+
+  ## Examples
+
+      iex> Sanbase.Metric.UIMetadata.DisplayOrder.get_available_statuses()
+      [:live, :hidden, :under_maintenance]
+  """
+  @spec get_available_statuses() :: [atom()]
+  def get_available_statuses() do
+    @allowed_statuses
   end
 
   @doc """

--- a/lib/sanbase_web/components/admin/admin_shared_components.ex
+++ b/lib/sanbase_web/components/admin/admin_shared_components.ex
@@ -131,9 +131,17 @@ defmodule SanbaseWeb.AdminSharedComponents do
   def status_badge(assigns) do
     ~H"""
     <span class={["badge whitespace-nowrap", status_variant(@status)]}>
-      {@status |> String.replace("_", " ") |> String.upcase()}
+      {status_text(@status)}
     </span>
     """
+  end
+
+  @doc """
+  Human-readable label for a status atom or string, e.g. `:under_maintenance -> "UNDER MAINTENANCE"`.
+  """
+  @spec status_text(atom() | String.t()) :: String.t()
+  def status_text(status) do
+    status |> to_string() |> String.replace("_", " ") |> String.upcase()
   end
 
   defp status_variant("approved"), do: "badge-success"
@@ -141,6 +149,8 @@ defmodule SanbaseWeb.AdminSharedComponents do
   defp status_variant("pending_approval"), do: "badge-warning"
   defp status_variant("pending_sync"), do: "badge-warning"
   defp status_variant("manual_drift"), do: "badge-error"
+  defp status_variant("hidden"), do: "badge-neutral"
+  defp status_variant("under_maintenance"), do: "badge-warning"
   defp status_variant(_), do: "badge-ghost"
 
   attr :current_user, :map, required: true

--- a/lib/sanbase_web/graphql/resolvers/metric/metric_display_order_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_display_order_resolver.ex
@@ -119,6 +119,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricDisplayOrderResolver do
       description: display_order.description,
       args: display_order.args,
       is_new: DisplayOrder.is_new?(display_order.inserted_at),
+      status: display_order.status,
       display_order: display_order.display_order,
       inserted_at: display_order.inserted_at,
       updated_at: display_order.updated_at

--- a/lib/sanbase_web/graphql/schema/types/metric_display_order_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_display_order_types.ex
@@ -5,6 +5,12 @@ defmodule SanbaseWeb.Graphql.MetricDisplayOrderTypes do
 
   alias SanbaseWeb.Graphql.Resolvers.MetricDisplayOrderResolver
 
+  enum :metric_display_order_status do
+    value(:live)
+    value(:hidden)
+    value(:under_maintenance)
+  end
+
   object :metric_display_order do
     field(:metric, non_null(:string))
     field(:type, :string)
@@ -18,6 +24,7 @@ defmodule SanbaseWeb.Graphql.MetricDisplayOrderTypes do
     field(:description, :string)
     field(:args, :json)
     field(:is_new, :boolean)
+    field(:status, :metric_display_order_status)
 
     field :source, :string do
       resolve(&MetricDisplayOrderResolver.deduce_source/3)

--- a/lib/sanbase_web/live/metric_registry/metric_display_order_form_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_display_order_form_live.ex
@@ -26,7 +26,8 @@ defmodule SanbaseWeb.MetricDisplayOrderFormLive do
            groups_by_category: form_data.groups_by_category,
            groups_for_category: form_data.groups_for_category,
            styles: form_data.styles,
-           formats: form_data.formats
+           formats: form_data.formats,
+           statuses: form_data.statuses
          )}
     end
   end
@@ -49,9 +50,10 @@ defmodule SanbaseWeb.MetricDisplayOrderFormLive do
     # Get groups for the current category
     groups_for_category = Map.get(groups_by_category, display_order.category_id, [])
 
-    # Get available styles and formats
+    # Get available styles, formats and statuses
     styles = DisplayOrder.get_available_chart_styles()
     formats = DisplayOrder.get_available_formats()
+    statuses = DisplayOrder.get_available_statuses()
 
     # Get category and group names for display
     category_name = if display_order.category, do: display_order.category.name, else: nil
@@ -66,7 +68,8 @@ defmodule SanbaseWeb.MetricDisplayOrderFormLive do
       groups_by_category: groups_by_category,
       groups_for_category: groups_for_category,
       styles: styles,
-      formats: formats
+      formats: formats,
+      statuses: statuses
     }
   end
 
@@ -84,7 +87,8 @@ defmodule SanbaseWeb.MetricDisplayOrderFormLive do
       "chart_style" => display_order.chart_style,
       "unit" => display_order.unit,
       "description" => display_order.description,
-      "args" => args_json
+      "args" => args_json,
+      "status" => display_order.status
     })
   end
 
@@ -110,6 +114,7 @@ defmodule SanbaseWeb.MetricDisplayOrderFormLive do
         groups_for_category={@groups_for_category}
         styles={@styles}
         formats={@formats}
+        statuses={@statuses}
       />
     </div>
     """
@@ -140,6 +145,7 @@ defmodule SanbaseWeb.MetricDisplayOrderFormLive do
   attr :groups_for_category, :list, required: true
   attr :styles, :list, required: true
   attr :formats, :list, required: true
+  attr :statuses, :list, required: true
 
   def metric_form(assigns) do
     ~H"""
@@ -179,6 +185,13 @@ defmodule SanbaseWeb.MetricDisplayOrderFormLive do
         field={@form[:args]}
         label="Args (JSON)"
         placeholder={~s|{"selector": {"slug": "ethereum"}}|}
+      />
+
+      <.input
+        type="select"
+        field={@form[:status]}
+        label="Status"
+        options={Enum.map(@statuses, fn s -> {AdminSharedComponents.status_text(s), s} end)}
       />
 
       <.button phx-disable-with="Saving...">Save Changes</.button>
@@ -231,7 +244,8 @@ defmodule SanbaseWeb.MetricDisplayOrderFormLive do
           chart_style: params["chart_style"],
           unit: params["unit"],
           description: params["description"],
-          args: args
+          args: args,
+          status: params["status"]
         }
 
         case DisplayOrder.do_update(display_order, attrs) do

--- a/lib/sanbase_web/live/metric_registry/metric_display_order_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_display_order_live.ex
@@ -19,6 +19,7 @@ defmodule SanbaseWeb.MetricDisplayOrderLive do
      |> assign(
        page_title: "Metric Display Order",
        metrics: metrics,
+       statuses: DisplayOrder.get_available_statuses(),
        categories: categories,
        selected_category: first_category_name,
        selected_group: nil,
@@ -73,6 +74,7 @@ defmodule SanbaseWeb.MetricDisplayOrderLive do
 
       <.metrics_table
         filtered_metrics={@filtered_metrics}
+        statuses={@statuses}
         highlighted_metric_id={@highlighted_metric_id}
       />
 
@@ -230,6 +232,7 @@ defmodule SanbaseWeb.MetricDisplayOrderLive do
   end
 
   attr :filtered_metrics, :list, required: true
+  attr :statuses, :list, required: true
   attr :highlighted_metric_id, :integer, default: nil
 
   def metrics_table(assigns) do
@@ -246,6 +249,7 @@ defmodule SanbaseWeb.MetricDisplayOrderLive do
             <th>Group</th>
             <th>Style</th>
             <th>Format</th>
+            <th>Status</th>
             <th>Actions</th>
           </tr>
         </thead>
@@ -253,6 +257,7 @@ defmodule SanbaseWeb.MetricDisplayOrderLive do
           <.metric_row
             :for={{metric, index} <- Enum.with_index(@filtered_metrics)}
             metric={metric}
+            statuses={@statuses}
             index={index}
             total_count={length(@filtered_metrics)}
             highlighted={@highlighted_metric_id && @highlighted_metric_id == metric.id}
@@ -264,11 +269,21 @@ defmodule SanbaseWeb.MetricDisplayOrderLive do
   end
 
   attr :metric, :map, required: true
+  attr :statuses, :list, required: true
   attr :index, :integer, required: true
   attr :total_count, :integer, required: true
   attr :highlighted, :boolean, default: false
 
   def metric_row(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :status_form,
+        to_form(%{"metric_id" => assigns.metric.id, "status" => assigns.metric.status},
+          as: :status_update
+        )
+      )
+
     ~H"""
     <tr id={"metric-#{@metric.id}"} data-id={@metric.id} class={[@highlighted && "bg-warning/20"]}>
       <td>
@@ -295,6 +310,10 @@ defmodule SanbaseWeb.MetricDisplayOrderLive do
       <td>
         {@metric.metric}
         <span :if={@metric.is_new} class="badge badge-xs badge-success ml-2">NEW</span>
+        <AdminSharedComponents.status_badge
+          :if={@metric.status != :live}
+          status={to_string(@metric.status)}
+        />
       </td>
       <td>{@metric.ui_human_readable_name}</td>
       <td>{@metric.ui_key}</td>
@@ -302,6 +321,23 @@ defmodule SanbaseWeb.MetricDisplayOrderLive do
       <td>{@metric.group_name}</td>
       <td>{@metric.chart_style}</td>
       <td>{@metric.unit}</td>
+      <td>
+        <.form for={@status_form} phx-change="change_status">
+          <input
+            type="hidden"
+            name={@status_form[:metric_id].name}
+            value={@status_form[:metric_id].value}
+          />
+          <.input
+            type="select"
+            field={@status_form[:status]}
+            id={"status-select-#{@metric.id}"}
+            options={Enum.map(@statuses, &{AdminSharedComponents.status_text(&1), &1})}
+            aria-label={"Status of #{@metric.metric}"}
+            outer_div_class="!mb-0"
+          />
+        </.form>
+      </td>
       <td>
         <.metric_actions metric={@metric} />
       </td>
@@ -409,6 +445,30 @@ defmodule SanbaseWeb.MetricDisplayOrderLive do
   end
 
   @impl true
+  def handle_event(
+        "change_status",
+        %{"status_update" => %{"metric_id" => id, "status" => status}},
+        socket
+      ) do
+    with {id, ""} <- Integer.parse(id),
+         {:ok, updated} <- DisplayOrder.update_status(id, status) do
+      {:noreply,
+       socket
+       |> put_flash(:info, "Metric status updated to #{updated.status}")
+       |> assign(
+         metrics: put_metric_status(socket.assigns.metrics, id, updated.status),
+         filtered_metrics: put_metric_status(socket.assigns.filtered_metrics, id, updated.status)
+       )}
+    else
+      {:error, error} ->
+        {:noreply, socket |> put_flash(:error, "Error updating status: #{inspect(error)}")}
+
+      _ ->
+        {:noreply, socket |> put_flash(:error, "Invalid metric ID")}
+    end
+  end
+
+  @impl true
   def handle_event("delete_metric", %{"id" => id}, socket) do
     {id, _} = Integer.parse(id)
 
@@ -496,6 +556,12 @@ defmodule SanbaseWeb.MetricDisplayOrderLive do
      |> push_patch(to: ~p"/admin/metric_registry/display_order")}
   end
 
+  defp put_metric_status(metrics, id, status) do
+    Enum.map(metrics, fn metric ->
+      if metric.id == id, do: %{metric | status: status}, else: metric
+    end)
+  end
+
   defp filter_metrics(socket) do
     %{metrics: metrics, selected_category: category, selected_group: group} = socket.assigns
 
@@ -539,14 +605,15 @@ defmodule SanbaseWeb.MetricDisplayOrderLive do
       >
         Edit
       </.link>
-      <.link
+      <button
+        type="button"
         phx-click="delete_metric"
         phx-value-id={@metric.id}
         data-confirm="Are you sure you want to delete this metric display order? This action cannot be undone."
         class="link link-error text-sm cursor-pointer"
       >
         Delete
-      </.link>
+      </button>
     </div>
     """
   end

--- a/lib/sanbase_web/live/metric_registry/metric_display_order_show_live.ex
+++ b/lib/sanbase_web/live/metric_registry/metric_display_order_show_live.ex
@@ -99,7 +99,11 @@ defmodule SanbaseWeb.MetricDisplayOrderShowLive do
       %{key: "Chart Style", value: assigns.display_order.chart_style || "line"},
       %{key: "Unit", value: assigns.display_order.unit || ""},
       %{key: "Description", value: assigns.display_order.description || ""},
-      %{key: "Args", value: inspect(assigns.display_order.args || %{})}
+      %{key: "Args", value: inspect(assigns.display_order.args || %{})},
+      %{
+        key: "Status",
+        value: AdminSharedComponents.status_text(assigns.display_order.status)
+      }
     ]
 
     assigns = assign(assigns, :rows, rows)

--- a/priv/repo/migrations/20260803150000_add_status_to_metric_display_order.exs
+++ b/priv/repo/migrations/20260803150000_add_status_to_metric_display_order.exs
@@ -1,0 +1,9 @@
+defmodule Sanbase.Repo.Migrations.AddStatusToMetricDisplayOrder do
+  use Ecto.Migration
+
+  def change do
+    alter table(:metric_display_order) do
+      add(:status, :string, default: "live", null: false)
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,10 +2,10 @@
 -- PostgreSQL database dump
 --
 
-\restrict EuO1FOFSdwRhrsmNwhuZYoYO5ic3xSG8nprNQIITLDdxClvvC5xNpSUi80sx8GD
+\restrict rfyXtDlrPfqgJZAAQGTpPZ1dlvrHY5xvDdsiJhJxFdfveh3D8duHyRoWbVeSkp0
 
--- Dumped from database version 17.10 (Homebrew)
--- Dumped by pg_dump version 17.10 (Homebrew)
+-- Dumped from database version 17.9 (Homebrew)
+-- Dumped by pg_dump version 17.9 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -2461,7 +2461,8 @@ CREATE TABLE public.metric_display_order (
     inserted_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     ui_key character varying(255),
-    short_label character varying(255)
+    short_label character varying(255),
+    status character varying(255) DEFAULT 'live'::character varying NOT NULL
 );
 
 
@@ -12022,7 +12023,7 @@ ALTER TABLE ONLY public.webinar_registrations
 -- PostgreSQL database dump complete
 --
 
-\unrestrict EuO1FOFSdwRhrsmNwhuZYoYO5ic3xSG8nprNQIITLDdxClvvC5xNpSUi80sx8GD
+\unrestrict rfyXtDlrPfqgJZAAQGTpPZ1dlvrHY5xvDdsiJhJxFdfveh3D8duHyRoWbVeSkp0
 
 INSERT INTO public."schema_migrations" (version) VALUES (20171008200815);
 INSERT INTO public."schema_migrations" (version) VALUES (20171008203355);
@@ -12611,3 +12612,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20260722120000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260722130000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260728132322);
 INSERT INTO public."schema_migrations" (version) VALUES (20260803120000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260803150000);

--- a/test/sanbase_web/graphql/metric/api_metric_display_order_test.exs
+++ b/test/sanbase_web/graphql/metric/api_metric_display_order_test.exs
@@ -159,6 +159,72 @@ defmodule SanbaseWeb.Graphql.ApiMetricDisplayOrderTest do
     assert Enum.sort(onchain_display_orders) == onchain_display_orders
   end
 
+  test "status is returned and does not filter out metrics", %{
+    conn: conn,
+    metric1: metric1,
+    metric2: metric2
+  } do
+    {:ok, _} = Sanbase.Metric.UIMetadata.DisplayOrder.update_status(metric2.id, :hidden)
+
+    {:ok, _} =
+      Sanbase.Metric.UIMetadata.DisplayOrder.update_status(metric1.id, :under_maintenance)
+
+    query = """
+    {
+      getOrderedMetrics {
+        metrics {
+          metric
+          status
+        }
+      }
+    }
+    """
+
+    metrics =
+      conn
+      |> post("/graphql", query_skeleton(query, "getOrderedMetrics"))
+      |> json_response(200)
+      |> get_in(["data", "getOrderedMetrics", "metrics"])
+
+    # All metrics are still returned, the status is just a field
+    assert length(metrics) == 4
+
+    statuses = Map.new(metrics, fn m -> {m["metric"], m["status"]} end)
+
+    assert statuses == %{
+             "price_usd" => "UNDER_MAINTENANCE",
+             "price_btc" => "HIDDEN",
+             "active_addresses_24h" => "LIVE",
+             "transaction_volume" => "LIVE"
+           }
+
+    by_category_query = """
+    {
+      getMetricsByCategory(category: "Financial") {
+        metric
+        status
+      }
+    }
+    """
+
+    by_category =
+      conn
+      |> post("/graphql", query_skeleton(by_category_query, "getMetricsByCategory"))
+      |> json_response(200)
+      |> get_in(["data", "getMetricsByCategory"])
+
+    assert Enum.map(by_category, & &1["metric"]) == ["price_usd", "price_btc"]
+    assert Enum.map(by_category, & &1["status"]) == ["UNDER_MAINTENANCE", "HIDDEN"]
+  end
+
+  test "update_status rejects invalid statuses", %{metric1: metric1} do
+    assert {:error, %Ecto.Changeset{}} =
+             Sanbase.Metric.UIMetadata.DisplayOrder.update_status(metric1.id, "not_a_status")
+
+    assert {:error, "Record not found"} =
+             Sanbase.Metric.UIMetadata.DisplayOrder.update_status(-1, :hidden)
+  end
+
   test "get metrics by category works properly", %{conn: conn} do
     query = """
     {

--- a/test/sanbase_web/live/metric_registry/metric_display_order_form_live_test.exs
+++ b/test/sanbase_web/live/metric_registry/metric_display_order_form_live_test.exs
@@ -72,6 +72,18 @@ defmodule SanbaseWeb.MetricDisplayOrderFormLiveTest do
       assert updated.args == %{"selector" => %{"slug" => "ethereum"}}
     end
 
+    test "saves status", %{conn: conn, metric: metric} do
+      {:ok, view, _html} = live(conn, "/admin/metric_registry/display_order/edit/#{metric.id}")
+
+      assert metric.status == :live
+
+      view
+      |> form("form", %{"status" => "under_maintenance"})
+      |> render_submit()
+
+      assert DisplayOrder.by_id(metric.id).status == :under_maintenance
+    end
+
     test "shows error for invalid JSON", %{conn: conn, metric: metric} do
       {:ok, view, _html} = live(conn, "/admin/metric_registry/display_order/edit/#{metric.id}")
 


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metric display statuses: Live, Hidden, and Under Maintenance.
  * Administrators can update metric status from display-order lists and edit forms.
  * Metric details and API responses now show status information.
  * Added status badges and readable labels for non-live metrics.

* **Bug Fixes**
  * Added validation for unsupported statuses and missing metrics.
  * Confirmed hidden and maintenance metrics remain available in API results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->