### PR TITLE
Fix how logger formatters are added and registered

### DIFF
--- a/lib/sanbase/application/application.ex
+++ b/lib/sanbase/application/application.ex
@@ -46,26 +46,8 @@ defmodule Sanbase.Application do
       config: %{metadata: [:file, :line]}
     })
 
-    # Redact Absinthe/Ecto log lines for users with NDA-protected
-    # activity. See Sanbase.Logger.MaybeHideActivityTraces. This filter
-    # is the only thing standing between a protected user's queries and
-    # the logs, so a silent failure to install it must not be allowed —
-    # treat "already registered" as success (a prior boot in the same
-    # VM) and fail fast on anything else.
-    case :logger.add_primary_filter(
-           :sanbase_maybe_hide_activity_traces,
-           {&Sanbase.Logger.MaybeHideActivityTraces.filter/2, []}
-         ) do
-      :ok ->
-        :ok
-
-      {:error, {:already_exist, _}} ->
-        :ok
-
-      {:error, reason} ->
-        raise "Failed to register the :sanbase_maybe_hide_activity_traces logger filter: " <>
-                "#{inspect(reason)}"
-    end
+    # Redact Absinthe/Ecto log lines for users with NDA-protected activity.
+    Sanbase.Logger.MaybeHideActivityTraces.install!()
 
     case Supervisor.start_link(children, opts) do
       {:ok, _} = ok ->
