### PR TITLE
Add bundle subscriptions entitlements

### DIFF
--- a/docs/composable-api-plans-handover.md
+++ b/docs/composable-api-plans-handover.md
@@ -31,9 +31,10 @@
 1. **Design: a `BUNDLE` plan marker + an entirely new entitlement path.** The `plans` row carries a plain marker name (`BUNDLE`) that encodes **nothing**. When the plan name is a bundle, a **new** code path decodes the subscription's items into an entitlement and answers all access and quota questions from it. Existing plans keep their existing code paths, untouched. See §5.
 2. **Backward compatibility is a deliverable, not a caveat.** It has its own subtask (§8, task **BC**), its own contract (§7.1), its own test strategy (§7.4), and its own DoD line (§12). The single most valuable thing to build first is the characterization test suite that pins today's behavior.
 3. **The entire risk of this design is one thing: finding every `case plan_name` site.** ✅ There are **8 functions with no catch-all clause** that raise `CaseClauseError` on a `BUNDLE` name — including `Plan.plan_name/1`, which runs on **every authenticated request**. Another **9** have catch-alls, so they don't crash; they silently grant the *wrong* access or quota. §7.5 is the complete verified inventory. §7.6 is the mechanism that turns a missed site into a compile error instead of a production 500 — **build it before the feature.**
