### PR TITLE
Add available metrics fro bundles

### DIFF
--- a/docs/composable-api-plans-handover.md
+++ b/docs/composable-api-plans-handover.md
@@ -246,7 +246,7 @@ Two supporting pieces:
 ### 5.5 What this design does **not** give you
 
 - **`available_metrics` / `AvailableMetricsLive`** — ✅ `available_metrics.ex` contains **no** plan or subscription reference at all. Genuinely new work (task **AM**).
-- **`getAvailableMetrics(plan:, product:)`** — ✅ the `plan` arg is `enum :plans_enum` (`metric_types.ex:17-25`) with values `free`/`basic`/`pro`/`max`/`business_pro`/`business_max`/`custom` only. A bundle **cannot be expressed** through this API. Needs either a `bundle` enum value or a caller-context variant.
+- **`getAvailableMetrics(plan:, product:)`** — ✅ `plans_enum` includes `bundle`. Catalog browse uses `metricPackages` (required for `BUNDLE`); AccessChecker entitlement path exists for callers that already hold one. Non-bundle plans unchanged.
 - **Purchase UI** — nothing in the backend design covers the pricing page / checkout (task **UI**).
 - **Stripe multi-item lifecycle** — items, proration, webhooks (tasks **SC**, **LC**, **WH**).
 - **Package → metric-set definition** — the actual content of each package (task **PD**).
@@ -579,7 +579,7 @@ This suite is the acceptance criterion for the BC contract in §7.1.
 
 | # | Site | Behavior today | Decision needed |
 |---|------|----------------|-----------------|
-| **C1** | `metric_types.ex:17-25` `enum :plans_enum` | no `bundle` value | Add `bundle`, or add a caller-context variant of `getAvailableMetrics` (task **AM**) |
+| **C1** | `metric_types.ex` `enum :plans_enum` | ✅ `bundle` added; catalog browse requires `metricPackages` | Done in task **AM** |
 | **C2** | `auth_plug.ex:350-362` `effective_plan_name/2` | SANBASE branch keys on `has_custom_restrictions: true` | What does a bundle map to for Sanbase? Do **not** set `has_custom_restrictions: true` on the `BUNDLE` rows — it would route into `fetch_base_plan_for_custom/1` → `Loader.get_plan/2` → 🔴 `FunctionClauseError` |
 | **C3** | `webinar_resolver.ex:9`, `sheets_template_resolver.ex:8`, `report_resolver.ex:17` | plan-name match finds nothing | Do bundle buyers get reports / webinars / sheet templates? |
 | **C4** | `plan.ex:16` `@plans_order` | `Keyword.get` → `nil`; term ordering sorts bundles last | Cosmetic; add an explicit order value |
@@ -676,10 +676,8 @@ One correction to the original description: monthly calls are **not** summed per
 **Deliverable:** struct + resolver + persistence + unit tests with fixtures.
 **Depends on:** A, PD, LC.
 
-### BA. Bundle access path — 🟡 partial
-**Implemented:** `plan_has_access?`, `historical_data_in_days`, `realtime_data_cut_off_in_days`, and `api_call_limits` on `Bundle.Access`. All three access functions take the optional entitlement argument of §5.8, and the entitlement is threaded from the request context through `AccessControl` and `Plan.Restrictions.get/5` (which the metric and signal resolvers use — without it a bundle customer would get a 500 on metric metadata). The shared-access-token path needs nothing: `token.plan` is hardcoded to `"PRO"` (`shared_access_token.ex:108`), so it can never carry a bundle.
-
-**Remaining (1 row in `bundle_entry_points/0`):** `get_available_metrics_for_plan` (task **AM**). The four Sanbase-side limits resolve to PRO now that Q5 is answered (§5.9), and the two quota functions are done — see §5.10.
+### BA. Bundle access path — ✅ done
+**Implemented:** `plan_has_access?`, `historical_data_in_days`, `realtime_data_cut_off_in_days`, `api_call_limits`, and `get_available_metrics_for_plan` on `Bundle.Access`. All access functions take the optional entitlement argument of §5.8, and the entitlement is threaded from the request context through `AccessControl` and `Plan.Restrictions.get/5` (which the metric and signal resolvers use — without it a bundle customer would get a 500 on metric metadata). The shared-access-token path needs nothing: `token.plan` is hardcoded to `"PRO"` (`shared_access_token.ex:108`), so it can never carry a bundle. `bundle_entry_points/0` is empty.
 
 **What:** The new path itself. `Bundle.Access` — six functions mirroring `CustomPlan.Access` (`plan_has_access?`, `get_available_metrics_for_plan`, `api_call_limits`, `historical_data_in_days`, `realtime_data_cut_off_in_days`, plus whatever C2 decides for Sanbase) reading the stored entitlement. Then fill in the `:bundle` clause at **every** site from §7.5 groups A and B, replacing the `"not implemented"` raises from **DP**.
 