@@ -316,6 +298,8 @@ defmodule Sanbase.Application do
       end
 
     [
+      Sanbase.Logger.ActivityTracesFilterWatchdog,
+
       # Telemetry metrics
       SanbaseWeb.Telemetry,
 

--- a/lib/sanbase/kafka/kafka_exporter.ex
+++ b/lib/sanbase/kafka/kafka_exporter.ex
@@ -52,7 +52,12 @@ defmodule Sanbase.KafkaExporter do
     buffering_max_messages = Keyword.get(opts, :buffering_max_messages, 1000)
 
     can_send_after_interval = Keyword.get(opts, :can_send_after_interval, 1000)
-    Process.send_after(self(), :flush, kafka_flush_timeout)
+
+    # An interval, not a re-arming `Process.send_after/3`: a `:flush`
+    # arriving while this module is unloaded (code purge) skips
+    # `handle_info/2`, so a re-arm there would kill the flush for good.
+    # `max/2` guards the test config's `kafka_flush_timeout: 0`.
+    {:ok, _tref} = :timer.send_interval(max(kafka_flush_timeout, 1), :flush)
 
     @producer.start_producer(topic)
 
@@ -151,10 +156,27 @@ defmodule Sanbase.KafkaExporter do
   end
 
   def handle_info(:flush, state) do
+    # Coalesce `:flush` messages queued while a previous send was blocked
+    # in `produce_sync/2`/`sleep_until/1` so the mailbox cannot grow.
+    drain_flush()
     send_data(state.data, state)
-
-    Process.send_after(self(), :flush, state.kafka_flush_timeout)
     {:noreply, %{state | data: [], size: 0}}
+  end
+
+  def handle_info(msg, state) do
+    Logger.warning(
+      "Unexpected message in the KafkaExporter for topic #{state.topic}: #{inspect(msg)}"
+    )
+
+    {:noreply, state}
+  end
+
+  defp drain_flush() do
+    receive do
+      :flush -> drain_flush()
+    after
+      0 -> :ok
+    end
   end
 
   defp send_data([], _), do: :ok

--- a/lib/sanbase/logger/activity_traces_filter_watchdog.ex
+++ b/lib/sanbase/logger/activity_traces_filter_watchdog.ex
@@ -1,0 +1,93 @@
+defmodule Sanbase.Logger.ActivityTracesFilterWatchdog do
+  @moduledoc """
+  Re-installs the `Sanbase.Logger.MaybeHideActivityTraces` primary filter
+  after OTP drops it.
+
+  `:logger` removes a primary filter permanently the first time it
+  raises, leaving protected users' queries unredacted until the node
+  restarts. The filter's own `catch` cannot cover its module being
+  unloaded (code purge, hot upgrade) — the `:undef` fires before the
+  `catch` is entered — so this watchdog polls and re-installs, logging
+  at `:error` so the redaction gap is visible in Sentry.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Sanbase.Logger.MaybeHideActivityTraces
+
+  # Inlined at compile time so detection never calls the module whose
+  # absence it detects.
+  @filter_id MaybeHideActivityTraces.filter_id()
+
+  @default_check_interval :timer.seconds(30)
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(opts) do
+    check_interval = Keyword.get(opts, :check_interval, @default_check_interval)
+
+    if not (is_integer(check_interval) and check_interval > 0) do
+      raise ArgumentError,
+            ":check_interval must be a positive integer, got: #{inspect(check_interval)}"
+    end
+
+    # Interval, not a re-arming send_after — see Sanbase.KafkaExporter.init/1.
+    {:ok, _tref} = :timer.send_interval(check_interval, :check)
+
+    {:ok, %{check_interval: check_interval}}
+  end
+
+  @doc """
+  Run a check synchronously.
+  """
+  @spec check_now() :: :ok
+  def check_now(), do: GenServer.call(__MODULE__, :check_now)
+
+  @impl true
+  def handle_call(:check_now, _from, state) do
+    check_and_reinstall(state)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_info(:check, state) do
+    check_and_reinstall(state)
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # Reads the config directly — detection must work while
+  # MaybeHideActivityTraces is unloaded.
+  defp check_and_reinstall(state) do
+    %{filters: filters} = :logger.get_primary_config()
+
+    if not List.keymember?(filters, @filter_id, 0) do
+      reinstall(state)
+    end
+
+    :ok
+  end
+
+  defp reinstall(state) do
+    MaybeHideActivityTraces.install!()
+
+    Logger.error(
+      "[ActivityTracesFilterWatchdog] The #{inspect(@filter_id)} logger filter was missing " <>
+        "and has been re-installed. Redaction was disabled since the preceding " <>
+        "{removed_failing_filter, #{inspect(@filter_id)}} error."
+    )
+  rescue
+    error ->
+      # Likely the filter module is mid-purge; retry on the next tick.
+      Logger.error(
+        "[ActivityTracesFilterWatchdog] Failed to re-install the #{inspect(@filter_id)} " <>
+          "logger filter, retrying in #{state.check_interval}ms: #{Exception.message(error)}"
+      )
+  end
+end

--- a/lib/sanbase/logger/maybe_hide_activity_traces.ex
+++ b/lib/sanbase/logger/maybe_hide_activity_traces.ex
@@ -20,15 +20,15 @@ defmodule Sanbase.Logger.MaybeHideActivityTraces do
        names the user and the reason. This covers both the GraphQL doc
        and the underlying ClickHouse/Postgres SQL text.
 
-  ## Why no try/rescue
+  ## Failure handling
 
-  Primary filters that raise are unregistered by OTP. To stay safe
-  without a rescue, every code path here is total: we only introspect
-  msg shapes we can match without calling `IO.iodata_to_binary/1` or
-  `:io_lib.format/2` (both can raise on malformed input), and treat
-  every other shape as `:other` — meta gets scrubbed, msg passes
-  through unchanged. Absinthe + Ecto both produce `{:string, iodata}`
-  events, so the narrower match is sufficient in practice.
+  `:logger` unregisters a primary filter permanently the first time it
+  raises, silently disabling redaction until the node restarts. Guards:
+  every code path here is total (no `IO.iodata_to_binary/1` or
+  `:io_lib.format/2`, both of which can raise — unmatched shapes pass
+  through with scrubbed meta); `install!/0` pre-loads `@runtime_modules`;
+  and the `ActivityTracesFilterWatchdog` re-installs the filter if OTP
+  drops it anyway — the only cover for this module itself being unloaded.
 
   Return values follow `:logger.filter_return/0`: a rewritten
   `log_event()` map replaces the original, `:ignore` leaves it
@@ -40,22 +40,61 @@ defmodule Sanbase.Logger.MaybeHideActivityTraces do
   alias Sanbase.RequestContext
   alias Sanbase.Accounts.ActivityTracesConfig
 
+  @filter_id :sanbase_maybe_hide_activity_traces
+
+  # Modules `filter/2` calls at runtime — an unloaded one raises `:undef`
+  # out of the filter. `Sanbase.RequestContext` appears only in patterns.
+  @runtime_modules [
+    __MODULE__,
+    Sanbase.Accounts.ActivityTracesConfig,
+    Sanbase.Cache.PersistentTermTtl
+  ]
+
   # Subset of the allowlist in `config :logger, :console, metadata: ...`
   # that can identify the customer or reveal the document. Kept in sync
   # with that allowlist; adding a new sensitive meta key to the logger
   # config means adding it here too.
   @sensitive_meta_keys [:remote_ip, :query, :san_balance]
 
+  @doc "The `:logger` filter id this module registers itself under."
+  @spec filter_id() :: atom()
+  def filter_id(), do: @filter_id
+
+  @doc """
+  Register the filter as a `:logger` primary filter, first loading every
+  module `filter/2` calls at runtime. Idempotent; raises on failure —
+  a silently missing filter means protected users' queries reach the logs.
+  """
+  @spec install!() :: :ok
+  def install!() do
+    Code.ensure_all_loaded!(@runtime_modules)
+
+    case :logger.add_primary_filter(@filter_id, {&__MODULE__.filter/2, []}) do
+      :ok ->
+        :ok
+
+      {:error, {:already_exist, _}} ->
+        :ok
+
+      {:error, reason} ->
+        raise "Failed to register the #{inspect(@filter_id)} logger filter: #{inspect(reason)}"
+    end
+  end
+
+  @doc "Whether the primary filter is currently registered."
+  @spec installed?() :: boolean()
+  def installed?() do
+    %{filters: filters} = :logger.get_primary_config()
+    List.keymember?(filters, @filter_id, 0)
+  end
+
   @spec filter(:logger.log_event(), term()) :: :logger.filter_return()
   def filter(event, extra) do
     do_filter(event, extra)
   catch
-    # NOT a defensive rescue for input shapes — those are already
-    # exhaustively pattern-matched below. This catches the transient
-    # `:undef` that OTP raises if a log event arrives during a hot code
-    # reload (after `code:purge/1`, before `code:load_binary/3`). Without
-    # it OTP would unregister the filter permanently and protected users
-    # would silently lose log redaction until the BEAM restarts.
+    # An `:undef` from a callee purged mid-recompile would make OTP drop
+    # the filter permanently. This cannot cover THIS module being unloaded
+    # (the `:undef` fires at the call site); the watchdog covers that.
     :error, :undef -> :ignore
   end
 

--- a/test/sanbase/kafka/kafka_exporter_test.exs
+++ b/test/sanbase/kafka/kafka_exporter_test.exs
@@ -1,6 +1,8 @@
 defmodule KafkaExporterTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
+
   setup do
     topic = :crypto.strong_rand_bytes(12) |> Base.encode64()
     %{topic: topic}
@@ -109,6 +111,52 @@ defmodule KafkaExporterTest do
     state = Sanbase.InMemoryKafka.Producer.get_state()
     topic_data = Map.get(state, topic)
     assert length(topic_data) == 10_000
+  end
+
+  test "the periodic flush keeps firing across intervals", %{topic: topic} do
+    {:ok, exporter_pid} =
+      Sanbase.KafkaExporter.start_link(
+        name: rand_atom(),
+        buffering_max_messages: 5000,
+        kafka_flush_timeout: 100,
+        can_send_after_interval: 0,
+        topic: topic
+      )
+
+    for round <- 1..3 do
+      :ok = Sanbase.KafkaExporter.persist_async(api_call_data(), exporter_pid)
+      Process.sleep(300)
+
+      topic_data = Sanbase.InMemoryKafka.Producer.get_state() |> Map.get(topic)
+
+      assert length(topic_data) == round,
+             "expected #{round} flushed message(s) after round #{round}"
+    end
+  end
+
+  test "an unexpected message does not kill the exporter", %{topic: topic} do
+    {:ok, exporter_pid} =
+      Sanbase.KafkaExporter.start_link(
+        name: rand_atom(),
+        buffering_max_messages: 5000,
+        kafka_flush_timeout: 100_000,
+        can_send_after_interval: 0,
+        topic: topic
+      )
+
+    log =
+      capture_log(fn ->
+        send(exporter_pid, {:DOWN, make_ref(), :process, self(), :normal})
+        send(exporter_pid, :not_a_flush)
+
+        # The call round-trips through the same mailbox, so both messages
+        # above have been handled by the time it returns.
+        assert :ok = Sanbase.KafkaExporter.flush(exporter_pid)
+      end)
+
+    assert Process.alive?(exporter_pid)
+    assert log =~ "Unexpected message in the KafkaExporter"
+    assert log =~ ":not_a_flush"
   end
 
   defp api_call_data() do

--- a/test/sanbase/logger/activity_traces_filter_watchdog_test.exs
+++ b/test/sanbase/logger/activity_traces_filter_watchdog_test.exs
@@ -1,0 +1,49 @@
+defmodule Sanbase.Logger.ActivityTracesFilterWatchdogTest do
+  # async: false — mutates the BEAM-global `:logger` primary filter list.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Sanbase.Logger.ActivityTracesFilterWatchdog, as: Watchdog
+  alias Sanbase.Logger.MaybeHideActivityTraces, as: Filter
+
+  setup do
+    on_exit(fn -> Filter.install!() end)
+    :ok
+  end
+
+  test "re-installs the primary filter after OTP removes it" do
+    # What OTP does when a primary filter raises.
+    :ok = :logger.remove_primary_filter(Filter.filter_id())
+    refute Filter.installed?()
+
+    {:ok, log} = with_log(fn -> Watchdog.check_now() end)
+
+    assert Filter.installed?()
+    assert log =~ "logger filter was missing"
+    assert log =~ "has been re-installed"
+  end
+
+  test "a check with the filter present is a no-op" do
+    assert Filter.installed?()
+
+    {:ok, log} = with_log(fn -> Watchdog.check_now() end)
+
+    assert Filter.installed?()
+    refute log =~ "has been re-installed"
+  end
+
+  test "rejects an invalid :check_interval" do
+    assert {:error, {%ArgumentError{}, _stacktrace}} =
+             GenServer.start(Watchdog, check_interval: :not_an_interval)
+  end
+
+  test "an unexpected message does not kill the watchdog" do
+    pid = Process.whereis(Watchdog)
+    send(pid, :something_unexpected)
+
+    # The call round-trips through the same mailbox after the message above.
+    assert :ok = Watchdog.check_now()
+    assert Process.alive?(pid)
+  end
+end

--- a/test/sanbase/logger/maybe_hide_activity_traces_test.exs
+++ b/test/sanbase/logger/maybe_hide_activity_traces_test.exs
@@ -222,6 +222,39 @@ defmodule Sanbase.Logger.MaybeHideActivityTracesTest do
     end
   end
 
+  describe "install!/0" do
+    setup do
+      on_exit(fn -> Filter.install!() end)
+      :ok
+    end
+
+    test "registers the filter and is idempotent" do
+      _ = :logger.remove_primary_filter(Filter.filter_id())
+      refute Filter.installed?()
+
+      assert :ok = Filter.install!()
+      assert Filter.installed?()
+
+      assert :ok = Filter.install!()
+      assert Filter.installed?()
+    end
+
+    test "loads the modules filter/2 calls at runtime" do
+      # `:code.delete/1` (no `:code.purge/1`) is enough to make
+      # `module_loaded/1` false without killing processes running old code.
+      callees = [Sanbase.Accounts.ActivityTracesConfig, Sanbase.Cache.PersistentTermTtl]
+
+      for module <- callees, do: true = :code.delete(module)
+      refute Enum.any?(callees, &:erlang.module_loaded(&1))
+
+      assert :ok = Filter.install!()
+
+      for module <- callees do
+        assert :erlang.module_loaded(module), "#{inspect(module)} was not loaded by install!/0"
+      end
+    end
+  end
+
   describe "primary filter installed at application startup" do
     setup do
       # Ensure no leakage from other tests.


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of activity-trace logging filters by automatically restoring them if removed.
  * Prevented Kafka exporting from stopping when unexpected messages are received.
  * Ensured Kafka export flushes continue reliably at regular intervals.
  * Improved handling of logger filter registration and runtime failures.

* **Tests**
  * Added coverage for filter restoration, repeated Kafka flushes, unexpected messages, and safe reinstallation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->