-4. **The product model in the original write-up is missing two dimensions** the code will force you to answer: data windows (historical depth / realtime cutoff) and query/signal access. Metrics alone will under-deliver Onchain Labels and Social. See §6.2.
+4. **The product model in the original write-up is missing two dimensions** the code forces you to answer: data windows (historical depth / realtime cutoff) and query/signal access. ✅ Both are now settled — windows are uniform full history (§5.7), and queries/signals are `"all"` for every bundle because they are already effectively unrestricted (§6.4). Neither needs product input; both still need to be written explicitly.
 5. **Two of the original "open questions" are answered by the code.** Package prices must *not* become rows in `plans` (§7.3 #2); hour/minute rate limits must *not* be summed (§6.2). See §9.
 6. **Do Stripe last, not first.** The catalog is cheap and reversible; entitlement semantics are not. See §8.
+7. **§15 is the running list of questions for product**, written in plain language for a non-engineer. Every decision the build needs goes there; answers move up into §9. Send product that section, not this document.
 
 ---
 
@@ -304,6 +305,47 @@ Two consequences worth knowing:
 
 ---
 
+### 5.8 How a bundle's entitlement reaches the code that needs it
+
+This is the one hole in §5.4 that had to be closed before any code. §5.4 says *where the entitlement is stored*; it never said *how the functions that answer access questions get hold of it*.
+
+**The problem.** Every function that decides access takes the plan **name** and nothing else:
+
+```elixir
+def plan_has_access?(query_or_argument, requested_product, plan_name)
+```
+
+For a per-customer plan this is enough, because the name identifies the customer — `CUSTOM_ACME` is one row, one restrictions blob, so `Loader.get_data(plan_name, product)` can find it. That is the load-bearing property of the `CUSTOM_*` design, and `BUNDLE` gives it up on purpose: ✅ every bundle subscription shares the single name `BUNDLE` (§5.7), so the name identifies *nothing*. `plan_has_access?({:metric, "price_usd"}, "SANAPI", "BUNDLE")` has nothing to look up.
+
+⚠️ Note the consequence for §8 **BA** as originally written: "six functions mirroring `CustomPlan.Access`" cannot work unchanged, because those signatures cannot reach a per-subscription value.
+
+**What already exists.** ✅ `auth_plug.ex:206-211` puts the whole subscription into the request context:
+
+```elixir
+auth: %{auth_method: :user_token, current_user: current_user,
+        subscription: subscription, plan: effective_plan_name(subscription, "SANBASE")}
+```
+
+✅ It is `access_control.ex:648-660` (`context_to_plan_name_product_code/1`) that reduces it to a plain string on the way to the access checker. The data is already there; only the last hop drops it. Adding the column to the subscription row (§5.4) makes it available for free, since AuthPlug already loads the row.
+
+**Decision: pass the entitlement as an extra, optional argument.**
+
+```elixir
+def plan_has_access?(query_or_argument, requested_product, plan_name, entitlement \\ nil)
+```
+
+- The `:standard` and `:custom` branches **ignore** it. Only the `:bundle` branch reads it.
+- ✅ Every existing caller keeps calling the three-argument form and is unaffected — including the BC characterization fixture, which is what makes this provably safe rather than merely believed safe.
+- The bundle branch **raises** on `nil` rather than falling back to the standard ladder. A missing entitlement is a bug, and §7.5 B1 is the reason: silently answering from the ordinal ladder gives a paying customer roughly FREE access with no error anywhere.
+
+**Quota needs a different answer.** ✅ There is no subscription in scope where limits are computed — `get_api_calls_maps/1` derives them purely from the `api_calls_limit_plan` string on the `api_call_limits` row (`api_call_limit.ex:481`), and that string is `"sanapi_bundle"` for every bundle customer alike. So the resolved numbers are **written onto the `api_call_limits` row** when the subscription syncs. ✅ That row already carries per-user overrides (`has_limits_no_matter_plan`, `has_limits` — `api_call_limit.ex:39-41`), so this fits the existing design rather than fighting it, and it is the same "resolve once at sync, store on the row" pattern as §5.4.
+
+**Rejected: naming plans `BUNDLE_<subscription_id>`.** It would mirror `CUSTOM_*` exactly and need *zero* signature changes — ✅ `Plan.type/1`'s prefix match already accepts it. Tempting, and rejected for two reasons: a `plans` row per subscription turns a small catalog into a per-customer table, and reusing `CustomPlan.Loader` for it would put a customer-triggered write into `:persistent_term`, which is the exact hazard §10 warns about.
+
+**Relationship to §14.** This is a small step *toward* the deferred unification, not away from it. §14's end state is one entitlement value per subscription carried in the context instead of the `auth.plan` string. Threading it as an optional argument is that same value arriving at the same functions — just alongside the plan name rather than replacing it. Nothing here has to be undone later.
+
+---
+
 ## 6. Target product model
 
 ### 6.1 Sellable line items (recurring)
@@ -329,7 +371,9 @@ The original write-up specified only metrics and monthly calls. `Restrictions` r
 | **Data windows** (`historical_data_in_days`, `realtime_data_cut_off_in_days`) | **Global, uniform**: `nil` history + `0` realtime cut-off. A package includes full history; no add-on in v1 | ✅ **decided** (§5.7) |
 | **API calls** | month: **sum** of package bases + add-ons. hour/minute: **do not sum** — see below | partially specified |
 
-**Queries and signals are not optional.** There are ~13 `access: :restricted` GraphQL queries, and they map directly onto the packages being sold — `historical_balance_queries.ex:114` (`min_plan: [sanapi: "PRO"]`), `blockchain_metric_queries.ex`, `social_data_queries.ex`. Top-holders and historical-balance functionality is core Onchain Labels surface and it lives in **queries**, not the metric registry. A package defined only as a metric set will under-deliver Onchain Labels and Social. ✅ verified.
+**Queries and signals are a required *field*, but not a per-package decision.** There are 13 `access: :restricted` GraphQL queries and 10 signals, and they do map onto the packages being sold — top-holders and historical-balance functionality is core Onchain Labels surface and lives in **queries**, not the metric registry.
+
+⚠️ **Corrected after verification:** an earlier draft of this section concluded that a metric-only package would under-deliver Onchain Labels and Social. That is wrong. `access: :restricted` means *window-limited*, not paywalled, and 12 of the 13 queries plus all 10 signals are reachable by a free user today. So a metric-only package under-delivers nothing — but the entitlement must still say `"all"` explicitly, because the allow-list denies by default. See §6.4 for the inventory and the reasoning.
 
 **Data windows — resolved, and deliberately so.** `nil` means *no restriction* (`custom_access_checker.ex:36-39` docstring), which is normally a trap: leaving the field unset silently ships full history and full realtime. Here it is the intended answer — a package includes full history (§5.7). Worth stating explicitly rather than leaving implied, because "we forgot to set it" and "we chose not to restrict it" produce identical code and very different conversations later.
 
@@ -342,13 +386,34 @@ The original write-up specified only metrics and monthly calls. `Restrictions` r
 ### 6.3 Rules (recommended)
 
 1. Metric / query / signal access = **union** of purchased packages
-2. Monthly API call limit = **sum** of per-package bases + add-ons
+2. Monthly API call limit = **flat 100,000 + add-ons**. ✅ Decided by product: *not* summed per package. `EN` never reads the package list to compute quota (§9)
 3. One **shared** call bucket (never split Social vs Onchain rate limits)
-4. Hour/minute limits from a **single base value**, not summed
+4. Hour/minute limits from a **single base value**, not summed — reuse `sanapi_pro` (30k/hour, 600/minute) as burst protection (§9)
 5. Data windows = **uniform**: full history (`nil`) and no realtime cut-off (`0`) for every bundle (§5.7)
 6. One Stripe subscription, many items, one invoice (Stripe native)
 7. Prefer composition of prices over combinatorial fixed combo SKUs
 8. Plan naming: `plans` rows named `BUNDLE` on SanAPI (one per interval) as markers; the entitlement comes from the items (§5.0, §5.7)
+9. Queries and signals = **`"all"` for every bundle** (§6.4)
+
+### 6.4 Queries and signals: the inventory, and why they need no per-package split
+
+⚠️ **`access: :restricted` does not mean paywalled.** It means *time-window limited*. Plan gating is a separate `min_plan` key, and ✅ the default when it is absent is `"FREE"` (`standard_access_checker.ex:87`).
+
+Consequence: of the 13 restricted queries, **exactly one is actually plan-gated** — `miners_balance` at `[sanapi: "PRO", sanbase: "FREE"]` (`historical_balance_queries.ex:114`). The other 12 are reachable by a free API user today, with only the history window varying. ✅ And all 10 signals are `access: free` on both products (`lib/sanbase/signal/signal_files/available_signals.json`).
+
+| Social (7) | On-Chain Labelled (5) | On-Chain (1) |
+|---|---|---|
+| `get_trending_words`, `get_trending_stories`, `get_word_trending_history`, `get_project_trending_history`, `word_context`, `words_context`, `words_social_volume` | `top_holders`, `realtime_top_holders`, `top_holders_percent_of_total_supply`, `top_exchanges_by_balance`, `miners_balance` ← the only paid one | `gas_used` |
+
+Nothing maps to **Market** or **Developer** — those two packages are metrics-only.
+
+Signals: `mvrv_usd_{{timebound}}_upper_zone`, `mvrv_usd_{{timebound}}_lower_zone`, `anomaly_project_in_trending_words`, `anomaly_total_liquidations`, `anomaly_eth_whale_dump`, `anomaly_hyperliquid_avg_funding_rate`, `anomaly_large_stablecoin_mint`, `anomaly_social_price_correlation`, `anomaly_social_dominance_spike`, `anomaly_price_network_activity_divergence`.
+
+**Therefore `query_access` and `signal_access` are `"all"` for every bundle.** Enumerating them per package would make a paying bundle customer *lose* queries a free user has today — a regression, not a feature. `miners_balance` comes along with `"all"`, which is correct: bundles are paid plans priced around PRO, and PRO has it.
+
+🔴 **But "unrestricted" still has to be stated explicitly.** The allow-list denies by default, and ✅ `query_access` / `signal_access` are in `@required_fields` (`custom_plan_restrictions.ex:28`, `:33`). A resolver that leaves them `nil` instead of `"all"` breaks *every* query and signal for bundle customers. ✅ `"all"` is already a first-class value in the loader (`custom_plan_loader.ex:124`, `:135`), so it is reuse, not new code — but **task EN needs an explicit test asserting both fields resolve to the full item set**, precisely because "no restriction" is the kind of answer that gets implemented as an omission.
+
+⚠️ If queries should later become a per-package selling point (Social's trending words only for Social buyers), decide it **before launch** — tightening access for existing customers is the expensive direction.
 
 ---
 
@@ -519,7 +584,9 @@ Ship as vertical slices. Changes from the original split: BC is promoted to a fi
 **Depends on:** A, PD, LC.
 
 ### BA. Bundle access path
-**What:** The new path itself. `Bundle.Access` — six functions mirroring `CustomPlan.Access` (`plan_has_access?/3`, `get_available_metrics_for_plan/3`, `api_call_limits/2`, `historical_data_in_days/4`, `realtime_data_cut_off_in_days/4`, plus whatever C2 decides for Sanbase) reading the stored entitlement. Then fill in the `:bundle` clause at **every** site from §7.5 groups A and B, replacing the `"not implemented"` raises from **DP**.
+**What:** The new path itself. `Bundle.Access` — six functions mirroring `CustomPlan.Access` (`plan_has_access?`, `get_available_metrics_for_plan`, `api_call_limits`, `historical_data_in_days`, `realtime_data_cut_off_in_days`, plus whatever C2 decides for Sanbase) reading the stored entitlement. Then fill in the `:bundle` clause at **every** site from §7.5 groups A and B, replacing the `"not implemented"` raises from **DP**.
+
+⚠️ **Not a straight mirror of `CustomPlan.Access`** — see §5.8. Those signatures take only a plan name, which cannot identify a bundle customer. The access functions gain an optional entitlement argument, and the quota functions read numbers stored on the `api_call_limits` row instead.
 **Deliverable:** `Bundle.Access` + ~20 one-line dispatch clauses + tests per site.
 **Depends on:** EN, DP. **Highest-risk task in the epic.** Acceptance: the §7.6 smoke matrix is green for `BUNDLE` and the **BC** fixture is unchanged.
 
@@ -602,23 +669,18 @@ Now **decided**:
 | `has_custom_restrictions` on the `BUNDLE` rows? | **No.** It would route Sanbase requests into `fetch_base_plan_for_custom/1` → `Loader.get_plan/2` → 🔴 `FunctionClauseError`. | §7.5 C2 |
 | Mixed monthly/yearly in one subscription? | **Not possible.** Stripe requires one interval per subscription, and it is also the product decision. Every sku needs both variants; switching interval is its own mutation. | §5.7 |
 | Data windows per package | **Full history included, no add-on in v1.** Window is global: `historical_data_in_days: nil`, `realtime_data_cut_off_in_days: 0`. Keeps `EN` free of per-grant windows. | §5.7 |
+| **API calls per bundle** | **100,000/month flat, regardless of how many packages.** Explicitly *not* summed per package — "choose several bundles, you get 100k API as default". Extra call packages sold as add-ons (tiers in Notion). So `EN` computes `100_000 + sum(add_ons)` and never reads the package list for quota. | product (Dmitry) |
+| Institutional API calls | **50,000/month.** Lower than a single $350 package — confirmed intentional. | product (Dmitry) |
+| Institutional history | **All data, 3-year history**, while every bundle gets full history. Confirmed intentional; Institutional is therefore *not* simply the top rung on the history dimension. | product (Dmitry) |
+| Hour / minute limits for bundles | **Constants, not derived from packages.** With a flat monthly cap there is nothing to sum. Reuse `sanapi_pro` (30k/hour, 600/minute) as burst protection — the 100k/month cap binds first, and that load is already accepted from PRO. ⚠️ Product notified, no objection needed. | §6.2 + this doc |
+| Prices | **Not final, and must stay changeable.** Prices are data (catalog table + Stripe), never hardcoded in Elixir. Note: a Stripe Price is **immutable** — changing an amount means creating a new Price and archiving the old, with both alive while anyone is subscribed. Catalog needs `stripe_price_id` + an active/deprecated flag; `plans.is_deprecated` already models exactly this pattern. | product (Dmitry), §7.3 #2 |
+| The "sixth package" | **It is the 500,000-call add-on, not a data pillar.** The pricing page's "six packages" = 5 data pillars + extra calls. So **PD** defines five packages, and the add-on is already modelled as `subscription_items.type: :api_calls` (§8 **LC**) — no new concept needed. | product (Dmitry) |
+| Queries & signals per package | **`"all"` for every bundle** — no per-package split. They are effectively unrestricted today (12 of 13 queries and all 10 signals default to `FREE`), so enumerating them per package would *remove* access a free user already has. Needs no product input: it is the BC-preserving choice. 🔴 Must still be written explicitly — `nil` breaks every query and signal. | §6.4 |
+| Existing SanAPI plans after launch | **Withdrawn from sale; current subscribers keep them indefinitely.** ✅ Mechanism already exists and is already enforced: `plans.is_deprecated` is checked in `billing_resolver.ex:27` (subscribe) and `:74` (update_subscription), so a deprecated plan can be neither newly subscribed to *nor* switched into, while existing subscriptions are untouched. ✅ It is an editable field in the plan admin (`generic_admin/plan.ex:22`) — a checkbox at launch, no deploy. This also removes the price/quota domination concern in §10. | product (Dmitry) |
 
-Still genuinely open (all ⚠️, all belong in task **A** or **PD**):
+**Open questions are in §15**, written for a product reader. When one is answered, move it up into the table above with its source.
 
-| Decision | Options / recommendation |
-|----------|---------------------------|
-| **Queries & signals per package** | Required by `Restrictions`; must be enumerated per package (Onchain Labels and Social depend on it) |
-| Base quota per package | e.g. 100k each — but check against `sanapi_pro` = 600k (§6.2) |
-| Extra call SKUs | e.g. +100k, +500k; prices |
-| 2 packages → calls | **200k shared** (recommended) vs 100k total vs split pools |
-| Hour/minute limits | **Do not sum** (§6.2). Recommend max or a base-plan constant |
-| Mid-cycle remove package | Limit drop immediate vs next period; used calls carry over. Recommend: raise immediately, drop at period end |
-| Proration | Stripe default immediate invoice vs period end |
-| Sanbase | Packages SANAPI-only? What `restricted_access_as_plan` value do they map to for Sanbase fallback? |
-| Package ↔ metrics source of truth | Versioned snapshot (recommended) vs live category membership (§8 **PD**) |
-| Combination cardinality | Confirm sold combinations stay in the tens (§5.3) |
-| Admin tooling | Edit package contents without deploy? (implies snapshot + publish flow) |
-| Trials & dunning | §8 **TR** |
+Engineering-side, needing no product input: package ↔ metrics source of truth (versioned snapshot recommended — §8 **PD**), and combination cardinality (confirm sold combinations stay in the tens — §5.3).
 
 ---
 
@@ -671,9 +733,9 @@ Three things, in this order. The first two are pure infrastructure and can start
 
 1. **Task BC** — the characterization fixture (~a day). Pure upside: required by the DoD, never needs rewriting, and it makes every later review a diff instead of an argument.
 2. **Task DP** — `Plan.type/1` + the §7.6 smoke matrix (~1–2 days). Land it as a behavior-preserving refactor with the fixture green. Its first commit should be the smoke matrix *failing* for `BUNDLE` on all eight Group A rows — that failure list is the epic's real definition of scope.
-3. **Vertical spike** (~a day, after DP) — one hardcoded two-package entitlement written directly into `subscriptions.bundle_entitlement`, `Bundle.Access` implemented for `plan_has_access?/3` and `api_call_limits/2` only, and `:bundle` clauses filled in at just those sites. Prove that a seeded bundle subscription gets exactly the right access and quota with the fixture unchanged. That validates the §5 design end-to-end before any Stripe, package-definition, or UI work.
+3. **First working slice** (~a day, after DP) — narrow but complete, from the database row all the way to the answer a request gets. One two-package entitlement written by hand into `subscriptions.bundle_entitlement`, `Bundle.Access` implemented for `plan_has_access?` and `api_call_limits` only, and the bundle branch filled in at just those two sites. Prove that a seeded bundle subscription gets exactly the right access and quota while the BC fixture stays unchanged. That validates the §5 design end to end before any Stripe, package-definition, or UI work. Everything it produces is kept — none of it is throwaway.
 
-In parallel, **task A** can proceed independently, and it should lead with the four items that cause rework: data windows, queries/signals per package, the hour/minute rule, and the base quota vs `sanapi_pro`'s existing 600k.
+✅ **All four of the items that were flagged as causing rework are now answered** — data windows (uniform full history, §5.7), queries/signals (`"all"`, §6.4), the hour/minute rule (constants, §9), and the base quota (flat 100k, §9). Task **A** is no longer on the critical path; what remains of it is in §15 and none of it blocks development.
 
 ---
 
@@ -697,6 +759,108 @@ Two findings that make it more tractable than it sounds:
 And the cost that makes it a separate epic:
 - The ordinal model's real virtue is that **a new metric lands in the right plans automatically** — the moduledoc says so (`standard_access_checker.ex:6-7`). Flip to plan-declares-items and every new metric across ~1046 needs a per-package decision, forever. Defining packages as category **rules** rather than frozen snapshots mitigates it but does not remove it.
 - The `BUNDLE` design in §5 does not block this. If task **EN** produces a real `%Bundle.Entitlement{}` struct (as specified) rather than a `Restrictions` map, that struct is the seed of the unified model, and this epic is a step toward it rather than away from it.
+
+---
+
+## 15. Questions for product
+
+**How to use this section.** Every time the build needs a product decision, it gets appended here — short question, why we need it, an example where that helps. No code, no jargon. When it's answered, the answer moves into the §9 table and the question is struck from here.
+
+Ordered by what is blocking work right now.
+
+### Blocking now
+
+**Q4. Are there extra API-call tiers beyond the 500,000 one, and what do they cost?**
+
+Q1 established that the "sixth package" is the 500,000-call add-on. If Notion has other tiers, we need to know they exist — the prices themselves can come later.
+
+**Prices are not needed to start building.** They are only needed for the Stripe catalog and the purchase page, which come last. What we need now is the *list of things sold*, not their amounts.
+
+*Answer:* partially — 500,000 confirmed; is that the only tier?
+
+---
+
+### Needed before launch
+
+**Q5. What does a package customer see in Sanbase, the web app?**
+
+Packages are for the API. If someone who bought the Market package logs into Sanbase, we have to show them *something* — nothing at all, the free experience, or something in between. The code has to pick one, so we would rather it were your choice than ours.
+
+*Answer:* pending
+
+---
+
+**Q6. Does Institutional's "3 seats" ship in the first version?**
+
+We have no concept of seats today — one subscription belongs to one account. Adding seats is a separate piece of work from packages. If it has to be there at launch, it needs planning now rather than later.
+
+*Answer:* pending
+
+---
+
+**Q7. What happens if a customer removes a package in the middle of a month?**
+
+They have already used some of their calls that month. We need to know whether their access stops straight away or at the end of the period they paid for, and whether anything is refunded.
+
+Our suggestion, unless you prefer otherwise: **adding** a package takes effect immediately, **removing** one takes effect at the end of the paid period. That is the least surprising for the customer and the simplest to get right.
+
+*Answer:* pending
+
+---
+
+**Q8. Do package subscriptions get the 14-day free trial?**
+
+Existing plans have one. If packages get it too, we need to know whether the trial covers any combination the customer picks, or only a specific one.
+
+*Answer:* pending
+
+---
+
+**Q9. What happens when a customer's payment fails?**
+
+Today the subscription is marked "past due" and we keep serving them for a while. For packages: do we cut off all access, or drop them to something smaller until they pay?
+
+*Answer:* pending
+
+---
+
+**Q13. What do we offer an existing API customer who wants to change their plan?**
+
+Once the old plans are withdrawn from sale, a customer on SanAPI PRO can stay on it forever — but the moment they want to change anything, their only options are the new packages. PRO gives them 600,000 calls for $420/month. The closest package costs $350 for 100,000, or $1,050 with the 500,000 add-on.
+
+So a customer who is happy today will find that changing their plan costs more and gives less. We should decide what we tell them before the first one asks.
+
+*Example:* a PRO customer wants to add Social. Today they would move to a package plus the add-on and go from 600,000 calls to 600,000 — at a higher price.
+
+Not blocking any code. It needs an answer before launch, not before development.
+
+*Answer:* pending
+
+---
+
+### Confirmations (we have assumed an answer — tell us if it is wrong)
+
+**Q10. Institutional is a single fixed plan, not something assembled from packages.**
+
+We read $799/month as one fixed product: everything included, 3-year history, 50,000 calls. We are building it that way, which is simpler and cheaper than treating it as a combination of packages. Say so if it is meant to be composable.
+
+*Assumed answer:* fixed plan.
+
+---
+
+**Q11. Yearly Institutional looks like it is missing its discount.**
+
+Yearly packages give roughly two months free — $350/month becomes $3,500/year. Yearly Institutional is $9,500 against $9,588 for twelve monthly payments, which is about 1%. We think this is a typo on the pricing page rather than a decision.
+
+*Assumed answer:* typo.
+
+---
+
+**Q12. Prices can still change, and we are building for that.**
+
+Prices will live as data rather than in code, so they can be added, replaced and retired without a developer. One constraint worth knowing: a price in Stripe cannot be edited. Changing an amount means creating a new price and retiring the old one, and both then exist side by side — anyone already subscribed keeps what they signed up for. That is normal and fine; it just means "change the price" is really "add the new one, stop selling the old one".
+
+*Assumed answer:* prices not final; build for change.
 
 ---
 

--- a/lib/sanbase/api_call_limit/api_call_limit.ex
+++ b/lib/sanbase/api_call_limit/api_call_limit.ex
@@ -519,7 +519,10 @@ defmodule Sanbase.ApiCallLimit do
       _ ->
         case Sanbase.Billing.Plan.type_of_api_call_limit_plan(plan) do
           :bundle ->
-            Sanbase.Billing.Plan.Bundle.not_implemented!(:plan_has_limits?, plan)
+            # Every bundle has a monthly call limit - a flat 100k plus whatever
+            # add-ons were bought (§9). There is no unlimited bundle, so this
+            # needs no entitlement to answer.
+            true
 
           :custom ->
             [product_code, plan_name] = plan |> String.upcase() |> String.split("_", parts: 2)
@@ -551,7 +554,14 @@ defmodule Sanbase.ApiCallLimit do
   def plan_to_api_call_limits(plan) do
     case Sanbase.Billing.Plan.type_of_api_call_limit_plan(plan) do
       :bundle ->
-        Sanbase.Billing.Plan.Bundle.not_implemented!(:plan_to_api_call_limits, plan)
+        # A bundle's limits cannot be derived from its name - every bundle is
+        # named BUNDLE, while the numbers differ per customer. They are worked out
+        # when the subscription syncs and stored on the api_call_limits row, so
+        # this function is the wrong way to ask. See §5.8.
+        Sanbase.Billing.Plan.Bundle.not_implemented!(
+          {:plan_to_api_call_limits, :read_from_api_call_limits_row_instead},
+          plan
+        )
 
       :custom ->
         "sanapi_" <> plan_name = plan

--- a/lib/sanbase/billing/plan/access_checker.ex
+++ b/lib/sanbase/billing/plan/access_checker.ex
@@ -6,6 +6,7 @@ defmodule Sanbase.Billing.Plan.AccessChecker do
   @type subscription_product :: String.t()
   @type product_code :: String.t()
   @type plan_name :: String.t()
+  @type entitlement :: Sanbase.Billing.Plan.Bundle.Entitlement.t() | nil
 
   alias Sanbase.Billing.Plan
   alias Sanbase.Billing.Plan.{BundleAccessChecker, CustomAccessChecker, StandardAccessChecker}
@@ -22,12 +23,25 @@ defmodule Sanbase.Billing.Plan.AccessChecker do
   end
 
   @doc ~s"""
+  Whether the given plan may use this metric, query or signal.
+
+  The last argument is only read by bundle plans, which cannot be identified by
+  name - every bundle is named `BUNDLE`, so the entitlement has to be handed in.
+  Standard and custom plans ignore it, which is why existing callers can keep
+  using the three-argument form unchanged. See §5.8 of
+  docs/composable-api-plans-handover.md.
   """
-  @spec plan_has_access?(query_or_argument, requested_product, plan_name) :: boolean()
-  def plan_has_access?(query_or_argument, requested_product, plan_name) do
+  @spec plan_has_access?(query_or_argument, requested_product, plan_name, entitlement) ::
+          boolean()
+  def plan_has_access?(query_or_argument, requested_product, plan_name, entitlement \\ nil) do
     case Plan.type(plan_name) do
       :bundle ->
-        BundleAccessChecker.plan_has_access?(query_or_argument, requested_product, plan_name)
+        BundleAccessChecker.plan_has_access?(
+          query_or_argument,
+          requested_product,
+          plan_name,
+          entitlement
+        )
 
       :custom ->
         CustomAccessChecker.plan_has_access?(query_or_argument, requested_product, plan_name)

--- a/lib/sanbase/billing/plan/access_map.ex
+++ b/lib/sanbase/billing/plan/access_map.ex
@@ -34,6 +34,55 @@ defmodule Sanbase.Billing.Plan.AccessMap do
   @type item :: String.t()
 
   @doc ~s"""
+  Problems with an access map, as a list of messages. Empty means it is usable.
+
+  Worth validating on the way in rather than on the way out: an invalid regex
+  reaches `Regex.compile!/1` during an access check and raises there, which turns
+  one bad stored value into a failure on every request that customer makes.
+  """
+  @spec errors(access_map()) :: [String.t()]
+  def errors(access_map) when is_map(access_map) do
+    Enum.flat_map(
+      [
+        {"accessible", :list_or_all},
+        {"not_accessible", :list_or_all},
+        {"accessible_patterns", :patterns},
+        {"not_accessible_patterns", :patterns}
+      ],
+      fn {key, kind} -> key_errors(key, kind, Map.get(access_map, key, :absent)) end
+    )
+  end
+
+  def errors(nil), do: []
+  def errors(_other), do: ["must be a map"]
+
+  defp key_errors(_key, _kind, :absent), do: []
+  defp key_errors(_key, :list_or_all, "all"), do: []
+
+  defp key_errors(key, :list_or_all, value) do
+    if is_list(value) and Enum.all?(value, &is_binary/1) do
+      []
+    else
+      [~s|"#{key}" must be "all" or a list of strings|]
+    end
+  end
+
+  defp key_errors(key, :patterns, value) do
+    cond do
+      not is_list(value) ->
+        [~s|"#{key}" must be a list of strings|]
+
+      not Enum.all?(value, &is_binary/1) ->
+        [~s|"#{key}" must be a list of strings|]
+
+      true ->
+        value
+        |> Enum.reject(&match?({:ok, _}, Regex.compile(&1)))
+        |> Enum.map(&~s|"#{key}" contains an invalid regular expression: #{inspect(&1)}|)
+    end
+  end
+
+  @doc ~s"""
   All items the access map allows, given a function returning every known item.
   """
   @spec resolve(access_map(), (-> [item()])) :: [item()]

--- a/lib/sanbase/billing/plan/access_map.ex
+++ b/lib/sanbase/billing/plan/access_map.ex
@@ -1,0 +1,126 @@
+defmodule Sanbase.Billing.Plan.AccessMap do
+  @moduledoc ~s"""
+  Interprets an "access map" - the allow-list shape used by both custom plans and
+  bundles to say which metrics, queries or signals a plan may use.
+
+      %{
+        "accessible" => ["price_usd", "active_addresses_24h"] | "all",
+        "accessible_patterns" => ["^social_"],
+        "not_accessible" => ["mvrv_usd"] | "all",
+        "not_accessible_patterns" => ["_change_"]
+      }
+
+  Every key is optional. `accessible` defaults to `[]`, which allows nothing, so
+  a map that is empty or `nil` grants no access at all - the safe direction for
+  an allow-list.
+
+  `not_accessible` always wins over `accessible`.
+
+  This logic was previously private to `CustomPlan.Loader`. It is extracted
+  unchanged so the bundle path can reuse it rather than growing a second,
+  subtly-different copy of the same rules. `Loader` now delegates here.
+
+  ## Two ways to ask
+
+  `resolve/2` returns the full list of allowed items. It walks every known metric
+  (~1000) and compiles the patterns, so it is only worth calling when the whole
+  list is genuinely wanted - listing what a plan offers, for instance.
+
+  `allows?/2` answers for a single item without building the list. Access checks
+  run on every request and ask about exactly one item, so they use this.
+  """
+
+  @type access_map :: map() | nil
+  @type item :: String.t()
+
+  @doc ~s"""
+  All items the access map allows, given a function returning every known item.
+  """
+  @spec resolve(access_map(), (-> [item()])) :: [item()]
+  def resolve(access_map, get_all_items) do
+    access_map = access_map || %{}
+
+    accessible = Map.get(access_map, "accessible", [])
+    accessible_patterns = Map.get(access_map, "accessible_patterns", [])
+    not_accessible = Map.get(access_map, "not_accessible", [])
+    not_accessible_patterns = Map.get(access_map, "not_accessible_patterns", [])
+
+    all_items = get_all_items.()
+
+    # Step 1: Build the accessible list from explicit items + pattern matches
+    accessible_list =
+      case accessible do
+        "all" ->
+          all_items
+
+        list when is_list(list) ->
+          accessible_by_pattern = matching_by_patterns(all_items, accessible_patterns)
+          Enum.uniq(list ++ accessible_by_pattern)
+      end
+
+    # Step 2: Remove not_accessible items (not_accessible has HIGHER priority)
+    not_accessible_list =
+      case not_accessible do
+        "all" -> all_items
+        list when is_list(list) -> list
+      end
+
+    not_accessible_by_pattern = matching_by_patterns(accessible_list, not_accessible_patterns)
+
+    accessible_list -- (not_accessible_list ++ not_accessible_by_pattern)
+  end
+
+  @doc ~s"""
+  Whether the access map allows a single item.
+
+  Equivalent to `item in resolve(access_map, get_all_items)` for any item that
+  exists, but without enumerating anything.
+
+  One deliberate difference: `resolve/2` matches `accessible_patterns` against
+  the list of known items, so a pattern can only ever grant access to something
+  real. Here there is no such list, so a **non-existent** name that matches an
+  accessible pattern is reported as allowed. That is harmless - the request then
+  fails further along because the metric does not exist - and it is the reason
+  this function is not used to build lists.
+  """
+  @spec allows?(access_map(), item()) :: boolean()
+  def allows?(access_map, item) when is_binary(item) do
+    access_map = access_map || %{}
+
+    allowed? =
+      accessible?(Map.get(access_map, "accessible", []), item) or
+        matches_any_pattern?(item, Map.get(access_map, "accessible_patterns", []))
+
+    denied? =
+      accessible?(Map.get(access_map, "not_accessible", []), item) or
+        matches_any_pattern?(item, Map.get(access_map, "not_accessible_patterns", []))
+
+    allowed? and not denied?
+  end
+
+  defp accessible?("all", _item), do: true
+  defp accessible?(list, item) when is_list(list), do: item in list
+  defp accessible?(_, _item), do: false
+
+  defp matches_any_pattern?(_item, []), do: false
+
+  defp matches_any_pattern?(item, patterns) when is_list(patterns) do
+    Enum.any?(patterns, fn pattern -> String.match?(item, Regex.compile!(pattern)) end)
+  end
+
+  defp matches_any_pattern?(_item, _patterns), do: false
+
+  # From the given list, return those items that match at least one of the
+  # provided regex patterns.
+  # Example: pattern "mvrv_" matches all MVRV metrics; pattern "^social_"
+  # matches all metrics starting with "social_".
+  defp matching_by_patterns(_list, []), do: []
+
+  defp matching_by_patterns(list, patterns) do
+    regex_list = Enum.map(patterns, &Regex.compile!/1)
+
+    Enum.filter(list, fn elem ->
+      Enum.any?(regex_list, fn regex -> String.match?(elem, regex) end)
+    end)
+  end
+end

--- a/lib/sanbase/billing/plan/bundle/bundle.ex
+++ b/lib/sanbase/billing/plan/bundle/bundle.ex
@@ -31,6 +31,32 @@ defmodule Sanbase.Billing.Plan.Bundle do
     defexception [:message]
   end
 
+  defmodule MissingEntitlementError do
+    @moduledoc """
+    Raised when a bundle subscription reaches an access or quota check without a
+    stored entitlement.
+
+    This is always a bug: either the subscription was never synced after its
+    items changed, or a caller failed to pass the entitlement through. It is
+    raised rather than defaulted because the only available default is the
+    standard plan ladder, which would silently give a paying customer roughly
+    free-tier access.
+    """
+    defexception [:message]
+  end
+
+  @spec missing_entitlement!(atom()) :: no_return()
+  def missing_entitlement!(site) do
+    raise MissingEntitlementError,
+      message: """
+      A bundle subscription reached #{inspect(site)} with no stored entitlement.
+
+      Either the subscription was not re-synced after its items changed, or the
+      entitlement was not passed through from the request context. See §5.8 of
+      docs/composable-api-plans-handover.md.
+      """
+  end
+
   @doc ~s"""
   Raise a descriptive error for an unimplemented bundle code path.
 

--- a/lib/sanbase/billing/plan/bundle/bundle.ex
+++ b/lib/sanbase/billing/plan/bundle/bundle.ex
@@ -45,6 +45,17 @@ defmodule Sanbase.Billing.Plan.Bundle do
     defexception [:message]
   end
 
+  @doc ~s"""
+  Raise because a bundle subscription arrived without its stored entitlement.
+
+  `site` identifies the function that was reached, so the failure names the
+  caller that failed to pass it through rather than surfacing as a
+  `FunctionClauseError` further along.
+
+  Distinct from `not_implemented!/2` on purpose: that one means the bundle path
+  for a feature does not exist yet, this one means the path exists but its input
+  is missing. The two have different fixes, so they are different errors.
+  """
   @spec missing_entitlement!(atom()) :: no_return()
   def missing_entitlement!(site) do
     raise MissingEntitlementError,

--- a/lib/sanbase/billing/plan/bundle/bundle_access.ex
+++ b/lib/sanbase/billing/plan/bundle/bundle_access.ex
@@ -1,0 +1,70 @@
+defmodule Sanbase.Billing.Plan.Bundle.Access do
+  @moduledoc ~s"""
+  Answers access and quota questions for a bundle subscription, reading the
+  entitlement stored on the subscription row.
+
+  The counterpart of `Sanbase.Billing.Plan.CustomPlan.Access` for bundles, with
+  one important difference. Custom plans are looked up **by name**, because a
+  custom plan's name identifies one customer. Every bundle shares the single name
+  `BUNDLE`, so the name identifies nothing and the entitlement has to be handed
+  in. See §5.8 of docs/composable-api-plans-handover.md.
+
+  ## A missing entitlement raises
+
+  Every function here refuses a `nil` entitlement instead of falling back to
+  anything. The alternative would be answering from the standard plan ladder,
+  which cannot express packages and would quietly give a paying customer roughly
+  free-tier access with no error anywhere - the worst failure mode in §7.5.
+  Failing loudly is the only safe choice.
+  """
+
+  alias Sanbase.Billing.Plan.Bundle
+  alias Sanbase.Billing.Plan.Bundle.Entitlement
+
+  @doc ~s"""
+  Whether the bundle may use this metric, query or signal.
+  """
+  @spec plan_has_access?({:metric | :query | :signal, term()}, Entitlement.t() | nil) :: boolean()
+  def plan_has_access?(query_or_argument, entitlement) do
+    entitlement
+    |> require_entitlement!(:plan_has_access?)
+    |> Entitlement.allows?(query_or_argument)
+  end
+
+  @doc ~s"""
+  The bundle's API call limits, keyed by `:month`, `:hour` and `:minute`.
+  """
+  @spec api_call_limits(Entitlement.t() | nil) :: %{
+          month: integer(),
+          hour: integer(),
+          minute: integer()
+        }
+  def api_call_limits(entitlement) do
+    entitlement
+    |> require_entitlement!(:api_call_limits)
+    |> Entitlement.api_call_limits()
+  end
+
+  @doc ~s"""
+  How many days of history the bundle can read. `nil` means no limit, which is
+  what every bundle gets today (§5.7).
+  """
+  @spec historical_data_in_days(Entitlement.t() | nil) :: non_neg_integer() | nil
+  def historical_data_in_days(entitlement) do
+    require_entitlement!(entitlement, :historical_data_in_days).historical_data_in_days
+  end
+
+  @doc ~s"""
+  How close to now the bundle can read. `0` means realtime.
+  """
+  @spec realtime_data_cut_off_in_days(Entitlement.t() | nil) :: non_neg_integer() | nil
+  def realtime_data_cut_off_in_days(entitlement) do
+    require_entitlement!(entitlement, :realtime_data_cut_off_in_days).realtime_data_cut_off_in_days
+  end
+
+  defp require_entitlement!(%Entitlement{} = entitlement, _site), do: entitlement
+
+  defp require_entitlement!(nil, site) do
+    Bundle.missing_entitlement!(site)
+  end
+end

--- a/lib/sanbase/billing/plan/bundle/bundle_access_checker.ex
+++ b/lib/sanbase/billing/plan/bundle/bundle_access_checker.ex
@@ -5,16 +5,38 @@ defmodule Sanbase.Billing.Plan.BundleAccessChecker do
   Mirrors the public surface of `Sanbase.Billing.Plan.CustomAccessChecker` so
   that `Sanbase.Billing.Plan.AccessChecker` can dispatch to either uniformly.
 
-  Every function currently raises - see `Sanbase.Billing.Plan.Bundle` for why,
-  and `docs/composable-api-plans-handover.md` task BA for what replaces it.
+  `plan_has_access?` is implemented. The rest still raise - see
+  `Sanbase.Billing.Plan.Bundle` for why, and
+  `docs/composable-api-plans-handover.md` task BA for what replaces them.
   """
 
   alias Sanbase.Billing.Plan.Bundle
+  alias Sanbase.Billing.Plan.Bundle.Entitlement
 
   @type query_or_argument :: {:metric, String.t()} | {:signal, String.t()} | {:query, atom()}
 
-  def plan_has_access?(_query_or_argument, _product_code, plan_name),
-    do: Bundle.not_implemented!(:plan_has_access?, plan_name)
+  @doc ~s"""
+  Whether a bundle may use this metric, query or signal.
+
+  The product is not consulted. A bundle's entitlement lists exactly what was
+  bought, and unlike the standard plans the same answer holds on both products.
+
+  Without an entitlement this cannot be answered at all, so it raises. Passing
+  one is the caller's job - see §5.8 of the handover doc for why the plan name
+  alone is not enough.
+  """
+  def plan_has_access?(query_or_argument, product_code, plan_name, entitlement \\ nil)
+
+  def plan_has_access?(
+        query_or_argument,
+        _product_code,
+        _plan_name,
+        %Entitlement{} = entitlement
+      ),
+      do: Bundle.Access.plan_has_access?(query_or_argument, entitlement)
+
+  def plan_has_access?(_query_or_argument, _product_code, _plan_name, nil),
+    do: Bundle.missing_entitlement!(:plan_has_access?)
 
   def get_available_metrics_for_plan(plan_name, _product_code, _restriction_type),
     do: Bundle.not_implemented!(:get_available_metrics_for_plan, plan_name)

--- a/lib/sanbase/billing/plan/bundle/entitlement.ex
+++ b/lib/sanbase/billing/plan/bundle/entitlement.ex
@@ -1,0 +1,143 @@
+defmodule Sanbase.Billing.Plan.Bundle.Entitlement do
+  @moduledoc ~s"""
+  What a bundle subscription is entitled to: which metrics, queries and signals
+  it may use, how many API calls it gets, and how far back its data goes.
+
+  Stored as JSON on `subscriptions.bundle_entitlement`, worked out once when the
+  subscription's items change rather than on every request. See
+  `docs/composable-api-plans-handover.md` §5.3 and §5.4.
+
+  `nil` for every subscription that is not a bundle, which today is all of them.
+
+  ## Why the packages are kept alongside the access maps
+
+  `packages` is not used to decide access - the access maps are. It is kept so
+  that support and invoicing can answer "what did this customer buy?" without
+  working backwards from a metric list.
+
+  ## Versions
+
+  `schema_version` marks the shape of this struct. If stored data was written by
+  older code, re-work it out rather than trusting it.
+
+  `package_snapshot_version` records which published definition of the packages
+  was used. Two customers who bought "Market" months apart can hold different
+  metric lists, which is intended: a customer keeps what they paid for until
+  something deliberately re-works it out.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Sanbase.Billing.Plan.AccessMap
+
+  @current_schema_version 1
+
+  @type t :: %__MODULE__{}
+
+  @primary_key false
+  embedded_schema do
+    field(:packages, {:array, :string}, default: [])
+
+    field(:metric_access, :map)
+    field(:query_access, :map)
+    field(:signal_access, :map)
+
+    field(:api_call_limits, :map)
+
+    field(:historical_data_in_days, :integer)
+    field(:realtime_data_cut_off_in_days, :integer, default: 0)
+
+    field(:package_snapshot_version, :integer)
+    field(:schema_version, :integer, default: @current_schema_version)
+  end
+
+  @fields [
+    :packages,
+    :metric_access,
+    :query_access,
+    :signal_access,
+    :api_call_limits,
+    :historical_data_in_days,
+    :realtime_data_cut_off_in_days,
+    :package_snapshot_version,
+    :schema_version
+  ]
+
+  # historical_data_in_days is deliberately optional: nil means "no limit", which
+  # is what every bundle gets today (§5.7).
+  @required_fields [
+    :metric_access,
+    :query_access,
+    :signal_access,
+    :api_call_limits,
+    :schema_version
+  ]
+
+  def current_schema_version, do: @current_schema_version
+
+  def changeset(%__MODULE__{} = entitlement, attrs) do
+    entitlement
+    |> cast(attrs, @fields)
+    |> validate_required(@required_fields)
+    |> validate_change(:api_call_limits, &validate_api_call_limits/2)
+  end
+
+  @doc ~s"""
+  Whether stored data was written by a different version of this struct and
+  should be worked out again rather than trusted.
+  """
+  @spec stale?(t :: %__MODULE__{} | nil) :: boolean()
+  def stale?(nil), do: false
+  def stale?(%__MODULE__{schema_version: version}), do: version != @current_schema_version
+
+  @doc ~s"""
+  Whether this entitlement allows a single metric, query or signal.
+
+  Queries arrive as atoms from the GraphQL layer and are compared as strings,
+  matching how the custom plan path does it.
+  """
+  @spec allows?(%__MODULE__{}, {:metric | :query | :signal, term()}) :: boolean()
+  def allows?(%__MODULE__{} = entitlement, {:metric, metric}) do
+    AccessMap.allows?(entitlement.metric_access, to_string(metric))
+  end
+
+  def allows?(%__MODULE__{} = entitlement, {:query, query}) do
+    AccessMap.allows?(entitlement.query_access, to_string(query))
+  end
+
+  def allows?(%__MODULE__{} = entitlement, {:signal, signal}) do
+    AccessMap.allows?(entitlement.signal_access, to_string(signal))
+  end
+
+  @doc ~s"""
+  The API call limits in the atom-keyed shape the quota code expects.
+  """
+  @spec api_call_limits(%__MODULE__{}) :: %{month: integer(), hour: integer(), minute: integer()}
+  def api_call_limits(%__MODULE__{api_call_limits: limits}) do
+    %{
+      month: Map.fetch!(limits, "month"),
+      hour: Map.fetch!(limits, "hour"),
+      minute: Map.fetch!(limits, "minute")
+    }
+  end
+
+  # Same rule the custom plans use: month > hour > minute > 0. A quota that is
+  # nil or out of order surfaces as an ArithmeticError several frames away
+  # (api_call_limit.ex:478-496), so it is rejected on the way in.
+  defp validate_api_call_limits(:api_call_limits, %{} = limits) do
+    case limits do
+      %{"minute" => minute, "hour" => hour, "month" => month}
+      when is_integer(minute) and is_integer(hour) and is_integer(month) and
+             month > hour and hour > minute and minute > 0 ->
+        []
+
+      _ ->
+        [
+          api_call_limits:
+            "must be a map with integer month, hour and minute where month > hour > minute > 0"
+        ]
+    end
+  end
+end

--- a/lib/sanbase/billing/plan/bundle/entitlement.ex
+++ b/lib/sanbase/billing/plan/bundle/entitlement.ex
@@ -82,6 +82,9 @@ defmodule Sanbase.Billing.Plan.Bundle.Entitlement do
     |> cast(attrs, @fields)
     |> validate_required(@required_fields)
     |> validate_change(:api_call_limits, &validate_api_call_limits/2)
+    |> validate_change(:metric_access, &validate_access_map/2)
+    |> validate_change(:query_access, &validate_access_map/2)
+    |> validate_change(:signal_access, &validate_access_map/2)
   end
 
   @doc ~s"""
@@ -121,6 +124,16 @@ defmodule Sanbase.Billing.Plan.Bundle.Entitlement do
       hour: Map.fetch!(limits, "hour"),
       minute: Map.fetch!(limits, "minute")
     }
+  end
+
+  # An invalid regex or a wrongly-shaped list would otherwise be stored happily
+  # and then raise during an access check, failing every request that customer
+  # makes rather than the one write that caused it.
+  defp validate_access_map(field_name, value) do
+    case AccessMap.errors(value) do
+      [] -> []
+      errors -> Enum.map(errors, &{field_name, &1})
+    end
   end
 
   # Same rule the custom plans use: month > hour > minute > 0. A quota that is

--- a/lib/sanbase/billing/plan/custom_plan/custom_plan_loader.ex
+++ b/lib/sanbase/billing/plan/custom_plan/custom_plan_loader.ex
@@ -110,48 +110,10 @@ defmodule Sanbase.Billing.Plan.CustomPlan.Loader do
     resolve_accessible_list(access_map, get_all_function)
   end
 
+  # The rules live in Sanbase.Billing.Plan.AccessMap so that the bundle path can
+  # apply exactly the same ones. Extracted verbatim; behavior is unchanged and
+  # the access-matrix fixture proves it.
   defp resolve_accessible_list(access_map, get_all_function) do
-    accessible = Map.get(access_map, "accessible", [])
-    accessible_patterns = Map.get(access_map, "accessible_patterns", [])
-    not_accessible = Map.get(access_map, "not_accessible", [])
-    not_accessible_patterns = Map.get(access_map, "not_accessible_patterns", [])
-
-    all_items = get_all_function.()
-
-    # Step 1: Build the accessible list from explicit items + pattern matches
-    accessible_list =
-      case accessible do
-        "all" ->
-          all_items
-
-        list when is_list(list) ->
-          accessible_by_pattern = get_matching_by_patterns(all_items, accessible_patterns)
-          Enum.uniq(list ++ accessible_by_pattern)
-      end
-
-    # Step 2: Remove not_accessible items (not_accessible has HIGHER priority)
-    not_accessible_list =
-      case not_accessible do
-        "all" -> all_items
-        list when is_list(list) -> list
-      end
-
-    not_accessible_by_pattern = get_matching_by_patterns(accessible_list, not_accessible_patterns)
-
-    accessible_list -- (not_accessible_list ++ not_accessible_by_pattern)
-  end
-
-  # From the given list, return those items that match at least one of the
-  # provided regex patterns.
-  # Example: pattern "mvrv_" matches all MVRV metrics; pattern "^social_"
-  # matches all metrics starting with "social_".
-  defp get_matching_by_patterns(_list, []), do: []
-
-  defp get_matching_by_patterns(list, patterns) do
-    regex_list = Enum.map(patterns, &Regex.compile!/1)
-
-    Enum.filter(list, fn elem ->
-      Enum.any?(regex_list, fn regex -> String.match?(elem, regex) end)
-    end)
+    Sanbase.Billing.Plan.AccessMap.resolve(access_map, get_all_function)
   end
 end

--- a/lib/sanbase/billing/subscription/subscription.ex
+++ b/lib/sanbase/billing/subscription/subscription.ex
@@ -66,6 +66,12 @@ defmodule Sanbase.Billing.Subscription do
 
     field(:payment_intent, :map, virtual: true)
 
+    # Only set for bundle subscriptions. Worked out from the subscription's items
+    # when they change, so access checks never have to decode items or call
+    # Stripe. NULL for every other subscription. See §5.4 of
+    # docs/composable-api-plans-handover.md
+    embeds_one(:bundle_entitlement, Sanbase.Billing.Plan.Bundle.Entitlement, on_replace: :update)
+
     belongs_to(:user, User)
     belongs_to(:plan, Plan)
 
@@ -87,6 +93,7 @@ defmodule Sanbase.Billing.Subscription do
       :inserted_at,
       :type
     ])
