### PR TITLE
Add stripe logic for bundle subs

### DIFF
--- a/config/scheduler_config.exs
+++ b/config/scheduler_config.exs
@@ -87,6 +87,14 @@ config :sanbase, Sanbase.Scrapers.Scheduler,
       schedule: "*/20 * * * *",
       task: {Sanbase.Billing, :remove_duplicate_subscriptions, []}
     ],
+    expire_bundle_subscription_items: [
+      schedule: "7 * * * *",
+      task: {Sanbase.Billing, :expire_bundle_subscription_items, []}
+    ],
+    cancel_stale_replaced_subscriptions: [
+      schedule: "17 * * * *",
+      task: {Sanbase.Billing, :cancel_stale_replaced_subscriptions, []}
+    ],
     create_free_basic_api: [
       schedule: "*/5 * * * *",
       task: {Sanbase.Billing, :create_free_basic_api, []}

--- a/docs/composable-api-plans-handover.md
+++ b/docs/composable-api-plans-handover.md
@@ -769,13 +769,13 @@ Changing a priced amount after Stripe exists = `Price.replace/1` + new Stripe Pr
 **Does not include:** Institutional / Enterprise Stripe prices — those are **IN** / **EP**.
 
 ### SL. Subscribe / add / remove / cancel — ✅ done
-**Implemented as:** `Bundle.Lifecycle` + GraphQL `subscribeBundle` / `addBundleItem` / `removeBundleItem` / `switchBundleInterval` / `cancelBundleSubscription`. Stripe multi-item create via Price ids; local `subscription_items` + `Resolver.sync/1` after each mutation. `upgrade_downgrade/2` rejects bundles. Legacy `subscribe` rejects `BUNDLE` markers and enforces `is_private` (team bypass).
+**Implemented as:** `Bundle.Lifecycle` + GraphQL `subscribeBundle` / `addBundleItem` / `removeBundleItem` / `switchBundleInterval` / `cancelBundleSubscription`. Stripe multi-item create via Price ids; local `subscription_items` + `Resolver.sync/1` after each mutation. `upgrade_downgrade/2` rejects bundles. Legacy `subscribe` rejects `BUNDLE` marker plans only — `is_private` is deliberately not a gate, since `PRO`, `PRO_PLUS`, `MAX` and `FREE` are all `is_private = true` on production and bought through it every day (§15 Q14).
 
 **Sale controls:** `Sanbase.Billing.Plan.SaleControls` + admin page `/admin/bundle_offering`. Activate/deactivate **bundle/new plans** (`BUNDLE*`, `INSTITUTIONAL*` via `is_private`) and **Business Pro/Max** (`is_deprecated`). GraphQL `bundleCatalog(interval)` is public when bundle plans are active, or always for Santiment team. Staff can preview/subscribe while bundle plans are deactivated.
 
-**Legacy → Bundle:** create new sub first, then cancel replaceable ladder (`BUSINESS_*`, grandfathered `PRO`/`BASIC`) with Stripe proration. Rejects active `CUSTOM_*` and already-on-bundle.
+**Legacy → Bundle:** create new sub first, then cancel replaceable ladder (`BUSINESS_*`, grandfathered `PRO`/`BASIC`) with Stripe proration. Rejects active `CUSTOM_*` and already-on-bundle. That cancel never fails the paid purchase, so `cancel_stale_replaced_subscriptions/0` retries it hourly as `cancel_stale_replaced_subscriptions` (§5.11).
 
-**Remove item:** marks `subscription_items.cancel_at_period_end` (access kept until period end; WH/finalize later).
+**Remove item:** `remove_item/3` only records the deadline in `subscription_items.remove_at`; the package keeps working and keeps being billed until it passes, because the customer paid for that period. `Sanbase.Billing.Plan.Bundle.ItemExpiry` — scheduled hourly as `expire_bundle_subscription_items` in `config/scheduler_config.exs` — then deletes the Stripe item with no proration, deletes the local row and re-resolves the entitlement.
 **Deliverable:** ✅ GraphQL + Stripe helpers + offering gate + admin Go Live/Rollback + mocked tests.
 **Depends on:** SC, LC, BA.
 **Does not include:** WH webhook branching; Institutional plan rows (**IN**); purchase UI.

--- a/docs/composable-api-plans-handover.md
+++ b/docs/composable-api-plans-handover.md
@@ -436,8 +436,58 @@ else in §5.9.
 by comparing plan *name* and status (`expected_plans_bulk/0`), and a bundle whose
 items changed still reports `sanapi_bundle`. The live path is covered —
 `Resolver.sync/1` rewrites the row — but if an entitlement is ever changed without
-going through it, the reconciler will not notice. Worth extending when **WH** lands
-and Stripe becomes a second writer.
+going through it, the reconciler will not notice. Worth extending when **WH**
+(webhook handling for multi-item subscriptions) lands and Stripe becomes a second
+writer.
+
+### 5.11 The lifecycle: buying, changing and leaving a bundle
+
+`Bundle.Lifecycle` is the one door for all of it — subscribe, add an item, remove
+an item, switch billing interval, cancel. Everything it does ends in
+`Resolver.sync/1`, so the entitlement and the quota row are recomputed from the
+items rather than adjusted in place.
+
+| Operation | Stripe | Local | Entitlement |
+|---|---|---|---|
+| `subscribe/2` | creates the subscription with one item per price | inserts the subscription and its items | resolved for the first time |
+| `add_item/3` | adds an item, prorated | claims the row first, then writes the Stripe id onto it | package available at once |
+| `remove_item/3` | **nothing yet** | records `remove_at` on the item | unchanged — the customer paid for this period |
+| `switch_interval/2` | re-prices every item by id, deletes those leaving | moves `plan_id`, refreshes item ids, deletes those leaving | unchanged |
+| `cancel/2` | `cancel_at_period_end` | synced from the response | unchanged until the period ends |
+| `ItemExpiry.run/1` (hourly) | deletes items past `remove_at`, no proration | deletes the rows | package finally goes away |
+
+Four rules hold this together, and each is the answer to a way it went wrong:
+
+* **Removal is a date, not a flag.** `subscription_items.remove_at` holds the
+  moment the item is due to go. A boolean cannot say *which* period end was meant,
+  and a subscription's `current_period_end` jumps forward the instant Stripe
+  renews — so "items whose subscription's period has ended" finds nothing once the
+  renewal is synced, and the item is billed forever.
+* **Stripe item ids are never invented.** An item with no id from Stripe stores
+  `nil`, not a synthetic string. `switch_interval` sends `id` plus `price` for
+  every item it keeps and `deleted: true` for every item it drops, because an
+  entry without an `id` tells Stripe to **add** another item, and items missing
+  from the array are not removed. Losing the real ids once means the next switch
+  bills the customer on both intervals.
+* **Whatever charges, compensates.** Money moves before the local state is
+  written. Any failure after the Stripe subscription is created cancels it with
+  proration and reports; if even that fails, it is a Sentry alert naming the
+  `stripe_id`, because a human then has to refund it. Everything checkable without
+  charging — a published snapshot, sellable prices, a usable coupon, the plan row —
+  is checked first.
+* **Nothing is decided by a read that two requests can both pass.** `add_item`
+  inserts the local row before calling Stripe, so the unique index on
+  `(subscription_id, sku)` settles a race and only the winner creates a Stripe
+  item. Two simultaneous `subscribe` calls both land, and the one with the higher
+  id withdraws itself — lowest id wins, so exactly one survives whichever order
+  they finish in.
+
+⚠️ **`remove_item/3` depends on a scheduled job.** If
+`expire_bundle_subscription_items` stops running, removals never happen: the
+customer keeps the package and keeps paying for it, with nothing in the API
+looking wrong. `cancel_stale_replaced_subscriptions` is the same shape — it is what
+catches a legacy `BUSINESS_PRO` that failed to cancel during a bundle purchase, and
+without it that customer pays for both.
 
 ---
 
@@ -1036,6 +1086,21 @@ The 500,000 tier is built and working. Adding another tier later is one line of 
 
 ### Needed before launch
 
+**Q13. Does the web app hide plans marked `isPrivate`, and are the current Sanbase tiers really meant to be private?**
+
+On production, `FREE` on both products and Sanbase `PRO`, `PRO_PLUS` and `MAX` all carry `is_private = true`, alongside `BUSINESS_PRO` and `BUSINESS_MAX`. The database column is commented "plans that customers can't subscribe on their own", but people evidently do subscribe to those tiers, so the flag does not mean what it says.
+
+Two things hang on the answer:
+
+* The admin switch that puts Business Pro/Max on sale currently clears both `is_deprecated` and `is_private`, because we cannot tell which one the web app reads. If only one is read, the other write is noise; if the app reads `isPrivate`, then the flag has to move or the button does nothing.
+* Enforcing `is_private` as "cannot be bought self-serve" would immediately stop Sanbase PRO and MAX from being sold. We deliberately did not add that check for exactly this reason.
+
+What we need: does the pricing page filter on `isPrivate`, and should those rows be `is_private = false` instead?
+
+*Answer:* pending
+
+---
+
 **Q6. Does Institutional's "3 seats" ship in the first version?**
 
 We have no concept of seats today — one subscription belongs to one account. Adding seats is a separate piece of work from packages. If it has to be there at launch, it needs planning now rather than later.
@@ -1044,13 +1109,7 @@ We have no concept of seats today — one subscription belongs to one account. A
 
 ---
 
-**Q7. What happens if a customer removes a package in the middle of a month?**
-
-They have already used some of their calls that month. We need to know whether their access stops straight away or at the end of the period they paid for, and whether anything is refunded.
-
-Our suggestion, unless you prefer otherwise: **adding** a package takes effect immediately, **removing** one takes effect at the end of the paid period. That is the least surprising for the customer and the simplest to get right.
-
-*Answer:* pending
+~~**Q7. What happens if a customer removes a package in the middle of a month?**~~ ✅ **Answered:** adding takes effect immediately, removing takes effect at the end of the paid period, and nothing is refunded — the customer keeps the package for the time they bought. Built: the deadline is recorded on the item and an hourly job carries it out. See §5.11.
 
 ---
 

--- a/docs/composable-api-plans-handover.md
+++ b/docs/composable-api-plans-handover.md
@@ -1086,18 +1086,17 @@ The 500,000 tier is built and working. Adding another tier later is one line of 
 
 ### Needed before launch
 
-**Q13. Does the web app hide plans marked `isPrivate`, and are the current Sanbase tiers really meant to be private?**
+~~**Q14. Does the web app hide plans marked `isPrivate`?**~~ ✅ **Answered by reading the frontend, no product call needed.** It does not — it never asks for the field.
 
-On production, `FREE` on both products and Sanbase `PRO`, `PRO_PLUS` and `MAX` all carry `is_private = true`, alongside `BUSINESS_PRO` and `BUSINESS_MAX`. The database column is commented "plans that customers can't subscribe on their own", but people evidently do subscribe to those tiers, so the flag does not mean what it says.
+The pricing page uses `queryProductsWithPlans` from `san-webkit-next` (pinned at `lib-e24c3dd8-180526`), whose query selects `id name interval amount isDeprecated`. `isPrivate` appears nowhere in `san-webkit` or in `sanbase-app`. Filtering is `!plan.isDeprecated` plus a name allow-list: `{FREE, PRO, MAX}` for Sanbase, `{BUSINESS_PRO, BUSINESS_MAX, CUSTOM}` for SanAPI.
 
-Two things hang on the answer:
+Three consequences, all now built in:
 
-* The admin switch that puts Business Pro/Max on sale currently clears both `is_deprecated` and `is_private`, because we cannot tell which one the web app reads. If only one is read, the other write is noise; if the app reads `isPrivate`, then the flag has to move or the button does nothing.
-* Enforcing `is_private` as "cannot be bought self-serve" would immediately stop Sanbase PRO and MAX from being sold. We deliberately did not add that check for exactly this reason.
+* **`is_deprecated` is the only sale switch.** `SaleControls` moves that and nothing else; writing `is_private` would change production data with no observable effect.
+* **`is_private` must never become a purchase gate.** On production `FREE` on both products and Sanbase `PRO`, `PRO_PLUS` and `MAX` are all `is_private = true` *and sold on the pricing page every day*. The column's comment — "plans that customers can't subscribe on their own" — has never been enforced anywhere, and enforcing it would stop those sales.
+* **`BUNDLE` rows can never appear on the pricing page by flipping any flag.** They are excluded server-side by name and would be dropped client-side by the allow-list anyway. Making the offering visible is frontend work against `bundleCatalog` — a launch dependency, not a configuration change.
 
-What we need: does the pricing page filter on `isPrivate`, and should those rows be `is_private = false` instead?
-
-*Answer:* pending
+Left over, and cosmetic: a bundle subscriber's account page renders the literal `"BUNDLE"`, because `getPlanName` falls back to the raw name for anything outside its display map. Worth a webkit entry before launch.
 
 ---
 

--- a/docs/composable-api-plans-handover.md
+++ b/docs/composable-api-plans-handover.md
@@ -718,10 +718,17 @@ Changing a priced amount after Stripe exists = `Price.replace/1` + new Stripe Pr
 **Depends on:** A, LC.
 **Does not include:** Institutional / Enterprise Stripe prices — those are **IN** / **EP**.
 
-### SL. Subscribe / add / remove / cancel
-**What:** New mutations for bundles only (`subscribeBundle`, add/remove item, **switch interval**, cancel) using Stripe Subscription Items + proration. Leave `subscribe` / `update_subscription` / `cancel_subscription` (`billing_queries.ex:127/149/162`) untouched, and add the guard from §7.3 #1 so a bundle sub can never reach `upgrade_downgrade/2`. Enforce §7.3 #6 one-active-sub-per-product, and reject mixed-interval carts and mixed-interval add-item before calling Stripe (§5.7).
-**Deliverable:** GraphQL + Stripe API + mocked tests.
+### SL. Subscribe / add / remove / cancel — ✅ done
+**Implemented as:** `Bundle.Lifecycle` + GraphQL `subscribeBundle` / `addBundleItem` / `removeBundleItem` / `switchBundleInterval` / `cancelBundleSubscription`. Stripe multi-item create via Price ids; local `subscription_items` + `Resolver.sync/1` after each mutation. `upgrade_downgrade/2` rejects bundles. Legacy `subscribe` rejects `BUNDLE` markers and enforces `is_private` (team bypass).
+
+**Sale controls:** `Sanbase.Billing.Plan.SaleControls` + admin page `/admin/bundle_offering`. Activate/deactivate **bundle/new plans** (`BUNDLE*`, `INSTITUTIONAL*` via `is_private`) and **Business Pro/Max** (`is_deprecated`). GraphQL `bundleCatalog(interval)` is public when bundle plans are active, or always for Santiment team. Staff can preview/subscribe while bundle plans are deactivated.
+
+**Legacy → Bundle:** create new sub first, then cancel replaceable ladder (`BUSINESS_*`, grandfathered `PRO`/`BASIC`) with Stripe proration. Rejects active `CUSTOM_*` and already-on-bundle.
+
+**Remove item:** marks `subscription_items.cancel_at_period_end` (access kept until period end; WH/finalize later).
+**Deliverable:** ✅ GraphQL + Stripe helpers + offering gate + admin Go Live/Rollback + mocked tests.
 **Depends on:** SC, LC, BA.
+**Does not include:** WH webhook branching; Institutional plan rows (**IN**); purchase UI.
 
 ### WH. Webhook / sync for multi-item
 **What:** Branch `customer.subscription.created|updated|deleted`: bundle → sync all items, **re-resolve and rewrite `bundle_entitlement`**, reset the `ApiCallLimit` record; else → current first-item behavior unchanged. Handle §7.3 #2–#5. Idempotency: item changes fire many `subscription.updated`, and re-resolving must be a pure recompute so repeats are harmless.
@@ -912,7 +919,8 @@ Engineering-side, needing no product input: package ↔ metrics source of truth 
 | **WH** — quota write | ✅ partial | The `api_call_limits` write is done (§5.10) — resolved numbers stored on the row, refreshed by `Resolver.sync/1`. The Stripe webhook branching it was bundled with is not. |
 | **AM** — available metrics | ✅ done | `getAvailableMetrics(plan: BUNDLE, metricPackages: [...])` catalogs from the latest published snapshot. AccessChecker entitlement path clears the last BA raise. Non-bundle plans unchanged. |
 | **SC** — Stripe catalog | ✅ done | `Bundle.Catalog` via `Billing.sync_bundle_catalog_with_stripe/0` (also in `@reboot` `sync_products_with_stripe`). 12 local rows; package Stripe Prices via Price API; `api_calls_500k` amount still TBD. |
-| **SL / UI** | ⬜ not started | Subscribe mutations → purchase UI. |
+| **SL** — subscribe lifecycle | ✅ done | `Bundle.Lifecycle` + GraphQL mutations; SaleControls activate/deactivate; legacy auto-replace; `upgrade_downgrade` guard. |
+| **UI** | ⬜ not started | Three-column pricing / checkout (webapp). |
 | **IN** — Institutional | ⬜ not started | Fixed flagship plan (§1.1 middle column). Specced in §8 **IN**; not a BUNDLE. |
 | **EP** — Enterprise | ⬜ not started | Sales-led custom tier (§1.1 right column). Specced in §8 **EP**; prefer CUSTOM path. |
 
@@ -952,21 +960,20 @@ new environment: `development` came back with only three metrics (`dev_activity`
 package. `PackageSnapshot.materialize/0` still refuses to build and lists the
 categories that *do* exist if a name is ever wrong.
 
-**What a bundle still cannot do:** be bought. There is no Stripe catalog and no
-mutation to subscribe, so items are created locally. Everything from an item to a
-granted metric — and to a counted API call — works end to end. Catalog browsing
-of package combinations works via
-`getAvailableMetrics(plan: BUNDLE, metricPackages: [...])` without a subscription.
+**What a bundle can do now:** be bought (staff preview in `:legacy` mode, or public after Go Live) via `subscribeBundle`, with add/remove/switch/cancel. Catalog browsing still works via `getAvailableMetrics(plan: BUNDLE, metricPackages: [...])` without a subscription.
+
+**Still needed for production durability:** **WH** — Stripe webhook branching to re-sync items + entitlement on Stripe-initiated events (mutations already write locally).
 
 ### 13.1 Next
 
-1. **`SL → WH`** — subscribe / add / remove / cancel + webhook branching (quota write already done in §5.10). SC catalog unblocks package checkout once `Billing.sync_products_with_stripe/0` (or `sync_bundle_catalog_with_stripe/0`) has run against Stripe.
-2. **`IN`** (parallel) — Institutional as a fixed standard plan. Does not share the multi-item path.
+1. **`WH`** — webhook branching for multi-item sync + entitlement refresh (quota write already done in §5.10).
+2. **`IN`** (parallel) — Institutional as a fixed standard plan. Does not share the multi-item path; uses offering gate + standard `subscribe`.
 3. **`EP`** — confirm Enterprise = CUSTOM sales path; thin plan/admin work only.
-4. **`UI`** — three-column pricing / checkout once SL (packages) and IN (flagship CTA) exist.
+4. **`UI`** — three-column pricing / checkout once SL (packages) and IN (flagship CTA) exist; use `bundleCatalog` + plan flags (`is_private` / `is_deprecated`).
 5. When product prices `api_calls_500k`: set amounts + `Sanbase.Billing.sync_bundle_catalog_with_stripe()` (or wait for `@reboot`) — no code change.
+6. Use `/admin/bundle_offering` to activate bundle plans and/or deactivate Business Pro/Max when ready.
 
-Prices on the mock are **not final** and must not gate SL.
+Prices on the mock are **not final** and must not gate further work.
 
 ### 13.2 Original plan, for reference
 

--- a/lib/sanbase/billing/billing.ex
+++ b/lib/sanbase/billing/billing.ex
@@ -9,6 +9,8 @@ defmodule Sanbase.Billing do
   alias Sanbase.Repo
   alias Sanbase.Billing.{Product, Plan, Subscription}
   alias Sanbase.Billing.Plan.Bundle.Catalog
+  alias Sanbase.Billing.Plan.Bundle.ItemExpiry
+  alias Sanbase.Billing.Plan.Bundle.Lifecycle
   alias Sanbase.Billing.Subscription.LiquiditySubscription
   alias Sanbase.Billing.Subscription.ProPlus
   alias Sanbase.Accounts.User
@@ -23,6 +25,11 @@ defmodule Sanbase.Billing do
 
   defdelegate sync_stripe_subscriptions, to: Subscription
   defdelegate remove_duplicate_subscriptions, to: Subscription
+
+  # Bundle subscriptions
+  defdelegate expire_bundle_subscription_items, to: ItemExpiry, as: :run
+
+  defdelegate cancel_stale_replaced_subscriptions, to: Lifecycle
 
   # LiquiditySubscription
   defdelegate create_liquidity_subscription(user_id), to: LiquiditySubscription

--- a/lib/sanbase/billing/plan.ex
+++ b/lib/sanbase/billing/plan.ex
@@ -267,15 +267,21 @@ defmodule Sanbase.Billing.Plan do
   per item in the bundle price catalog. Listing them here would show a $0 plan on
   the pricing page and offer `subscribe(plan_id:)` a plan that flow cannot
   correctly create.
+
+  Deprecated plans are never listed. Private plans are listed only when
+  `include_private: true` (Santiment team preview).
   """
-  def product_with_plans do
+  def product_with_plans(opts \\ []) do
+    include_private? = Keyword.get(opts, :include_private, false)
     bundle_pattern = @bundle_prefix <> "%"
 
     query =
       from(p in Product,
         join: pl in __MODULE__,
         on: pl.product_id == p.id,
-        where: not pl.is_ppp and not like(pl.name, ^bundle_pattern),
+        where:
+          not pl.is_deprecated and not pl.is_ppp and not like(pl.name, ^bundle_pattern) and
+            (^include_private? or pl.is_private == false or is_nil(pl.is_private)),
         order_by: [desc: pl.order, asc: pl.id],
         preload: [plans: pl]
       )
@@ -283,6 +289,19 @@ defmodule Sanbase.Billing.Plan do
     product_with_plans = Repo.all(query)
 
     {:ok, product_with_plans}
+  end
+
+  @doc ~s"""
+  Marker `BUNDLE` plan for the given billing interval (`"month"` / `"year"`).
+  """
+  @spec bundle_plan(String.t()) :: %__MODULE__{} | nil
+  def bundle_plan(interval) when interval in ["month", "year"] do
+    Repo.get_by(__MODULE__,
+      name: @bundle_prefix,
+      interval: interval,
+      product_id: Product.product_api()
+    )
+    |> Repo.preload(:product)
   end
 
   @doc """

--- a/lib/sanbase/billing/plan.ex
+++ b/lib/sanbase/billing/plan.ex
@@ -142,6 +142,14 @@ defmodule Sanbase.Billing.Plan do
 
   @bundle_prefix "BUNDLE"
   @custom_prefix "CUSTOM_"
+  @institutional_prefix "INSTITUTIONAL"
+
+  # The two plans whose availability for sale is toggled by
+  # `Sanbase.Billing.Plan.SaleControls`.
+  @business_plan_names ["BUSINESS_PRO", "BUSINESS_MAX"]
+
+  @spec business_plan_names() :: [String.t()]
+  def business_plan_names, do: @business_plan_names
 
   def plan_name(%__MODULE__{} = plan) do
     case plan.name do
@@ -262,26 +270,39 @@ defmodule Sanbase.Billing.Plan do
   @doc """
   List all products with corresponding subscription plans
 
-  `BUNDLE` rows are left out. They are markers that a subscription is a bundle,
-  not tiers anyone can subscribe to - their amount is 0 and the real prices live
-  per item in the bundle price catalog. Listing them here would show a $0 plan on
-  the pricing page and offer `subscribe(plan_id:)` a plan that flow cannot
-  correctly create.
+  `BUNDLE` and `INSTITUTIONAL` rows are left out. They are markers that a
+  subscription belongs to the new offering, not tiers anyone can subscribe to -
+  their amount is 0 and the real prices live per item in the bundle price
+  catalog. Listing them here would show a $0 plan on the pricing page and offer
+  `subscribe(plan_id:)` a plan that flow cannot correctly create. The bundle
+  catalog is served by `bundleCatalog` instead.
 
-  Deprecated plans are never listed. Private plans are listed only when
-  `include_private: true` (Santiment team preview).
+  ## Why `is_deprecated` is only applied to the Business plans
+
+  Withdrawing Business Pro/Max from sale has to remove them from this list, or
+  the admin toggle in `Sanbase.Billing.Plan.SaleControls` would have no visible
+  effect. Every other row is returned exactly as it was before that toggle
+  existed, and that is deliberate: `is_private` and `is_deprecated` are set on
+  plenty of rows that are still expected here. On production `FREE` on both
+  products, and `PRO`, `PRO_PLUS` and `MAX` on Sanbase, are all
+  `is_private = true`, and Sanbase `BASIC` is deprecated - filtering on either
+  field across the board empties most of the pricing page. Both fields are
+  exposed on the GraphQL plan type, so a caller that wants to hide such rows
+  still can.
   """
-  def product_with_plans(opts \\ []) do
-    include_private? = Keyword.get(opts, :include_private, false)
+  def product_with_plans do
     bundle_pattern = @bundle_prefix <> "%"
+    institutional_pattern = @institutional_prefix <> "%"
 
     query =
       from(p in Product,
         join: pl in __MODULE__,
         on: pl.product_id == p.id,
         where:
-          not pl.is_deprecated and not pl.is_ppp and not like(pl.name, ^bundle_pattern) and
-            (^include_private? or pl.is_private == false or is_nil(pl.is_private)),
+          not pl.is_ppp and not like(pl.name, ^bundle_pattern) and
+            not like(pl.name, ^institutional_pattern) and
+            (pl.name not in ^@business_plan_names or
+               coalesce(pl.is_deprecated, false) == false),
         order_by: [desc: pl.order, asc: pl.id],
         preload: [plans: pl]
       )

--- a/lib/sanbase/billing/plan/bundle/item_expiry.ex
+++ b/lib/sanbase/billing/plan/bundle/item_expiry.ex
@@ -47,11 +47,21 @@ defmodule Sanbase.Billing.Plan.Bundle.ItemExpiry do
       Logger.info("[BundleItemExpiry] #{length(due)} bundle item(s) due for removal.")
     end
 
-    due
-    |> Enum.group_by(& &1.subscription_id)
-    |> Enum.reduce(%{removed: 0, failed: 0}, fn {subscription_id, items}, acc ->
-      merge_counts(acc, expire_subscription_items(subscription_id, items))
-    end)
+    summary =
+      due
+      |> Enum.group_by(& &1.subscription_id)
+      |> Enum.reduce(%{removed: 0, failed: 0}, fn {subscription_id, items}, acc ->
+        merge_counts(acc, expire_subscription_items(subscription_id, items))
+      end)
+
+    if due != [] do
+      Logger.info(
+        "[BundleItemExpiry] Removed #{summary.removed} bundle item(s), " <>
+          "#{summary.failed} failed."
+      )
+    end
+
+    summary
   end
 
   defp expire_subscription_items(subscription_id, items) do

--- a/lib/sanbase/billing/plan/bundle/item_expiry.ex
+++ b/lib/sanbase/billing/plan/bundle/item_expiry.ex
@@ -1,0 +1,151 @@
+defmodule Sanbase.Billing.Plan.Bundle.ItemExpiry do
+  @moduledoc ~s"""
+  Finishes the removals that `Bundle.Lifecycle.remove_item/3` only scheduled.
+
+  Dropping a package is not immediate: the customer paid for the period they are
+  in, so the item keeps working and keeps being billed until that period ends.
+  `remove_item/3` records the deadline in `subscription_items.remove_at` and
+  stops there. This is what acts on it - deletes the item in Stripe so the next
+  invoice is smaller, deletes the local row so the entitlement stops including
+  it, and re-resolves the entitlement.
+
+  Without this, `remove_item/3` is a promise nothing keeps: the customer would be
+  billed for the package forever and keep its metrics forever.
+
+  ## Runs on a schedule, not on a timer per item
+
+  Scheduled from `config/scheduler_config.exs`, hourly. An item therefore goes
+  away some time within the hour after its deadline, never before it. Sleeping
+  until an exact moment would not survive a deploy, and paying for a few extra
+  minutes is the safe direction to err in.
+
+  ## Safe to run again
+
+  Every step is idempotent. An item whose Stripe side is already gone counts as
+  deleted (`resource_missing`), so a run that failed halfway finishes on the next
+  pass. Anything that fails for another reason keeps its row and its deadline,
+  and is retried an hour later rather than being silently dropped.
+  """
+
+  alias Sanbase.Billing.Plan.Bundle.Resolver
+  alias Sanbase.Billing.Subscription.Item
+  alias Sanbase.Repo
+  alias Sanbase.StripeApi
+
+  require Logger
+
+  @type summary :: %{removed: non_neg_integer(), failed: non_neg_integer()}
+
+  @doc ~s"""
+  Remove every item whose deadline has passed.
+  """
+  @spec run(DateTime.t()) :: summary()
+  def run(now \\ DateTime.utc_now()) do
+    due = Item.due_for_removal(now)
+
+    if due != [] do
+      Logger.info("[BundleItemExpiry] #{length(due)} bundle item(s) due for removal.")
+    end
+
+    due
+    |> Enum.group_by(& &1.subscription_id)
+    |> Enum.reduce(%{removed: 0, failed: 0}, fn {subscription_id, items}, acc ->
+      merge_counts(acc, expire_subscription_items(subscription_id, items))
+    end)
+  end
+
+  defp expire_subscription_items(subscription_id, items) do
+    counts =
+      Enum.reduce(items, %{removed: 0, failed: 0}, fn item, acc ->
+        case expire_item(item) do
+          :ok -> Map.update!(acc, :removed, &(&1 + 1))
+          :error -> Map.update!(acc, :failed, &(&1 + 1))
+        end
+      end)
+
+    # Only worth re-resolving if something actually went away, and only once per
+    # subscription no matter how many of its items expired together.
+    if counts.removed > 0, do: resync(subscription_id)
+
+    counts
+  end
+
+  defp expire_item(%Item{} = item) do
+    case delete_in_stripe(item) do
+      :ok ->
+        case Repo.delete(item) do
+          {:ok, _} ->
+            :ok
+
+          {:error, reason} ->
+            # The Stripe item is gone but the row is not, so the entitlement still
+            # grants it while the invoice no longer charges for it. Next run picks
+            # the row up again and the Stripe delete is a no-op by then.
+            report(item, "the local row could not be deleted", reason)
+            :error
+        end
+
+      {:error, reason} ->
+        report(item, "its Stripe item could not be deleted", reason)
+        :error
+    end
+  end
+
+  # `proration_behavior: "none"` because the deadline has already passed - the
+  # customer used the whole period they paid for, so there is nothing to credit.
+  # Prorating here would hand back money for time that was actually served.
+  defp delete_in_stripe(%Item{stripe_item_id: stripe_item_id})
+       when is_binary(stripe_item_id) do
+    case StripeApi.delete_subscription_item(stripe_item_id, proration_behavior: "none") do
+      {:ok, _} -> :ok
+      {:error, %Stripe.Error{code: :resource_missing}} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # An item that was never mirrored into Stripe has nothing to delete there.
+  defp delete_in_stripe(%Item{}), do: :ok
+
+  defp resync(subscription_id) do
+    case Resolver.sync(subscription_id) do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error("""
+        [BundleItemExpiry] Removed expired item(s) from subscription \
+        #{subscription_id} but could not re-resolve its entitlement: \
+        #{inspect(reason)}. The customer keeps the removed package until the next \
+        successful sync.
+        """)
+
+        Sentry.capture_message("bundle_item_expiry_resync_failed",
+          extra: %{subscription_id: subscription_id, reason: inspect(reason)}
+        )
+
+        :error
+    end
+  end
+
+  defp report(%Item{} = item, what, reason) do
+    Logger.error("""
+    [BundleItemExpiry] Item #{item.id} (#{item.sku}) on subscription \
+    #{item.subscription_id} was due for removal at #{item.remove_at} but #{what}: \
+    #{inspect(reason)}. It will be retried on the next run.
+    """)
+
+    Sentry.capture_message("bundle_item_expiry_failed",
+      extra: %{
+        item_id: item.id,
+        sku: item.sku,
+        subscription_id: item.subscription_id,
+        stripe_item_id: item.stripe_item_id,
+        reason: inspect(reason)
+      }
+    )
+  end
+
+  defp merge_counts(left, right) do
+    %{removed: left.removed + right.removed, failed: left.failed + right.failed}
+  end
+end

--- a/lib/sanbase/billing/plan/bundle/lifecycle.ex
+++ b/lib/sanbase/billing/plan/bundle/lifecycle.ex
@@ -8,18 +8,40 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
   When the user already has a replaceable legacy SanAPI sub (`BUSINESS_PRO` /
   `BUSINESS_MAX`, or grandfathered `PRO` / `BASIC`), that sub is canceled with
   proration after the new bundle sub is created.
+
+  ## Removing is scheduled, not immediate
+
+  `remove_item/3` records a deadline on the item and returns. The customer paid
+  for the period they are in, so the package keeps working and keeps being billed
+  until it ends. `Sanbase.Billing.Plan.Bundle.ItemExpiry` is what deletes the
+  Stripe item and the row once that moment passes.
+
+  ## Everything that charges compensates
+
+  Money moves before the local state is written - a Stripe subscription is
+  created and the first invoice is paid, and only then can items fail to persist
+  or the entitlement fail to resolve. Every such failure cancels the Stripe
+  subscription it just created before returning the error, because the
+  alternative is a customer who has paid and whose every request is refused.
+
+  Anything that can be checked without charging is checked first, including that
+  a package snapshot exists to resolve against.
   """
+
+  import Ecto.Query
 
   alias Sanbase.Accounts.User
   alias Sanbase.Billing
   alias Sanbase.Billing.Plan
+  alias Sanbase.Billing.Plan.Bundle.PackageSnapshot
   alias Sanbase.Billing.Plan.Bundle.Price
   alias Sanbase.Billing.Plan.Bundle.Resolver
-  alias Sanbase.Billing.Product
   alias Sanbase.Billing.Plan.SaleControls
+  alias Sanbase.Billing.Product
   alias Sanbase.Billing.Subscription
   alias Sanbase.Billing.Subscription.Item
   alias Sanbase.Billing.Subscription.Query
+  alias Sanbase.Billing.UserPromoCode
   alias Sanbase.Repo
   alias Sanbase.StripeApi
 
@@ -54,14 +76,13 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
          {:ok, skus} <- build_skus(packages, api_calls_addon),
          {:ok, prices} <- resolve_sellable_prices(skus, interval),
          {:ok, plan} <- fetch_bundle_plan(interval),
-         :ok <- ensure_can_subscribe_bundle(user),
-         replaceable <- list_replaceable_sanapi_subs(user),
+         :ok <- ensure_snapshot_published(),
+         :ok <- ensure_coupon_usable(coupon, plan),
+         {:ok, replaceable} <- classify_for_subscribe(user),
          {:ok, user} <- ensure_stripe_customer(user, card_token, payment_method_id),
          {:ok, stripe_sub} <- create_stripe_bundle_sub(user, prices, coupon),
-         {:ok, db_sub} <- Subscription.create_subscription_db(stripe_sub, user, plan),
-         :ok <- persist_items(db_sub, prices, stripe_sub),
-         {:ok, db_sub} <- Resolver.sync(db_sub.id) do
-      maybe_cancel_replaceable(replaceable)
+         {:ok, db_sub} <- store_subscription(stripe_sub, user, plan, prices) do
+      cancel_replaceable(replaceable)
 
       {:ok, Subscription.by_id(db_sub.id)}
     end
@@ -74,17 +95,8 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
          {:ok, sub} <- fetch_owned_bundle(user, subscription_id),
          :ok <- validate_not_cancelling(sub),
          {:ok, price} <- sellable_price_for_sub(sku, sub),
-         :ok <- ensure_sku_absent(sub, sku),
-         {:ok, stripe_item} <-
-           StripeApi.create_subscription_item(sub.stripe_id, price.stripe_price_id, []),
-         {:ok, _} <-
-           Item.create(%{
-             subscription_id: sub.id,
-             stripe_item_id: stripe_item.id,
-             sku: price.sku,
-             type: price.type,
-             quantity: 1
-           }),
+         {:ok, item} <- claim_item(sub, price),
+         {:ok, _item} <- mirror_item_in_stripe(sub, item, price),
          {:ok, synced} <- Resolver.sync(sub.id) do
       {:ok, Subscription.by_id(synced.id)}
     end
@@ -97,8 +109,9 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
          {:ok, sub} <- fetch_owned_bundle(user, subscription_id),
          :ok <- validate_not_cancelling(sub),
          {:ok, item} <- fetch_item(sub, sku),
+         :ok <- ensure_not_already_removed(item),
          :ok <- ensure_not_last_package(sub, item),
-         {:ok, _} <- mark_item_cancel_at_period_end(item),
+         {:ok, _} <- schedule_item_removal(item, sub),
          {:ok, synced} <- Resolver.sync(sub.id) do
       {:ok, Subscription.by_id(synced.id)}
     end
@@ -110,13 +123,12 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
     with :ok <- ensure_offering_visible(user),
          {:ok, sub} <- fetch_owned_bundle(user, subscription_id),
          :ok <- validate_not_cancelling(sub),
-         items <- Item.by_subscription(sub.id),
+         {:ok, staying, leaving} <- items_to_switch(sub),
          {:ok, new_interval} <- counterpart_interval(sub.plan.interval),
          {:ok, new_plan} <- fetch_bundle_plan(new_interval),
-         {:ok, new_prices} <- resolve_sellable_prices(Enum.map(items, & &1.sku), new_interval),
-         {:ok, _stripe_sub} <- swap_stripe_items(sub, items, new_prices),
-         {:ok, _} <- Subscription.update_subscription_db(sub, %{plan_id: new_plan.id}),
-         :ok <- replace_local_items(sub.id, items, new_prices),
+         {:ok, new_prices} <- resolve_sellable_prices(Enum.map(staying, & &1.sku), new_interval),
+         {:ok, stripe_sub} <- swap_stripe_items(sub, staying, leaving, new_prices),
+         :ok <- apply_interval_switch(sub, new_plan, staying, leaving, new_prices, stripe_sub),
          {:ok, synced} <- Resolver.sync(sub.id) do
       {:ok, Subscription.by_id(synced.id)}
     end
@@ -125,6 +137,9 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
   @spec cancel(User.t(), integer()) ::
           {:ok, map()} | {:error, term()}
   def cancel(%User{} = user, subscription_id) do
+    # Deliberately not gated on `ensure_offering_visible/1`, unlike its four
+    # siblings. Withdrawing the offering from sale must never trap the customers
+    # who already bought it.
     with {:ok, sub} <- fetch_owned_bundle(user, subscription_id),
          :ok <- validate_not_cancelling(sub),
          {:ok, result} <- Billing.cancel_subscription_at_period_end(sub) do
@@ -133,15 +148,42 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
   end
 
   @doc ~s"""
-  Whether the user may purchase a new SanAPI offering (Bundle / Institutional).
+  Cancel legacy SanAPI subscriptions belonging to users who now have a bundle.
 
-  Returns `:ok`, `{:replace, [subs]}` for replaceable legacy ladder subs, or an error.
+  The cancel at the end of `subscribe/2` can fail on its own - Stripe is down,
+  the request times out - and it must not fail the purchase that has already been
+  paid for. This is the retry, so a customer cannot be left paying for both the
+  bundle and the plan it replaced.
+  """
+  @spec cancel_stale_replaced_subscriptions() :: %{
+          canceled: non_neg_integer(),
+          failed: non_neg_integer()
+        }
+  def cancel_stale_replaced_subscriptions do
+    stale = stale_replaced_subscriptions()
+
+    if stale != [] do
+      Logger.info(
+        "[BundleLifecycle] #{length(stale)} legacy SanAPI subscription(s) still active " <>
+          "alongside a bundle."
+      )
+    end
+
+    Enum.reduce(stale, %{canceled: 0, failed: 0}, fn sub, acc ->
+      case cancel_replaced_subscription(sub) do
+        :ok -> Map.update!(acc, :canceled, &(&1 + 1))
+        :error -> Map.update!(acc, :failed, &(&1 + 1))
+      end
+    end)
+  end
+
+  @doc ~s"""
+  Whether the user may purchase a new SanAPI offering (Bundle / Institutional).
   """
   @spec ensure_can_subscribe_bundle(User.t()) :: :ok | {:error, String.t()}
   def ensure_can_subscribe_bundle(%User{} = user) do
-    case classify_active_sanapi(user) do
-      {:ok, :none} -> :ok
-      {:ok, :replaceable, _subs} -> :ok
+    case classify_for_subscribe(user) do
+      {:ok, _subs} -> :ok
       {:error, _} = error -> error
     end
   end
@@ -200,6 +242,33 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
     end
   end
 
+  # Checked before charging rather than discovered after. Resolving an entitlement
+  # needs a published snapshot, and without one the customer would be billed for a
+  # subscription that grants nothing.
+  defp ensure_snapshot_published do
+    case PackageSnapshot.latest() do
+      %PackageSnapshot{} ->
+        :ok
+
+      nil ->
+        {:error,
+         "The bundle package catalog has not been published yet, so a bundle cannot be sold"}
+    end
+  end
+
+  # The standard `subscribe` mutation validates the coupon before charging. The
+  # bundle flow has to do the same, or a code that is expired, exhausted or
+  # restricted to another product is redeemed against our own counter and only
+  # then argued about with Stripe.
+  defp ensure_coupon_usable(nil, _plan), do: :ok
+
+  defp ensure_coupon_usable(coupon, %Plan{} = plan) do
+    case UserPromoCode.is_coupon_usable(coupon, plan) do
+      true -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   defp ensure_stripe_customer(user, _card_token, payment_method_id)
        when is_binary(payment_method_id) do
     StripeApi.attach_payment_method_to_customer(user, payment_method_id)
@@ -228,17 +297,92 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
     StripeApi.create_bundle_subscription(params)
   end
 
+  # Everything after the charge. Any failure here cancels the subscription that
+  # was just paid for, because a bundle with no items or no entitlement refuses
+  # every request the customer makes.
+  defp store_subscription(stripe_sub, user, plan, prices) do
+    with {:ok, db_sub} <- Subscription.create_subscription_db(stripe_sub, user, plan),
+         :ok <- ensure_sole_bundle_subscription(db_sub, user),
+         :ok <- persist_items(db_sub, prices, stripe_sub),
+         {:ok, db_sub} <- Resolver.sync(db_sub.id) do
+      {:ok, db_sub}
+    else
+      {:error, reason} ->
+        abort_stripe_subscription(stripe_sub, reason)
+        {:error, reason}
+    end
+  end
+
+  # Two requests that arrive together both pass the "no active SanAPI
+  # subscription" check before either has inserted anything, and both then create
+  # a Stripe subscription. Rather than lock around a call to Stripe, both rows are
+  # allowed to land and the loser withdraws: the lowest id wins, so exactly one
+  # survives no matter which order the two finish in.
+  defp ensure_sole_bundle_subscription(%Subscription{id: id}, user) do
+    winner =
+      user
+      |> active_bundle_subscription_ids()
+      |> Enum.min(fn -> id end)
+
+    if winner == id do
+      :ok
+    else
+      {:error,
+       "Another bundle subscription for this account was created at the same time. " <>
+         "This one was withdrawn - reload and use the existing subscription."}
+    end
+  end
+
+  defp abort_stripe_subscription(%Stripe.Subscription{id: stripe_id}, reason) do
+    Logger.error("""
+    [BundleLifecycle] Bundle subscription #{stripe_id} was created and charged but \
+    could not be set up locally: #{inspect(reason)}. Cancelling it with proration.
+    """)
+
+    Sentry.capture_message("bundle_subscribe_rolled_back",
+      extra: %{stripe_subscription_id: stripe_id, reason: inspect(reason)}
+    )
+
+    case StripeApi.cancel_subscription_with_proration(stripe_id) do
+      {:ok, _} ->
+        cancel_local_subscription(stripe_id)
+        :ok
+
+      {:error, cancel_reason} ->
+        # The customer has been charged for a subscription we could not set up and
+        # could not cancel. Nothing here can fix that; a human has to.
+        Logger.error("""
+        [BundleLifecycle] Bundle subscription #{stripe_id} could not be cancelled \
+        after a failed setup: #{inspect(cancel_reason)}. It is charging the customer \
+        and grants nothing - cancel and refund it by hand.
+        """)
+
+        Sentry.capture_message("bundle_subscribe_rollback_failed",
+          extra: %{stripe_subscription_id: stripe_id, reason: inspect(cancel_reason)}
+        )
+
+        :error
+    end
+  end
+
+  defp cancel_local_subscription(stripe_id) do
+    case Subscription.by_stripe_id(stripe_id) do
+      %Subscription{} = sub -> Subscription.update_subscription_db(sub, %{status: :canceled})
+      nil -> :ok
+    end
+  end
+
+  # `stripe_item_id` is left nil when Stripe's response does not name the item for
+  # a price, rather than filled with something that looks like a Stripe id but is
+  # not. A synthetic id cannot be used to change or delete anything, and every
+  # later caller would have to know the difference.
   defp persist_items(db_sub, prices, stripe_sub) do
     stripe_items = stripe_items_by_price(stripe_sub)
 
     Enum.reduce_while(prices, :ok, fn price, :ok ->
-      stripe_item_id =
-        Map.get(stripe_items, price.stripe_price_id) ||
-          "local_#{db_sub.id}_#{price.sku}"
-
       case Item.create(%{
              subscription_id: db_sub.id,
-             stripe_item_id: stripe_item_id,
+             stripe_item_id: Map.get(stripe_items, price.stripe_price_id),
              sku: price.sku,
              type: price.type,
              quantity: 1
@@ -250,47 +394,94 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
   end
 
   defp stripe_items_by_price(%Stripe.Subscription{items: %Stripe.List{data: data}}) do
-    Map.new(data, fn item ->
-      price_id =
-        cond do
-          match?(%{price: %{id: _}}, item) -> item.price.id
-          match?(%{price: id} when is_binary(id), item) -> item.price
-          match?(%{plan: %{id: _}}, item) -> item.plan.id
-          true -> nil
-        end
-
-      {price_id, item.id}
-    end)
+    data
+    |> Enum.map(fn item -> {stripe_item_price_id(item), item.id} end)
+    |> Enum.reject(fn {price_id, _item_id} -> is_nil(price_id) end)
+    |> Map.new()
   end
 
   defp stripe_items_by_price(_), do: %{}
 
-  defp maybe_cancel_replaceable([]), do: :ok
+  defp stripe_item_price_id(item) do
+    cond do
+      match?(%{price: %{id: _}}, item) -> item.price.id
+      match?(%{price: id} when is_binary(id), item) -> item.price
+      match?(%{plan: %{id: _}}, item) -> item.plan.id
+      true -> nil
+    end
+  end
 
-  defp maybe_cancel_replaceable(subs) do
-    Enum.each(subs, fn sub ->
-      case sub.stripe_id do
-        id when is_binary(id) ->
-          case StripeApi.cancel_subscription_with_proration(id) do
-            {:ok, stripe_sub} ->
-              Subscription.sync_subscription_with_stripe(stripe_sub, sub)
+  defp cancel_replaceable([]), do: :ok
 
-            {:error, reason} ->
-              Logger.error(
-                "Failed to cancel replaced SanAPI sub #{sub.id} after bundle subscribe: #{inspect(reason)}"
-              )
-
-              Sentry.capture_message("bundle_subscribe_replace_cancel_failed",
-                extra: %{subscription_id: sub.id, reason: inspect(reason)}
-              )
-          end
-
-        _ ->
-          Subscription.update_subscription_db(sub, %{status: :canceled})
-      end
-    end)
+  defp cancel_replaceable(subs) do
+    Enum.each(subs, &cancel_replaced_subscription/1)
 
     :ok
+  end
+
+  # Never fails the purchase. The new subscription is paid for and valid; the old
+  # one lingering is a billing problem to be retried, which
+  # `cancel_stale_replaced_subscriptions/0` does on a schedule.
+  defp cancel_replaced_subscription(%Subscription{stripe_id: stripe_id} = sub)
+       when is_binary(stripe_id) do
+    case StripeApi.cancel_subscription_with_proration(stripe_id) do
+      {:ok, stripe_sub} ->
+        Subscription.sync_subscription_with_stripe(stripe_sub, sub)
+        :ok
+
+      {:error, reason} ->
+        Logger.error(
+          "[BundleLifecycle] Failed to cancel replaced SanAPI sub #{sub.id} after bundle " <>
+            "subscribe: #{inspect(reason)}. Will be retried."
+        )
+
+        Sentry.capture_message("bundle_subscribe_replace_cancel_failed",
+          extra: %{subscription_id: sub.id, reason: inspect(reason)}
+        )
+
+        :error
+    end
+  end
+
+  # No Stripe object to cancel - a locally created row, so marking it is the whole
+  # job.
+  defp cancel_replaced_subscription(%Subscription{} = sub) do
+    case Subscription.update_subscription_db(sub, %{status: :canceled}) do
+      {:ok, _} -> :ok
+      {:error, _} -> :error
+    end
+  end
+
+  defp stale_replaced_subscriptions do
+    product_api = Product.product_api()
+
+    on_new_offering =
+      from(s in Subscription,
+        join: p in Plan,
+        on: s.plan_id == p.id,
+        where:
+          s.status in ^@active_statuses and p.product_id == ^product_api and
+            (like(p.name, "BUNDLE%") or like(p.name, "INSTITUTIONAL%")),
+        select: s.user_id
+      )
+
+    from(s in Subscription,
+      join: p in Plan,
+      on: s.plan_id == p.id,
+      where:
+        s.status in ^@active_statuses and p.product_id == ^product_api and
+          p.name in ^@replaceable_plan_names and s.user_id in subquery(on_new_offering),
+      preload: [plan: :product]
+    )
+    |> Repo.all()
+  end
+
+  defp classify_for_subscribe(user) do
+    case classify_active_sanapi(user) do
+      {:ok, :none} -> {:ok, []}
+      {:ok, :replaceable, subs} -> {:ok, subs}
+      {:error, _} = error -> error
+    end
   end
 
   defp classify_active_sanapi(%User{id: user_id}) do
@@ -317,6 +508,15 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
       true ->
         {:error, "You already have an active SanAPI subscription"}
     end
+  end
+
+  defp active_bundle_subscription_ids(%User{id: user_id}) do
+    Subscription
+    |> Query.user_has_any_subscriptions_for_product(user_id, Product.product_api())
+    |> Query.join_plan_and_product()
+    |> Repo.all()
+    |> Enum.filter(fn s -> s.status in @active_statuses and new_offering_plan?(s) end)
+    |> Enum.map(& &1.id)
   end
 
   defp custom_plan?(%Subscription{plan: %Plan{name: "CUSTOM_" <> _}}), do: true
@@ -362,11 +562,50 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
     end
   end
 
-  defp ensure_sku_absent(sub, sku) do
-    if Enum.any?(Item.by_subscription(sub.id), &(&1.sku == sku)) do
-      {:error, "SKU #{sku} is already on this subscription"}
-    else
-      :ok
+  # The local row is written before Stripe is called so the unique index on
+  # (subscription_id, sku) is what decides a race, not a read that two requests
+  # can both pass. The loser is rejected before it can create a second Stripe item
+  # the customer would be billed for.
+  defp claim_item(sub, price) do
+    case Item.create(%{
+           subscription_id: sub.id,
+           sku: price.sku,
+           type: price.type,
+           quantity: 1
+         }) do
+      {:ok, item} ->
+        {:ok, item}
+
+      {:error, %Ecto.Changeset{} = changeset} = error ->
+        if duplicate_sku?(changeset) do
+          {:error, "SKU #{price.sku} is already on this subscription"}
+        else
+          error
+        end
+    end
+  end
+
+  # The unique index covers (subscription_id, sku), so Ecto reports the violation
+  # against `subscription_id` - the first field named - not against `sku`. Matching
+  # the constraint by name says what is meant regardless.
+  defp duplicate_sku?(%Ecto.Changeset{errors: errors}) do
+    Enum.any?(errors, fn {_field, {_message, opts}} ->
+      Keyword.get(opts, :constraint_name) == "subscription_items_subscription_id_sku_index"
+    end)
+  end
+
+  defp mirror_item_in_stripe(sub, %Item{} = item, price) do
+    case StripeApi.create_subscription_item(sub.stripe_id, price.stripe_price_id, []) do
+      {:ok, stripe_item} ->
+        item
+        |> Item.changeset(%{stripe_item_id: stripe_item.id})
+        |> Repo.update()
+
+      {:error, reason} ->
+        # Undo the claim, otherwise the customer holds a package Stripe never
+        # billed them for and cannot retry adding it.
+        Repo.delete(item)
+        {:error, reason}
     end
   end
 
@@ -377,12 +616,18 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
     end
   end
 
-  defp ensure_not_last_package(sub, %Item{type: :package}) do
-    packages =
-      Item.by_subscription(sub.id)
-      |> Enum.filter(&(&1.type == :package and not &1.cancel_at_period_end))
+  defp ensure_not_already_removed(%Item{sku: sku} = item) do
+    if Item.scheduled_for_removal?(item) do
+      {:error, "SKU #{sku} is already scheduled for removal"}
+    else
+      :ok
+    end
+  end
 
-    if length(packages) <= 1 do
+  defp ensure_not_last_package(sub, %Item{type: :package}) do
+    staying = Item.staying_on_subscription(sub.id) |> Enum.filter(&(&1.type == :package))
+
+    if length(staying) <= 1 do
       {:error, "Cannot remove the last package; cancel the subscription instead"}
     else
       :ok
@@ -391,53 +636,84 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
 
   defp ensure_not_last_package(_sub, _item), do: :ok
 
-  defp mark_item_cancel_at_period_end(%Item{} = item) do
+  # A locally created subscription has no billing period, so there is nothing to
+  # wait for and the removal is due at once.
+  defp schedule_item_removal(%Item{} = item, %Subscription{current_period_end: period_end}) do
+    remove_at = period_end || DateTime.utc_now()
+
     item
-    |> Item.changeset(%{cancel_at_period_end: true})
+    |> Item.changeset(%{remove_at: remove_at})
     |> Repo.update()
+  end
+
+  defp items_to_switch(sub) do
+    all = Item.by_subscription(sub.id)
+    {leaving, staying} = Enum.split_with(all, &Item.scheduled_for_removal?/1)
+
+    if staying == [] do
+      {:error, "This subscription has no items to switch"}
+    else
+      {:ok, staying, leaving}
+    end
   end
 
   defp counterpart_interval("month"), do: {:ok, "year"}
   defp counterpart_interval("year"), do: {:ok, "month"}
   defp counterpart_interval(_), do: {:error, "Unknown interval"}
 
-  defp swap_stripe_items(sub, items, new_prices) do
+  # Items already scheduled for removal are dropped here rather than re-priced.
+  # Carrying them over would undo the customer's removal, and there is no period
+  # left to honour once the subscription is billed on a different cycle.
+  defp swap_stripe_items(sub, staying, leaving, new_prices) do
     price_by_sku = Map.new(new_prices, &{&1.sku, &1})
 
-    stripe_items =
-      Enum.map(items, fn item ->
+    repriced =
+      Enum.map(staying, fn item ->
         new_price = Map.fetch!(price_by_sku, item.sku)
 
-        cond do
-          is_binary(item.stripe_item_id) and
-              not String.starts_with?(item.stripe_item_id, "local_") ->
-            %{id: item.stripe_item_id, price: new_price.stripe_price_id}
-
-          true ->
-            %{price: new_price.stripe_price_id}
+        case item.stripe_item_id do
+          id when is_binary(id) -> %{id: id, price: new_price.stripe_price_id}
+          nil -> %{price: new_price.stripe_price_id}
         end
       end)
 
+    deleted =
+      leaving
+      |> Enum.filter(&is_binary(&1.stripe_item_id))
+      |> Enum.map(&%{id: &1.stripe_item_id, deleted: true})
+
     StripeApi.update_subscription(sub.stripe_id, %{
-      items: stripe_items,
+      items: repriced ++ deleted,
       proration_behavior: "create_prorations"
     })
   end
 
-  defp replace_local_items(subscription_id, old_items, new_prices) do
-    Repo.transaction(fn ->
-      Enum.each(old_items, fn item -> Repo.delete!(item) end)
+  # The item ids Stripe reports back are the authority. Changing an item's price
+  # keeps its id, but reading them from the response also repairs any row that had
+  # none, and is what lets a second switch address the existing items instead of
+  # asking Stripe to add more alongside them.
+  #
+  # One transaction, because a subscription whose plan says one interval while its
+  # items are priced on the other cannot be told apart from a correct one later.
+  defp apply_interval_switch(sub, new_plan, staying, leaving, new_prices, stripe_sub) do
+    item_id_by_price = stripe_items_by_price(stripe_sub)
+    price_id_by_sku = Map.new(new_prices, &{&1.sku, &1.stripe_price_id})
 
-      Enum.each(new_prices, fn price ->
-        case Item.create(%{
-               subscription_id: subscription_id,
-               stripe_item_id: "local_#{subscription_id}_#{price.sku}_#{price.interval}",
-               sku: price.sku,
-               type: price.type,
-               quantity: 1
-             }) do
-          {:ok, _} -> :ok
-          {:error, changeset} -> Repo.rollback(changeset)
+    Repo.transaction(fn ->
+      case Subscription.update_subscription_db(sub, %{plan_id: new_plan.id}) do
+        {:ok, _} -> :ok
+        {:error, reason} -> Repo.rollback(reason)
+      end
+
+      Enum.each(leaving, &Repo.delete!/1)
+
+      Enum.each(staying, fn item ->
+        new_item_id = Map.get(item_id_by_price, Map.get(price_id_by_sku, item.sku))
+
+        if is_binary(new_item_id) and new_item_id != item.stripe_item_id do
+          item
+          |> Item.changeset(%{stripe_item_id: new_item_id})
+          |> Repo.update!()
         end
       end)
 

--- a/lib/sanbase/billing/plan/bundle/lifecycle.ex
+++ b/lib/sanbase/billing/plan/bundle/lifecycle.ex
@@ -1,0 +1,451 @@
+defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
+  @moduledoc ~s"""
+  Subscribe / add / remove / switch-interval / cancel for bundle subscriptions.
+
+  Uses Stripe Subscription Items + Price ids from `Bundle.Price`. Writes local
+  `subscription_items` and re-resolves entitlement via `Resolver.sync/1`.
+
+  When the user already has a replaceable legacy SanAPI sub (`BUSINESS_PRO` /
+  `BUSINESS_MAX`, or grandfathered `PRO` / `BASIC`), that sub is canceled with
+  proration after the new bundle sub is created.
+  """
+
+  alias Sanbase.Accounts.User
+  alias Sanbase.Billing
+  alias Sanbase.Billing.Plan
+  alias Sanbase.Billing.Plan.Bundle.Price
+  alias Sanbase.Billing.Plan.Bundle.Resolver
+  alias Sanbase.Billing.Product
+  alias Sanbase.Billing.Plan.SaleControls
+  alias Sanbase.Billing.Subscription
+  alias Sanbase.Billing.Subscription.Item
+  alias Sanbase.Billing.Subscription.Query
+  alias Sanbase.Repo
+  alias Sanbase.StripeApi
+
+  require Logger
+
+  @replaceable_plan_names ~w(BUSINESS_PRO BUSINESS_MAX PRO BASIC)
+  @active_statuses [:active, :past_due, :trialing]
+
+  @type interval :: String.t()
+  @type subscribe_opts :: [
+          packages: [String.t()],
+          api_calls_addon: String.t() | nil,
+          interval: interval(),
+          card_token: String.t() | nil,
+          payment_method_id: String.t() | nil,
+          coupon: String.t() | nil
+        ]
+
+  @spec subscribe(User.t(), subscribe_opts()) ::
+          {:ok, Subscription.t()} | {:error, term()}
+  def subscribe(%User{} = user, opts) do
+    packages = Keyword.fetch!(opts, :packages)
+    interval = Keyword.fetch!(opts, :interval)
+    api_calls_addon = Keyword.get(opts, :api_calls_addon)
+    card_token = Keyword.get(opts, :card_token)
+    payment_method_id = Keyword.get(opts, :payment_method_id)
+    coupon = Keyword.get(opts, :coupon)
+
+    with :ok <- ensure_offering_visible(user),
+         :ok <- validate_packages(packages),
+         :ok <- validate_interval(interval),
+         {:ok, skus} <- build_skus(packages, api_calls_addon),
+         {:ok, prices} <- resolve_sellable_prices(skus, interval),
+         {:ok, plan} <- fetch_bundle_plan(interval),
+         :ok <- ensure_can_subscribe_bundle(user),
+         replaceable <- list_replaceable_sanapi_subs(user),
+         {:ok, user} <- ensure_stripe_customer(user, card_token, payment_method_id),
+         {:ok, stripe_sub} <- create_stripe_bundle_sub(user, prices, coupon),
+         {:ok, db_sub} <- Subscription.create_subscription_db(stripe_sub, user, plan),
+         :ok <- persist_items(db_sub, prices, stripe_sub),
+         {:ok, db_sub} <- Resolver.sync(db_sub.id) do
+      maybe_cancel_replaceable(replaceable)
+
+      {:ok, Subscription.by_id(db_sub.id)}
+    end
+  end
+
+  @spec add_item(User.t(), integer(), String.t()) ::
+          {:ok, Subscription.t()} | {:error, term()}
+  def add_item(%User{} = user, subscription_id, sku) when is_binary(sku) do
+    with :ok <- ensure_offering_visible(user),
+         {:ok, sub} <- fetch_owned_bundle(user, subscription_id),
+         :ok <- validate_not_cancelling(sub),
+         {:ok, price} <- sellable_price_for_sub(sku, sub),
+         :ok <- ensure_sku_absent(sub, sku),
+         {:ok, stripe_item} <-
+           StripeApi.create_subscription_item(sub.stripe_id, price.stripe_price_id, []),
+         {:ok, _} <-
+           Item.create(%{
+             subscription_id: sub.id,
+             stripe_item_id: stripe_item.id,
+             sku: price.sku,
+             type: price.type,
+             quantity: 1
+           }),
+         {:ok, synced} <- Resolver.sync(sub.id) do
+      {:ok, Subscription.by_id(synced.id)}
+    end
+  end
+
+  @spec remove_item(User.t(), integer(), String.t()) ::
+          {:ok, Subscription.t()} | {:error, term()}
+  def remove_item(%User{} = user, subscription_id, sku) when is_binary(sku) do
+    with :ok <- ensure_offering_visible(user),
+         {:ok, sub} <- fetch_owned_bundle(user, subscription_id),
+         :ok <- validate_not_cancelling(sub),
+         {:ok, item} <- fetch_item(sub, sku),
+         :ok <- ensure_not_last_package(sub, item),
+         {:ok, _} <- mark_item_cancel_at_period_end(item),
+         {:ok, synced} <- Resolver.sync(sub.id) do
+      {:ok, Subscription.by_id(synced.id)}
+    end
+  end
+
+  @spec switch_interval(User.t(), integer()) ::
+          {:ok, Subscription.t()} | {:error, term()}
+  def switch_interval(%User{} = user, subscription_id) do
+    with :ok <- ensure_offering_visible(user),
+         {:ok, sub} <- fetch_owned_bundle(user, subscription_id),
+         :ok <- validate_not_cancelling(sub),
+         items <- Item.by_subscription(sub.id),
+         {:ok, new_interval} <- counterpart_interval(sub.plan.interval),
+         {:ok, new_plan} <- fetch_bundle_plan(new_interval),
+         {:ok, new_prices} <- resolve_sellable_prices(Enum.map(items, & &1.sku), new_interval),
+         {:ok, _stripe_sub} <- swap_stripe_items(sub, items, new_prices),
+         {:ok, _} <- Subscription.update_subscription_db(sub, %{plan_id: new_plan.id}),
+         :ok <- replace_local_items(sub.id, items, new_prices),
+         {:ok, synced} <- Resolver.sync(sub.id) do
+      {:ok, Subscription.by_id(synced.id)}
+    end
+  end
+
+  @spec cancel(User.t(), integer()) ::
+          {:ok, map()} | {:error, term()}
+  def cancel(%User{} = user, subscription_id) do
+    with {:ok, sub} <- fetch_owned_bundle(user, subscription_id),
+         :ok <- validate_not_cancelling(sub),
+         {:ok, result} <- Billing.cancel_subscription_at_period_end(sub) do
+      {:ok, result}
+    end
+  end
+
+  @doc ~s"""
+  Whether the user may purchase a new SanAPI offering (Bundle / Institutional).
+
+  Returns `:ok`, `{:replace, [subs]}` for replaceable legacy ladder subs, or an error.
+  """
+  @spec ensure_can_subscribe_bundle(User.t()) :: :ok | {:error, String.t()}
+  def ensure_can_subscribe_bundle(%User{} = user) do
+    case classify_active_sanapi(user) do
+      {:ok, :none} -> :ok
+      {:ok, :replaceable, _subs} -> :ok
+      {:error, _} = error -> error
+    end
+  end
+
+  @spec list_replaceable_sanapi_subs(User.t()) :: [Subscription.t()]
+  def list_replaceable_sanapi_subs(%User{} = user) do
+    case classify_active_sanapi(user) do
+      {:ok, :replaceable, subs} -> subs
+      _ -> []
+    end
+  end
+
+  # --- private ---
+
+  defp ensure_offering_visible(user) do
+    if SaleControls.bundle_plans_visible?(user) do
+      :ok
+    else
+      {:error, "Bundle plans are not available for purchase yet"}
+    end
+  end
+
+  defp validate_packages([]), do: {:error, "At least one package is required"}
+  defp validate_packages(packages) when is_list(packages), do: :ok
+  defp validate_packages(_), do: {:error, "packages must be a list"}
+
+  defp validate_interval(interval) when interval in ["month", "year"], do: :ok
+  defp validate_interval(_), do: {:error, "interval must be month or year"}
+
+  defp build_skus(packages, nil), do: {:ok, Enum.uniq(packages)}
+
+  defp build_skus(packages, addon) when is_binary(addon) do
+    {:ok, Enum.uniq(packages ++ [addon])}
+  end
+
+  defp resolve_sellable_prices(skus, interval) do
+    sellable = Price.sellable(interval) |> Map.new(&{&1.sku, &1})
+
+    skus
+    |> Enum.reduce_while({:ok, []}, fn sku, {:ok, acc} ->
+      case Map.get(sellable, sku) do
+        %Price{} = price -> {:cont, {:ok, [price | acc]}}
+        nil -> {:halt, {:error, "SKU #{sku} is not sellable for #{interval}"}}
+      end
+    end)
+    |> case do
+      {:ok, prices} -> {:ok, Enum.reverse(prices)}
+      error -> error
+    end
+  end
+
+  defp fetch_bundle_plan(interval) do
+    case Plan.bundle_plan(interval) do
+      %Plan{} = plan -> {:ok, plan}
+      nil -> {:error, "BUNDLE plan for #{interval} is not configured"}
+    end
+  end
+
+  defp ensure_stripe_customer(user, _card_token, payment_method_id)
+       when is_binary(payment_method_id) do
+    StripeApi.attach_payment_method_to_customer(user, payment_method_id)
+  end
+
+  defp ensure_stripe_customer(user, card_token, _payment_method_id) do
+    Billing.create_or_update_stripe_customer(user, card_token)
+  end
+
+  defp create_stripe_bundle_sub(user, prices, coupon) do
+    items = Enum.map(prices, fn %Price{stripe_price_id: id} -> %{price: id} end)
+
+    params = %{
+      customer: user.stripe_customer_id,
+      items: items,
+      off_session: true
+    }
+
+    params =
+      if coupon do
+        Map.put(params, :coupon, coupon)
+      else
+        params
+      end
+
+    StripeApi.create_bundle_subscription(params)
+  end
+
+  defp persist_items(db_sub, prices, stripe_sub) do
+    stripe_items = stripe_items_by_price(stripe_sub)
+
+    Enum.reduce_while(prices, :ok, fn price, :ok ->
+      stripe_item_id =
+        Map.get(stripe_items, price.stripe_price_id) ||
+          "local_#{db_sub.id}_#{price.sku}"
+
+      case Item.create(%{
+             subscription_id: db_sub.id,
+             stripe_item_id: stripe_item_id,
+             sku: price.sku,
+             type: price.type,
+             quantity: 1
+           }) do
+        {:ok, _} -> {:cont, :ok}
+        {:error, changeset} -> {:halt, {:error, changeset}}
+      end
+    end)
+  end
+
+  defp stripe_items_by_price(%Stripe.Subscription{items: %Stripe.List{data: data}}) do
+    Map.new(data, fn item ->
+      price_id =
+        cond do
+          match?(%{price: %{id: _}}, item) -> item.price.id
+          match?(%{price: id} when is_binary(id), item) -> item.price
+          match?(%{plan: %{id: _}}, item) -> item.plan.id
+          true -> nil
+        end
+
+      {price_id, item.id}
+    end)
+  end
+
+  defp stripe_items_by_price(_), do: %{}
+
+  defp maybe_cancel_replaceable([]), do: :ok
+
+  defp maybe_cancel_replaceable(subs) do
+    Enum.each(subs, fn sub ->
+      case sub.stripe_id do
+        id when is_binary(id) ->
+          case StripeApi.cancel_subscription_with_proration(id) do
+            {:ok, stripe_sub} ->
+              Subscription.sync_subscription_with_stripe(stripe_sub, sub)
+
+            {:error, reason} ->
+              Logger.error(
+                "Failed to cancel replaced SanAPI sub #{sub.id} after bundle subscribe: #{inspect(reason)}"
+              )
+
+              Sentry.capture_message("bundle_subscribe_replace_cancel_failed",
+                extra: %{subscription_id: sub.id, reason: inspect(reason)}
+              )
+          end
+
+        _ ->
+          Subscription.update_subscription_db(sub, %{status: :canceled})
+      end
+    end)
+
+    :ok
+  end
+
+  defp classify_active_sanapi(%User{id: user_id}) do
+    subs =
+      Subscription
+      |> Query.user_has_any_subscriptions_for_product(user_id, Product.product_api())
+      |> Query.join_plan_and_product()
+      |> Repo.all()
+      |> Enum.filter(fn s -> s.status in @active_statuses end)
+
+    cond do
+      subs == [] ->
+        {:ok, :none}
+
+      Enum.any?(subs, &custom_plan?/1) ->
+        {:error, "Active custom/enterprise SanAPI subscription cannot be auto-replaced"}
+
+      Enum.any?(subs, &new_offering_plan?/1) ->
+        {:error, "You already have an active SanAPI subscription on the new offering"}
+
+      Enum.any?(subs, &replaceable_plan?/1) ->
+        {:ok, :replaceable, Enum.filter(subs, &replaceable_plan?/1)}
+
+      true ->
+        {:error, "You already have an active SanAPI subscription"}
+    end
+  end
+
+  defp custom_plan?(%Subscription{plan: %Plan{name: "CUSTOM_" <> _}}), do: true
+  defp custom_plan?(_), do: false
+
+  defp new_offering_plan?(%Subscription{plan: %Plan{name: "BUNDLE" <> _}}), do: true
+  defp new_offering_plan?(%Subscription{plan: %Plan{name: "INSTITUTIONAL" <> _}}), do: true
+  defp new_offering_plan?(_), do: false
+
+  defp replaceable_plan?(%Subscription{plan: %Plan{name: name}})
+       when name in @replaceable_plan_names,
+       do: true
+
+  defp replaceable_plan?(_), do: false
+
+  defp fetch_owned_bundle(%User{id: user_id}, subscription_id) do
+    case Subscription.by_id(subscription_id) do
+      %Subscription{user_id: ^user_id, plan: %Plan{name: name}} = sub ->
+        if Plan.type(name) == :bundle do
+          {:ok, Repo.preload(sub, plan: :product)}
+        else
+          {:error, "Subscription is not a bundle"}
+        end
+
+      %Subscription{} ->
+        {:error, "Subscription does not belong to the user"}
+
+      nil ->
+        {:error, "Subscription not found"}
+    end
+  end
+
+  defp validate_not_cancelling(%Subscription{cancel_at_period_end: true}) do
+    {:error, "Subscription is already scheduled for cancellation"}
+  end
+
+  defp validate_not_cancelling(_), do: :ok
+
+  defp sellable_price_for_sub(sku, %Subscription{plan: %Plan{interval: interval}}) do
+    case Price.sellable(interval) |> Enum.find(&(&1.sku == sku)) do
+      %Price{} = price -> {:ok, price}
+      nil -> {:error, "SKU #{sku} is not sellable for #{interval}"}
+    end
+  end
+
+  defp ensure_sku_absent(sub, sku) do
+    if Enum.any?(Item.by_subscription(sub.id), &(&1.sku == sku)) do
+      {:error, "SKU #{sku} is already on this subscription"}
+    else
+      :ok
+    end
+  end
+
+  defp fetch_item(sub, sku) do
+    case Enum.find(Item.by_subscription(sub.id), &(&1.sku == sku)) do
+      %Item{} = item -> {:ok, item}
+      nil -> {:error, "SKU #{sku} is not on this subscription"}
+    end
+  end
+
+  defp ensure_not_last_package(sub, %Item{type: :package}) do
+    packages =
+      Item.by_subscription(sub.id)
+      |> Enum.filter(&(&1.type == :package and not &1.cancel_at_period_end))
+
+    if length(packages) <= 1 do
+      {:error, "Cannot remove the last package; cancel the subscription instead"}
+    else
+      :ok
+    end
+  end
+
+  defp ensure_not_last_package(_sub, _item), do: :ok
+
+  defp mark_item_cancel_at_period_end(%Item{} = item) do
+    item
+    |> Item.changeset(%{cancel_at_period_end: true})
+    |> Repo.update()
+  end
+
+  defp counterpart_interval("month"), do: {:ok, "year"}
+  defp counterpart_interval("year"), do: {:ok, "month"}
+  defp counterpart_interval(_), do: {:error, "Unknown interval"}
+
+  defp swap_stripe_items(sub, items, new_prices) do
+    price_by_sku = Map.new(new_prices, &{&1.sku, &1})
+
+    stripe_items =
+      Enum.map(items, fn item ->
+        new_price = Map.fetch!(price_by_sku, item.sku)
+
+        cond do
+          is_binary(item.stripe_item_id) and
+              not String.starts_with?(item.stripe_item_id, "local_") ->
+            %{id: item.stripe_item_id, price: new_price.stripe_price_id}
+
+          true ->
+            %{price: new_price.stripe_price_id}
+        end
+      end)
+
+    StripeApi.update_subscription(sub.stripe_id, %{
+      items: stripe_items,
+      proration_behavior: "create_prorations"
+    })
+  end
+
+  defp replace_local_items(subscription_id, old_items, new_prices) do
+    Repo.transaction(fn ->
+      Enum.each(old_items, fn item -> Repo.delete!(item) end)
+
+      Enum.each(new_prices, fn price ->
+        case Item.create(%{
+               subscription_id: subscription_id,
+               stripe_item_id: "local_#{subscription_id}_#{price.sku}_#{price.interval}",
+               sku: price.sku,
+               type: price.type,
+               quantity: 1
+             }) do
+          {:ok, _} -> :ok
+          {:error, changeset} -> Repo.rollback(changeset)
+        end
+      end)
+
+      :ok
+    end)
+    |> case do
+      {:ok, :ok} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/lib/sanbase/billing/plan/bundle/lifecycle.ex
+++ b/lib/sanbase/billing/plan/bundle/lifecycle.ex
@@ -60,6 +60,16 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
           coupon: String.t() | nil
         ]
 
+  @doc ~s"""
+  Buy a bundle subscription for the given packages on the given interval.
+
+  Everything that can be checked without charging is checked first, and only then
+  is the Stripe subscription created and its first invoice paid. Any failure after
+  that point cancels the Stripe subscription again, because a customer who has
+  paid and is refused every request is worse off than one who was not charged. A
+  legacy SanAPI subscription that the bundle replaces is canceled with proration
+  once the purchase is through.
+  """
   @spec subscribe(User.t(), subscribe_opts()) ::
           {:ok, Subscription.t()} | {:error, term()}
   def subscribe(%User{} = user, opts) do
@@ -88,6 +98,15 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
     end
   end
 
+  @doc ~s"""
+  Add one package or add-on to a bundle subscription the user owns.
+
+  The item takes effect at once and Stripe charges a proration for the rest of the
+  current period. The local row is written before Stripe is called, so two
+  requests for the same SKU cannot both succeed; if Stripe then refuses, the row
+  is removed again so the customer can retry. Returns the subscription with its
+  entitlement re-resolved.
+  """
   @spec add_item(User.t(), integer(), String.t()) ::
           {:ok, Subscription.t()} | {:error, term()}
   def add_item(%User{} = user, subscription_id, sku) when is_binary(sku) do
@@ -102,6 +121,15 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
     end
   end
 
+  @doc ~s"""
+  Schedule a package or add-on to be dropped at the end of the paid period.
+
+  Nothing is removed now. The customer paid for the period they are in, so the
+  item keeps working and keeps being billed until it ends; all this records is the
+  deadline, and `Sanbase.Billing.Plan.Bundle.ItemExpiry` is what then deletes the
+  Stripe item and the local row. The last remaining package cannot be removed -
+  cancel the subscription instead.
+  """
   @spec remove_item(User.t(), integer(), String.t()) ::
           {:ok, Subscription.t()} | {:error, term()}
   def remove_item(%User{} = user, subscription_id, sku) when is_binary(sku) do
@@ -117,6 +145,16 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
     end
   end
 
+  @doc ~s"""
+  Move a bundle subscription to the other billing interval, monthly to yearly or
+  back.
+
+  The items that are staying are re-priced in Stripe on the counterpart interval
+  with prorations, and any item already scheduled for removal is dropped rather
+  than carried over, since there is no period left to honour on a new cycle. The
+  local plan and item ids are updated in one transaction, so the subscription is
+  never left claiming one interval while its items are priced on the other.
+  """
   @spec switch_interval(User.t(), integer()) ::
           {:ok, Subscription.t()} | {:error, term()}
   def switch_interval(%User{} = user, subscription_id) do
@@ -169,12 +207,22 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
       )
     end
 
-    Enum.reduce(stale, %{canceled: 0, failed: 0}, fn sub, acc ->
-      case cancel_replaced_subscription(sub) do
-        :ok -> Map.update!(acc, :canceled, &(&1 + 1))
-        :error -> Map.update!(acc, :failed, &(&1 + 1))
-      end
-    end)
+    summary =
+      Enum.reduce(stale, %{canceled: 0, failed: 0}, fn sub, acc ->
+        case cancel_replaced_subscription(sub) do
+          :ok -> Map.update!(acc, :canceled, &(&1 + 1))
+          :error -> Map.update!(acc, :failed, &(&1 + 1))
+        end
+      end)
+
+    if stale != [] do
+      Logger.info(
+        "[BundleLifecycle] Canceled #{summary.canceled} legacy SanAPI subscription(s), " <>
+          "#{summary.failed} failed."
+      )
+    end
+
+    summary
   end
 
   @doc ~s"""
@@ -611,9 +659,31 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
       {:error, reason} ->
         # Undo the claim, otherwise the customer holds a package Stripe never
         # billed them for and cannot retry adding it.
-        Repo.delete(item)
+        case Repo.delete(item) do
+          {:ok, _} -> :ok
+          {:error, delete_error} -> report_undo_failed(item, reason, delete_error)
+        end
+
         {:error, reason}
     end
+  end
+
+  defp report_undo_failed(%Item{} = item, reason, delete_error) do
+    Logger.error("""
+    [BundleLifecycle] Stripe refused to add #{item.sku} to subscription \
+    #{item.subscription_id} (#{inspect(reason)}) and item #{item.id} could not be \
+    deleted afterwards: #{inspect(delete_error)}. The customer holds a package Stripe \
+    is not billing them for and cannot add it again - delete the row by hand.
+    """)
+
+    Sentry.capture_message("bundle_add_item_rollback_failed",
+      extra: %{
+        item_id: item.id,
+        sku: item.sku,
+        subscription_id: item.subscription_id,
+        reason: inspect(delete_error)
+      }
+    )
   end
 
   defp fetch_item(sub, sku) do
@@ -706,29 +776,66 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
     item_id_by_price = stripe_items_by_price(stripe_sub)
     price_id_by_sku = Map.new(new_prices, &{&1.sku, &1.stripe_price_id})
 
-    Repo.transaction(fn ->
-      case Subscription.update_subscription_db(sub, %{plan_id: new_plan.id}) do
-        {:ok, _} -> :ok
-        {:error, reason} -> Repo.rollback(reason)
+    result =
+      try do
+        Repo.transaction(fn ->
+          case Subscription.update_subscription_db(sub, %{plan_id: new_plan.id}) do
+            {:ok, _} -> :ok
+            {:error, reason} -> Repo.rollback(reason)
+          end
+
+          Enum.each(leaving, &Repo.delete!/1)
+
+          Enum.each(staying, fn item ->
+            new_item_id = Map.get(item_id_by_price, Map.get(price_id_by_sku, item.sku))
+
+            if is_binary(new_item_id) and new_item_id != item.stripe_item_id do
+              item
+              |> Item.changeset(%{stripe_item_id: new_item_id})
+              |> Repo.update!()
+            end
+          end)
+
+          :ok
+        end)
+      rescue
+        e -> {:error, Exception.message(e)}
       end
 
-      Enum.each(leaving, &Repo.delete!/1)
+    case result do
+      {:ok, :ok} ->
+        :ok
 
-      Enum.each(staying, fn item ->
-        new_item_id = Map.get(item_id_by_price, Map.get(price_id_by_sku, item.sku))
+      {:error, reason} ->
+        # Reported, never undone. Cancelling a paying customer's subscription
+        # because a local write failed does far more damage than the interval
+        # mismatch it would be fixing.
+        report_interval_switch_failed(sub, new_plan, reason)
 
-        if is_binary(new_item_id) and new_item_id != item.stripe_item_id do
-          item
-          |> Item.changeset(%{stripe_item_id: new_item_id})
-          |> Repo.update!()
-        end
-      end)
-
-      :ok
-    end)
-    |> case do
-      {:ok, :ok} -> :ok
-      {:error, reason} -> {:error, reason}
+        # The real cause goes to the log and to Sentry, not to the caller: a
+        # rescued database exception carries its own message, and the resolver
+        # hands any string error straight to the API client.
+        {:error,
+         "The billing interval could not be switched. The change has been reported and " <>
+           "will be corrected - please do not retry."}
     end
+  end
+
+  defp report_interval_switch_failed(sub, new_plan, reason) do
+    Logger.error("""
+    [BundleLifecycle] Bundle subscription #{sub.id} was re-priced in Stripe to the \
+    #{new_plan.interval} interval but the local switch failed: #{inspect(reason)}. \
+    Stripe is now billing the new interval while the local plan and item ids still \
+    say the old one - reconcile it by hand.
+    """)
+
+    Sentry.capture_message("bundle_interval_switch_failed",
+      extra: %{
+        subscription_id: sub.id,
+        stripe_subscription_id: sub.stripe_id,
+        target_interval: new_plan.interval,
+        reason: inspect(reason)
+      }
+    )
   end
 end

--- a/lib/sanbase/billing/plan/bundle/lifecycle.ex
+++ b/lib/sanbase/billing/plan/bundle/lifecycle.ex
@@ -452,6 +452,12 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
     end
   end
 
+  # `not is_nil(s.stripe_id)` is the whole safety of this job. It exists to finish
+  # a replacement that `subscribe/2` started, and only a real Stripe purchase can
+  # have started one. Bundle rows created by hand in the admin panel have no
+  # Stripe object, and without this condition a test bundle handed to a real
+  # account would cancel that customer's genuine, paid SanAPI subscription an hour
+  # later - with proration, in Stripe, unprompted.
   defp stale_replaced_subscriptions do
     product_api = Product.product_api()
 
@@ -461,6 +467,7 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
         on: s.plan_id == p.id,
         where:
           s.status in ^@active_statuses and p.product_id == ^product_api and
+            not is_nil(s.stripe_id) and
             (like(p.name, "BUNDLE%") or like(p.name, "INSTITUTIONAL%")),
         select: s.user_id
       )

--- a/lib/sanbase/billing/plan/sale_controls.ex
+++ b/lib/sanbase/billing/plan/sale_controls.ex
@@ -4,26 +4,46 @@ defmodule Sanbase.Billing.Plan.SaleControls do
 
   * **Bundle / new plans** (`BUNDLE*`, `INSTITUTIONAL*`) — `is_private` false = active
     (self-serve), true = deactivated (staff can still preview via team role).
-  * **Business plans** (`BUSINESS_PRO`, `BUSINESS_MAX`) — `is_deprecated` false = active
-    for sale, true = withdrawn from sale (existing subscribers keep access).
+  * **Business plans** (`BUSINESS_PRO`, `BUSINESS_MAX`) — active for sale means
+    `is_deprecated` false *and* `is_private` false; withdrawn sets both true.
+    Existing subscribers keep access either way.
+
+  ## Why the Business plans move both flags
+
+  `Sanbase.Billing.Plan.product_with_plans/0` filters those two names on
+  `is_deprecated`, so that is what makes them appear on the pricing page. But
+  both flags are exposed on the GraphQL plan type and a client may well hide
+  anything `isPrivate`, and the Business rows are `is_private = true` on
+  production today. Moving one flag without the other leaves a plan that is for
+  sale by one reading and not by the other, which is exactly the state this
+  module exists to remove.
   """
 
   import Ecto.Query
 
   alias Sanbase.Accounts.Role
   alias Sanbase.Accounts.User
+  alias Sanbase.Accounts.UserRole
   alias Sanbase.Billing.Plan
   alias Sanbase.Billing.Product
   alias Sanbase.Repo
 
-  @business_names ["BUSINESS_PRO", "BUSINESS_MAX"]
-
   @spec business_plan_names() :: [String.t()]
-  def business_plan_names, do: @business_names
+  def business_plan_names, do: Plan.business_plan_names()
 
+  @doc ~s"""
+  Whether the user is a Santiment team member.
+
+  Asked once per request on the bundle catalog and on every subscribe, so it is a
+  single scoped `exists?` rather than reading every row of `user_roles` and
+  searching the result in memory.
+  """
   @spec team_member?(User.t() | nil) :: boolean()
   def team_member?(%User{id: user_id}) when is_integer(user_id) do
-    user_id in Role.san_team_ids()
+    from(ur in UserRole,
+      where: ur.user_id == ^user_id and ur.role_id == ^Role.san_team_role_id()
+    )
+    |> Repo.exists?()
   end
 
   def team_member?(_), do: false
@@ -56,8 +76,8 @@ defmodule Sanbase.Billing.Plan.SaleControls do
     product_api = Product.product_api()
 
     from(p in Plan,
-      where: p.product_id == ^product_api and p.name in ^@business_names,
-      where: p.is_deprecated == false,
+      where: p.product_id == ^product_api and p.name in ^business_plan_names(),
+      where: coalesce(p.is_deprecated, false) == false,
       select: count(p.id)
     )
     |> Repo.one()
@@ -86,10 +106,10 @@ defmodule Sanbase.Billing.Plan.SaleControls do
   def deactivate_bundle_plans, do: set_new_offering_private(true)
 
   @spec activate_business_plans() :: {:ok, [integer()]} | {:error, term()}
-  def activate_business_plans, do: set_business_deprecated(false)
+  def activate_business_plans, do: set_business_for_sale(true)
 
   @spec deactivate_business_plans() :: {:ok, [integer()]} | {:error, term()}
-  def deactivate_business_plans, do: set_business_deprecated(true)
+  def deactivate_business_plans, do: set_business_for_sale(false)
 
   defp set_new_offering_private(private?) do
     product_api = Product.product_api()
@@ -110,19 +130,19 @@ defmodule Sanbase.Billing.Plan.SaleControls do
     {:ok, ids}
   end
 
-  defp set_business_deprecated(deprecated?) do
+  defp set_business_for_sale(for_sale?) do
     product_api = Product.product_api()
 
     ids =
       from(p in Plan,
-        where: p.product_id == ^product_api and p.name in ^@business_names,
+        where: p.product_id == ^product_api and p.name in ^business_plan_names(),
         select: p.id
       )
       |> Repo.all()
 
     if ids != [] do
       from(p in Plan, where: p.id in ^ids)
-      |> Repo.update_all(set: [is_deprecated: deprecated?])
+      |> Repo.update_all(set: [is_deprecated: not for_sale?, is_private: not for_sale?])
     end
 
     {:ok, ids}
@@ -143,7 +163,7 @@ defmodule Sanbase.Billing.Plan.SaleControls do
     product_api = Product.product_api()
 
     from(p in Plan,
-      where: p.product_id == ^product_api and p.name in ^@business_names,
+      where: p.product_id == ^product_api and p.name in ^business_plan_names(),
       order_by: [asc: p.name, asc: p.interval]
     )
     |> Repo.all()

--- a/lib/sanbase/billing/plan/sale_controls.ex
+++ b/lib/sanbase/billing/plan/sale_controls.ex
@@ -1,0 +1,151 @@
+defmodule Sanbase.Billing.Plan.SaleControls do
+  @moduledoc ~s"""
+  Admin toggles for which SanAPI plans are for sale.
+
+  * **Bundle / new plans** (`BUNDLE*`, `INSTITUTIONAL*`) — `is_private` false = active
+    (self-serve), true = deactivated (staff can still preview via team role).
+  * **Business plans** (`BUSINESS_PRO`, `BUSINESS_MAX`) — `is_deprecated` false = active
+    for sale, true = withdrawn from sale (existing subscribers keep access).
+  """
+
+  import Ecto.Query
+
+  alias Sanbase.Accounts.Role
+  alias Sanbase.Accounts.User
+  alias Sanbase.Billing.Plan
+  alias Sanbase.Billing.Product
+  alias Sanbase.Repo
+
+  @business_names ["BUSINESS_PRO", "BUSINESS_MAX"]
+
+  @spec business_plan_names() :: [String.t()]
+  def business_plan_names, do: @business_names
+
+  @spec team_member?(User.t() | nil) :: boolean()
+  def team_member?(%User{id: user_id}) when is_integer(user_id) do
+    user_id in Role.san_team_ids()
+  end
+
+  def team_member?(_), do: false
+
+  @doc ~s"""
+  Bundle catalog and mutations are available when new plans are activated, or
+  always for Santiment team members (preview while deactivated).
+  """
+  @spec bundle_plans_visible?(User.t() | nil) :: boolean()
+  def bundle_plans_visible?(user) do
+    bundle_plans_active?() or team_member?(user)
+  end
+
+  @spec bundle_plans_active?() :: boolean()
+  def bundle_plans_active? do
+    product_api = Product.product_api()
+
+    from(p in Plan,
+      where: p.product_id == ^product_api,
+      where: like(p.name, "BUNDLE%") or like(p.name, "INSTITUTIONAL%"),
+      where: p.is_private == false,
+      select: count(p.id)
+    )
+    |> Repo.one()
+    |> Kernel.>(0)
+  end
+
+  @spec business_plans_active?() :: boolean()
+  def business_plans_active? do
+    product_api = Product.product_api()
+
+    from(p in Plan,
+      where: p.product_id == ^product_api and p.name in ^@business_names,
+      where: p.is_deprecated == false,
+      select: count(p.id)
+    )
+    |> Repo.one()
+    |> Kernel.>(0)
+  end
+
+  @spec status() :: %{
+          bundle_plans_active?: boolean(),
+          business_plans_active?: boolean(),
+          bundle_plan_ids: [integer()],
+          business_plan_ids: [integer()]
+        }
+  def status do
+    %{
+      bundle_plans_active?: bundle_plans_active?(),
+      business_plans_active?: business_plans_active?(),
+      bundle_plan_ids: Enum.map(list_new_offering_plans(), & &1.id),
+      business_plan_ids: Enum.map(list_business_plans(), & &1.id)
+    }
+  end
+
+  @spec activate_bundle_plans() :: {:ok, [integer()]} | {:error, term()}
+  def activate_bundle_plans, do: set_new_offering_private(false)
+
+  @spec deactivate_bundle_plans() :: {:ok, [integer()]} | {:error, term()}
+  def deactivate_bundle_plans, do: set_new_offering_private(true)
+
+  @spec activate_business_plans() :: {:ok, [integer()]} | {:error, term()}
+  def activate_business_plans, do: set_business_deprecated(false)
+
+  @spec deactivate_business_plans() :: {:ok, [integer()]} | {:error, term()}
+  def deactivate_business_plans, do: set_business_deprecated(true)
+
+  defp set_new_offering_private(private?) do
+    product_api = Product.product_api()
+
+    ids =
+      from(p in Plan,
+        where: p.product_id == ^product_api,
+        where: like(p.name, "BUNDLE%") or like(p.name, "INSTITUTIONAL%"),
+        select: p.id
+      )
+      |> Repo.all()
+
+    if ids != [] do
+      from(p in Plan, where: p.id in ^ids)
+      |> Repo.update_all(set: [is_private: private?])
+    end
+
+    {:ok, ids}
+  end
+
+  defp set_business_deprecated(deprecated?) do
+    product_api = Product.product_api()
+
+    ids =
+      from(p in Plan,
+        where: p.product_id == ^product_api and p.name in ^@business_names,
+        select: p.id
+      )
+      |> Repo.all()
+
+    if ids != [] do
+      from(p in Plan, where: p.id in ^ids)
+      |> Repo.update_all(set: [is_deprecated: deprecated?])
+    end
+
+    {:ok, ids}
+  end
+
+  defp list_new_offering_plans do
+    product_api = Product.product_api()
+
+    from(p in Plan,
+      where: p.product_id == ^product_api,
+      where: like(p.name, "BUNDLE%") or like(p.name, "INSTITUTIONAL%"),
+      order_by: [asc: p.name, asc: p.interval]
+    )
+    |> Repo.all()
+  end
+
+  defp list_business_plans do
+    product_api = Product.product_api()
+
+    from(p in Plan,
+      where: p.product_id == ^product_api and p.name in ^@business_names,
+      order_by: [asc: p.name, asc: p.interval]
+    )
+    |> Repo.all()
+  end
+end

--- a/lib/sanbase/billing/plan/sale_controls.ex
+++ b/lib/sanbase/billing/plan/sale_controls.ex
@@ -4,19 +4,22 @@ defmodule Sanbase.Billing.Plan.SaleControls do
 
   * **Bundle / new plans** (`BUNDLE*`, `INSTITUTIONAL*`) — `is_private` false = active
     (self-serve), true = deactivated (staff can still preview via team role).
-  * **Business plans** (`BUSINESS_PRO`, `BUSINESS_MAX`) — active for sale means
-    `is_deprecated` false *and* `is_private` false; withdrawn sets both true.
-    Existing subscribers keep access either way.
+  * **Business plans** (`BUSINESS_PRO`, `BUSINESS_MAX`) — `is_deprecated` false =
+    active for sale, true = withdrawn from sale. Existing subscribers keep access
+    either way.
 
-  ## Why the Business plans move both flags
+  ## Why the Business plans do not touch `is_private`
 
-  `Sanbase.Billing.Plan.product_with_plans/0` filters those two names on
-  `is_deprecated`, so that is what makes them appear on the pricing page. But
-  both flags are exposed on the GraphQL plan type and a client may well hide
-  anything `isPrivate`, and the Business rows are `is_private = true` on
-  production today. Moving one flag without the other leaves a plan that is for
-  sale by one reading and not by the other, which is exactly the state this
-  module exists to remove.
+  `is_deprecated` is the only one of the two that decides anything. It is what
+  `Sanbase.Billing.Plan.product_with_plans/0` filters those names on, and it is
+  the only field the web app asks for - its plans query selects
+  `id name interval amount isDeprecated`, and `isPrivate` appears nowhere in
+  `san-webkit` or `sanbase-app`. The Business rows are `is_private = true` on
+  production while being sold on the pricing page every day, which is the same
+  point from the other direction: nothing reads it.
+
+  So writing it here would change production data on a button press with no
+  effect anyone can observe.
   """
 
   import Ecto.Query
@@ -142,7 +145,7 @@ defmodule Sanbase.Billing.Plan.SaleControls do
 
     if ids != [] do
       from(p in Plan, where: p.id in ^ids)
-      |> Repo.update_all(set: [is_deprecated: not for_sale?, is_private: not for_sale?])
+      |> Repo.update_all(set: [is_deprecated: not for_sale?])
     end
 
     {:ok, ids}

--- a/lib/sanbase/billing/subscription/item.ex
+++ b/lib/sanbase/billing/subscription/item.ex
@@ -9,6 +9,19 @@ defmodule Sanbase.Billing.Subscription.Item do
   Only bundle subscriptions have items. Every legacy subscription has none, which
   is how the two are told apart without asking Stripe.
 
+  ## `remove_at` rather than a cancelled flag
+
+  An item the customer has asked to drop keeps working until the period they have
+  already paid for runs out, so removal is a date, not a state. That date is
+  written when the removal is requested and read by
+  `Sanbase.Billing.Plan.Bundle.ItemExpiry`, which is what finally deletes the
+  Stripe item and the row.
+
+  It has to be stored here rather than derived from the subscription: a
+  subscription's `current_period_end` jumps forward the moment Stripe renews, so
+  "the period end at the time of the request" is not recoverable from the
+  subscription afterwards.
+
   ## SKUs are validated against the definitions, not just the database
 
   `sku` is a plain string column, but a `:package` item must name a real package
@@ -36,7 +49,7 @@ defmodule Sanbase.Billing.Subscription.Item do
           sku: String.t(),
           type: item_type(),
           quantity: pos_integer(),
-          cancel_at_period_end: boolean()
+          remove_at: DateTime.t() | nil
         }
 
   schema "subscription_items" do