@@ -702,8 +700,8 @@ One correction to the original description: monthly calls are **not** summed per
 **Deliverable:** updates in the Stripe event → subscription sync path + tests both ways.
 **Depends on:** LC, EN. **Critical for BC.**
 
-### AM. `available_metrics` by entitlement
-**What:** ✅ `available_metrics.ex` has **no** plan/subscription awareness today, so this is new work. ✅ `getAvailableMetrics`'s `plan` arg is `enum :plans_enum` (`metric_types.ex:17-25`) with no `bundle` value, so a bundle cannot be expressed through it — add the enum value or a caller-context variant (§7.5 C1). Align the LiveView/docs with the category/group filters already shipped.
+### AM. `available_metrics` by entitlement — ✅ done
+**What:** Catalog browse via `getAvailableMetrics(plan: BUNDLE, metricPackages: ["social", ...])` — packages required; resolves from the latest published `PackageSnapshot`. AccessChecker `get_available_metrics_for_plan/4` answers from an entitlement (clears BA). Non-bundle plans unchanged. `plans_enum` includes `bundle` (§7.5 C1).
 **Depends on:** EN, BA.
 
 ### OB. Admin / support visibility
@@ -835,10 +833,11 @@ Engineering-side, needing no product input: package ↔ metrics source of truth 
 | **PD** — package definition + snapshot | ✅ done | `Bundle.Package` (five packages as category rules), `bundle_package_snapshots` table, `Bundle.PackageSnapshot` with `publish/1` and `pending_changes/0`, dual-membership leak check. Admin diff *screen* not built — `pending_changes/0` is the logic it needs. |
 | **LC** — local multi-item model | ✅ done | `subscription_items`, `bundle_prices` catalog, `BUNDLE` marker plan rows (301 month / 302 year, SanAPI). |
 | **EN** — entitlement resolver | ✅ done | `Bundle.Resolver.resolve/2` (pure) + `sync/1` (persists). All §6.3 rules applied. |
-| **BA** — bundle access path | 🟡 partial | Access, data windows and the call quota all implemented and reaching the entitlement. The four Sanbase-side limits answer as PRO (§5.9). **1** entry point still raises: `get_available_metrics_for_plan` (task **AM**). |
+| **BA** — bundle access path | ✅ done | Access, data windows, call quota, and `get_available_metrics_for_plan` all implemented. `bundle_entry_points/0` is empty. The four Sanbase-side limits answer as PRO (§5.9). |
 | **OB** — admin visibility | ✅ done | Two admin pages, `/admin/bundle_packages` and `/admin/bundle_subscriptions`. |
 | **WH** — quota write | ✅ partial | The `api_call_limits` write is done (§5.10) — resolved numbers stored on the row, refreshed by `Resolver.sync/1`. The Stripe webhook branching it was bundled with is not. |
-| **SC / SL / UI / AM** | ⬜ not started | |
+| **AM** — available metrics | ✅ done | `getAvailableMetrics(plan: BUNDLE, metricPackages: [...])` catalogs from the latest published snapshot. AccessChecker entitlement path clears the last BA raise. Non-bundle plans unchanged. |
+| **SC / SL / UI** | ⬜ not started | |
 
 **Admin pages.** `/admin/bundle_packages` shows what each package contains live vs
 published, the pending-changes diff, and publishes snapshots.