+    |> cast_embed(:bundle_entitlement)
     |> foreign_key_constraint(:plan_id, name: :subscriptions_plan_id_fkey)
   end
 

--- a/lib/sanbase/billing/subscription/subscription.ex
+++ b/lib/sanbase/billing/subscription/subscription.ex
@@ -70,7 +70,11 @@ defmodule Sanbase.Billing.Subscription do
     # when they change, so access checks never have to decode items or call
     # Stripe. NULL for every other subscription. See §5.4 of
     # docs/composable-api-plans-handover.md
-    embeds_one(:bundle_entitlement, Sanbase.Billing.Plan.Bundle.Entitlement, on_replace: :update)
+    # on_replace: :delete, not :update - a new entitlement replaces the old one
+    # outright. Merging would let a field the new calculation omits keep its old
+    # value, so a customer who dropped a package could keep part of what it gave
+    # them. See bundle_entitlement_changeset/2.
+    embeds_one(:bundle_entitlement, Sanbase.Billing.Plan.Bundle.Entitlement, on_replace: :delete)
 
     belongs_to(:user, User)
     belongs_to(:plan, Plan)
@@ -93,8 +97,47 @@ defmodule Sanbase.Billing.Subscription do
       :inserted_at,
       :type
     ])
-    |> cast_embed(:bundle_entitlement)
     |> foreign_key_constraint(:plan_id, name: :subscriptions_plan_id_fkey)