@@ -44,14 +57,14 @@ defmodule Sanbase.Billing.Subscription.Item do
     field(:sku, :string)
     field(:type, Ecto.Enum, values: [:package, :api_calls])
     field(:quantity, :integer, default: 1)
-    field(:cancel_at_period_end, :boolean, default: false)
+    field(:remove_at, :utc_datetime)
 
     belongs_to(:subscription, Subscription)
 
     timestamps()
   end
 
-  @fields [:subscription_id, :stripe_item_id, :sku, :type, :quantity, :cancel_at_period_end]
+  @fields [:subscription_id, :stripe_item_id, :sku, :type, :quantity, :remove_at]
 
   @doc false
   def changeset(%__MODULE__{} = item, attrs) do
@@ -69,13 +82,48 @@ defmodule Sanbase.Billing.Subscription.Item do
   end
 
   @doc ~s"""
-  All items on a subscription.
+  All items on a subscription, including any awaiting removal.
   """
   @spec by_subscription(integer()) :: [t()]
   def by_subscription(subscription_id) when is_integer(subscription_id) do
     from(i in __MODULE__, where: i.subscription_id == ^subscription_id, order_by: [asc: i.id])
     |> Repo.all()
   end
+
+  @doc ~s"""
+  The items on a subscription that are not scheduled for removal.
+
+  What the customer is going to have next period, as opposed to what they have
+  now. Use it for decisions about the future - whether a package can still be
+  dropped, or what to carry over to a different billing interval.
+  """
+  @spec staying_on_subscription(integer()) :: [t()]
+  def staying_on_subscription(subscription_id) when is_integer(subscription_id) do
+    from(i in __MODULE__,
+      where: i.subscription_id == ^subscription_id and is_nil(i.remove_at),
+      order_by: [asc: i.id]
+    )
+    |> Repo.all()
+  end
+
+  @doc ~s"""
+  Items whose removal date has passed, oldest deadline first.
+  """
+  @spec due_for_removal(DateTime.t()) :: [t()]
+  def due_for_removal(%DateTime{} = now) do
+    from(i in __MODULE__,
+      where: not is_nil(i.remove_at) and i.remove_at <= ^now,
+      order_by: [asc: i.remove_at, asc: i.id],
+      preload: [:subscription]
+    )
+    |> Repo.all()
+  end
+
+  @doc ~s"""
+  Whether the item is scheduled to be removed.
+  """
+  @spec scheduled_for_removal?(t()) :: boolean()
+  def scheduled_for_removal?(%__MODULE__{remove_at: remove_at}), do: not is_nil(remove_at)
 
   @doc ~s"""
   Create an item.

--- a/lib/sanbase/billing/subscription/item.ex
+++ b/lib/sanbase/billing/subscription/item.ex
@@ -35,7 +35,8 @@ defmodule Sanbase.Billing.Subscription.Item do
           stripe_item_id: String.t() | nil,
           sku: String.t(),
           type: item_type(),
-          quantity: pos_integer()
+          quantity: pos_integer(),
+          cancel_at_period_end: boolean()
         }
 
   schema "subscription_items" do
@@ -43,13 +44,14 @@ defmodule Sanbase.Billing.Subscription.Item do
     field(:sku, :string)
     field(:type, Ecto.Enum, values: [:package, :api_calls])
     field(:quantity, :integer, default: 1)
+    field(:cancel_at_period_end, :boolean, default: false)
 
     belongs_to(:subscription, Subscription)
 
     timestamps()
   end
 
-  @fields [:subscription_id, :stripe_item_id, :sku, :type, :quantity]
+  @fields [:subscription_id, :stripe_item_id, :sku, :type, :quantity, :cancel_at_period_end]
 
   @doc false
   def changeset(%__MODULE__{} = item, attrs) do

--- a/lib/sanbase/billing/subscription/subscription.ex
+++ b/lib/sanbase/billing/subscription/subscription.ex
@@ -874,11 +874,23 @@ defmodule Sanbase.Billing.Subscription do
   def add_payment_intent(result, _), do: result
 
   defp fetch_plan_id(db_subscription, stripe_subscription) do
-    # Legacy single-item subs carry a Stripe Plan id. Bundle items use the Price
-    # API (`price` set, `plan` nil) — keep the local BUNDLE marker plan_id.
+    # Three cases, in order:
+    #   1. Legacy single-item subs report a Stripe Plan id — resolve it locally.
+    #   2. Subs created via the Price API report `price` and no `plan` — the
+    #      legacy plan's id is reachable there, so resolve it the same way.
+    #   3. Nothing resolvable — keep the local plan_id.
+    # Bundle items only ever hit 2/3: their price ids live in `bundle_prices`,
+    # never in `plans.stripe_id`, so the lookup misses and the local BUNDLE
+    # marker plan_id is kept.
     case stripe_subscription.items.data do
       [%{plan: %{id: stripe_plan_id}} | _] when is_binary(stripe_plan_id) ->
         case Plan.by_stripe_id(stripe_plan_id) do
+          %Plan{id: plan_id} -> plan_id
+          nil -> db_subscription.plan_id
+        end
+
+      [%{price: %{id: stripe_price_id}} | _] when is_binary(stripe_price_id) ->
+        case Plan.by_stripe_id(stripe_price_id) do
           %Plan{id: plan_id} -> plan_id
           nil -> db_subscription.plan_id
         end

--- a/lib/sanbase/billing/subscription/subscription.ex
+++ b/lib/sanbase/billing/subscription/subscription.ex
@@ -874,11 +874,17 @@ defmodule Sanbase.Billing.Subscription do
   def add_payment_intent(result, _), do: result
 
   defp fetch_plan_id(db_subscription, stripe_subscription) do
-    stripe_plan_id = (stripe_subscription.items.data |> hd()).plan.id
+    # Legacy single-item subs carry a Stripe Plan id. Bundle items use the Price
+    # API (`price` set, `plan` nil) — keep the local BUNDLE marker plan_id.
+    case stripe_subscription.items.data do
+      [%{plan: %{id: stripe_plan_id}} | _] when is_binary(stripe_plan_id) ->
+        case Plan.by_stripe_id(stripe_plan_id) do
+          %Plan{id: plan_id} -> plan_id
+          nil -> db_subscription.plan_id
+        end
 
-    case Plan.by_stripe_id(stripe_plan_id) do
-      %Plan{id: plan_id} -> plan_id
-      nil -> db_subscription.plan_id
+      _ ->
+        db_subscription.plan_id
     end
   end
 

--- a/lib/sanbase/billing/user_promo_codes.ex
+++ b/lib/sanbase/billing/user_promo_codes.ex
@@ -87,7 +87,9 @@ defmodule Sanbase.Billing.UserPromoCode do
         true
 
       %__MODULE__{} = promo ->
-        product = get_in(promo, [:metadata, "product"])
+        # `promo.metadata` is read directly rather than through `get_in/2`: structs
+        # do not implement Access, so `get_in(promo, [...])` raises.
+        product = Map.get(promo.metadata || %{}, "product")
 
         cond do
           not is_nil(product) and product != plan.product.code ->
@@ -96,16 +98,31 @@ defmodule Sanbase.Billing.UserPromoCode do
           # The rest of the checks are not really needed as Stripe API will
           # check them anyway, but we do them here to avoid unnecessary API
           # calls and to have more unified coupon validation failed messages
-          DateTime.compare(DateTime.utc_now(), coupon.redeem_by) == :gt ->
+          expired?(promo) ->
             {:error, "The coupon has expired."}
 
-          promo.times_redeemed >= promo.max_redemptions ->
+          exhausted?(promo) ->
             {:error, "The coupon has been used too many times."}
 
           true ->
             true
         end
     end
+  end
+
+  # `coupon` is the code, a string - the dates live on the row it was looked up
+  # from. A coupon with no expiry never expires, and one with no cap on
+  # redemptions is never exhausted.
+  defp expired?(%__MODULE__{redeem_by: nil}), do: false
+
+  defp expired?(%__MODULE__{redeem_by: redeem_by}) do
+    DateTime.compare(DateTime.utc_now(), redeem_by) == :gt
+  end
+
+  defp exhausted?(%__MODULE__{max_redemptions: nil}), do: false
+
+  defp exhausted?(%__MODULE__{times_redeemed: times_redeemed, max_redemptions: max_redemptions}) do
+    (times_redeemed || 0) >= max_redemptions
   end
 
   # Private functions

--- a/lib/sanbase/billing/user_promo_codes.ex
+++ b/lib/sanbase/billing/user_promo_codes.ex
@@ -92,6 +92,12 @@ defmodule Sanbase.Billing.UserPromoCode do
         product = Map.get(promo.metadata || %{}, "product")
 
         cond do
+          # The query that lists a user's own codes already filters on `valid`
+          # (`user_promo_codes_base_query/1`), so without this a code hidden from
+          # that list stays redeemable by anyone who kept the string.
+          promo.valid == false ->
+            {:error, "The coupon is no longer valid."}
+
           not is_nil(product) and product != plan.product.code ->
             {:error, "The coupon is not valid for this product."}
 

--- a/lib/sanbase/stripe/stripe_api.ex
+++ b/lib/sanbase/stripe/stripe_api.ex
@@ -244,8 +244,17 @@ defmodule Sanbase.StripeApi do
     |> update_subscription(%{cancel_at_period_end: true})
   end
 
-  def cancel_subscription_immediately(stripe_id) do
-    Stripe.Subscription.cancel(stripe_id)
+  def cancel_subscription_immediately(stripe_id, params \\ %{})
+
+  def cancel_subscription_immediately(stripe_id, params) when is_map(params) do
+    Stripe.Subscription.cancel(stripe_id, params)
+  end
+
+  @doc ~s"""
+  Cancel a Stripe subscription immediately and prorate unused time.
+  """
+  def cancel_subscription_with_proration(stripe_id) when is_binary(stripe_id) do
+    cancel_subscription_immediately(stripe_id, %{prorate: true})
   end
 
   def retrieve_subscription(stripe_id) do
@@ -256,19 +265,67 @@ defmodule Sanbase.StripeApi do
     Stripe.Subscription.list(params, kw_list)
   end
 
+  @doc ~s"""
+  Create a multi-item Stripe subscription using Price API ids (`price_…`).
+  """
+  @spec create_bundle_subscription(map()) ::
+          {:ok, Stripe.Subscription.t()} | {:error, Stripe.Error.t()} | {:error, term()}
+  def create_bundle_subscription(%{customer: customer, items: items} = params)
+      when is_binary(customer) and is_list(items) and items != [] do
+    Stripe.Subscription.create(params, expand: ["latest_invoice.payment_intent"])
+  end
+
+  @doc ~s"""
+  Add a Price-based item to an existing Stripe subscription with proration.
+  """
+  def create_subscription_item(subscription_stripe_id, price_id, opts \\ [])
+      when is_binary(subscription_stripe_id) and is_binary(price_id) do
+    params = %{
+      subscription: subscription_stripe_id,
+      price: price_id,
+      quantity: Keyword.get(opts, :quantity, 1),
+      proration_behavior: Keyword.get(opts, :proration_behavior, "create_prorations")
+    }
+
+    Stripe.SubscriptionItem.create(params)
+  end
+
+  def delete_subscription_item(stripe_item_id, opts \\ []) when is_binary(stripe_item_id) do
+    params = %{
+      proration_behavior: Keyword.get(opts, :proration_behavior, "create_prorations")
+    }
+
+    Stripe.SubscriptionItem.delete(stripe_item_id, params)
+  end
+
   def upgrade_downgrade(db_subscription, plan) do
-    with {:ok, params} <- get_upgrade_downgrade_subscription_params(db_subscription, plan),
-         # Remove coupon for free basic API subscription
-         {:ok, params} <- maybe_remove_coupon(params, db_subscription, plan),
-         {:ok, stripe_subscription} <- update_subscription(db_subscription.stripe_id, params) do
-      {:ok, stripe_subscription}
+    db_subscription = Sanbase.Repo.preload(db_subscription, :plan)
+
+    cond do
+      match?(%Plan{name: name} when is_binary(name), db_subscription.plan) and
+          Plan.type(db_subscription.plan.name) == :bundle ->
+        {:error, "Bundle subscriptions cannot use upgrade/downgrade; use bundle item mutations"}
+
+      true ->
+        with {:ok, params} <- get_upgrade_downgrade_subscription_params(db_subscription, plan),
+             {:ok, params} <- maybe_remove_coupon(params, db_subscription, plan),
+             {:ok, stripe_subscription} <- update_subscription(db_subscription.stripe_id, params) do
+          {:ok, stripe_subscription}
+        end
     end
   end
 
   def get_upgrade_downgrade_subscription_params(db_subscription, plan) do
-    with {:ok, item_id} <- get_subscription_first_item_id(db_subscription.stripe_id) do
-      params = %{items: [%{id: item_id, plan: plan.stripe_id}]}
-      {:ok, params}
+    db_subscription = Sanbase.Repo.preload(db_subscription, :plan)
+
+    if match?(%Plan{name: name} when is_binary(name), db_subscription.plan) and
+         Plan.type(db_subscription.plan.name) == :bundle do
+      {:error, "Bundle subscriptions cannot use upgrade/downgrade; use bundle item mutations"}
+    else
+      with {:ok, item_id} <- get_subscription_first_item_id(db_subscription.stripe_id) do
+        params = %{items: [%{id: item_id, plan: plan.stripe_id}]}
+        {:ok, params}
+      end
     end
   end
 

--- a/lib/sanbase/stripe/stripe_api.ex
+++ b/lib/sanbase/stripe/stripe_api.ex
@@ -164,18 +164,13 @@ defmodule Sanbase.StripeApi do
   end
 
   def attach_payment_method_to_customer(user, payment_method_id) do
-    # Step 1: Attach payment method to the customer
-    {:ok, user} = Billing.create_or_update_stripe_customer(user)
-
-    {:ok, pm} =
-      Stripe.PaymentMethod.attach(payment_method_id, %{customer: user.stripe_customer_id})
-
-    # Step 2: Set this payment method as default for the customer
-    update_params = %{
-      invoice_settings: %{default_payment_method: pm.id}
-    }
-
-    with {:ok, _} <- update_customer(user.stripe_customer_id, update_params) do
+    with {:ok, user} <- Billing.create_or_update_stripe_customer(user),
+         {:ok, pm} <-
+           Stripe.PaymentMethod.attach(payment_method_id, %{customer: user.stripe_customer_id}),
+         {:ok, _} <-
+           update_customer(user.stripe_customer_id, %{
+             invoice_settings: %{default_payment_method: pm.id}
+           }) do
       remove_duplicate_payment_methods(pm.id, user.stripe_customer_id)
 
       {:ok, user}
@@ -299,19 +294,10 @@ defmodule Sanbase.StripeApi do
   end
 
   def upgrade_downgrade(db_subscription, plan) do
-    db_subscription = Sanbase.Repo.preload(db_subscription, :plan)
-
-    cond do
-      match?(%Plan{name: name} when is_binary(name), db_subscription.plan) and
-          Plan.type(db_subscription.plan.name) == :bundle ->
-        {:error, "Bundle subscriptions cannot use upgrade/downgrade; use bundle item mutations"}
-
-      true ->
-        with {:ok, params} <- get_upgrade_downgrade_subscription_params(db_subscription, plan),
-             {:ok, params} <- maybe_remove_coupon(params, db_subscription, plan),
-             {:ok, stripe_subscription} <- update_subscription(db_subscription.stripe_id, params) do
-          {:ok, stripe_subscription}
-        end
+    with {:ok, params} <- get_upgrade_downgrade_subscription_params(db_subscription, plan),
+         {:ok, params} <- maybe_remove_coupon(params, db_subscription, plan),
+         {:ok, stripe_subscription} <- update_subscription(db_subscription.stripe_id, params) do
+      {:ok, stripe_subscription}
     end
   end
 

--- a/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
@@ -10,8 +10,21 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
 
   require Logger
 
-  def products_with_plans(_root, _args, _resolution) do
-    Plan.product_with_plans()
+  def products_with_plans(_root, _args, resolution) do
+    user = current_user(resolution)
+
+    Plan.product_with_plans(include_private: Sanbase.Billing.Plan.SaleControls.team_member?(user))
+  end
+
+  def bundle_catalog(_root, %{interval: interval}, resolution) do
+    user = current_user(resolution)
+    interval = to_string(interval)
+
+    if Sanbase.Billing.Plan.SaleControls.bundle_plans_visible?(user) do
+      {:ok, Sanbase.Billing.Plan.Bundle.Price.sellable(interval)}
+    else
+      {:error, "Bundle catalog is not available"}
+    end
   end
 
   def ppp_settings(_root, _args, _resolution) do
@@ -25,6 +38,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
     coupon = Map.get(args, :coupon)
 
     with {_, %Plan{is_deprecated: false} = plan} <- {:plan?, Plan.by_id(plan_id)},
+         :ok <- ensure_standard_subscribe_allowed(current_user, plan),
          true <- UserPromoCode.is_coupon_usable(coupon, plan),
          {:ok, subscription} <- route_subscription(current_user, plan, payment_instrument, coupon) do
       # If the coupon exists in the user_promo_codes table, times_redeemed
@@ -40,6 +54,86 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
           "Subscription attempt failed",
           %{plan_id: plan_id}
         )
+    end
+  end
+
+  def subscribe_bundle(_root, args, %{context: %{auth: %{current_user: current_user}}}) do
+    opts = [
+      packages: Map.fetch!(args, :packages),
+      api_calls_addon: Map.get(args, :api_calls_addon),
+      interval: to_string(Map.fetch!(args, :interval)),
+      card_token: Map.get(args, :card_token),
+      payment_method_id: Map.get(args, :payment_method_id),
+      coupon: Map.get(args, :coupon)
+    ]
+
+    case Sanbase.Billing.Plan.Bundle.Lifecycle.subscribe(current_user, opts) do
+      {:ok, subscription} ->
+        if opts[:coupon], do: UserPromoCode.use_coupon(opts[:coupon])
+        {:ok, subscription}
+
+      result ->
+        handle_subscription_error_result(result, "Bundle subscription attempt failed", %{})
+    end
+  end
+
+  def add_bundle_item(_root, %{subscription_id: subscription_id, sku: sku}, %{
+        context: %{auth: %{current_user: current_user}}
+      }) do
+    case Sanbase.Billing.Plan.Bundle.Lifecycle.add_item(current_user, subscription_id, sku) do
+      {:ok, subscription} ->
+        {:ok, subscription}
+
+      result ->
+        handle_subscription_error_result(result, "Add bundle item failed", %{
+          user_id: current_user.id,
+          subscription_id: subscription_id
+        })
+    end
+  end
+
+  def remove_bundle_item(_root, %{subscription_id: subscription_id, sku: sku}, %{
+        context: %{auth: %{current_user: current_user}}
+      }) do
+    case Sanbase.Billing.Plan.Bundle.Lifecycle.remove_item(current_user, subscription_id, sku) do
+      {:ok, subscription} ->
+        {:ok, subscription}
+
+      result ->
+        handle_subscription_error_result(result, "Remove bundle item failed", %{
+          user_id: current_user.id,
+          subscription_id: subscription_id
+        })
+    end
+  end
+
+  def switch_bundle_interval(_root, %{subscription_id: subscription_id}, %{
+        context: %{auth: %{current_user: current_user}}
+      }) do
+    case Sanbase.Billing.Plan.Bundle.Lifecycle.switch_interval(current_user, subscription_id) do
+      {:ok, subscription} ->
+        {:ok, subscription}
+
+      result ->
+        handle_subscription_error_result(result, "Switch bundle interval failed", %{
+          user_id: current_user.id,
+          subscription_id: subscription_id
+        })
+    end
+  end
+
+  def cancel_bundle_subscription(_root, %{subscription_id: subscription_id}, %{
+        context: %{auth: %{current_user: current_user}}
+      }) do
+    case Sanbase.Billing.Plan.Bundle.Lifecycle.cancel(current_user, subscription_id) do
+      {:ok, result} ->
+        {:ok, result}
+
+      result ->
+        handle_subscription_error_result(result, "Cancel bundle subscription failed", %{
+          user_id: current_user.id,
+          subscription_id: subscription_id
+        })
     end
   end
 
@@ -72,6 +166,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
          {_, %Subscription{cancel_at_period_end: false}} <-
            {:not_cancelled?, subscription},
          {_, %Plan{is_deprecated: false} = new_plan} <- {:plan?, Plan.by_id(plan_id)},
+         :ok <- ensure_standard_subscribe_allowed(current_user, new_plan),
+         :ok <- ensure_not_bundle_subscription(subscription),
          {:ok, subscription} <- Billing.update_subscription(subscription, new_plan) do
       {:ok, subscription}
     else
@@ -484,9 +580,44 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
         log_error(log_message, reason)
         {:error, reason}
 
+      {:error, reason} when is_binary(reason) ->
+        log_error(log_message, reason)
+        {:error, reason}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        reason = inspect(changeset.errors)
+        log_error(log_message, reason)
+        {:error, reason}
+
       {:error, reason} ->
         log_error(log_message, reason)
         {:error, Subscription.generic_error_message()}
+    end
+  end
+
+  defp current_user(%{context: %{auth: %{current_user: user}}}), do: user
+  defp current_user(_), do: nil
+
+  defp ensure_standard_subscribe_allowed(user, %Plan{} = plan) do
+    cond do
+      Plan.type(plan.name) == :bundle ->
+        {:error, "Bundle plans must be purchased via subscribeBundle"}
+
+      plan.is_private == true and not Sanbase.Billing.Plan.SaleControls.team_member?(user) ->
+        {:error, "This plan is not available for self-serve purchase"}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp ensure_not_bundle_subscription(%Subscription{} = subscription) do
+    subscription = Sanbase.Repo.preload(subscription, :plan)
+
+    if subscription.plan && Plan.type(subscription.plan.name) == :bundle do
+      {:error, "Bundle subscriptions cannot use upgrade/downgrade; use bundle item mutations"}
+    else
+      :ok
     end
   end
 

--- a/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
@@ -10,18 +10,24 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
 
   require Logger
 
-  def products_with_plans(_root, _args, resolution) do
-    user = current_user(resolution)
-
-    Plan.product_with_plans(include_private: Sanbase.Billing.Plan.SaleControls.team_member?(user))
+  def products_with_plans(_root, _args, _resolution) do
+    Plan.product_with_plans()
   end
 
   def bundle_catalog(_root, %{interval: interval}, resolution) do
     user = current_user(resolution)
-    interval = to_string(interval)
 
     if Sanbase.Billing.Plan.SaleControls.bundle_plans_visible?(user) do
-      {:ok, Sanbase.Billing.Plan.Bundle.Price.sellable(interval)}
+      prices =
+        interval
+        |> to_string()
+        |> Sanbase.Billing.Plan.Bundle.Price.sellable()
+        # `interval` is a string column, and the field is a GraphQL enum. Absinthe
+        # serializes an enum from its internal value, so handing it the string
+        # raises rather than returning a catalog.
+        |> Enum.map(&%{&1 | interval: interval})
+
+      {:ok, prices}
     else
       {:error, "Bundle catalog is not available"}
     end
@@ -38,7 +44,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
     coupon = Map.get(args, :coupon)
 
     with {_, %Plan{is_deprecated: false} = plan} <- {:plan?, Plan.by_id(plan_id)},
-         :ok <- ensure_standard_subscribe_allowed(current_user, plan),
+         :ok <- ensure_standard_subscribe_allowed(plan),
          true <- UserPromoCode.is_coupon_usable(coupon, plan),
          {:ok, subscription} <- route_subscription(current_user, plan, payment_instrument, coupon) do
       # If the coupon exists in the user_promo_codes table, times_redeemed
@@ -166,7 +172,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
          {_, %Subscription{cancel_at_period_end: false}} <-
            {:not_cancelled?, subscription},
          {_, %Plan{is_deprecated: false} = new_plan} <- {:plan?, Plan.by_id(plan_id)},
-         :ok <- ensure_standard_subscribe_allowed(current_user, new_plan),
+         :ok <- ensure_standard_subscribe_allowed(new_plan),
          :ok <- ensure_not_bundle_subscription(subscription),
          {:ok, subscription} <- Billing.update_subscription(subscription, new_plan) do
       {:ok, subscription}
@@ -585,9 +591,11 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
         {:error, reason}
 
       {:error, %Ecto.Changeset{} = changeset} ->
-        reason = inspect(changeset.errors)
-        log_error(log_message, reason)
-        {:error, reason}
+        # Logged in full, reported generically. Changeset errors name database
+        # fields and validation internals, which is of no use to the caller and
+        # not ours to publish.
+        log_error(log_message, inspect(changeset.errors))
+        {:error, Subscription.generic_error_message()}
 
       {:error, reason} ->
         log_error(log_message, reason)
@@ -598,16 +606,16 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
   defp current_user(%{context: %{auth: %{current_user: user}}}), do: user
   defp current_user(_), do: nil
 
-  defp ensure_standard_subscribe_allowed(user, %Plan{} = plan) do
-    cond do
-      Plan.type(plan.name) == :bundle ->
-        {:error, "Bundle plans must be purchased via subscribeBundle"}
-
-      plan.is_private == true and not Sanbase.Billing.Plan.SaleControls.team_member?(user) ->
-        {:error, "This plan is not available for self-serve purchase"}
-
-      true ->
-        :ok
+  # Only the bundle marker plans are rejected here. `is_private` deliberately is
+  # not enforced: on production the current Sanbase tiers (`PRO`, `PRO_PLUS`,
+  # `MAX`) and `FREE` are all `is_private = true` and are bought through this
+  # mutation every day, whatever the field's name suggests. Turning it into a
+  # gate would stop those purchases.
+  defp ensure_standard_subscribe_allowed(%Plan{} = plan) do
+    if Plan.type(plan.name) == :bundle do
+      {:error, "Bundle plans must be purchased via subscribeBundle"}
+    else
+      :ok
     end
   end
 

--- a/lib/sanbase_web/graphql/schema/queries/billing_queries.ex
+++ b/lib/sanbase_web/graphql/schema/queries/billing_queries.ex
@@ -99,6 +99,18 @@ defmodule SanbaseWeb.Graphql.Schema.BillingQueries do
 
       resolve(&BillingResolver.check_sanr_nft_subscription_eligibility/3)
     end
+
+    @desc ~s"""
+    Sellable bundle catalog prices for an interval. Visible when bundle/new plans
+    are activated (not private), or always for Santiment team members.
+    """
+    field :bundle_catalog, list_of(:bundle_catalog_price) do
+      meta(access: :free)
+
+      arg(:interval, non_null(:billing_interval))
+
+      resolve(&BillingResolver.bundle_catalog/3)
+    end
   end
 
   object :billing_mutations do
@@ -210,6 +222,56 @@ defmodule SanbaseWeb.Graphql.Schema.BillingQueries do
       middleware(JWTAuth)
 
       resolve(&BillingResolver.create_stripe_setup_intent/3)
+    end
+
+    @desc ~s"""
+    Subscribe to a composable API bundle (one or more packages, optional API-call add-on).
+    """
+    field :subscribe_bundle, :subscription_plan do
+      arg(:packages, non_null(list_of(non_null(:string))))
+      arg(:api_calls_addon, :string)
+      arg(:interval, non_null(:billing_interval))
+      arg(:card_token, :string, default_value: nil)
+      arg(:payment_method_id, :string, default_value: nil)
+      arg(:coupon, :string, default_value: nil)
+
+      middleware(JWTAuth)
+
+      resolve(&BillingResolver.subscribe_bundle/3)
+    end
+
+    field :add_bundle_item, :subscription_plan do
+      arg(:subscription_id, non_null(:integer))
+      arg(:sku, non_null(:string))
+
+      middleware(JWTAuth)
+
+      resolve(&BillingResolver.add_bundle_item/3)
+    end
+
+    field :remove_bundle_item, :subscription_plan do
+      arg(:subscription_id, non_null(:integer))
+      arg(:sku, non_null(:string))
+
+      middleware(JWTAuth)
+
+      resolve(&BillingResolver.remove_bundle_item/3)
+    end
+
+    field :switch_bundle_interval, :subscription_plan do
+      arg(:subscription_id, non_null(:integer))
+
+      middleware(JWTAuth)
+
+      resolve(&BillingResolver.switch_bundle_interval/3)
+    end
+
+    field :cancel_bundle_subscription, :subscription_cancellation do
+      arg(:subscription_id, non_null(:integer))
+
+      middleware(JWTAuth)
+
+      resolve(&BillingResolver.cancel_bundle_subscription/3)
     end
   end
 end

--- a/lib/sanbase_web/graphql/schema/types/billing_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/billing_types.ex
@@ -32,6 +32,16 @@ defmodule SanbaseWeb.Graphql.BillingTypes do
     value(:jp)
   end
 
+  enum :billing_interval do
+    value(:month)
+    value(:year)
+  end
+
+  enum :bundle_price_type do
+    value(:package)
+    value(:api_calls)
+  end
+
   object :product do
     field(:id, :id)
     field(:name, :string)
@@ -46,6 +56,16 @@ defmodule SanbaseWeb.Graphql.BillingTypes do
     field(:amount, :integer)
     field(:is_deprecated, :boolean)
     field(:is_private, :boolean)
+  end
+
+  object :bundle_catalog_price do
+    field(:id, :id)
+    field(:sku, non_null(:string))
+    field(:type, non_null(:bundle_price_type))
+    field(:interval, non_null(:billing_interval))
+    field(:amount, :integer)
+    field(:currency, :string)
+    field(:stripe_price_id, :string)
   end
 
   object :public_subscription_plan do

--- a/lib/sanbase_web/live/admin/bundle_offering_live.ex
+++ b/lib/sanbase_web/live/admin/bundle_offering_live.ex
@@ -1,0 +1,172 @@
+defmodule SanbaseWeb.Admin.BundleOfferingLive do
+  @moduledoc ~s"""
+  Activate / deactivate SanAPI self-serve plan groups.
+
+  * Bundle / new plans — toggles `is_private` on `BUNDLE*` and `INSTITUTIONAL*`.
+  * Business plans — toggles `is_deprecated` on `BUSINESS_PRO` / `BUSINESS_MAX`.
+  """
+
+  use SanbaseWeb, :live_view
+
+  alias Sanbase.Billing.Plan.SaleControls
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "Plan sale controls")
+     |> load()}
+  end
+
+  @impl true
+  def handle_event("activate_bundle", _params, socket) do
+    {:ok, ids} = SaleControls.activate_bundle_plans()
+
+    {:noreply,
+     socket
+     |> put_flash(:info, "Activated bundle/new plans (#{length(ids)} rows).")
+     |> load()}
+  end
+
+  def handle_event("deactivate_bundle", _params, socket) do
+    {:ok, ids} = SaleControls.deactivate_bundle_plans()
+
+    {:noreply,
+     socket
+     |> put_flash(
+       :info,
+       "Deactivated bundle/new plans (#{length(ids)} rows). Team can still preview."
+     )
+     |> load()}
+  end
+
+  def handle_event("activate_business", _params, socket) do
+    {:ok, ids} = SaleControls.activate_business_plans()
+
+    {:noreply,
+     socket
+     |> put_flash(:info, "Activated Business Pro/Max for sale (#{length(ids)} rows).")
+     |> load()}
+  end
+
+  def handle_event("deactivate_business", _params, socket) do
+    {:ok, ids} = SaleControls.deactivate_business_plans()
+
+    {:noreply,
+     socket
+     |> put_flash(
+       :info,
+       "Deactivated Business Pro/Max for new sale (#{length(ids)} rows). Existing subscribers keep access."
+     )
+     |> load()}
+  end
+
+  def handle_event("refresh", _params, socket) do
+    {:noreply, load(socket)}
+  end
+
+  defp load(socket) do
+    status = SaleControls.status()
+
+    socket
+    |> assign(:bundle_active?, status.bundle_plans_active?)
+    |> assign(:business_active?, status.business_plans_active?)
+    |> assign(:bundle_count, length(status.bundle_plan_ids))
+    |> assign(:business_count, length(status.business_plan_ids))
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="flex flex-col items-start justify-start p-4 min-h-screen bg-gray-100">
+      <div class="bg-white rounded-lg shadow-sm w-full max-w-3xl p-6 space-y-8">
+        <div class="flex items-center justify-between gap-4">
+          <h1 class="text-2xl font-bold">Plan sale controls</h1>
+          <button
+            id="plan-sale-refresh"
+            type="button"
+            phx-click="refresh"
+            class="px-3 py-1 text-sm rounded bg-gray-200 hover:bg-gray-300"
+          >
+            Refresh
+          </button>
+        </div>
+
+        <section id="bundle-plan-controls" class="space-y-3 border rounded p-4">
+          <h2 class="text-lg font-semibold">Bundle / new plans</h2>
+          <p class="text-sm text-gray-600">
+            `BUNDLE*` and `INSTITUTIONAL*` — toggles <code>is_private</code>.
+            Deactivated = hidden from public catalog; Santiment team can still preview and subscribe.
+          </p>
+          <p class="text-sm">
+            Status:
+            <span class="font-semibold">
+              {if @bundle_active?, do: "ACTIVE", else: "DEACTIVATED"}
+            </span>
+            ({@bundle_count} plan rows)
+          </p>
+          <div class="flex flex-wrap gap-3">
+            <button
+              id="activate-bundle-plans"
+              type="button"
+              phx-click="activate_bundle"
+              data-confirm="Activate bundle/new plans for self-serve (set is_private=false)?"
+              class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-40"
+              disabled={@bundle_active?}
+            >
+              Activate bundle plans
+            </button>
+            <button
+              id="deactivate-bundle-plans"
+              type="button"
+              phx-click="deactivate_bundle"
+              data-confirm="Deactivate bundle/new plans (set is_private=true)?"
+              class="px-4 py-2 rounded bg-gray-700 text-white hover:bg-gray-800 disabled:opacity-40"
+              disabled={not @bundle_active?}
+            >
+              Deactivate bundle plans
+            </button>
+          </div>
+        </section>
+
+        <section id="business-plan-controls" class="space-y-3 border rounded p-4">
+          <h2 class="text-lg font-semibold">Business plans</h2>
+          <p class="text-sm text-gray-600">
+            `BUSINESS_PRO` / `BUSINESS_MAX` — toggles <code>is_deprecated</code>.
+            Deactivated = not for new sale; existing subscribers keep access.
+          </p>
+          <p class="text-sm">
+            Status:
+            <span class="font-semibold">
+              {if @business_active?, do: "ACTIVE", else: "DEACTIVATED"}
+            </span>
+            ({@business_count} plan rows)
+          </p>
+          <div class="flex flex-wrap gap-3">
+            <button
+              id="activate-business-plans"
+              type="button"
+              phx-click="activate_business"
+              data-confirm="Activate Business Pro/Max for sale (clear is_deprecated)?"
+              class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-40"
+              disabled={@business_active?}
+            >
+              Activate business plans
+            </button>
+            <button
+              id="deactivate-business-plans"
+              type="button"
+              phx-click="deactivate_business"
+              data-confirm="Withdraw Business Pro/Max from sale (set is_deprecated)?"
+              class="px-4 py-2 rounded bg-gray-700 text-white hover:bg-gray-800 disabled:opacity-40"
+              disabled={not @business_active?}
+            >
+              Deactivate business plans
+            </button>
+          </div>
+        </section>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/sanbase_web/live/admin/bundle_offering_live.ex
+++ b/lib/sanbase_web/live/admin/bundle_offering_live.ex
@@ -3,7 +3,9 @@ defmodule SanbaseWeb.Admin.BundleOfferingLive do
   Activate / deactivate SanAPI self-serve plan groups.
 
   * Bundle / new plans — toggles `is_private` on `BUNDLE*` and `INSTITUTIONAL*`.
-  * Business plans — toggles `is_deprecated` on `BUSINESS_PRO` / `BUSINESS_MAX`.
+  * Business plans — toggles `is_deprecated` and `is_private` together on
+    `BUSINESS_PRO` / `BUSINESS_MAX`, so the plan is for sale by every reading of
+    it rather than one.
   """
 
   use SanbaseWeb, :live_view