@@ -878,15 +877,14 @@ categories that *do* exist if a name is ever wrong.
 
 **What a bundle still cannot do:** be bought. There is no Stripe catalog and no
 mutation to subscribe, so items are created locally. Everything from an item to a
-granted metric — and to a counted API call — works end to end.
+granted metric — and to a counted API call — works end to end. Catalog browsing
+of package combinations works via
+`getAvailableMetrics(plan: BUNDLE, metricPackages: [...])` without a subscription.
 
 ### 13.1 Next
 
-`AM` is the last raising entry point and is independent of everything else: it
-surfaces the entitlement through `getAvailableMetrics`, whose `plan` argument is an
-enum with no bundle value (§7.5 C1). Then `SC → SL → WH` for the purchase
-lifecycle, where `WH` is now only the webhook branching — its quota write landed
-with §5.10.
+`SC → SL → WH` for the purchase lifecycle, where `WH` is now only the webhook
+branching — its quota write landed with §5.10. Then `UI` for self-serve checkout.
 
 ### 13.2 Original plan, for reference
 

--- a/lib/sanbase/billing/plan/access_checker.ex
+++ b/lib/sanbase/billing/plan/access_checker.ex
@@ -60,16 +60,30 @@ defmodule Sanbase.Billing.Plan.AccessChecker do
     StandardAccessChecker.min_plan(product_code, query_or_argument)
   end
 
-  @spec get_available_metrics_for_plan(plan_name, product_code, Atom.t()) :: list(binary())
-  def get_available_metrics_for_plan(plan_name, product_code, restriction_type \\ :all)
+  @doc ~s"""
+  Metrics available under this plan.
 
-  def get_available_metrics_for_plan(plan_name, product_code, restriction_type) do
+  The last argument is only read by bundle plans - every bundle is named
+  `BUNDLE`, so the entitlement has to be handed in. Standard and custom plans
+  ignore it.
+  """
+  @spec get_available_metrics_for_plan(plan_name, product_code, Atom.t(), entitlement) ::
+          list(binary())
+  def get_available_metrics_for_plan(
+        plan_name,
+        product_code,
+        restriction_type \\ :all,
+        entitlement \\ nil
+      )
+
+  def get_available_metrics_for_plan(plan_name, product_code, restriction_type, entitlement) do
     case Plan.type(plan_name) do
       :bundle ->
         BundleAccessChecker.get_available_metrics_for_plan(
           plan_name,
           product_code,
-          restriction_type
+          restriction_type,
+          entitlement
         )
 
       :custom ->

--- a/lib/sanbase/billing/plan/bundle/bundle_access.ex
+++ b/lib/sanbase/billing/plan/bundle/bundle_access.ex
@@ -18,6 +18,7 @@ defmodule Sanbase.Billing.Plan.Bundle.Access do
   Failing loudly is the only safe choice.
   """
 
+  alias Sanbase.Billing.Plan.AccessMap
   alias Sanbase.Billing.Plan.Bundle
   alias Sanbase.Billing.Plan.Bundle.Entitlement
 
@@ -29,6 +30,21 @@ defmodule Sanbase.Billing.Plan.Bundle.Access do
     entitlement
     |> require_entitlement!(:plan_has_access?)
     |> Entitlement.allows?(query_or_argument)
+  end
+
+  @doc ~s"""
+  The metrics this entitlement allows, resolved against the same universe custom
+  plans use (`free_metrics` ∪ `restricted_metrics`).
+  """
+  @spec get_available_metrics_for_plan(Entitlement.t() | nil) :: [String.t()]
+  def get_available_metrics_for_plan(entitlement) do
+    entitlement
+    |> require_entitlement!(:get_available_metrics_for_plan)
+    |> then(fn %Entitlement{metric_access: access_map} ->
+      AccessMap.resolve(access_map, fn ->
+        Sanbase.Metric.free_metrics() ++ Sanbase.Metric.restricted_metrics()
+      end)
+    end)
   end
 
   @doc ~s"""

--- a/lib/sanbase/billing/plan/bundle/bundle_access_checker.ex
+++ b/lib/sanbase/billing/plan/bundle/bundle_access_checker.ex
@@ -5,10 +5,9 @@ defmodule Sanbase.Billing.Plan.BundleAccessChecker do
   Mirrors the public surface of `Sanbase.Billing.Plan.CustomAccessChecker` so
   that `Sanbase.Billing.Plan.AccessChecker` can dispatch to either uniformly.
 