+  end
+
+  @doc ~s"""
+  Sets the resolved bundle entitlement, replacing any previous one outright.
+
+  Deliberately separate from `changeset/2`: an entitlement is what a customer is
+  allowed to use and how much of it, so it is only ever written by the code that
+  works it out from the subscription's items - never carried in with ordinary
+  subscription attributes.
+
+  The replacement is wholesale rather than a merge. Building on top of the stored
+  value would let a field the new calculation leaves out keep its old value, so a
+  customer who dropped a package could silently keep part of what it granted.
+  """
+  @spec bundle_entitlement_changeset(%__MODULE__{}, map() | nil) :: Ecto.Changeset.t()
+  def bundle_entitlement_changeset(%__MODULE__{} = subscription, nil) do
+    subscription
+    |> change()
+    |> put_embed(:bundle_entitlement, nil)
+  end
+
+  def bundle_entitlement_changeset(%__MODULE__{} = subscription, attrs) when is_map(attrs) do
+    changeset = subscription |> change()
+
+    # Built from a blank struct so nothing carries over from the stored value.
+    %Plan.Bundle.Entitlement{}
+    |> Plan.Bundle.Entitlement.changeset(attrs)
+    |> case do
+      %{valid?: true} = entitlement_changeset ->
+        put_embed(
+          changeset,
+          :bundle_entitlement,
+          Ecto.Changeset.apply_changes(entitlement_changeset)
+        )
+
+      invalid ->
+        changeset
+        |> put_embed(:bundle_entitlement, invalid)
+        |> Map.put(:valid?, false)
+    end
   end
 
   def create(params, opts \\ []) do