@@ -132,8 +134,10 @@ defmodule SanbaseWeb.Admin.BundleOfferingLive do
         <section id="business-plan-controls" class="space-y-3 border rounded p-4">
           <h2 class="text-lg font-semibold">Business plans</h2>
           <p class="text-sm text-gray-600">
-            `BUSINESS_PRO` / `BUSINESS_MAX` — toggles <code>is_deprecated</code>.
-            Deactivated = not for new sale; existing subscribers keep access.
+            `BUSINESS_PRO` / `BUSINESS_MAX` — toggles <code>is_deprecated</code>
+            and <code>is_private</code>
+            together.
+            Deactivated = not for new sale and not listed; existing subscribers keep access.
           </p>
           <p class="text-sm">
             Status:
@@ -147,7 +151,7 @@ defmodule SanbaseWeb.Admin.BundleOfferingLive do
               id="activate-business-plans"
               type="button"
               phx-click="activate_business"
-              data-confirm="Activate Business Pro/Max for sale (clear is_deprecated)?"
+              data-confirm="Activate Business Pro/Max for sale (clear is_deprecated and is_private)?"
               class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-40"
               disabled={@business_active?}
             >
@@ -157,7 +161,7 @@ defmodule SanbaseWeb.Admin.BundleOfferingLive do
               id="deactivate-business-plans"
               type="button"
               phx-click="deactivate_business"