-  `plan_has_access?` and the two data-window functions are implemented.
-  `get_available_metrics_for_plan` still raises - see
-  `Sanbase.Billing.Plan.Bundle` for why, and
-  `docs/composable-api-plans-handover.md` task BA for what replaces it.
+  `plan_has_access?`, the two data-window functions, and
+  `get_available_metrics_for_plan` are implemented. Each needs the stored
+  entitlement - the plan name alone cannot answer (§5.8).
 
   ## Why the products are ignored
 
@@ -44,8 +43,30 @@ defmodule Sanbase.Billing.Plan.BundleAccessChecker do
   def plan_has_access?(_query_or_argument, _product_code, _plan_name, nil),
     do: Bundle.missing_entitlement!(:plan_has_access?)
 
-  def get_available_metrics_for_plan(plan_name, _product_code, _restriction_type),
-    do: Bundle.not_implemented!(:get_available_metrics_for_plan, plan_name)
+  @doc ~s"""
+  The metrics a bundle may use.
+
+  Without an entitlement this cannot be answered - every bundle is named
+  `BUNDLE` while the metric set differs per customer. Passing one is the
+  caller's job.
+  """
+  def get_available_metrics_for_plan(
+        plan_name,
+        product_code,
+        restriction_type,
+        entitlement \\ nil
+      )
+
+  def get_available_metrics_for_plan(
+        _plan_name,
+        _product_code,
+        _restriction_type,
+        %Entitlement{} = entitlement
+      ),
+      do: Bundle.Access.get_available_metrics_for_plan(entitlement)
+
+  def get_available_metrics_for_plan(_plan_name, _product_code, _restriction_type, nil),
+    do: Bundle.missing_entitlement!(:get_available_metrics_for_plan)
 
   @doc ~s"""
   How many days of history the bundle can read, or `nil` for no limit.

--- a/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
@@ -11,6 +11,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   import SanbaseWeb.Graphql.Helpers.Utils
 
   alias Sanbase.Metric
+  alias Sanbase.Billing.Plan.Bundle.Package
+  alias Sanbase.Billing.Plan.Bundle.PackageSnapshot
   alias Sanbase.Billing.Plan.Restrictions
   alias Sanbase.Billing.Plan.AccessChecker
   alias SanbaseWeb.Graphql.Resolvers.MetricTransform
@@ -59,37 +61,42 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
     {:ok, Process.get(:__executed_clickhouse_sql_list__, []) |> Enum.reverse()}
   end
 
-  def get_available_metrics(_root, %{plan: plan, product: product} = args, resolution) do
+  def get_available_metrics(_root, %{plan: plan, product: product} = args, resolution)
+      when not is_nil(plan) do
     product_code = product |> Atom.to_string() |> String.upcase()
     plan_name = plan |> to_string() |> String.upcase()
+    packages = Map.get(args, :metric_packages)
 
-    user_metric_access_level = resolution_to_metric_access_level(resolution)
+    cond do
+      plan_name == "BUNDLE" ->
+        available_metrics_for_bundle_packages(packages, args, resolution)
 
-    metrics =
-      AccessChecker.get_available_metrics_for_plan(plan_name, product_code)
-      |> maybe_filter_incomplete_metrics(args[:has_incomplete_data])
-      |> maybe_apply_regex_filter(args[:name_regex_filter])
-      |> remove_hidden_metrics()
-      |> maybe_remove_alpha_and_beta_metrics(user_metric_access_level)
-      |> Enum.uniq()
-      |> Enum.sort(:asc)
+      not is_nil(packages) ->
+        {:error, "metricPackages is only valid with plan: BUNDLE"}
 
-    {:ok, metrics}
+      true ->
+        user_metric_access_level = resolution_to_metric_access_level(resolution)
+
+        metrics =
+          AccessChecker.get_available_metrics_for_plan(plan_name, product_code)
+          |> finalize_available_metrics(args, user_metric_access_level)
+
+        {:ok, metrics}
+    end
   end
 
   def get_available_metrics(_root, args, resolution) do
-    user_metric_access_level = resolution_to_metric_access_level(resolution)
+    if Map.get(args, :metric_packages) do
+      {:error, "metricPackages is only valid with plan: BUNDLE"}
+    else
+      user_metric_access_level = resolution_to_metric_access_level(resolution)
 
-    metrics =
-      Metric.available_metrics()
-      |> maybe_filter_incomplete_metrics(args[:has_incomplete_data])
-      |> maybe_apply_regex_filter(args[:name_regex_filter])
-      |> remove_hidden_metrics()
-      |> maybe_remove_alpha_and_beta_metrics(user_metric_access_level)
-      |> Enum.uniq()
-      |> Enum.sort(:asc)
+      metrics =
+        Metric.available_metrics()
+        |> finalize_available_metrics(args, user_metric_access_level)
 
-    {:ok, metrics}
+      {:ok, metrics}
+    end
   end
 
   def get_available_metrics_for_selector(_root, args, resolution) do
@@ -804,6 +811,46 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
   defp maybe_apply_regex_filter(metrics, regex) do
     {:ok, regex} = Regex.compile(regex)
     Enum.filter(metrics, fn metric -> Regex.match?(regex, metric) end)
+  end
+
+  defp available_metrics_for_bundle_packages(packages, args, resolution)
+       when is_list(packages) and packages != [] do
+    case Enum.reject(packages, &Package.valid_slug?/1) do
+      [] ->
+        case PackageSnapshot.latest() do
+          nil ->
+            {:error,
+             "No published package snapshot exists yet. Publish one before browsing bundle metrics."}
+
+          snapshot ->
+            user_metric_access_level = resolution_to_metric_access_level(resolution)
+
+            metrics =
+              PackageSnapshot.metrics_for(snapshot, packages)
+              |> finalize_available_metrics(args, user_metric_access_level)
+
+            {:ok, metrics}
+        end
+
+      invalid ->
+        {:error,
+         "Unknown metric package(s): #{Enum.join(invalid, ", ")}. " <>
+           "Known packages: #{Enum.join(Package.slugs(), ", ")}."}
+    end
+  end
+
+  defp available_metrics_for_bundle_packages(_packages, _args, _resolution) do
+    {:error, "metricPackages is required when plan is BUNDLE"}
+  end
+
+  defp finalize_available_metrics(metrics, args, user_metric_access_level) do
+    metrics
+    |> maybe_filter_incomplete_metrics(args[:has_incomplete_data])
+    |> maybe_apply_regex_filter(args[:name_regex_filter])
+    |> remove_hidden_metrics()
+    |> maybe_remove_alpha_and_beta_metrics(user_metric_access_level)
+    |> Enum.uniq()
+    |> Enum.sort(:asc)
   end
 
   defp remove_hidden_metrics(metrics) do

--- a/lib/sanbase_web/graphql/schema/queries/metric_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/metric_queries.ex
@@ -28,6 +28,13 @@ defmodule SanbaseWeb.Graphql.Schema.MetricQueries do
       arg(:has_incomplete_data, :boolean, default_value: nil)
 
       @desc ~s"""