--- a/priv/repo/migrations/20260803120000_add_bundle_entitlement_to_subscriptions.exs
+++ b/priv/repo/migrations/20260803120000_add_bundle_entitlement_to_subscriptions.exs
@@ -1,0 +1,26 @@
+defmodule Sanbase.Repo.Migrations.AddBundleEntitlementToSubscriptions do
+  use Ecto.Migration
+
+  @moduledoc """
+  Holds the resolved entitlement of a bundle subscription.
+
+  It is resolved once when the subscription's items change and stored here, so
+  that answering "what does this customer have access to?" never needs to decode
+  items or hit Stripe. See docs/composable-api-plans-handover.md §5.4.
+
+  NULL for every non-bundle subscription, which is every subscription that
+  exists today.
+  """
+
+  def up do
+    alter table(:subscriptions) do
+      add(:bundle_entitlement, :jsonb, null: true)
+    end
+  end
+
+  def down do
+    alter table(:subscriptions) do
+      remove(:bundle_entitlement)
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,10 +2,10 @@
 -- PostgreSQL database dump
 --
 
-\restrict 8TFxEqYyUTDHGEFUCK9gVhPC8CI7eb6xub7FJQx4pVB3JUchhApahllPMPExwYO
+\restrict EuO1FOFSdwRhrsmNwhuZYoYO5ic3xSG8nprNQIITLDdxClvvC5xNpSUi80sx8GD
 