-              data-confirm="Withdraw Business Pro/Max from sale (set is_deprecated)?"
+              data-confirm="Withdraw Business Pro/Max from sale (set is_deprecated and is_private)?"
               class="px-4 py-2 rounded bg-gray-700 text-white hover:bg-gray-800 disabled:opacity-40"
               disabled={not @business_active?}
             >

--- a/lib/sanbase_web/live/admin/bundle_offering_live.ex
+++ b/lib/sanbase_web/live/admin/bundle_offering_live.ex
@@ -3,9 +3,9 @@ defmodule SanbaseWeb.Admin.BundleOfferingLive do
   Activate / deactivate SanAPI self-serve plan groups.
 
   * Bundle / new plans — toggles `is_private` on `BUNDLE*` and `INSTITUTIONAL*`.
-  * Business plans — toggles `is_deprecated` and `is_private` together on
-    `BUSINESS_PRO` / `BUSINESS_MAX`, so the plan is for sale by every reading of
-    it rather than one.
+  * Business plans — toggles `is_deprecated` on `BUSINESS_PRO` / `BUSINESS_MAX`.
+    That is the only field the pricing page reads; `is_private` is deliberately
+    left alone.
   """
 
   use SanbaseWeb, :live_view
@@ -134,10 +134,9 @@ defmodule SanbaseWeb.Admin.BundleOfferingLive do
         <section id="business-plan-controls" class="space-y-3 border rounded p-4">
           <h2 class="text-lg font-semibold">Business plans</h2>
           <p class="text-sm text-gray-600">
-            `BUSINESS_PRO` / `BUSINESS_MAX` — toggles <code>is_deprecated</code>
-            and <code>is_private</code>
-            together.
-            Deactivated = not for new sale and not listed; existing subscribers keep access.
+            `BUSINESS_PRO` / `BUSINESS_MAX` — toggles <code>is_deprecated</code>, the only
+            field the pricing page reads.
+            Deactivated = not for new sale; existing subscribers keep access.
           </p>
           <p class="text-sm">
             Status:
@@ -151,7 +150,7 @@ defmodule SanbaseWeb.Admin.BundleOfferingLive do
               id="activate-business-plans"
               type="button"
               phx-click="activate_business"
-              data-confirm="Activate Business Pro/Max for sale (clear is_deprecated and is_private)?"
+              data-confirm="Activate Business Pro/Max for sale (clear is_deprecated)?"
               class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-40"
               disabled={@business_active?}
             >
@@ -161,7 +160,7 @@ defmodule SanbaseWeb.Admin.BundleOfferingLive do
               id="deactivate-business-plans"
               type="button"
               phx-click="deactivate_business"
-              data-confirm="Withdraw Business Pro/Max from sale (set is_deprecated and is_private)?"
+              data-confirm="Withdraw Business Pro/Max from sale (set is_deprecated)?"
               class="px-4 py-2 rounded bg-gray-700 text-white hover:bg-gray-800 disabled:opacity-40"
               disabled={not @business_active?}
             >

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -244,6 +244,12 @@ defmodule SanbaseWeb.Router do
       end
     end
 
+    scope "/bundle_offering" do
+      live_session :bundle_offering_admin, on_mount: @admin_panel_on_mount do
+        live("/", Admin.BundleOfferingLive)
+      end
+    end
+
     scope "/invoices" do
       live_session :invoices_authenticated_user,
         on_mount: @admin_panel_on_mount do

--- a/priv/repo/migrations/20260805111145_add_cancel_at_period_end_to_subscription_items.exs
+++ b/priv/repo/migrations/20260805111145_add_cancel_at_period_end_to_subscription_items.exs
@@ -1,0 +1,9 @@
+defmodule Sanbase.Repo.Migrations.AddCancelAtPeriodEndToSubscriptionItems do
+  use Ecto.Migration
+
+  def change do
+    alter table(:subscription_items) do
+      add(:cancel_at_period_end, :boolean, null: false, default: false)
+    end
+  end
+end

--- a/priv/repo/migrations/20260805125543_replace_item_cancel_at_period_end_with_remove_at.exs
+++ b/priv/repo/migrations/20260805125543_replace_item_cancel_at_period_end_with_remove_at.exs
@@ -1,0 +1,26 @@
+defmodule Sanbase.Repo.Migrations.ReplaceItemCancelAtPeriodEndWithRemoveAt do
+  @moduledoc ~s"""
+  Replace the `cancel_at_period_end` boolean on subscription items with the
+  moment the item is due to go away.
+
+  A boolean cannot say *which* period end was meant. A subscription's
+  `current_period_end` moves forward the instant Stripe renews it, so a job
+  looking for "items on subscriptions whose period has ended" finds nothing once
+  the renewal is synced - and the item is then billed forever. A deadline stored
+  on the item is unaffected by anything the subscription does afterwards.
+
+  Nothing is migrated across. The boolean was added days ago on this same
+  unreleased branch and no row anywhere has it set.
+  """
+
+  use Ecto.Migration
+
+  def change do
+    alter table(:subscription_items) do
+      add(:remove_at, :utc_datetime, null: true)
+      remove(:cancel_at_period_end, :boolean, null: false, default: false)
+    end
+
+    create(index(:subscription_items, [:remove_at]))
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict yK1vdxL3X0JtU4lmw5P8cNJtjINq8i2YYat2g05ZJ1aQkSGCwE3D5hTg0kl6yHK
+\restrict mvrGIBlnHSFC9neYljbMSnKDwNdshb0g2BP3GKe6MhwDzN3PjhadTtoTGyeVZtu
 
 -- Dumped from database version 17.10 (Homebrew)
 -- Dumped by pg_dump version 17.10 (Homebrew)
@@ -4895,7 +4895,8 @@ CREATE TABLE public.subscription_items (
     type character varying(255) NOT NULL,
     quantity integer DEFAULT 1 NOT NULL,
     inserted_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    cancel_at_period_end boolean DEFAULT false NOT NULL
 );
 
 
@@ -12219,7 +12220,7 @@ ALTER TABLE ONLY public.webinar_registrations
 -- PostgreSQL database dump complete
 --
 
-\unrestrict yK1vdxL3X0JtU4lmw5P8cNJtjINq8i2YYat2g05ZJ1aQkSGCwE3D5hTg0kl6yHK
+\unrestrict mvrGIBlnHSFC9neYljbMSnKDwNdshb0g2BP3GKe6MhwDzN3PjhadTtoTGyeVZtu
 
 INSERT INTO public."schema_migrations" (version) VALUES (20171008200815);
 INSERT INTO public."schema_migrations" (version) VALUES (20171008203355);
@@ -12814,3 +12815,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20260803150000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260804120000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260804140000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260804145231);
+INSERT INTO public."schema_migrations" (version) VALUES (20260805111145);

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict mvrGIBlnHSFC9neYljbMSnKDwNdshb0g2BP3GKe6MhwDzN3PjhadTtoTGyeVZtu
+\restrict vRvBMnR6yeJFcSDUdBWjzLeQF7FFNGEPxze7qTAgNFZoPss3b43lQy2k6FPwHmJ
 
 -- Dumped from database version 17.10 (Homebrew)
 -- Dumped by pg_dump version 17.10 (Homebrew)
@@ -4896,7 +4896,7 @@ CREATE TABLE public.subscription_items (
     quantity integer DEFAULT 1 NOT NULL,
     inserted_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    cancel_at_period_end boolean DEFAULT false NOT NULL
+    remove_at timestamp(0) without time zone
 );
 
 
@@ -10175,6 +10175,13 @@ CREATE INDEX signals_historical_activity_user_trigger_id_index ON public.signals
 
 
 --
+-- Name: subscription_items_remove_at_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX subscription_items_remove_at_index ON public.subscription_items USING btree (remove_at);
+
+
+--
 -- Name: subscription_items_stripe_item_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12220,7 +12227,7 @@ ALTER TABLE ONLY public.webinar_registrations
 -- PostgreSQL database dump complete
 --
 
-\unrestrict mvrGIBlnHSFC9neYljbMSnKDwNdshb0g2BP3GKe6MhwDzN3PjhadTtoTGyeVZtu
+\unrestrict vRvBMnR6yeJFcSDUdBWjzLeQF7FFNGEPxze7qTAgNFZoPss3b43lQy2k6FPwHmJ
 
 INSERT INTO public."schema_migrations" (version) VALUES (20171008200815);
 INSERT INTO public."schema_migrations" (version) VALUES (20171008203355);
@@ -12816,3 +12823,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20260804120000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260804140000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260804145231);
 INSERT INTO public."schema_migrations" (version) VALUES (20260805111145);
+INSERT INTO public."schema_migrations" (version) VALUES (20260805125543);

--- a/test/sanbase/billing/plan/bundle/item_expiry_test.exs
+++ b/test/sanbase/billing/plan/bundle/item_expiry_test.exs
@@ -1,0 +1,229 @@
+defmodule Sanbase.Billing.Plan.Bundle.ItemExpiryTest do
+  use Sanbase.DataCase, async: false
+
+  import Ecto.Query
+  import Mock
+  import Sanbase.Factory
+
+  alias Sanbase.ApiCallLimit
+  alias Sanbase.Billing.Plan
+
+  alias Sanbase.Billing.Plan.Bundle.{
+    Catalog,
+    ItemExpiry,
+    Package,
+    PackageSnapshot,
+    Price,
+    Resolver
+  }
+
+  alias Sanbase.Billing.Subscription
+  alias Sanbase.Billing.Subscription.Item
+  alias Sanbase.Metric.Category.MetricCategory
+  alias Sanbase.Metric.Category.MetricCategoryMapping
+  alias Sanbase.Repo
+  alias Sanbase.StripeApi
+
+  @packaged_metrics %{
+    "market" => "price_usd",
+    "development" => "dev_activity",
+    "social" => "social_volume_total",
+    "onchain_core" => "mvrv_usd",
+    "onchain_labels" => "nvt"
+  }
+
+  setup context do
+    categorize_metrics()
+    {:ok, _} = PackageSnapshot.publish(notes: "item expiry test")
+    {:ok, _} = Catalog.ensure_local_catalog()
+
+    for sku <- ["market", "social"], interval <- ["month", "year"] do
+      from(p in Price, where: p.sku == ^sku and p.interval == ^interval and p.is_active)
+      |> Repo.update_all(set: [stripe_price_id: "price_#{sku}_#{interval}", amount: 35_000])
+    end
+
+    Repo.query!("ALTER SEQUENCE plans_id_seq RESTART WITH 9700")
+
+    plan =
+      case Plan.bundle_plan("month") do
+        %Plan{} = plan ->
+          plan
+
+        nil ->
+          insert(:plan_pro,
+            id: 9701,
+            name: "BUNDLE",
+            product_id: context.product_api.id,
+            interval: "month",
+            amount: 0,
+            is_private: true,
+            stripe_id: "plan_bundle_month_" <> Ecto.UUID.generate()
+          )
+      end
+
+    user = insert(:user, stripe_customer_id: "cus_expiry_" <> Ecto.UUID.generate())
+
+    subscription =
+      insert(:subscription_pro,
+        user_id: user.id,
+        plan_id: plan.id,
+        status: :active,
+        stripe_id: "sub_expiry_" <> Ecto.UUID.generate(),
+        current_period_end:
+          DateTime.utc_now() |> DateTime.add(30, :day) |> DateTime.truncate(:second)
+      )
+
+    for {sku, stripe_item_id} <- [{"market", "si_market"}, {"social", "si_social"}] do
+      {:ok, _} =
+        Item.create(%{
+          subscription_id: subscription.id,
+          stripe_item_id: stripe_item_id,
+          sku: sku,
+          type: :package,
+          quantity: 1
+        })
+    end
+
+    {:ok, subscription} = Resolver.sync(subscription.id)
+
+    %{user: user, subscription: subscription}
+  end
+
+  test "leaves alone an item whose deadline has not arrived", %{subscription: subscription} do
+    schedule_removal("social", subscription, DateTime.add(DateTime.utc_now(), 5, :day))
+
+    with_mock StripeApi, [:passthrough], delete_subscription_item: &record_delete/2 do
+      assert %{removed: 0, failed: 0} = ItemExpiry.run()
+
+      assert deletes() == []
+      assert Enum.map(items(subscription), & &1.sku) == ["market", "social"]
+    end
+  end
+
+  test "removes an item whose deadline has passed", %{subscription: subscription} = context do
+    schedule_removal("social", subscription, DateTime.add(DateTime.utc_now(), -1, :second))
+
+    with_mock StripeApi, [:passthrough], delete_subscription_item: &record_delete/2 do
+      assert %{removed: 1, failed: 0} = ItemExpiry.run()
+
+      # Told Stripe, so the next invoice is smaller. No proration: the period the
+      # customer paid for was served in full.
+      assert [{"si_social", opts}] = deletes()
+      assert Keyword.get(opts, :proration_behavior) == "none"
+
+      assert Enum.map(items(subscription), & &1.sku) == ["market"]
+
+      # And the entitlement no longer grants it.
+      reloaded = Subscription.by_id(subscription.id)
+      assert reloaded.bundle_entitlement.packages == ["market"]
+
+      refute "social_volume_total" in reloaded.bundle_entitlement.metric_access["accessible"]
+
+      # The quota row is rewritten off the new entitlement rather than left stale.
+      acl = Repo.get_by(ApiCallLimit, user_id: context.user.id)
+      assert acl.resolved_api_call_limits["month"] > 0
+    end
+  end
+
+  test "treats an item already gone from Stripe as removed", %{subscription: subscription} do
+    schedule_removal("social", subscription, DateTime.add(DateTime.utc_now(), -1, :second))
+
+    missing = fn _id, _opts ->
+      {:error,
+       %Stripe.Error{
+         source: :stripe,
+         code: :resource_missing,
+         message: "No such subscription item"
+       }}
+    end
+
+    with_mock StripeApi, [:passthrough], delete_subscription_item: missing do
+      assert %{removed: 1, failed: 0} = ItemExpiry.run()
+      assert Enum.map(items(subscription), & &1.sku) == ["market"]
+    end
+  end
+
+  test "keeps the row when Stripe refuses, so the next run retries",
+       %{subscription: subscription} do
+    schedule_removal("social", subscription, DateTime.add(DateTime.utc_now(), -1, :second))
+
+    refuse = fn _id, _opts ->
+      {:error, %Stripe.Error{source: :stripe, code: :api_error, message: "boom"}}
+    end
+
+    with_mock StripeApi, [:passthrough], delete_subscription_item: refuse do
+      assert %{removed: 0, failed: 1} = ItemExpiry.run()
+    end
+
+    # Still there, still scheduled - nothing was silently dropped.
+    social = Enum.find(items(subscription), &(&1.sku == "social"))
+    assert social.remove_at != nil
+
+    with_mock StripeApi, [:passthrough], delete_subscription_item: &record_delete/2 do
+      assert %{removed: 1, failed: 0} = ItemExpiry.run()
+      assert Enum.map(items(subscription), & &1.sku) == ["market"]
+    end
+  end
+
+  test "an item that never reached Stripe is removed locally", %{subscription: subscription} do
+    social = Enum.find(items(subscription), &(&1.sku == "social"))
+
+    {:ok, _} =
+      social
+      |> Item.changeset(%{
+        stripe_item_id: nil,
+        remove_at: DateTime.utc_now() |> DateTime.add(-1, :second) |> DateTime.truncate(:second)
+      })
+      |> Repo.update()
+
+    with_mock StripeApi, [:passthrough], delete_subscription_item: &record_delete/2 do
+      assert %{removed: 1, failed: 0} = ItemExpiry.run()
+
+      assert deletes() == []
+      assert Enum.map(items(subscription), & &1.sku) == ["market"]
+    end
+  end
+
+  # --- helpers ---
+
+  defp schedule_removal(sku, subscription, remove_at) do
+    item = Enum.find(items(subscription), &(&1.sku == sku))
+
+    {:ok, item} =
+      item
+      |> Item.changeset(%{remove_at: DateTime.truncate(remove_at, :second)})
+      |> Repo.update()
+
+    item
+  end
+
+  defp items(subscription), do: Item.by_subscription(subscription.id)
+
+  defp record_delete(stripe_item_id, opts) do
+    Process.put(:deletes, [{stripe_item_id, opts} | Process.get(:deletes, [])])
+    {:ok, %{id: stripe_item_id, deleted: true}}
+  end
+
+  defp deletes, do: Process.get(:deletes, []) |> Enum.reverse()
+
+  defp categorize_metrics do
+    for {package, index} <- Enum.with_index(Package.all()) do
+      {:ok, category} =
+        case Repo.get_by(MetricCategory, name: package.category) do
+          nil -> MetricCategory.create(%{name: package.category, display_order: index})
+          cat -> {:ok, cat}
+        end
+
+      metric = Map.fetch!(@packaged_metrics, package.slug)
+
+      unless Repo.get_by(MetricCategoryMapping, metric: metric) do
+        {:ok, _} =
+          MetricCategoryMapping.create(%{
+            module: "Sanbase.Metric.BundleItemExpiryTestAdapter",
+            metric: metric,
+            category_id: category.id
+          })
+      end
+    end
+  end
+end

--- a/test/sanbase/billing/plan/bundle/item_expiry_test.exs
+++ b/test/sanbase/billing/plan/bundle/item_expiry_test.exs
@@ -42,7 +42,7 @@ defmodule Sanbase.Billing.Plan.Bundle.ItemExpiryTest do
       |> Repo.update_all(set: [stripe_price_id: "price_#{sku}_#{interval}", amount: 35_000])
     end
 
-    Repo.query!("ALTER SEQUENCE plans_id_seq RESTART WITH 9700")
+    Repo.query!("ALTER SEQUENCE plans_id_seq RESTART WITH 9702")
 
     plan =
       case Plan.bundle_plan("month") do

--- a/test/sanbase/billing/plan/bundle/lifecycle_test.exs
+++ b/test/sanbase/billing/plan/bundle/lifecycle_test.exs
@@ -468,6 +468,36 @@ defmodule Sanbase.Billing.Plan.Bundle.LifecycleTest do
     end
   end
 
+  test "cancel_stale_replaced_subscriptions ignores a bundle created by hand in the admin panel",
+       %{user: user} = context do
+    bundle_plan = Plan.bundle_plan("month")
+
+    # No stripe_id: exactly what /admin/bundle_subscriptions inserts. Nothing was
+    # bought, so nothing is being replaced.
+    insert(:subscription_pro,
+      user_id: user.id,
+      plan_id: bundle_plan.id,
+      status: :active,
+      stripe_id: nil
+    )
+
+    legacy =
+      insert(:subscription_pro,
+        user_id: user.id,
+        plan_id: context.plans.plan_business_pro_monthly.id,
+        status: :active,
+        stripe_id: "sub_real_" <> Ecto.UUID.generate()
+      )
+
+    with_mocks stripe_mocks() do
+      assert %{canceled: 0, failed: 0} = Lifecycle.cancel_stale_replaced_subscriptions()
+
+      # The customer's real, paid subscription is untouched.
+      assert Repo.reload!(legacy).status == :active
+      assert calls(:cancel_with_proration) == []
+    end
+  end
+
   # --- helpers ---
 
   # Every mocked call is recorded so a test can assert what Stripe was actually

--- a/test/sanbase/billing/plan/bundle/lifecycle_test.exs
+++ b/test/sanbase/billing/plan/bundle/lifecycle_test.exs
@@ -1,0 +1,256 @@
+defmodule Sanbase.Billing.Plan.Bundle.LifecycleTest do
+  use Sanbase.DataCase, async: false
+
+  import Ecto.Query
+  import Mock
+  import Sanbase.Factory
+
+  alias Sanbase.Accounts.Role
+  alias Sanbase.Accounts.UserRole
+  alias Sanbase.Billing.Plan
+  alias Sanbase.Billing.Plan.Bundle.{Catalog, Lifecycle, Package, PackageSnapshot, Price}
+  alias Sanbase.Billing.Subscription.Item
+  alias Sanbase.Metric.Category.MetricCategory
+  alias Sanbase.Metric.Category.MetricCategoryMapping
+  alias Sanbase.Repo
+  alias Sanbase.StripeApi
+  alias Sanbase.StripeApiTestResponse
+
+  @packaged_metrics %{
+    "market" => "price_usd",
+    "development" => "dev_activity",
+    "social" => "social_volume_total",
+    "onchain_core" => "mvrv_usd",
+    "onchain_labels" => "nvt"
+  }
+
+  setup context do
+    insert(:role_san_team)
+    categorize_metrics()
+    {:ok, _} = PackageSnapshot.publish(notes: "lifecycle test")
+    {:ok, _} = Catalog.ensure_local_catalog()
+
+    # Mark packages sellable without Stripe sync
+    for sku <- ["market", "social", "development"], interval <- ["month", "year"] do
+      from(p in Price, where: p.sku == ^sku and p.interval == ^interval and p.is_active)
+      |> Repo.update_all(
+        set: [
+          stripe_price_id: "price_#{sku}_#{interval}",
+          amount: 35_000
+        ]
+      )
+    end
+
+    Repo.query!("ALTER SEQUENCE plans_id_seq RESTART WITH 9600")
+
+    for {interval, id} <- [{"month", 9601}, {"year", 9602}] do
+      case Plan.bundle_plan(interval) do
+        nil ->
+          insert(:plan_pro,
+            id: id,
+            name: "BUNDLE",
+            product_id: context.product_api.id,
+            interval: interval,
+            amount: 0,
+            is_private: true,
+            stripe_id: "plan_bundle_#{interval}_" <> Ecto.UUID.generate()
+          )
+
+        %Plan{} = plan ->
+          plan
+          |> Plan.changeset(%{is_private: true})
+          |> Repo.update!()
+      end
+    end
+
+    user =
+      insert(:user, stripe_customer_id: "cus_lifecycle_" <> Ecto.UUID.generate())
+
+    %{user: user}
+  end
+
+  test "rejects subscribe when offering is legacy and user is not team", %{user: user} do
+    assert {:error, "Bundle plans are not available for purchase yet"} =
+             Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+  end
+
+  test "subscribe creates items and entitlement for team in legacy mode", %{user: user} do
+    {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+
+    with_mocks stripe_mocks(["price_market_month"]) do
+      assert {:ok, sub} =
+               Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+
+      assert Plan.type(sub.plan.name) == :bundle
+      assert sub.bundle_entitlement != nil
+
+      items = Item.by_subscription(sub.id)
+      assert Enum.map(items, & &1.sku) == ["market"]
+    end
+  end
+
+  test "auto-replaces BUSINESS_PRO after successful subscribe", %{user: user} = context do
+    {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+
+    legacy =
+      insert(:subscription_pro,
+        user_id: user.id,
+        plan_id: context.plans.plan_business_pro_monthly.id,
+        status: :active,
+        stripe_id: "sub_legacy_" <> Ecto.UUID.generate()
+      )
+
+    with_mocks stripe_mocks(["price_market_month"], cancel_legacy: true) do
+      assert {:ok, sub} =
+               Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+
+      assert Plan.type(sub.plan.name) == :bundle
+      assert Repo.reload!(legacy).status == :canceled
+    end
+  end
+
+  test "rejects second bundle subscribe", %{user: user} do
+    {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+
+    with_mocks stripe_mocks(["price_market_month"]) do
+      assert {:ok, _} = Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+
+      assert {:error, "You already have an active SanAPI subscription on the new offering"} =
+               Lifecycle.subscribe(user, packages: ["social"], interval: "month")
+    end
+  end
+
+  test "rejects CUSTOM auto-replace", %{user: user} = context do
+    {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+
+    {:ok, custom} =
+      %Plan{}
+      |> Plan.changeset(%{
+        name: "CUSTOM_ACME",
+        product_id: context.product_api.id,
+        amount: 100_000,
+        currency: "USD",
+        interval: "month",
+        is_private: true,
+        stripe_id: "plan_custom_" <> Ecto.UUID.generate()
+      })
+      |> Repo.insert()
+
+    insert(:subscription_pro,
+      user_id: user.id,
+      plan_id: custom.id,
+      status: :active,
+      stripe_id: "sub_custom_" <> Ecto.UUID.generate()
+    )
+
+    assert {:error, "Active custom/enterprise SanAPI subscription cannot be auto-replaced"} =
+             Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+  end
+
+  test "add_item and remove_item (period-end flag)", %{user: user} do
+    {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+
+    with_mocks stripe_mocks(["price_market_month", "price_social_month"]) do
+      assert {:ok, sub} =
+               Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+
+      assert {:ok, sub} = Lifecycle.add_item(user, sub.id, "social")
+      assert Enum.sort(Enum.map(Item.by_subscription(sub.id), & &1.sku)) == ["market", "social"]
+
+      assert {:ok, sub} = Lifecycle.remove_item(user, sub.id, "social")
+      social = Enum.find(Item.by_subscription(sub.id), &(&1.sku == "social"))
+      assert social.cancel_at_period_end
+    end
+  end
+
+  test "upgrade_downgrade rejects bundle subscriptions", %{user: user} = context do
+    {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+
+    with_mocks stripe_mocks(["price_market_month"]) do
+      assert {:ok, sub} =
+               Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+
+      assert {:error, msg} =
+               StripeApi.upgrade_downgrade(sub, context.plans.plan_business_max_monthly)
+
+      assert msg =~ "Bundle subscriptions cannot use upgrade/downgrade"
+    end
+  end
+
+  defp stripe_mocks(price_ids, opts \\ []) do
+    cancel_legacy? = Keyword.get(opts, :cancel_legacy, false)
+
+    base = [
+      {StripeApi, [:passthrough],
+       [
+         create_bundle_subscription: fn params ->
+           ids =
+             params.items
+             |> Enum.map(fn
+               %{price: id} -> id
+               _ -> nil
+             end)
+             |> Enum.reject(&is_nil/1)
+
+           StripeApiTestResponse.create_bundle_subscription_resp(price_ids: ids)
+         end,
+         create_subscription_item: fn _sub, price_id, _opts ->
+           StripeApiTestResponse.create_subscription_item_resp(price_id: price_id)
+         end,
+         update_subscription: fn _id, _params ->
+           StripeApiTestResponse.update_subscription_resp(price_ids: price_ids)
+         end,
+         cancel_subscription_at_period_end: fn id ->
+           StripeApiTestResponse.update_subscription_resp(stripe_id: id)
+         end
+       ]}
+    ]
+
+    if cancel_legacy? do
+      [
+        {StripeApi, [:passthrough],
+         [
+           create_bundle_subscription: fn params ->
+             ids = Enum.map(params.items, & &1.price)
+             StripeApiTestResponse.create_bundle_subscription_resp(price_ids: ids)
+           end,
+           create_subscription_item: fn _sub, price_id, _opts ->
+             StripeApiTestResponse.create_subscription_item_resp(price_id: price_id)
+           end,
+           update_subscription: fn _id, _params ->
+             StripeApiTestResponse.update_subscription_resp(price_ids: price_ids)
+           end,
+           cancel_subscription_with_proration: fn id ->
+             StripeApiTestResponse.cancel_subscription_with_proration_resp(stripe_id: id)
+           end,
+           cancel_subscription_at_period_end: fn id ->
+             StripeApiTestResponse.update_subscription_resp(stripe_id: id)
+           end
+         ]}
+      ]
+    else
+      base
+    end
+  end
+
+  defp categorize_metrics do
+    for {package, index} <- Enum.with_index(Package.all()) do
+      {:ok, category} =
+        case Repo.get_by(MetricCategory, name: package.category) do
+          nil -> MetricCategory.create(%{name: package.category, display_order: index})
+          cat -> {:ok, cat}
+        end
+
+      metric = Map.fetch!(@packaged_metrics, package.slug)
+
+      unless Repo.get_by(MetricCategoryMapping, metric: metric) do
+        {:ok, _} =
+          MetricCategoryMapping.create(%{
+            module: "Sanbase.Metric.BundleLifecycleTestAdapter",
+            metric: metric,
+            category_id: category.id
+          })
+      end
+    end
+  end
+end

--- a/test/sanbase/billing/plan/bundle/lifecycle_test.exs
+++ b/test/sanbase/billing/plan/bundle/lifecycle_test.exs
@@ -42,7 +42,7 @@ defmodule Sanbase.Billing.Plan.Bundle.LifecycleTest do
       )
     end
 
-    Repo.query!("ALTER SEQUENCE plans_id_seq RESTART WITH 9600")
+    Repo.query!("ALTER SEQUENCE plans_id_seq RESTART WITH 9603")
 
     for {interval, id} <- [{"month", 9601}, {"year", 9602}] do
       case Plan.bundle_plan(interval) do
@@ -186,6 +186,29 @@ defmodule Sanbase.Billing.Plan.Bundle.LifecycleTest do
                    coupon: "OLDCODE"
                  )
 
+        assert calls(:create_bundle_subscription) == []
+      end
+    end
+
+    test "reports a refused payment method instead of charging", %{user: user} do
+      # A card Stripe refuses used to blow up as a MatchError inside
+      # attach_payment_method_to_customer, so the caller got a crash instead of
+      # something it could show the customer.
+      declined = %Stripe.Error{
+        source: :stripe,
+        code: :card_declined,
+        message: "Your card was declined."
+      }
+
+      with_mocks stripe_mocks(attach_payment_method_to_customer: {:error, declined}) do
+        assert {:error, ^declined} =
+                 Lifecycle.subscribe(user,
+                   packages: ["market"],
+                   interval: "month",
+                   payment_method_id: "pm_declined"
+                 )
+
+        assert calls(:attach_payment_method_to_customer) == ["pm_declined"]
         assert calls(:create_bundle_subscription) == []
       end
     end
@@ -505,10 +528,16 @@ defmodule Sanbase.Billing.Plan.Bundle.LifecycleTest do
   # request is sent, which is the whole class of bug worth testing here.
   defp stripe_mocks(opts \\ []) do
     item_result = Keyword.get(opts, :create_subscription_item)
+    attach_result = Keyword.get(opts, :attach_payment_method_to_customer)
 
     [
       {StripeApi, [:passthrough],
        [
+         attach_payment_method_to_customer: fn user, payment_method_id ->
+           record(:attach_payment_method_to_customer, payment_method_id)
+
+           attach_result || :meck.passthrough([user, payment_method_id])
+         end,
          create_bundle_subscription: fn params ->
            record(:create_bundle_subscription, params)
            price_ids = Enum.map(params.items, & &1.price)

--- a/test/sanbase/billing/plan/bundle/lifecycle_test.exs
+++ b/test/sanbase/billing/plan/bundle/lifecycle_test.exs
@@ -9,6 +9,7 @@ defmodule Sanbase.Billing.Plan.Bundle.LifecycleTest do
   alias Sanbase.Accounts.UserRole
   alias Sanbase.Billing.Plan
   alias Sanbase.Billing.Plan.Bundle.{Catalog, Lifecycle, Package, PackageSnapshot, Price}
+  alias Sanbase.Billing.Subscription
   alias Sanbase.Billing.Subscription.Item
   alias Sanbase.Metric.Category.MetricCategory
   alias Sanbase.Metric.Category.MetricCategoryMapping
@@ -74,101 +75,368 @@ defmodule Sanbase.Billing.Plan.Bundle.LifecycleTest do
              Lifecycle.subscribe(user, packages: ["market"], interval: "month")
   end
 
-  test "subscribe creates items and entitlement for team in legacy mode", %{user: user} do
-    {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
-
-    with_mocks stripe_mocks(["price_market_month"]) do
-      assert {:ok, sub} =
-               Lifecycle.subscribe(user, packages: ["market"], interval: "month")
-
-      assert Plan.type(sub.plan.name) == :bundle
-      assert sub.bundle_entitlement != nil
-
-      items = Item.by_subscription(sub.id)
-      assert Enum.map(items, & &1.sku) == ["market"]
+  describe "subscribe" do
+    setup %{user: user} do
+      {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+      :ok
     end
-  end
 
-  test "auto-replaces BUSINESS_PRO after successful subscribe", %{user: user} = context do
-    {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+    test "creates items and entitlement for team in legacy mode", %{user: user} do
+      with_mocks stripe_mocks() do
+        assert {:ok, sub} =
+                 Lifecycle.subscribe(user, packages: ["market"], interval: "month")
 
-    legacy =
+        assert Plan.type(sub.plan.name) == :bundle
+        assert sub.bundle_entitlement != nil
+
+        items = Item.by_subscription(sub.id)
+        assert Enum.map(items, & &1.sku) == ["market"]
+
+        # The Stripe item id is stored as Stripe reported it, so the item can be
+        # addressed later.
+        assert Enum.map(items, & &1.stripe_item_id) == ["si_price_market_month"]
+      end
+    end
+
+    test "auto-replaces BUSINESS_PRO after success", %{user: user} = context do
+      legacy =
+        insert(:subscription_pro,
+          user_id: user.id,
+          plan_id: context.plans.plan_business_pro_monthly.id,
+          status: :active,
+          stripe_id: "sub_legacy_" <> Ecto.UUID.generate()
+        )
+
+      with_mocks stripe_mocks() do
+        assert {:ok, sub} = Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+
+        assert Plan.type(sub.plan.name) == :bundle
+        assert Repo.reload!(legacy).status == :canceled
+        assert legacy.stripe_id in calls(:cancel_with_proration)
+      end
+    end
+
+    test "rejects a second bundle subscribe and leaves the first alone", %{user: user} do
+      with_mocks stripe_mocks() do
+        assert {:ok, first} = Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+
+        assert {:error, "You already have an active SanAPI subscription on the new offering"} =
+                 Lifecycle.subscribe(user, packages: ["social"], interval: "month")
+
+        assert Repo.reload!(first).status == :active
+        assert Enum.map(Item.by_subscription(first.id), & &1.sku) == ["market"]
+      end
+    end
+
+    test "rejects CUSTOM auto-replace", %{user: user} = context do
+      {:ok, custom} =
+        %Plan{}
+        |> Plan.changeset(%{
+          name: "CUSTOM_ACME",
+          product_id: context.product_api.id,
+          amount: 100_000,
+          currency: "USD",
+          interval: "month",
+          is_private: true,
+          stripe_id: "plan_custom_" <> Ecto.UUID.generate()
+        })
+        |> Repo.insert()
+
       insert(:subscription_pro,
         user_id: user.id,
-        plan_id: context.plans.plan_business_pro_monthly.id,
+        plan_id: custom.id,
         status: :active,
-        stripe_id: "sub_legacy_" <> Ecto.UUID.generate()
+        stripe_id: "sub_custom_" <> Ecto.UUID.generate()
       )
 
-    with_mocks stripe_mocks(["price_market_month"], cancel_legacy: true) do
-      assert {:ok, sub} =
+      assert {:error, "Active custom/enterprise SanAPI subscription cannot be auto-replaced"} =
                Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+    end
 
-      assert Plan.type(sub.plan.name) == :bundle
-      assert Repo.reload!(legacy).status == :canceled
+    test "rejects an unknown package before charging", %{user: user} do
+      with_mocks stripe_mocks() do
+        assert {:error, message} =
+                 Lifecycle.subscribe(user, packages: ["not_a_package"], interval: "month")
+
+        assert message =~ "is not sellable"
+        assert calls(:create_bundle_subscription) == []
+      end
+    end
+
+    test "refuses to sell before a package snapshot is published", %{user: user} do
+      Repo.delete_all(PackageSnapshot)
+
+      with_mocks stripe_mocks() do
+        assert {:error, message} =
+                 Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+
+        assert message =~ "has not been published yet"
+        assert calls(:create_bundle_subscription) == []
+      end
+    end
+
+    test "rejects an expired coupon before charging", %{user: user} do
+      insert_promo_code(user, "OLDCODE", DateTime.add(DateTime.utc_now(), -10, :day))
+
+      with_mocks stripe_mocks() do
+        assert {:error, "The coupon has expired."} =
+                 Lifecycle.subscribe(user,
+                   packages: ["market"],
+                   interval: "month",
+                   coupon: "OLDCODE"
+                 )
+
+        assert calls(:create_bundle_subscription) == []
+      end
+    end
+
+    test "cancels the Stripe subscription when the items cannot be stored", %{user: user} do
+      # Sellable, but not a real package - so the price resolves, Stripe charges,
+      # and only then does the item fail to validate.
+      insert_unsellable_looking_price("bogus_package", "month")
+
+      with_mocks stripe_mocks() do
+        assert {:error, _reason} =
+                 Lifecycle.subscribe(user, packages: ["bogus_package"], interval: "month")
+
+        # Charged, then cancelled again rather than left charging for a
+        # subscription that grants nothing.
+        assert [stripe_id] = calls(:cancel_with_proration)
+        assert %Subscription{status: :canceled} = Subscription.by_stripe_id(stripe_id)
+      end
     end
   end
 
-  test "rejects second bundle subscribe", %{user: user} do
-    {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+  describe "items" do
+    setup %{user: user} do
+      {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+      :ok
+    end
 
-    with_mocks stripe_mocks(["price_market_month"]) do
-      assert {:ok, _} = Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+    test "add_item stores the Stripe item id it was given", %{user: user} do
+      with_mocks stripe_mocks() do
+        assert {:ok, sub} = Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+        assert {:ok, sub} = Lifecycle.add_item(user, sub.id, "social")
 
-      assert {:error, "You already have an active SanAPI subscription on the new offering"} =
-               Lifecycle.subscribe(user, packages: ["social"], interval: "month")
+        items = Item.by_subscription(sub.id)
+        assert Enum.sort(Enum.map(items, & &1.sku)) == ["market", "social"]
+
+        social = Enum.find(items, &(&1.sku == "social"))
+        assert social.stripe_item_id == "si_price_social_month"
+      end
+    end
+
+    test "add_item refuses a SKU that is already there, and does not call Stripe twice",
+         %{user: user} do
+      with_mocks stripe_mocks() do
+        assert {:ok, sub} = Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+        assert {:ok, _} = Lifecycle.add_item(user, sub.id, "social")
+
+        assert {:error, message} = Lifecycle.add_item(user, sub.id, "social")
+        assert message =~ "already on this subscription"
+
+        assert length(calls(:create_subscription_item)) == 1
+      end
+    end
+
+    test "add_item leaves nothing behind when Stripe refuses", %{user: user} do
+      with_mocks stripe_mocks(create_subscription_item: {:error, :card_declined}) do
+        assert {:ok, sub} = Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+
+        assert {:error, :card_declined} = Lifecycle.add_item(user, sub.id, "social")
+
+        # The claim was rolled back, so the customer can try again.
+        assert Enum.map(Item.by_subscription(sub.id), & &1.sku) == ["market"]
+      end
+    end
+
+    test "remove_item schedules the removal and changes nothing yet", %{user: user} do
+      with_mocks stripe_mocks() do
+        assert {:ok, sub} = Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+        assert {:ok, sub} = Lifecycle.add_item(user, sub.id, "social")
+
+        assert {:ok, sub} = Lifecycle.remove_item(user, sub.id, "social")
+
+        social = Enum.find(Item.by_subscription(sub.id), &(&1.sku == "social"))
+        assert social.remove_at == DateTime.truncate(sub.current_period_end, :second)
+
+        # Paid for, so still owned: the entitlement keeps the package and Stripe has
+        # not been asked to drop the item yet.
+        assert Enum.sort(sub.bundle_entitlement.packages) == ["market", "social"]
+        assert calls(:delete_subscription_item) == []
+      end
+    end
+
+    test "remove_item refuses the last package", %{user: user} do
+      with_mocks stripe_mocks() do
+        assert {:ok, sub} = Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+
+        assert {:error, message} = Lifecycle.remove_item(user, sub.id, "market")
+        assert message =~ "Cannot remove the last package"
+      end
+    end
+
+    test "remove_item refuses the second-to-last package once the other is going",
+         %{user: user} do
+      with_mocks stripe_mocks() do
+        assert {:ok, sub} =
+                 Lifecycle.subscribe(user, packages: ["market", "social"], interval: "month")
+
+        assert {:ok, _} = Lifecycle.remove_item(user, sub.id, "social")
+
+        assert {:error, message} = Lifecycle.remove_item(user, sub.id, "market")
+        assert message =~ "Cannot remove the last package"
+      end
+    end
+
+    test "remove_item refuses an item already scheduled for removal", %{user: user} do
+      with_mocks stripe_mocks() do
+        assert {:ok, sub} =
+                 Lifecycle.subscribe(user, packages: ["market", "social"], interval: "month")
+
+        assert {:ok, _} = Lifecycle.remove_item(user, sub.id, "social")
+
+        assert {:error, message} = Lifecycle.remove_item(user, sub.id, "social")
+        assert message =~ "already scheduled for removal"
+      end
     end
   end
 
-  test "rejects CUSTOM auto-replace", %{user: user} = context do
-    {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+  describe "switch_interval" do
+    setup %{user: user} do
+      {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+      :ok
+    end
 
-    {:ok, custom} =
-      %Plan{}
-      |> Plan.changeset(%{
-        name: "CUSTOM_ACME",
-        product_id: context.product_api.id,
-        amount: 100_000,
-        currency: "USD",
-        interval: "month",
-        is_private: true,
-        stripe_id: "plan_custom_" <> Ecto.UUID.generate()
-      })
-      |> Repo.insert()
+    test "moves the plan and re-prices the items by id", %{user: user} do
+      with_mocks stripe_mocks() do
+        assert {:ok, sub} = Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+        assert sub.plan.interval == "month"
 
-    insert(:subscription_pro,
-      user_id: user.id,
-      plan_id: custom.id,
-      status: :active,
-      stripe_id: "sub_custom_" <> Ecto.UUID.generate()
-    )
+        assert {:ok, switched} = Lifecycle.switch_interval(user, sub.id)
+        assert switched.plan.interval == "year"
 
-    assert {:error, "Active custom/enterprise SanAPI subscription cannot be auto-replaced"} =
-             Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+        assert [%{items: [item]}] = calls(:update_subscription)
+        assert item == %{id: "si_price_market_month", price: "price_market_year"}
+
+        assert Enum.map(Item.by_subscription(sub.id), & &1.stripe_item_id) ==
+                 ["si_price_market_year"]
+      end
+    end
+
+    test "switching twice never asks Stripe to add items alongside the old ones",
+         %{user: user} do
+      with_mocks stripe_mocks() do
+        assert {:ok, sub} = Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+
+        assert {:ok, _} = Lifecycle.switch_interval(user, sub.id)
+        assert {:ok, back} = Lifecycle.switch_interval(user, sub.id)
+
+        assert back.plan.interval == "month"
+
+        # Every item in every request carries an id. An entry without one is an
+        # instruction to Stripe to add another item and bill for both.
+        for %{items: items} <- calls(:update_subscription), item <- items do
+          assert Map.has_key?(item, :id)
+        end
+      end
+    end
+
+    test "drops an item that was scheduled for removal", %{user: user} do
+      with_mocks stripe_mocks() do
+        assert {:ok, sub} =
+                 Lifecycle.subscribe(user, packages: ["market", "social"], interval: "month")
+
+        assert {:ok, _} = Lifecycle.remove_item(user, sub.id, "social")
+        assert {:ok, _} = Lifecycle.switch_interval(user, sub.id)
+
+        assert [%{items: items}] = calls(:update_subscription)
+        assert %{id: "si_price_social_month", deleted: true} in items
+
+        # Gone locally too, rather than carried onto the new interval.
+        assert Enum.map(Item.by_subscription(sub.id), & &1.sku) == ["market"]
+      end
+    end
   end
 
-  test "add_item and remove_item (period-end flag)", %{user: user} do
-    {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+  describe "cancel" do
+    setup %{user: user} do
+      {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+      :ok
+    end
 
-    with_mocks stripe_mocks(["price_market_month", "price_social_month"]) do
-      assert {:ok, sub} =
-               Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+    test "schedules cancellation at period end", %{user: user} do
+      with_mocks stripe_mocks() do
+        assert {:ok, sub} = Lifecycle.subscribe(user, packages: ["market"], interval: "month")
 
-      assert {:ok, sub} = Lifecycle.add_item(user, sub.id, "social")
-      assert Enum.sort(Enum.map(Item.by_subscription(sub.id), & &1.sku)) == ["market", "social"]
+        assert {:ok, %{is_scheduled_for_cancellation: true}} = Lifecycle.cancel(user, sub.id)
+        assert sub.stripe_id in calls(:cancel_at_period_end)
+      end
+    end
 
-      assert {:ok, sub} = Lifecycle.remove_item(user, sub.id, "social")
-      social = Enum.find(Item.by_subscription(sub.id), &(&1.sku == "social"))
-      assert social.cancel_at_period_end
+    test "works even after the offering is withdrawn from sale", %{user: user} do
+      with_mocks stripe_mocks() do
+        assert {:ok, sub} = Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+
+        # Not a team member any more and the plans are private: buying is closed,
+        # cancelling must not be.
+        Repo.delete_all(UserRole)
+
+        assert {:ok, %{is_scheduled_for_cancellation: true}} = Lifecycle.cancel(user, sub.id)
+      end
+    end
+
+    test "a cancelling subscription refuses further changes", %{user: user} do
+      with_mocks stripe_mocks() do
+        assert {:ok, sub} = Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+        assert {:ok, _} = Lifecycle.cancel(user, sub.id)
+
+        assert {:error, message} = Lifecycle.add_item(user, sub.id, "social")
+        assert message =~ "already scheduled for cancellation"
+      end
+    end
+  end
+
+  describe "ownership" do
+    test "another user cannot touch the subscription", %{user: user} do
+      {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+      other = insert(:user)
+      {:ok, _} = UserRole.create(other.id, Role.san_team_role_id())
+
+      with_mocks stripe_mocks() do
+        assert {:ok, sub} = Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+
+        assert {:error, "Subscription does not belong to the user"} =
+                 Lifecycle.add_item(other, sub.id, "social")
+
+        assert {:error, "Subscription does not belong to the user"} =
+                 Lifecycle.cancel(other, sub.id)
+      end
+    end
+
+    test "a non-bundle subscription is refused", %{user: user} = context do
+      {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+
+      legacy =
+        insert(:subscription_pro,
+          user_id: user.id,
+          plan_id: context.plans.plan_business_pro_monthly.id,
+          status: :active,
+          stripe_id: "sub_legacy_" <> Ecto.UUID.generate()
+        )
+
+      assert {:error, "Subscription is not a bundle"} =
+               Lifecycle.add_item(user, legacy.id, "social")
+
+      assert {:error, "Subscription is not a bundle"} = Lifecycle.cancel(user, legacy.id)
     end
   end
 
   test "upgrade_downgrade rejects bundle subscriptions", %{user: user} = context do
     {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
 
-    with_mocks stripe_mocks(["price_market_month"]) do
-      assert {:ok, sub} =
-               Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+    with_mocks stripe_mocks() do
+      assert {:ok, sub} = Lifecycle.subscribe(user, packages: ["market"], interval: "month")
 
       assert {:error, msg} =
                StripeApi.upgrade_downgrade(sub, context.plans.plan_business_max_monthly)
@@ -177,60 +445,169 @@ defmodule Sanbase.Billing.Plan.Bundle.LifecycleTest do
     end
   end
 
-  defp stripe_mocks(price_ids, opts \\ []) do
-    cancel_legacy? = Keyword.get(opts, :cancel_legacy, false)
+  test "cancel_stale_replaced_subscriptions cancels a legacy sub left behind",
+       %{user: user} = context do
+    {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
 
-    base = [
+    with_mocks stripe_mocks() do
+      assert {:ok, _} = Lifecycle.subscribe(user, packages: ["market"], interval: "month")
+    end
+
+    # Added after the purchase, the way a failed cancel leaves it behind.
+    legacy =
+      insert(:subscription_pro,
+        user_id: user.id,
+        plan_id: context.plans.plan_business_pro_monthly.id,
+        status: :active,
+        stripe_id: "sub_leftover_" <> Ecto.UUID.generate()
+      )
+
+    with_mocks stripe_mocks() do
+      assert %{canceled: 1, failed: 0} = Lifecycle.cancel_stale_replaced_subscriptions()
+      assert Repo.reload!(legacy).status == :canceled
+    end
+  end
+
+  # --- helpers ---
+
+  # Every mocked call is recorded so a test can assert what Stripe was actually
+  # asked to do. A mock that ignores its arguments cannot fail when the wrong
+  # request is sent, which is the whole class of bug worth testing here.
+  defp stripe_mocks(opts \\ []) do
+    item_result = Keyword.get(opts, :create_subscription_item)
+
+    [
       {StripeApi, [:passthrough],
        [
          create_bundle_subscription: fn params ->
-           ids =
-             params.items
-             |> Enum.map(fn
-               %{price: id} -> id
-               _ -> nil
-             end)
-             |> Enum.reject(&is_nil/1)
+           record(:create_bundle_subscription, params)
+           price_ids = Enum.map(params.items, & &1.price)
+           stripe_id = "sub_test_" <> Integer.to_string(System.unique_integer([:positive]))
+           remember_prices(stripe_id, price_ids)
 
-           StripeApiTestResponse.create_bundle_subscription_resp(price_ids: ids)
+           StripeApiTestResponse.create_bundle_subscription_resp(
+             stripe_id: stripe_id,
+             price_ids: price_ids
+           )
+           |> with_stable_item_ids()
          end,
-         create_subscription_item: fn _sub, price_id, _opts ->
-           StripeApiTestResponse.create_subscription_item_resp(price_id: price_id)
+         create_subscription_item: fn subscription_id, price_id, _opts ->
+           record(:create_subscription_item, {subscription_id, price_id})
+
+           item_result ||
+             StripeApiTestResponse.create_subscription_item_resp(
+               id: "si_" <> price_id,
+               price_id: price_id,
+               subscription: subscription_id
+             )
          end,
-         update_subscription: fn _id, _params ->
-           StripeApiTestResponse.update_subscription_resp(price_ids: price_ids)
+         update_subscription: fn stripe_id, params ->
+           record(:update_subscription, params)
+
+           price_ids =
+             case Map.get(params, :items) do
+               nil ->
+                 remembered_prices(stripe_id)
+
+               items ->
+                 items
+                 |> Enum.reject(&Map.get(&1, :deleted, false))
+                 |> Enum.map(& &1.price)
+             end
+
+           remember_prices(stripe_id, price_ids)
+
+           StripeApiTestResponse.update_subscription_resp(
+             stripe_id: stripe_id,
+             price_ids: price_ids
+           )
+           |> with_stable_item_ids()
          end,
-         cancel_subscription_at_period_end: fn id ->
-           StripeApiTestResponse.update_subscription_resp(stripe_id: id)
+         delete_subscription_item: fn stripe_item_id, opts ->
+           record(:delete_subscription_item, {stripe_item_id, opts})
+           {:ok, %{id: stripe_item_id, deleted: true}}
+         end,
+         cancel_subscription_with_proration: fn stripe_id ->
+           record(:cancel_with_proration, stripe_id)
+
+           StripeApiTestResponse.cancel_subscription_with_proration_resp(
+             stripe_id: stripe_id,
+             price_ids: remembered_prices(stripe_id)
+           )
+         end,
+         cancel_subscription_at_period_end: fn stripe_id ->
+           record(:cancel_at_period_end, stripe_id)
+
+           # Stripe answers with the subscription carrying the flag it was just
+           # asked to set; a response without it would let the local row disagree.
+           {:ok, stripe_sub} =
+             StripeApiTestResponse.update_subscription_resp(
+               stripe_id: stripe_id,
+               price_ids: remembered_prices(stripe_id)
+             )
+
+           {:ok, %{stripe_sub | cancel_at_period_end: true}}
          end
        ]}
     ]
+  end
 
-    if cancel_legacy? do
-      [
-        {StripeApi, [:passthrough],
-         [
-           create_bundle_subscription: fn params ->
-             ids = Enum.map(params.items, & &1.price)
-             StripeApiTestResponse.create_bundle_subscription_resp(price_ids: ids)
-           end,
-           create_subscription_item: fn _sub, price_id, _opts ->
-             StripeApiTestResponse.create_subscription_item_resp(price_id: price_id)
-           end,
-           update_subscription: fn _id, _params ->
-             StripeApiTestResponse.update_subscription_resp(price_ids: price_ids)
-           end,
-           cancel_subscription_with_proration: fn id ->
-             StripeApiTestResponse.cancel_subscription_with_proration_resp(stripe_id: id)
-           end,
-           cancel_subscription_at_period_end: fn id ->
-             StripeApiTestResponse.update_subscription_resp(stripe_id: id)
-           end
-         ]}
-      ]
-    else
-      base
-    end
+  # Stripe keeps an item's id when its price changes. The canned response invents a
+  # random one per call, which would hide a code path that loses ids, so they are
+  # made a function of the price instead.
+  defp with_stable_item_ids({:ok, %Stripe.Subscription{items: %Stripe.List{} = list} = sub}) do
+    data = Enum.map(list.data, fn item -> %{item | id: "si_" <> item.price.id} end)
+
+    {:ok, %{sub | items: %{list | data: data}}}
+  end
+
+  defp record(key, value) do
+    Process.put({:stripe_calls, key}, [value | Process.get({:stripe_calls, key}, [])])
+  end
+
+  # A bundle subscription's items are Price-based, so every response about one has
+  # to report prices rather than a legacy `plan` object. Remembering what a
+  # subscription was last given keeps that true for the calls that carry no items
+  # of their own, like cancelling.
+  defp remember_prices(stripe_id, price_ids) do
+    Process.put({:stripe_prices, stripe_id}, price_ids)
+  end
+
+  defp remembered_prices(stripe_id), do: Process.get({:stripe_prices, stripe_id}, [])
+
+  defp calls(key), do: Process.get({:stripe_calls, key}, []) |> Enum.reverse()
+
+  defp insert_promo_code(user, coupon, redeem_by) do
+    {:ok, promo} =
+      %Sanbase.Billing.UserPromoCode{}
+      |> Sanbase.Billing.UserPromoCode.changeset(%{
+        campaign: "lifecycle test",
+        coupon: coupon,
+        user_id: user.id,
+        percent_off: 20,
+        redeem_by: DateTime.truncate(redeem_by, :second)
+      })
+      |> Repo.insert()
+
+    promo
+  end
+
+  defp insert_unsellable_looking_price(sku, interval) do
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    Repo.insert_all("bundle_prices", [
+      %{
+        sku: sku,
+        type: "package",
+        interval: interval,
+        stripe_price_id: "price_#{sku}_#{interval}",
+        amount: 35_000,
+        currency: "USD",
+        is_active: true,
+        inserted_at: now,
+        updated_at: now
+      }
+    ])
   end
 
   defp categorize_metrics do

--- a/test/sanbase/billing/plan/sale_controls_test.exs
+++ b/test/sanbase/billing/plan/sale_controls_test.exs
@@ -1,0 +1,105 @@
+defmodule Sanbase.Billing.Plan.SaleControlsTest do
+  use Sanbase.DataCase, async: false
+
+  import Sanbase.Factory
+
+  alias Sanbase.Accounts.Role
+  alias Sanbase.Accounts.UserRole
+  alias Sanbase.Billing.Plan
+  alias Sanbase.Billing.Plan.SaleControls
+  alias Sanbase.Repo
+
+  setup context do
+    for plan <- [
+          context.plans.plan_business_pro_monthly,
+          context.plans.plan_business_max_monthly
+        ] do
+      plan
+      |> Plan.changeset(%{is_deprecated: false, is_private: false})
+      |> Repo.update!()
+    end
+
+    bundle =
+      case Plan.bundle_plan("month") do
+        %Plan{} = plan ->
+          plan
+          |> Plan.changeset(%{is_private: true, is_deprecated: false})
+          |> Repo.update!()
+
+        nil ->
+          Repo.query!("ALTER SEQUENCE plans_id_seq RESTART WITH 9800")
+
+          insert(:plan_pro,
+            id: 9801,
+            name: "BUNDLE",
+            product_id: context.product_api.id,
+            interval: "month",
+            amount: 0,
+            is_deprecated: false,
+            is_private: true,
+            stripe_id: "plan_bundle_m_" <> Ecto.UUID.generate()
+          )
+      end
+
+    insert(:role_san_team)
+
+    %{bundle: bundle}
+  end
+
+  test "bundle starts deactivated (private); business starts active", context do
+    refute SaleControls.bundle_plans_active?()
+    assert SaleControls.business_plans_active?()
+    assert Repo.reload!(context.bundle).is_private
+  end
+
+  test "activate/deactivate bundle plans toggles is_private", context do
+    assert {:ok, ids} = SaleControls.activate_bundle_plans()
+    assert context.bundle.id in ids
+    assert SaleControls.bundle_plans_active?()
+    refute Repo.reload!(context.bundle).is_private
+
+    assert {:ok, _} = SaleControls.deactivate_bundle_plans()
+    refute SaleControls.bundle_plans_active?()
+    assert Repo.reload!(context.bundle).is_private
+  end
+
+  test "activate/deactivate business plans toggles is_deprecated", context do
+    assert {:ok, _} = SaleControls.deactivate_business_plans()
+    refute SaleControls.business_plans_active?()
+    assert Repo.reload!(context.plans.plan_business_pro_monthly).is_deprecated
+
+    assert {:ok, _} = SaleControls.activate_business_plans()
+    assert SaleControls.business_plans_active?()
+    refute Repo.reload!(context.plans.plan_business_pro_monthly).is_deprecated
+  end
+
+  test "bundle_plans_visible? is false for regular users when deactivated" do
+    user = insert(:user)
+    refute SaleControls.bundle_plans_visible?(user)
+  end
+
+  test "bundle_plans_visible? is true for team when deactivated" do
+    user = insert(:user)
+    {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+    assert SaleControls.bundle_plans_visible?(user)
+  end
+
+  test "bundle_plans_visible? is true for everyone when activated" do
+    user = insert(:user)
+    assert {:ok, _} = SaleControls.activate_bundle_plans()
+    assert SaleControls.bundle_plans_visible?(user)
+  end
+
+  test "product_with_plans hides deprecated business plans after deactivate" do
+    assert {:ok, _} = SaleControls.deactivate_business_plans()
+    assert {:ok, products} = Plan.product_with_plans()
+
+    plan_names =
+      products
+      |> Enum.flat_map(& &1.plans)
+      |> Enum.map(& &1.name)
+
+    refute "BUSINESS_PRO" in plan_names
+    refute "BUSINESS_MAX" in plan_names
+  end
+end

--- a/test/sanbase/billing/plan/sale_controls_test.exs
+++ b/test/sanbase/billing/plan/sale_controls_test.exs
@@ -63,20 +63,33 @@ defmodule Sanbase.Billing.Plan.SaleControlsTest do
     assert Repo.reload!(context.bundle).is_private
   end
 
-  test "activate/deactivate business plans moves both flags together", context do
+  test "activate/deactivate business plans toggles is_deprecated and nothing else", context do
+    # Private on production while being sold every day, so the toggle must not
+    # touch it - nothing reads it, and moving it would be an invisible data change.
+    business = context.plans.plan_business_pro_monthly
+    business |> Plan.changeset(%{is_private: true}) |> Repo.update!()
+
     assert {:ok, _} = SaleControls.deactivate_business_plans()
     refute SaleControls.business_plans_active?()
 
-    withdrawn = Repo.reload!(context.plans.plan_business_pro_monthly)
+    withdrawn = Repo.reload!(business)
     assert withdrawn.is_deprecated
     assert withdrawn.is_private
 
     assert {:ok, _} = SaleControls.activate_business_plans()
     assert SaleControls.business_plans_active?()
 
-    for_sale = Repo.reload!(context.plans.plan_business_pro_monthly)
+    for_sale = Repo.reload!(business)
     refute for_sale.is_deprecated
-    refute for_sale.is_private
+    assert for_sale.is_private
+  end
+
+  test "a private business plan is still listed when it is for sale", context do
+    context.plans.plan_business_pro_monthly
+    |> Plan.changeset(%{is_private: true, is_deprecated: false})
+    |> Repo.update!()
+
+    assert "BUSINESS_PRO" in listed_plan_names()
   end
 
   test "bundle_plans_visible? is false for regular users when deactivated" do

--- a/test/sanbase/billing/plan/sale_controls_test.exs
+++ b/test/sanbase/billing/plan/sale_controls_test.exs
@@ -63,14 +63,20 @@ defmodule Sanbase.Billing.Plan.SaleControlsTest do
     assert Repo.reload!(context.bundle).is_private
   end
 
-  test "activate/deactivate business plans toggles is_deprecated", context do
+  test "activate/deactivate business plans moves both flags together", context do
     assert {:ok, _} = SaleControls.deactivate_business_plans()
     refute SaleControls.business_plans_active?()
-    assert Repo.reload!(context.plans.plan_business_pro_monthly).is_deprecated
+
+    withdrawn = Repo.reload!(context.plans.plan_business_pro_monthly)
+    assert withdrawn.is_deprecated
+    assert withdrawn.is_private
 
     assert {:ok, _} = SaleControls.activate_business_plans()
     assert SaleControls.business_plans_active?()
-    refute Repo.reload!(context.plans.plan_business_pro_monthly).is_deprecated
+
+    for_sale = Repo.reload!(context.plans.plan_business_pro_monthly)
+    refute for_sale.is_deprecated
+    refute for_sale.is_private
   end
 
   test "bundle_plans_visible? is false for regular users when deactivated" do
@@ -92,14 +98,67 @@ defmodule Sanbase.Billing.Plan.SaleControlsTest do
 
   test "product_with_plans hides deprecated business plans after deactivate" do
     assert {:ok, _} = SaleControls.deactivate_business_plans()
-    assert {:ok, products} = Plan.product_with_plans()
 
-    plan_names =
-      products
-      |> Enum.flat_map(& &1.plans)
-      |> Enum.map(& &1.name)
+    plan_names = listed_plan_names()
 
     refute "BUSINESS_PRO" in plan_names
     refute "BUSINESS_MAX" in plan_names
+  end
+
+  test "product_with_plans lists business plans again after activate" do
+    assert {:ok, _} = SaleControls.deactivate_business_plans()
+    assert {:ok, _} = SaleControls.activate_business_plans()
+
+    plan_names = listed_plan_names()
+
+    assert "BUSINESS_PRO" in plan_names
+    assert "BUSINESS_MAX" in plan_names
+  end
+
+  # The sale controls must not reach any further than the two names they manage.
+  # On production `FREE` on both products and the current Sanbase tiers are all
+  # `is_private = true`, and several plans people still hold are deprecated -
+  # filtering on either field in general empties most of the pricing page.
+  test "product_with_plans keeps private plans and deprecated non-business plans", context do
+    Repo.query!("ALTER SEQUENCE plans_id_seq RESTART WITH 9850")
+
+    insert(:plan_pro,
+      id: 9851,
+      name: "PRIVATELY_SOLD",
+      product_id: context.product_api.id,
+      interval: "month",
+      is_private: true,
+      is_deprecated: false,
+      stripe_id: "plan_private_" <> Ecto.UUID.generate()
+    )
+
+    insert(:plan_pro,
+      id: 9852,
+      name: "GRANDFATHERED",
+      product_id: context.product_api.id,
+      interval: "month",
+      is_private: false,
+      is_deprecated: true,
+      stripe_id: "plan_grandfathered_" <> Ecto.UUID.generate()
+    )
+
+    plan_names = listed_plan_names()
+
+    assert "PRIVATELY_SOLD" in plan_names
+    assert "GRANDFATHERED" in plan_names
+  end
+
+  test "product_with_plans never lists the BUNDLE marker plans" do
+    assert {:ok, _} = SaleControls.activate_bundle_plans()
+
+    refute "BUNDLE" in listed_plan_names()
+  end
+
+  defp listed_plan_names do
+    assert {:ok, products} = Plan.product_with_plans()
+
+    products
+    |> Enum.flat_map(& &1.plans)
+    |> Enum.map(& &1.name)
   end
 end

--- a/test/sanbase/billing/query_access_level_test.exs
+++ b/test/sanbase/billing/query_access_level_test.exs
@@ -41,6 +41,7 @@ defmodule Sanbase.Billing.QueryAccessLevelTest do
           :blockchain_address_transaction_volume_over_time,
           :blockchain_address_user_pair,
           :blockchain_address,
+          :bundle_catalog,
           :chart_configuration,
           :chart_configurations,
           :chat,

--- a/test/sanbase_web/graphql/billing/bundle_mutations_api_test.exs
+++ b/test/sanbase_web/graphql/billing/bundle_mutations_api_test.exs
@@ -48,7 +48,7 @@ defmodule SanbaseWeb.Graphql.BundleMutationsApiTest do
       |> Repo.update_all(set: [stripe_price_id: "price_#{sku}_#{interval}", amount: 35_000])
     end
 
-    Repo.query!("ALTER SEQUENCE plans_id_seq RESTART WITH 9900")
+    Repo.query!("ALTER SEQUENCE plans_id_seq RESTART WITH 9903")
 
     for {interval, id} <- [{"month", 9901}, {"year", 9902}] do
       case Plan.bundle_plan(interval) do

--- a/test/sanbase_web/graphql/billing/bundle_mutations_api_test.exs
+++ b/test/sanbase_web/graphql/billing/bundle_mutations_api_test.exs
@@ -1,0 +1,374 @@
+defmodule SanbaseWeb.Graphql.BundleMutationsApiTest do
+  @moduledoc ~s"""
+  The five bundle mutations and the catalog query over real GraphQL requests.
+
+  The lifecycle unit tests prove what the operations do. These prove the layer
+  above: that the mutations exist under the names the frontend was given, that
+  they authenticate, that one account cannot act on another's subscription, and
+  that a refusal reaches the caller as a message rather than as a crash or as
+  somebody else's data.
+  """
+
+  use SanbaseWeb.ConnCase, async: false
+
+  import Ecto.Query
+  import Mock
+  import Sanbase.Factory
+  import SanbaseWeb.Graphql.TestHelpers
+
+  alias Sanbase.Accounts.Role
+  alias Sanbase.Accounts.UserRole
+  alias Sanbase.Billing.Plan
+  alias Sanbase.Billing.Plan.Bundle.{Catalog, PackageSnapshot, Price}
+  alias Sanbase.Billing.Subscription.Item
+  alias Sanbase.Metric.Category.MetricCategory
+  alias Sanbase.Metric.Category.MetricCategoryMapping
+  alias Sanbase.Repo
+  alias Sanbase.StripeApi
+  alias Sanbase.StripeApiTestResponse
+
+  @moduletag capture_log: true
+
+  @packaged_metrics %{
+    "market" => "price_usd",
+    "development" => "dev_activity",
+    "social" => "social_volume_total",
+    "onchain_core" => "mvrv_usd",
+    "onchain_labels" => "nvt"
+  }
+
+  setup context do
+    insert(:role_san_team)
+    categorize_metrics()
+    {:ok, _} = PackageSnapshot.publish(notes: "bundle mutations test")
+    {:ok, _} = Catalog.ensure_local_catalog()
+
+    for sku <- ["market", "social", "development"], interval <- ["month", "year"] do
+      from(p in Price, where: p.sku == ^sku and p.interval == ^interval and p.is_active)
+      |> Repo.update_all(set: [stripe_price_id: "price_#{sku}_#{interval}", amount: 35_000])
+    end
+
+    Repo.query!("ALTER SEQUENCE plans_id_seq RESTART WITH 9900")
+
+    for {interval, id} <- [{"month", 9901}, {"year", 9902}] do
+      case Plan.bundle_plan(interval) do
+        nil ->
+          insert(:plan_pro,
+            id: id,
+            name: "BUNDLE",
+            product_id: context.product_api.id,
+            interval: interval,
+            amount: 0,
+            is_private: true,
+            stripe_id: "plan_bundle_#{interval}_" <> Ecto.UUID.generate()
+          )
+
+        %Plan{} = plan ->
+          plan |> Plan.changeset(%{is_private: true}) |> Repo.update!()
+      end
+    end
+
+    user = insert(:user, stripe_customer_id: "cus_api_" <> Ecto.UUID.generate())
+    {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+
+    %{user: user, conn: setup_jwt_auth(build_conn(), user)}
+  end
+
+  describe "bundleCatalog" do
+    test "is refused for an anonymous caller while the offering is private" do
+      error = execute_query_with_error(build_conn(), catalog_query("MONTH"), "bundleCatalog")
+
+      assert error =~ "not available"
+    end
+
+    test "lists the sellable prices for a team member", %{conn: conn} do
+      prices = execute_query(conn, catalog_query("MONTH"), "bundleCatalog")
+
+      skus = prices |> Enum.map(& &1["sku"]) |> Enum.sort()
+      assert "market" in skus
+      assert "social" in skus
+
+      market = Enum.find(prices, &(&1["sku"] == "market"))
+      assert market["amount"] == 35_000
+      assert market["interval"] == "MONTH"
+      assert market["stripePriceId"] == "price_market_month"
+    end
+  end
+
+  describe "subscribeBundle" do
+    test "requires authentication" do
+      error =
+        execute_mutation_with_error(
+          build_conn(),
+          subscribe_mutation(["market"], "MONTH")
+        )
+
+      assert error =~ "unauthorized" or error =~ "not logged in"
+    end
+
+    test "buys a bundle and returns the subscription", %{conn: conn} do
+      with_mocks stripe_mocks() do
+        result =
+          execute_mutation(conn, subscribe_mutation(["market"], "MONTH"), "subscribeBundle")
+
+        assert result["status"] == "ACTIVE"
+        assert result["plan"]["name"] == "BUNDLE"
+        assert result["plan"]["interval"] == "month"
+      end
+    end
+
+    test "reports an unknown package as a message", %{conn: conn} do
+      with_mocks stripe_mocks() do
+        error =
+          execute_mutation_with_error(conn, subscribe_mutation(["not_a_package"], "MONTH"))
+
+        assert error =~ "is not sellable"
+      end
+    end
+  end
+
+  describe "managing an existing bundle" do
+    setup %{conn: conn} do
+      with_mocks stripe_mocks() do
+        subscription =
+          execute_mutation(
+            conn,
+            subscribe_mutation(["market", "social"], "MONTH"),
+            "subscribeBundle"
+          )
+
+        %{subscription_id: String.to_integer(subscription["id"])}
+      end
+    end
+
+    test "addBundleItem adds a package", %{conn: conn, subscription_id: id} do
+      with_mocks stripe_mocks() do
+        result =
+          execute_mutation(
+            conn,
+            item_mutation("addBundleItem", id, "development"),
+            "addBundleItem"
+          )
+
+        assert result["id"] == to_string(id)
+        assert "development" in Enum.map(Item.by_subscription(id), & &1.sku)
+      end
+    end
+
+    test "removeBundleItem schedules a package for removal", %{conn: conn, subscription_id: id} do
+      with_mocks stripe_mocks() do
+        _result =
+          execute_mutation(
+            conn,
+            item_mutation("removeBundleItem", id, "social"),
+            "removeBundleItem"
+          )
+
+        social = Enum.find(Item.by_subscription(id), &(&1.sku == "social"))
+        assert social.remove_at != nil
+      end
+    end
+
+    test "switchBundleInterval moves the plan", %{conn: conn, subscription_id: id} do
+      with_mocks stripe_mocks() do
+        result =
+          execute_mutation(
+            conn,
+            """
+            mutation {
+              switchBundleInterval(subscriptionId: #{id}) {
+                id
+                plan { name interval }
+              }
+            }
+            """,
+            "switchBundleInterval"
+          )
+
+        assert result["plan"]["interval"] == "year"
+      end
+    end
+
+    test "cancelBundleSubscription schedules cancellation", %{conn: conn, subscription_id: id} do
+      with_mocks stripe_mocks() do
+        result =
+          execute_mutation(
+            conn,
+            """
+            mutation {
+              cancelBundleSubscription(subscriptionId: #{id}) {
+                isScheduledForCancellation
+                scheduledForCancellationAt
+              }
+            }
+            """,
+            "cancelBundleSubscription"
+          )
+
+        assert result["isScheduledForCancellation"] == true
+      end
+    end
+
+    test "another account cannot manage the subscription", %{subscription_id: id} do
+      other = insert(:user)
+      {:ok, _} = UserRole.create(other.id, Role.san_team_role_id())
+      other_conn = setup_jwt_auth(build_conn(), other)
+
+      with_mocks stripe_mocks() do
+        error =
+          execute_mutation_with_error(
+            other_conn,
+            item_mutation("addBundleItem", id, "development")
+          )
+
+        assert error =~ "does not belong to the user"
+      end
+    end
+
+    test "a changeset failure is not reported to the caller verbatim", %{
+      conn: conn,
+      subscription_id: id
+    } do
+      # `market` is already on the subscription, so the insert violates the unique
+      # index. The caller gets a sentence, not Ecto's error list.
+      with_mocks stripe_mocks() do
+        error = execute_mutation_with_error(conn, item_mutation("addBundleItem", id, "market"))
+
+        refute error =~ "constraint"
+        refute error =~ "Ecto"
+      end
+    end
+  end
+
+  # --- helpers ---
+
+  defp catalog_query(interval) do
+    """
+    {
+      bundleCatalog(interval: #{interval}) {
+        sku
+        type
+        interval
+        amount
+        currency
+        stripePriceId
+      }
+    }
+    """
+  end
+
+  defp subscribe_mutation(packages, interval) do
+    packages = packages |> Enum.map(&~s("#{&1}")) |> Enum.join(", ")
+
+    """
+    mutation {
+      subscribeBundle(packages: [#{packages}], interval: #{interval}, paymentMethodId: "pm_test") {
+        id
+        status
+        plan { name interval }
+      }
+    }
+    """
+  end
+
+  defp item_mutation(name, subscription_id, sku) do
+    """
+    mutation {
+      #{name}(subscriptionId: #{subscription_id}, sku: "#{sku}") {
+        id
+        status
+        plan { name interval }
+      }
+    }
+    """
+  end
+
+  defp stripe_mocks do
+    [
+      {StripeApi, [:passthrough],
+       [
+         attach_payment_method_to_customer: fn user, _payment_method_id -> {:ok, user} end,
+         create_bundle_subscription: fn params ->
+           price_ids = Enum.map(params.items, & &1.price)
+           stripe_id = "sub_api_" <> Integer.to_string(System.unique_integer([:positive]))
+           remember_prices(stripe_id, price_ids)
+
+           StripeApiTestResponse.create_bundle_subscription_resp(
+             stripe_id: stripe_id,
+             price_ids: price_ids
+           )
+           |> with_stable_item_ids()
+         end,
+         create_subscription_item: fn subscription_id, price_id, _opts ->
+           StripeApiTestResponse.create_subscription_item_resp(
+             id: "si_" <> price_id,
+             price_id: price_id,
+             subscription: subscription_id
+           )
+         end,
+         update_subscription: fn stripe_id, params ->
+           price_ids =
+             case Map.get(params, :items) do
+               nil ->
+                 remembered_prices(stripe_id)
+
+               items ->
+                 items
+                 |> Enum.reject(&Map.get(&1, :deleted, false))
+                 |> Enum.map(& &1.price)
+             end
+
+           remember_prices(stripe_id, price_ids)
+
+           StripeApiTestResponse.update_subscription_resp(
+             stripe_id: stripe_id,
+             price_ids: price_ids
+           )
+           |> with_stable_item_ids()
+         end,
+         cancel_subscription_at_period_end: fn stripe_id ->
+           {:ok, stripe_sub} =
+             StripeApiTestResponse.update_subscription_resp(
+               stripe_id: stripe_id,
+               price_ids: remembered_prices(stripe_id)
+             )
+
+           {:ok, %{stripe_sub | cancel_at_period_end: true}}
+         end
+       ]}
+    ]
+  end
+
+  defp with_stable_item_ids({:ok, %Stripe.Subscription{items: %Stripe.List{} = list} = sub}) do
+    data = Enum.map(list.data, fn item -> %{item | id: "si_" <> item.price.id} end)
+
+    {:ok, %{sub | items: %{list | data: data}}}
+  end
+
+  defp remember_prices(stripe_id, price_ids) do
+    Process.put({:stripe_prices, stripe_id}, price_ids)
+  end
+
+  defp remembered_prices(stripe_id), do: Process.get({:stripe_prices, stripe_id}, [])
+
+  defp categorize_metrics do
+    for {package, index} <- Enum.with_index(Sanbase.Billing.Plan.Bundle.Package.all()) do
+      {:ok, category} =
+        case Repo.get_by(MetricCategory, name: package.category) do
+          nil -> MetricCategory.create(%{name: package.category, display_order: index})
+          cat -> {:ok, cat}
+        end
+
+      metric = Map.fetch!(@packaged_metrics, package.slug)
+
+      unless Repo.get_by(MetricCategoryMapping, metric: metric) do
+        {:ok, _} =
+          MetricCategoryMapping.create(%{
+            module: "Sanbase.Metric.BundleMutationsApiTestAdapter",
+            metric: metric,
+            category_id: category.id
+          })
+      end
+    end
+  end
+end

--- a/test/sanbase_web/live/admin/bundle_admin_live_test.exs
+++ b/test/sanbase_web/live/admin/bundle_admin_live_test.exs
@@ -18,8 +18,10 @@ defmodule SanbaseWeb.Admin.BundleAdminLiveTest do
   import Sanbase.Factory
 
   alias Sanbase.Accounts.UserRole
+  alias Sanbase.Billing.Plan
   alias Sanbase.Billing.Plan.Bundle.Package
   alias Sanbase.Billing.Plan.Bundle.PackageSnapshot
+  alias Sanbase.Billing.Plan.SaleControls
   alias Sanbase.Billing.Subscription
   alias Sanbase.Metric.Category.MetricCategory
   alias Sanbase.Metric.Category.MetricCategoryMapping
@@ -229,15 +231,85 @@ defmodule SanbaseWeb.Admin.BundleAdminLiveTest do
 
   describe "/admin/bundle_offering" do
     test "shows activate/deactivate controls for bundle and business plans", %{conn: conn} do
-      {:ok, _view, html} = live(conn, "/admin/bundle_offering")
+      {:ok, view, _html} = live(conn, "/admin/bundle_offering")
 
-      assert html =~ "Plan sale controls"
-      assert html =~ "Activate bundle plans"
-      assert html =~ "Deactivate bundle plans"
-      assert html =~ "Activate business plans"
-      assert html =~ "Deactivate business plans"
+      assert has_element?(view, "#plan-sale-refresh")
+
+      assert has_element?(view, "#bundle-plan-controls")
+      assert has_element?(view, "#activate-bundle-plans")
+      assert has_element?(view, "#deactivate-bundle-plans")
+
+      assert has_element?(view, "#business-plan-controls")
+      assert has_element?(view, "#activate-business-plans")
+      assert has_element?(view, "#deactivate-business-plans")
+    end
+
+    test "the bundle buttons put the plans on and off sale", %{
+      conn: conn,
+      bundle_plan: bundle_plan
+    } do
+      # The starting position of the switch is written directly, because reaching
+      # it through SaleControls would be using the thing under test to set up its
+      # own test.
+      bundle_plan |> Plan.changeset(%{is_private: true}) |> Repo.update!()
+
+      {:ok, view, _html} = live(conn, "/admin/bundle_offering")
+
+      assert bundle_section(view) =~ "DEACTIVATED"
+      refute has_element?(view, "#activate-bundle-plans[disabled]")
+
+      view |> element("#activate-bundle-plans") |> render_click()
+
+      assert bundle_section(view) =~ "ACTIVE"
+      assert SaleControls.bundle_plans_active?()
+
+      # Only the move that changes something is offered, so an admin cannot
+      # activate what is already active.
+      assert has_element?(view, "#activate-bundle-plans[disabled]")
+      refute has_element?(view, "#deactivate-bundle-plans[disabled]")
+
+      view |> element("#deactivate-bundle-plans") |> render_click()
+
+      assert bundle_section(view) =~ "DEACTIVATED"
+      refute SaleControls.bundle_plans_active?()
+      assert has_element?(view, "#deactivate-bundle-plans[disabled]")
+    end
+
+    test "the business buttons withdraw the plans from sale and bring them back",
+         %{conn: conn} do
+      bundle_active_before? = SaleControls.bundle_plans_active?()
+
+      {:ok, view, _html} = live(conn, "/admin/bundle_offering")
+
+      # The seeded BUSINESS_PRO/BUSINESS_MAX rows are not deprecated, so these
+      # plans start on sale.
+      assert business_section(view) =~ "ACTIVE"
+      refute has_element?(view, "#deactivate-business-plans[disabled]")
+
+      view |> element("#deactivate-business-plans") |> render_click()
+
+      assert business_section(view) =~ "DEACTIVATED"
+      refute SaleControls.business_plans_active?()
+      assert has_element?(view, "#deactivate-business-plans[disabled]")
+      refute has_element?(view, "#activate-business-plans[disabled]")
+
+      view |> element("#activate-business-plans") |> render_click()
+
+      assert business_section(view) =~ "ACTIVE"
+      assert SaleControls.business_plans_active?()
+      assert has_element?(view, "#activate-business-plans[disabled]")
+
+      # Two independent switches: the business buttons write `is_deprecated` and
+      # must leave the bundle plans' `is_private` where it was.
+      assert SaleControls.bundle_plans_active?() == bundle_active_before?
     end
   end
+
+  # The status line is the page's own answer about what is on sale, so it is read
+  # back from the rendered section rather than from the database.
+  defp bundle_section(view), do: view |> element("#bundle-plan-controls") |> render()
+
+  defp business_section(view), do: view |> element("#business-plan-controls") |> render()
 
   defp categorize_metrics do
     for {package, index} <- Enum.with_index(Package.all()) do

--- a/test/sanbase_web/live/admin/bundle_admin_live_test.exs
+++ b/test/sanbase_web/live/admin/bundle_admin_live_test.exs
@@ -227,6 +227,18 @@ defmodule SanbaseWeb.Admin.BundleAdminLiveTest do
     view |> element("button", "Create subscription") |> render_click()
   end
 
+  describe "/admin/bundle_offering" do
+    test "shows activate/deactivate controls for bundle and business plans", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/admin/bundle_offering")
+
+      assert html =~ "Plan sale controls"
+      assert html =~ "Activate bundle plans"
+      assert html =~ "Deactivate bundle plans"
+      assert html =~ "Activate business plans"
+      assert html =~ "Deactivate business plans"
+    end
+  end
+
   defp categorize_metrics do
     for {package, index} <- Enum.with_index(Package.all()) do
       {:ok, category} = MetricCategory.create(%{name: package.category, display_order: index})

--- a/test/support/stripe_api_test_response.ex
+++ b/test/support/stripe_api_test_response.ex
@@ -205,6 +205,55 @@ defmodule Sanbase.StripeApiTestResponse do
     stripe_id = stripe_id || "sub_" <> Base.encode16(:crypto.strong_rand_bytes(7))
     status = Keyword.get(opts, :status, "active")
     trial_end = Keyword.get(opts, :trial_end, nil)
+    price_ids = Keyword.get(opts, :price_ids, nil)
+
+    items =
+      if is_list(price_ids) and price_ids != [] do
+        Enum.map(price_ids, fn price_id ->
+          %Stripe.SubscriptionItem{
+            created: 1_558_185_787,
+            id: "si_" <> Base.encode16(:crypto.strong_rand_bytes(6), case: :lower),
+            metadata: %{},
+            object: "subscription_item",
+            price: %{id: price_id, object: "price"},
+            plan: nil,
+            quantity: 1,
+            subscription: stripe_id
+          }
+        end)
+      else
+        [
+          %Stripe.SubscriptionItem{
+            created: 1_558_185_787,
+            id: "si_anothernonexistingid",
+            metadata: %{},
+            object: "subscription_item",
+            plan: %Stripe.Plan{
+              active: true,
+              aggregate_usage: nil,
+              amount: 35_900,
+              billing_scheme: "per_unit",
+              created: 1_558_178_870,
+              currency: "usd",
+              id: "plan_F5bv8ZRkhnAnmR",
+              interval: "month",
+              interval_count: 1,
+              livemode: false,
+              metadata: %{},
+              nickname: nil,
+              object: "plan",
+              product: "prod_nonexistingproduct",
+              tiers: nil,
+              tiers_mode: nil,
+              transform_usage: nil,
+              trial_period_days: nil,
+              usage_type: "licensed"
+            },
+            quantity: 1,
+            subscription: "sub_nonexistingsub"
+          }
+        ]
+      end
 
     {:ok,
      %Stripe.Subscription{
@@ -229,41 +278,11 @@ defmodule Sanbase.StripeApiTestResponse do
          }
        },
        items: %Stripe.List{
-         data: [
-           %Stripe.SubscriptionItem{
-             created: 1_558_185_787,
-             id: "si_anothernonexistingid",
-             metadata: %{},
-             object: "subscription_item",
-             plan: %Stripe.Plan{
-               active: true,
-               aggregate_usage: nil,
-               amount: 35_900,
-               billing_scheme: "per_unit",
-               created: 1_558_178_870,
-               currency: "usd",
-               id: "plan_F5bv8ZRkhnAnmR",
-               interval: "month",
-               interval_count: 1,
-               livemode: false,
-               metadata: %{},
-               nickname: nil,
-               object: "plan",
-               product: "prod_nonexistingproduct",
-               tiers: nil,
-               tiers_mode: nil,
-               transform_usage: nil,
-               trial_period_days: nil,
-               usage_type: "licensed"
-             },
-             quantity: 1,
-             subscription: "sub_nonexistingsub"
-           }
-         ],
+         data: items,
          has_more: false,
          object: "list",
-         total_count: 1,
-         url: "/v1/subscription_items?subscription=sub_nonexistingsub"
+         total_count: length(items),
+         url: "/v1/subscription_items?subscription=#{stripe_id}"
        },
        livemode: false,
        metadata: %{},
@@ -272,6 +291,28 @@ defmodule Sanbase.StripeApiTestResponse do
        status: status,
        trial_end: trial_end,
        trial_start: nil
+     }}
+  end
+
+  def create_bundle_subscription_resp(opts \\ []) do
+    create_subscription_resp(opts)
+  end
+
+  def create_subscription_item_resp(opts \\ []) do
+    id =
+      Keyword.get(opts, :id, "si_" <> Base.encode16(:crypto.strong_rand_bytes(6), case: :lower))
+
+    price_id = Keyword.get(opts, :price_id, "price_test")
+
+    {:ok,
+     %Stripe.SubscriptionItem{
+       created: 1_558_185_787,
+       id: id,
+       metadata: %{},
+       object: "subscription_item",
+       price: %{id: price_id, object: "price"},
+       quantity: 1,
+       subscription: Keyword.get(opts, :subscription, "sub_test")
      }}
   end
 
@@ -284,6 +325,11 @@ defmodule Sanbase.StripeApiTestResponse do
   end
 
   def cancel_subscription_immediately_resp(opts \\ []) do
-    create_subscription_resp(opts)
+    {:ok, sub} = create_subscription_resp(opts)
+    {:ok, %{sub | status: "canceled", canceled_at: 1_558_185_800}}
+  end
+
+  def cancel_subscription_with_proration_resp(opts \\ []) do
+    cancel_subscription_immediately_resp(opts)
   end
 end

--- a/test/support/stripe_api_test_response.ex
+++ b/test/support/stripe_api_test_response.ex
@@ -250,7 +250,7 @@ defmodule Sanbase.StripeApiTestResponse do
               usage_type: "licensed"
             },
             quantity: 1,
-            subscription: "sub_nonexistingsub"
+            subscription: stripe_id
           }
         ]
       end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

### Catalog

```graphql
query BundleCatalog($interval: billing_interval!) {
  bundleCatalog(interval: $interval) {
    id
    sku
    type
    interval
    amount
    currency
    stripePriceId
  }
}

{ "interval": "MONTH|YEAR" }
```

### Payment (existing)

```graphql
mutation {
  createStripeSetupIntent {
    clientSecret
  }
}
```

### Subscribe

```graphql
mutation SubscribeBundle(
  $packages: [String!]!
  $interval: billing_interval!
  $apiCallsAddon: String
  $paymentMethodId: String
  $cardToken: String
  $coupon: String
) {
  subscribeBundle(
    packages: $packages
    interval: $interval
    apiCallsAddon: $apiCallsAddon
    paymentMethodId: $paymentMethodId
    cardToken: $cardToken
    coupon: $coupon
  ) {
    id
    status
    currentPeriodEnd
    cancelAtPeriodEnd
    plan {
      id
      name
      interval
    }
    paymentIntent {
      id
      status
      clientSecret
    }
  }
}

{
  "packages": ["market", "social"],
  "interval": "MONTH",
  "apiCallsAddon": null,
  "paymentMethodId": "pm_xxx"
}
```

### Manage subscription

```graphql
mutation AddBundleItem($subscriptionId: Int!, $sku: String!) {
  addBundleItem(subscriptionId: $subscriptionId, sku: $sku) {
    id
    status
    plan { name interval }
  }
}

mutation RemoveBundleItem($subscriptionId: Int!, $sku: String!) {
  removeBundleItem(subscriptionId: $subscriptionId, sku: $sku) {
    id
    status
    plan { name interval }
  }
}

mutation SwitchBundleInterval($subscriptionId: Int!) {
  switchBundleInterval(subscriptionId: $subscriptionId) {
    id
    status
    plan { name interval }
  }
}

mutation CancelBundleSubscription($subscriptionId: Int!) {
  cancelBundleSubscription(subscriptionId: $subscriptionId) {
    isScheduledForCancellation
    scheduledForCancellationAt
  }
}
```

### Notes for FE
* Sum selected amounts client-side for the checkout total.
* `removeBundleItem` schedules removal for the end of the paid period: access and billing both continue until then, and an hourly job deletes the Stripe item and stops the charge. The item's `remove_at` is when it happens. The last remaining package cannot be removed — cancel instead.
* `addBundleItem` takes effect immediately and is prorated.
* `switchBundleInterval` re-prices the existing items; items already scheduled for removal are dropped rather than carried onto the new interval.
* Active Business Pro/Max is auto-replaced on `subscribeBundle` (create new, then cancel legacy with proration). CUSTOM_* is rejected.
* Errors arrive as messages. If any step after the charge fails, the Stripe subscription is cancelled again with proration and the mutation returns an error — there is no half-bought state to handle.

### Deployment steps
* One migration on `subscription_items`: replaces `cancel_at_period_end` with `remove_at`.
* Two new scheduled jobs: `expire_bundle_subscription_items` (hourly) carries out scheduled removals, `cancel_stale_replaced_subscriptions` (hourly) retries a legacy cancel that failed during a purchase. **Removals do not happen if the first one is not running.**


## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added composable API bundles with catalog browsing, subscription creation, package management, billing-interval switching, and cancellation.
  * Added administrative controls for activating or deactivating bundle and business plan offerings.
  * Added automatic handling of expired bundle items and replaced subscriptions.

* **Bug Fixes**
  * Improved billing resilience for missing Stripe details, coupon limits, and subscription synchronization.
  * Prevented unsupported upgrades or downgrades for bundle subscriptions.

* **Documentation**
  * Expanded bundle lifecycle and rollout documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->