+      Package slugs to preview when `plan` is `BUNDLE` (e.g. `social`, `market`).
+      Required for `BUNDLE`; rejected for every other plan. A bundle's metric set
+      cannot be derived from the plan name alone.
+      """
+      arg(:metric_packages, list_of(non_null(:string)))
+
+      @desc ~s"""
       Accepts PCRE (Perl Compatible Regular Expressions) format
 
       Example: { getAvailableMetrics(nameRegexFilter: "^mean_age_[\\d]+") }

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -22,6 +22,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     value(:business_pro)
     value(:business_max)
     value(:custom)
+    value(:bundle)
   end
 
   enum :only_project_channels_spec_enum do

--- a/test/sanbase/billing/plan_type_dispatch_test.exs
+++ b/test/sanbase/billing/plan_type_dispatch_test.exs
@@ -46,12 +46,9 @@ defmodule Sanbase.Billing.PlanTypeDispatchTest do
   @item {:metric, "price_usd"}
 
   # {label, fun} pairs where fun takes (plan_name, product) and reaches exactly
-  # one dispatch site.
+  # one dispatch site. Empty means every site has a real implementation (BA done).
   defp bundle_entry_points do
-    [
-      {:get_available_metrics_for_plan,
-       &AccessChecker.get_available_metrics_for_plan(&1, &2, :all)}
-    ]
+    []
   end
 
   # Entry points that have a real bundle implementation, and so are asserted