--- Dumped from database version 17.9 (Homebrew)
--- Dumped by pg_dump version 17.9 (Homebrew)
+-- Dumped from database version 17.10 (Homebrew)
+-- Dumped by pg_dump version 17.10 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -4856,7 +4856,8 @@ CREATE TABLE public.subscriptions (
     trial_end timestamp without time zone,
     inserted_at timestamp without time zone,
     updated_at timestamp without time zone,
-    type public.subscription_type DEFAULT 'fiat'::public.subscription_type NOT NULL
+    type public.subscription_type DEFAULT 'fiat'::public.subscription_type NOT NULL,
+    bundle_entitlement jsonb
 );
 
 
@@ -12021,7 +12022,7 @@ ALTER TABLE ONLY public.webinar_registrations
 -- PostgreSQL database dump complete
 --
 
-\unrestrict 8TFxEqYyUTDHGEFUCK9gVhPC8CI7eb6xub7FJQx4pVB3JUchhApahllPMPExwYO
+\unrestrict EuO1FOFSdwRhrsmNwhuZYoYO5ic3xSG8nprNQIITLDdxClvvC5xNpSUi80sx8GD
 
 INSERT INTO public."schema_migrations" (version) VALUES (20171008200815);
 INSERT INTO public."schema_migrations" (version) VALUES (20171008203355);
@@ -12609,3 +12610,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20260720115000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260722120000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260722130000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260728132322);
+INSERT INTO public."schema_migrations" (version) VALUES (20260803120000);

