### PR TITLE
Add hex cooldown 14d so we skip new packages

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,6 +13,10 @@ defmodule Sanbase.Mixfile do
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),
+      # Withhold hex packages published less than 14 days ago (supply-chain
+      # attack mitigation). Requires Hex >= 2.5.0; older Hex ignores this key.
+      # Versions already in mix.lock are not affected.
+      hex: [cooldown: "14d"],
       # source_url: "https://github.com/santiment/sanbase2/",
       homepage_url: "https://app.santiment.net/projects",
       # Supress errors that should not be shown


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a package freshness safeguard that excludes recently published packages from dependency resolution.
  * Existing locked dependencies remain unaffected.
  * Older package manager versions will ignore this setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->