@@ -84,6 +81,26 @@ defmodule Sanbase.Billing.PlanTypeDispatchTest do
       for product <- @products do
         assert_raise Bundle.MissingEntitlementError, fn ->
           AccessChecker.plan_has_access?(@item, product, @bundle_plan)
+        end
+      end
+    end
+
+    test "get_available_metrics_for_plan answers from the entitlement it is handed" do
+      entitlement = bundle_entitlement()
+
+      for product <- @products do
+        metrics =
+          AccessChecker.get_available_metrics_for_plan(@bundle_plan, product, :all, entitlement)
+
+        assert "price_usd" in metrics
+        refute "mvrv_usd" in metrics
+      end
+    end
+
+    test "get_available_metrics_for_plan refuses to answer without an entitlement" do
+      for product <- @products do
+        assert_raise Bundle.MissingEntitlementError, fn ->
+          AccessChecker.get_available_metrics_for_plan(@bundle_plan, product, :all)
         end
       end
     end
@@ -370,18 +387,6 @@ defmodule Sanbase.Billing.PlanTypeDispatchTest do
                branch keyed on Plan.type/1.
                """
       end
-    end
-
-    test "the failure names the site and the plan" do
-      # The point of a dedicated error is diagnosability - a CaseClauseError
-      # several frames from the cause is what this replaces.
-      error =
-        assert_raise Bundle.NotImplementedError, fn ->
-          AccessChecker.get_available_metrics_for_plan(@bundle_plan, "SANAPI", :all)
-        end
-
-      assert error.message =~ "get_available_metrics_for_plan"
-      assert error.message =~ @bundle_plan
     end
 
     test "Plan.Restrictions.get passes the entitlement down to the bundle path" do

--- a/test/sanbase_web/graphql/billing/bundle_available_metrics_test.exs
+++ b/test/sanbase_web/graphql/billing/bundle_available_metrics_test.exs
@@ -1,0 +1,178 @@
+defmodule Sanbase.Billing.BundleAvailableMetricsTest do
+  @moduledoc ~s"""
+  Catalog browsing for bundle packages via `getAvailableMetrics`.
+
+  `plan: BUNDLE` cannot answer from the plan name alone, so it requires
+  `metricPackages`. Non-bundle plans must keep working exactly as before.
+  """
+
+  use SanbaseWeb.ConnCase, async: false
+
+  import SanbaseWeb.Graphql.TestHelpers
+
+  alias Sanbase.Billing.Plan.Bundle
+  alias Sanbase.Billing.Plan.Bundle.PackageSnapshot
+  alias Sanbase.Billing.Plan.AccessChecker
+  alias Sanbase.Metric.Category.MetricCategory
+  alias Sanbase.Metric.Category.MetricCategoryMapping
+
+  @moduletag capture_log: true
+
+  @packaged_metrics %{
+    "market" => "price_usd",
+    "development" => "dev_activity",
+    "social" => "social_volume_total",
+    "onchain_core" => "mvrv_usd",
+    "onchain_labels" => "nvt"
+  }
+
+  setup do
+    publish_snapshot()
+    :ok
+  end
+
+  describe "backwards compatibility" do
+    test "plan PRO is unchanged", %{conn: conn} do
+      metrics = get_available_metrics(conn, %{plan: :pro, product: :sanapi})
+
+      expected =
+        AccessChecker.get_available_metrics_for_plan("PRO", "SANAPI")
+        |> Enum.reject(&(&1 in Sanbase.Metric.hidden_metrics()))
+        |> Enum.reject(&(&1 in Sanbase.Metric.experimental_metrics()))
+        |> Enum.uniq()
+        |> Enum.sort()
+
+      assert metrics == expected
+    end
+
+    test "omitting plan still returns the full catalog", %{conn: conn} do
+      query = """
+      {
+        getAvailableMetrics
+      }
+      """
+
+      metrics = execute_query(conn, query, "getAvailableMetrics")
+
+      assert is_list(metrics)
+      assert "price_usd" in metrics
+      assert length(metrics) > 100
+    end
+  end
+
+  describe "plan BUNDLE with metricPackages" do
+    test "returns the union of the requested packages", %{conn: conn} do
+      metrics =
+        get_available_metrics(conn, %{
+          plan: :bundle,
+          product: :sanapi,
+          metric_packages: ["social", "market"]
+        })
+
+      assert "social_volume_total" in metrics
+      assert "price_usd" in metrics
+      refute "mvrv_usd" in metrics
+      refute "dev_activity" in metrics
+    end
+
+    test "a single package returns only its metrics", %{conn: conn} do
+      metrics =
+        get_available_metrics(conn, %{
+          plan: :bundle,
+          product: :sanapi,
+          metric_packages: ["social"]
+        })
+
+      assert metrics == ["social_volume_total"]
+    end
+
+    test "requires metricPackages", %{conn: conn} do
+      error = get_available_metrics_error(conn, %{plan: :bundle, product: :sanapi})
+
+      assert error =~ "metricPackages is required"
+    end
+
+    test "rejects an empty metricPackages list", %{conn: conn} do
+      error =
+        get_available_metrics_error(conn, %{
+          plan: :bundle,
+          product: :sanapi,
+          metric_packages: []
+        })
+
+      assert error =~ "metricPackages is required"
+    end
+
+    test "rejects unknown package slugs", %{conn: conn} do
+      error =
+        get_available_metrics_error(conn, %{
+          plan: :bundle,
+          product: :sanapi,
+          metric_packages: ["social", "not_a_package"]
+        })
+
+      assert error =~ "Unknown metric package"
+      assert error =~ "not_a_package"
+    end
+
+    test "rejects metricPackages on a non-bundle plan", %{conn: conn} do
+      error =
+        get_available_metrics_error(conn, %{
+          plan: :pro,
+          product: :sanapi,
+          metric_packages: ["social"]
+        })
+
+      assert error =~ "metricPackages is only valid with plan: BUNDLE"
+    end
+
+    test "rejects metricPackages without a plan", %{conn: conn} do
+      error = get_available_metrics_error(conn, %{metric_packages: ["social"]})
+
+      assert error =~ "metricPackages is only valid with plan: BUNDLE"
+    end
+  end
+
+  defp get_available_metrics(conn, args) do
+    query = """
+    {
+      getAvailableMetrics(#{map_to_args(args)})
+    }
+    """
+
+    execute_query(conn, query, "getAvailableMetrics")
+  end
+
+  defp get_available_metrics_error(conn, args) do
+    query = """
+    {
+      getAvailableMetrics(#{map_to_args(args)})
+    }
+    """
+
+    result =
+      conn
+      |> post("/graphql", query_skeleton(query))
+      |> json_response(200)
+
+    assert result["data"]["getAvailableMetrics"] == nil
+    hd(result["errors"])["message"]
+  end
+
+  defp publish_snapshot do
+    for {package, index} <- Enum.with_index(Bundle.Package.all()) do
+      {:ok, category} =
+        MetricCategory.create(%{name: package.category, display_order: index})
+
+      {:ok, _} =
+        MetricCategoryMapping.create(%{
+          module: "Sanbase.Metric.BundleAvailableMetricsTestAdapter",
+          metric: Map.fetch!(@packaged_metrics, package.slug),
+          category_id: category.id
+        })
+    end
+
+    {:ok, snapshot} = PackageSnapshot.publish(notes: "test")
+    snapshot
+  end
+end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

```graphql
getAvailableMetrics(plan: BUNDLE, metricPackages: ["social", "market"])
```

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bundle plans to available metric retrieval.
  * Added support for selecting metric packages for bundle plans.
  * Added validation for missing, empty, or invalid package selections.
  * Added bundle plan support to the plans API.

* **Bug Fixes**
  * Improved metric filtering, sorting, uniqueness, and access handling across plan types.

* **Documentation**
  * Updated implementation status and next steps for billing plan support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->