--- a/test/sanbase/billing/plan/access_map_test.exs
+++ b/test/sanbase/billing/plan/access_map_test.exs
@@ -1,0 +1,109 @@
+defmodule Sanbase.Billing.Plan.AccessMapTest do
+  @moduledoc ~s"""
+  Tests the allow-list rules shared by custom plans and bundles.
+
+  The important property is that the two ways of asking agree: `allows?/2`
+  answers for one item without building a list, and `resolve/2` builds the whole
+  list. If they ever disagree, a customer's access depends on which function
+  happened to be called, which is the kind of bug that shows up as "it works in
+  the metric list but 403s on the actual call".
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Sanbase.Billing.Plan.AccessMap
+
+  @all [
+    "price_usd",
+    "volume_usd",
+    "social_volume_total",
+    "social_dominance",
+    "mvrv_usd",
+    "dev_activity"
+  ]
+
+  defp all, do: fn -> @all end
+
+  describe "resolve/2" do
+    test "an explicit list is taken as is" do
+      map = %{"accessible" => ["price_usd", "mvrv_usd"]}
+      assert AccessMap.resolve(map, all()) |> Enum.sort() == ["mvrv_usd", "price_usd"]
+    end
+
+    test "\"all\" means every known item" do
+      assert AccessMap.resolve(%{"accessible" => "all"}, all()) == @all
+    end
+
+    test "patterns add to the explicit list" do
+      map = %{"accessible" => ["price_usd"], "accessible_patterns" => ["^social_"]}
+
+      assert AccessMap.resolve(map, all()) |> Enum.sort() ==
+               ["price_usd", "social_dominance", "social_volume_total"]
+    end
+
+    test "not_accessible wins over accessible" do
+      map = %{"accessible" => "all", "not_accessible" => ["mvrv_usd"]}
+      refute "mvrv_usd" in AccessMap.resolve(map, all())
+    end
+
+    test "not_accessible_patterns win over accessible" do
+      map = %{"accessible" => "all", "not_accessible_patterns" => ["^social_"]}
+      resolved = AccessMap.resolve(map, all())
+
+      refute "social_volume_total" in resolved
+      refute "social_dominance" in resolved
+      assert "price_usd" in resolved
+    end
+
+    test "an empty or nil map allows nothing" do
+      assert AccessMap.resolve(%{}, all()) == []
+      assert AccessMap.resolve(nil, all()) == []
+    end
+  end
+
+  describe "allows?/2 agrees with resolve/2" do
+    # Every shape the maps can take, checked item by item against the list.
+    @maps [
+      %{"accessible" => "all"},
+      %{"accessible" => []},
+      %{"accessible" => ["price_usd", "mvrv_usd"]},
+      %{"accessible" => ["price_usd"], "accessible_patterns" => ["^social_"]},
+      %{"accessible" => "all", "not_accessible" => ["mvrv_usd"]},
+      %{"accessible" => "all", "not_accessible_patterns" => ["^social_"]},
+      %{
+        "accessible" => "all",
+        "not_accessible" => ["price_usd"],
+        "not_accessible_patterns" => ["^dev_"]
+      },
+      %{
+        "accessible" => ["price_usd"],
+        "accessible_patterns" => ["^social_"],
+        "not_accessible_patterns" => ["_dominance$"]
+      },
+      %{"accessible" => "all", "not_accessible" => "all"},
+      %{}
+    ]
+
+    test "for every map shape and every known item" do
+      for map <- @maps do
+        resolved = AccessMap.resolve(map, all())
+
+        for item <- @all do
+          assert AccessMap.allows?(map, item) == item in resolved,
+                 """
+                 allows?/2 and resolve/2 disagree.
+
+                   map:      #{inspect(map)}
+                   item:     #{inspect(item)}
+                   allows?:  #{inspect(AccessMap.allows?(map, item))}
+                   in list:  #{inspect(item in resolved)}
+                 """
+        end
+      end
+    end
+
+    test "nil map allows nothing" do
+      refute AccessMap.allows?(nil, "price_usd")
+    end
+  end
+end

--- a/test/sanbase/billing/plan/bundle/bundle_entitlement_test.exs
+++ b/test/sanbase/billing/plan/bundle/bundle_entitlement_test.exs
@@ -106,6 +106,77 @@ defmodule Sanbase.Billing.Plan.Bundle.EntitlementTest do
              ).bundle_entitlement.api_call_limits
     end
 
+    test "is rejected when a pattern is not a valid regular expression", %{plan: plan} do
+      # Stored unchecked, this raises Regex.CompileError inside every access check
+      # instead of failing the one write that caused it.
+      broken = %{
+        @market_and_social
+        | "metric_access" => %{"accessible" => [], "accessible_patterns" => ["^social_(", "*bad"]}
+      }
+
+      assert {:error, changeset} = insert_bundle_subscription(plan, broken)
+
+      errors = errors_on(changeset).bundle_entitlement.metric_access
+
+      assert Enum.any?(errors, &String.contains?(&1, "invalid regular expression"))
+      assert length(errors) == 2
+    end
+
+    test "is rejected when an access list is not a list of strings", %{plan: plan} do
+      broken = %{@market_and_social | "query_access" => %{"accessible" => [1, 2]}}
+
+      assert {:error, changeset} = insert_bundle_subscription(plan, broken)
+
+      assert ~s|"accessible" must be "all" or a list of strings| in errors_on(changeset).bundle_entitlement.query_access
+    end
+
+    test "is replaced wholesale, so a dropped package leaves nothing behind", %{plan: plan} do
+      # A merge would let fields the new calculation omits keep their old values.
+      subscription = create_bundle_subscription(plan, @market_and_social)
+
+      {:ok, updated} =
+        subscription
+        |> Subscription.bundle_entitlement_changeset(@developer_only)
+        |> Repo.update()
+
+      stored = Repo.get!(Subscription, updated.id).bundle_entitlement
+
+      assert stored.packages == ["developer"]
+      assert stored.metric_access == %{"accessible" => ["dev_activity"]}
+      refute Map.has_key?(stored.metric_access, "accessible_patterns")
+    end
+
+    test "can be cleared", %{plan: plan} do
+      subscription = create_bundle_subscription(plan, @market_and_social)
+
+      {:ok, updated} =
+        subscription
+        |> Subscription.bundle_entitlement_changeset(nil)
+        |> Repo.update()
+
+      assert Repo.get!(Subscription, updated.id).bundle_entitlement == nil
+    end
+
+    test "is not writable through the ordinary subscription changeset", %{plan: plan} do
+      # An entitlement decides what a customer may use and how much. It is only
+      # ever written by the code that works it out, never carried in alongside
+      # ordinary attributes.
+      subscription = create_bundle_subscription(plan, @market_and_social)
+
+      {:ok, updated} =
+        subscription
+        |> Subscription.changeset(%{
+          status: :past_due,
+          bundle_entitlement: @developer_only
+        })
+        |> Repo.update()
+
+      stored = Repo.get!(Subscription, updated.id)
+
+      assert stored.status == :past_due
+      assert stored.bundle_entitlement.packages == ["market", "social"]
+    end
+
     test "detects data written by an older version" do
       current = %Entitlement{schema_version: Entitlement.current_schema_version()}
       older = %Entitlement{schema_version: 0}
@@ -287,14 +358,15 @@ defmodule Sanbase.Billing.Plan.Bundle.EntitlementTest do
   defp insert_bundle_subscription(plan, entitlement_attrs) do
     user = insert(:user)
 
-    %Subscription{}
-    |> Subscription.changeset(%{
-      user_id: user.id,
-      plan_id: plan.id,
-      stripe_id: "sub_" <> Ecto.UUID.generate(),
-      status: :active,
-      bundle_entitlement: entitlement_attrs
-    })
-    |> Repo.insert()
+    subscription =
+      insert(:subscription_pro,
+        user_id: user.id,
+        plan_id: plan.id,
+        stripe_id: "sub_" <> Ecto.UUID.generate()
+      )
+
+    subscription
+    |> Subscription.bundle_entitlement_changeset(entitlement_attrs)
+    |> Repo.update()
   end
 end

--- a/test/sanbase/billing/plan/bundle/bundle_entitlement_test.exs
+++ b/test/sanbase/billing/plan/bundle/bundle_entitlement_test.exs
@@ -1,0 +1,300 @@
+defmodule Sanbase.Billing.Plan.Bundle.EntitlementTest do
+  @moduledoc ~s"""
+  The first working slice of the bundle path, checked from the database row all
+  the way to the answer a request would get.
+
+  What this proves:
+
+    * an entitlement survives a round trip through the JSON column
+    * access answers come from the entitlement, not from the plan ladder
+    * two bundle subscriptions on the *same* plan name get *different* answers,
+      which is the whole point of §5.8 and the thing a name-based lookup cannot do
+    * a missing entitlement raises instead of quietly falling back
+
+  It does **not** create anything in Stripe, does not use subscription items, and
+  does not work the entitlement out from purchased packages. The entitlement is
+  written by hand. That is deliberate: it validates the design before any of that
+  machinery exists.
+  """
+
+  use Sanbase.DataCase, async: false
+
+  import Sanbase.Factory
+
+  alias Sanbase.Billing.Plan.AccessChecker
+  alias Sanbase.Billing.Plan.Bundle
+  alias Sanbase.Billing.Plan.Bundle.Entitlement
+  alias Sanbase.Billing.Subscription
+  alias Sanbase.Repo
+
+  @bundle_plan_name "BUNDLE"
+
+  # Market + Social, as a customer who bought those two packages would have.
+  @market_and_social %{
+    "packages" => ["market", "social"],
+    "metric_access" => %{
+      "accessible" => ["price_usd", "volume_usd"],
+      "accessible_patterns" => ["^social_"],
+      "not_accessible" => [],
+      "not_accessible_patterns" => []
+    },
+    "query_access" => %{"accessible" => "all"},
+    "signal_access" => %{"accessible" => "all"},
+    "api_call_limits" => %{"month" => 100_000, "hour" => 30_000, "minute" => 600},
+    "historical_data_in_days" => nil,
+    "realtime_data_cut_off_in_days" => 0,
+    "package_snapshot_version" => 1,
+    "schema_version" => 1
+  }
+
+  # A different customer, on the same BUNDLE plan, who bought only Developer.
+  @developer_only %{
+    @market_and_social
+    | "packages" => ["developer"],
+      "metric_access" => %{"accessible" => ["dev_activity"]},
+      "api_call_limits" => %{"month" => 600_000, "hour" => 30_000, "minute" => 600}
+  }
+
+  setup context do
+    Repo.query!("ALTER SEQUENCE plans_id_seq RESTART WITH 9001")
+
+    # amount: 0 because the real amounts live per item in the price catalog, not
+    # on the plan row (§5.7).
+    plan =
+      insert(:plan_pro,
+        id: 9200,
+        name: @bundle_plan_name,
+        product_id: context.product_api.id,
+        amount: 0,
+        stripe_id: "stripe_plan_" <> Ecto.UUID.generate()
+      )
+
+    %{plan: plan}
+  end
+
+  describe "the stored entitlement" do
+    test "survives a round trip through the database", %{plan: plan} do
+      subscription = create_bundle_subscription(plan, @market_and_social)
+
+      %Subscription{bundle_entitlement: stored} = Repo.get!(Subscription, subscription.id)
+
+      assert %Entitlement{} = stored
+      assert stored.packages == ["market", "social"]
+      assert stored.api_call_limits == %{"month" => 100_000, "hour" => 30_000, "minute" => 600}
+      assert stored.historical_data_in_days == nil
+      assert stored.realtime_data_cut_off_in_days == 0
+      assert stored.schema_version == Entitlement.current_schema_version()
+    end
+
+    test "is nil for a subscription that is not a bundle", %{plan: plan} do
+      user = insert(:user)
+      subscription = insert(:subscription_pro, user_id: user.id, plan_id: plan.id)
+
+      assert Repo.get!(Subscription, subscription.id).bundle_entitlement == nil
+    end
+
+    test "is rejected when the call limits are not ordered", %{plan: plan} do
+      broken = %{
+        @market_and_social
+        | "api_call_limits" => %{"month" => 1, "hour" => 2, "minute" => 3}
+      }
+
+      assert {:error, changeset} = insert_bundle_subscription(plan, broken)
+
+      assert "must be a map with integer month, hour and minute where month > hour > minute > 0" in errors_on(
+               changeset
+             ).bundle_entitlement.api_call_limits
+    end
+
+    test "detects data written by an older version" do
+      current = %Entitlement{schema_version: Entitlement.current_schema_version()}
+      older = %Entitlement{schema_version: 0}
+
+      refute Entitlement.stale?(current)
+      assert Entitlement.stale?(older)
+      refute Entitlement.stale?(nil)
+    end
+  end
+
+  describe "access comes from the entitlement" do
+    setup %{plan: plan} do
+      %{entitlement: create_bundle_subscription(plan, @market_and_social).bundle_entitlement}
+    end
+
+    test "a metric that was bought is allowed", %{entitlement: entitlement} do
+      assert AccessChecker.plan_has_access?(
+               {:metric, "price_usd"},
+               "SANAPI",
+               @bundle_plan_name,
+               entitlement
+             )
+    end
+
+    test "a metric matched by a pattern is allowed", %{entitlement: entitlement} do
+      assert AccessChecker.plan_has_access?(
+               {:metric, "social_volume_total"},
+               "SANAPI",
+               @bundle_plan_name,
+               entitlement
+             )
+    end
+
+    test "a metric that was not bought is refused", %{entitlement: entitlement} do
+      refute AccessChecker.plan_has_access?(
+               {:metric, "mvrv_usd"},
+               "SANAPI",
+               @bundle_plan_name,
+               entitlement
+             )
+    end
+
+    test "queries and signals are all allowed, matching today's behavior", %{
+      entitlement: entitlement
+    } do
+      # §6.4 - queries and signals are effectively unrestricted, so bundles get
+      # "all" rather than a per-package list.
+      assert AccessChecker.plan_has_access?(
+               {:query, :get_trending_words},
+               "SANAPI",
+               @bundle_plan_name,
+               entitlement
+             )
+
+      assert AccessChecker.plan_has_access?(
+               {:signal, "anomaly_eth_whale_dump"},
+               "SANAPI",
+               @bundle_plan_name,
+               entitlement
+             )
+    end
+
+    test "the answer is the same on both products", %{entitlement: entitlement} do
+      for product <- ["SANAPI", "SANBASE"] do
+        assert AccessChecker.plan_has_access?(
+                 {:metric, "price_usd"},
+                 product,
+                 @bundle_plan_name,
+                 entitlement
+               )
+
+        refute AccessChecker.plan_has_access?(
+                 {:metric, "mvrv_usd"},
+                 product,
+                 @bundle_plan_name,
+                 entitlement
+               )
+      end
+    end
+  end
+
+  describe "two customers on the same plan name" do
+    test "get different answers", %{plan: plan} do
+      # This is the case a name-based lookup cannot handle, and the reason the
+      # entitlement is passed in rather than looked up. Both subscriptions point
+      # at the same BUNDLE plan row.
+      market_social = create_bundle_subscription(plan, @market_and_social).bundle_entitlement
+      developer = create_bundle_subscription(plan, @developer_only).bundle_entitlement
+
+      assert AccessChecker.plan_has_access?(
+               {:metric, "price_usd"},
+               "SANAPI",
+               @bundle_plan_name,
+               market_social
+             )
+
+      refute AccessChecker.plan_has_access?(
+               {:metric, "price_usd"},
+               "SANAPI",
+               @bundle_plan_name,
+               developer
+             )
+
+      refute AccessChecker.plan_has_access?(
+               {:metric, "dev_activity"},
+               "SANAPI",
+               @bundle_plan_name,
+               market_social
+             )
+
+      assert AccessChecker.plan_has_access?(
+               {:metric, "dev_activity"},
+               "SANAPI",
+               @bundle_plan_name,
+               developer
+             )
+
+      assert Bundle.Access.api_call_limits(market_social).month == 100_000
+      assert Bundle.Access.api_call_limits(developer).month == 600_000
+    end
+  end
+
+  describe "quota" do
+    test "comes from the entitlement, keyed the way the quota code expects", %{plan: plan} do
+      entitlement = create_bundle_subscription(plan, @market_and_social).bundle_entitlement
+
+      assert Bundle.Access.api_call_limits(entitlement) == %{
+               month: 100_000,
+               hour: 30_000,
+               minute: 600
+             }
+    end
+
+    test "a bundle always has limits" do
+      # Answerable without an entitlement: there is no unlimited bundle.
+      assert Sanbase.ApiCallLimit.plan_has_limits?("sanapi_bundle")
+    end
+
+    test "asking for limits by plan name still refuses, and says why" do
+      # Every bundle is named BUNDLE, so the name cannot carry the numbers. The
+      # error names the right place to look instead of returning something wrong.
+      error =
+        assert_raise Bundle.NotImplementedError, fn ->
+          Sanbase.ApiCallLimit.plan_to_api_call_limits("sanapi_bundle")
+        end
+
+      assert error.message =~ "read_from_api_call_limits_row_instead"
+    end
+  end
+
+  describe "a missing entitlement" do
+    test "raises rather than falling back to the standard ladder" do
+      # Falling back would answer from the ordinal plan ladder, which cannot
+      # express packages, and would give a paying customer roughly free-tier
+      # access with no error anywhere (§7.5 B1).
+      error =
+        assert_raise Bundle.MissingEntitlementError, fn ->
+          AccessChecker.plan_has_access?({:metric, "price_usd"}, "SANAPI", @bundle_plan_name, nil)
+        end
+
+      assert error.message =~ "plan_has_access?"
+      assert error.message =~ "no stored entitlement"
+    end
+
+    test "raises when the three-argument form is used for a bundle" do
+      # The old signature cannot carry an entitlement, so it must fail rather
+      # than silently answer.
+      assert_raise Bundle.MissingEntitlementError, fn ->
+        AccessChecker.plan_has_access?({:metric, "price_usd"}, "SANAPI", @bundle_plan_name)
+      end
+    end
+  end
+
+  defp create_bundle_subscription(plan, entitlement_attrs) do
+    {:ok, subscription} = insert_bundle_subscription(plan, entitlement_attrs)
+    subscription
+  end
+
+  defp insert_bundle_subscription(plan, entitlement_attrs) do
+    user = insert(:user)
+
+    %Subscription{}
+    |> Subscription.changeset(%{
+      user_id: user.id,
+      plan_id: plan.id,
+      stripe_id: "sub_" <> Ecto.UUID.generate(),
+      status: :active,
+      bundle_entitlement: entitlement_attrs
+    })
+    |> Repo.insert()
+  end
+end

--- a/test/sanbase/billing/plan_type_dispatch_test.exs
+++ b/test/sanbase/billing/plan_type_dispatch_test.exs
@@ -49,7 +49,6 @@ defmodule Sanbase.Billing.PlanTypeDispatchTest do
   # one dispatch site.
   defp bundle_entry_points do
     [
-      {:plan_has_access?, &AccessChecker.plan_has_access?(@item, &2, &1)},
       {:get_available_metrics_for_plan,
        &AccessChecker.get_available_metrics_for_plan(&1, &2, :all)},
       {:historical_data_in_days, &AccessChecker.historical_data_in_days(@item, &2, &2, &1)},
@@ -63,9 +62,55 @@ defmodule Sanbase.Billing.PlanTypeDispatchTest do
       # stored in api_call_limits.api_calls_limit_plan.
       {:plan_to_api_call_limits, &ApiCallLimit.plan_to_api_call_limits(acl_plan(&2, &1))},
       {:plan_to_response_size_limits,
-       &ApiCallLimit.plan_to_response_size_limits(acl_plan(&2, &1))},
-      {:plan_has_limits?, &ApiCallLimit.plan_has_limits?(acl_plan(&2, &1))}
+       &ApiCallLimit.plan_to_response_size_limits(acl_plan(&2, &1))}
     ]
+  end
+
+  # Entry points that have a real bundle implementation, and so are asserted
+  # directly rather than through the "must raise" list above. When
+  # bundle_entry_points/0 is empty, task BA is complete.
+  describe "implemented bundle entry points" do
+    test "plan_has_access? answers from the entitlement it is handed" do
+      entitlement = %Bundle.Entitlement{
+        metric_access: %{"accessible" => ["price_usd"]},
+        query_access: %{"accessible" => "all"},
+        signal_access: %{"accessible" => "all"},
+        api_call_limits: %{"month" => 100_000, "hour" => 30_000, "minute" => 600},
+        schema_version: Bundle.Entitlement.current_schema_version()
+      }
+
+      for product <- @products do
+        assert AccessChecker.plan_has_access?(
+                 {:metric, "price_usd"},
+                 product,
+                 @bundle_plan,
+                 entitlement
+               )
+
+        refute AccessChecker.plan_has_access?(
+                 {:metric, "mvrv_usd"},
+                 product,
+                 @bundle_plan,
+                 entitlement
+               )
+      end
+    end
+
+    test "plan_has_access? refuses to answer without an entitlement" do
+      # Not NotImplementedError - the path exists, the input is missing. Falling
+      # back to the standard ladder here would silently under-deliver.
+      for product <- @products do
+        assert_raise Bundle.MissingEntitlementError, fn ->
+          AccessChecker.plan_has_access?(@item, product, @bundle_plan)
+        end
+      end
+    end
+
+    test "plan_has_limits? says a bundle always has limits" do
+      for product <- @products do
+        assert ApiCallLimit.plan_has_limits?(acl_plan(product, @bundle_plan))
+      end
+    end
   end
 
   describe "Plan.type/1" do
@@ -169,10 +214,10 @@ defmodule Sanbase.Billing.PlanTypeDispatchTest do
       # several frames from the cause is what this replaces.
       error =
         assert_raise Bundle.NotImplementedError, fn ->
-          AccessChecker.plan_has_access?(@item, "SANAPI", @bundle_plan)
+          AccessChecker.get_available_metrics_for_plan(@bundle_plan, "SANAPI", :all)
         end
 
-      assert error.message =~ "plan_has_access?"
+      assert error.message =~ "get_available_metrics_for_plan"
       assert error.message =~ @bundle_plan
     end
   end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added entitlement-based access controls for bundle subscriptions across metrics, queries, and signals.
  * Added bundle-specific API quotas, historical-data limits, and realtime access cutoffs.
  * Bundle entitlements are now stored with subscriptions for consistent access decisions.
  * Added support for explicit allow and deny rules in access permissions.

* **Bug Fixes**
  * Bundle access and limits now return clear errors when entitlement data is unavailable.

* **Tests**
  * Added comprehensive coverage for entitlement validation, persistence, access rules, and quota behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->