### PR TITLE
harden alerts checks

### DIFF
--- a/lib/sanbase/alerts/alert.ex
+++ b/lib/sanbase/alerts/alert.ex
@@ -173,11 +173,7 @@ defimpl Sanbase.Alert, for: Any do
 
       response = Sanbase.Telegram.send_message(user_trigger.user, payload)
 
-      # Deactivate the alert if the message is sent to telegram, telegram
-      # is the only channel and the telegram bot is blocked by the user.
-      # The function returns :ok or {:error, reason} which is used in the
-      # caller.
-      maybe_deactivate_trigger(response, user_trigger)
+      normalize_telegram_response(response, user_trigger)
     end
 
     send_or_limit("telegram", user_trigger, max_alerts_to_send, fun)
@@ -239,11 +235,8 @@ defimpl Sanbase.Alert, for: Any do
       # Send a reply to the original message, if it was delived successfuly
       # It contains the chat preview image.
       maybe_send_preview_image_as_reply(response, user_trigger, channel, opts)
-      # Deactivate the alert if the message is sent to telegram, telegram
-      # is the only channel and the telegram bot is blocked by the user.
-      # The function returns :ok or {:error, reason} which is used in the
-      # caller.
-      maybe_deactivate_trigger(response, user_trigger)
+
+      normalize_telegram_response(response, user_trigger)
     end
 
     send_or_limit("telegram_channel", user_trigger, max_alerts_to_send, fun)
@@ -267,7 +260,9 @@ defimpl Sanbase.Alert, for: Any do
 
   defp maybe_send_preview_image_as_reply(_, _, _, _), do: :ok
 
-  defp maybe_deactivate_trigger({:error, error}, user_trigger) do
+  # Convert known telegram API errors to reason maps. The scheduler
+  # deactivates alerts whose reason marks a permanently broken destination.
+  defp normalize_telegram_response({:error, error}, user_trigger) do
     cond do
       not is_binary(error) ->
         # If the error is not binary, for example :closed, do not alerts_template
@@ -275,29 +270,14 @@ defimpl Sanbase.Alert, for: Any do
         :ok
 
       String.contains?(error, "chat not found") ->
-        # In case the user_trigger does not have other channels but only telegram
-        # and the user has blocked our telegram bot, the alert is disabled
-        # so it does not spend resources running
-        deactivate_if_telegram_channel_only(user_trigger)
-
         %{user: %User{id: user_id}, trigger: %{id: trigger_id}} = user_trigger
         {:error, %{reason: :telegram_chat_not_found, user_id: user_id, trigger_id: trigger_id}}
 
       String.contains?(error, "blocked the telegram bot") ->
-        # In case the user_trigger does not have other channels but only telegram
-        # and the user has blocked our telegram bot, the alert is disabled
-        # so it does not spend resources running
-        deactivate_if_telegram_channel_only(user_trigger)
-
         %{user: %User{id: user_id}, trigger: %{id: trigger_id}} = user_trigger
         {:error, %{reason: :telegram_bot_blocked, user_id: user_id, trigger_id: trigger_id}}
 
       String.contains?(error, "error 404. Reason: Not Found") ->
-        # In case the user_trigger does not have other channels but only telegram
-        # and the user has blocked our telegram bot, the alert is disabled
-        # so it does not spend resources running
-        deactivate_if_telegram_channel_only(user_trigger)
-
         %{user: %User{id: user_id}, trigger: %{id: trigger_id}} = user_trigger
 
         {:error,
@@ -308,7 +288,7 @@ defimpl Sanbase.Alert, for: Any do
     end
   end
 
-  defp maybe_deactivate_trigger(_response, _trigger), do: :ok
+  defp normalize_telegram_response(_response, _trigger), do: :ok
 
   defp send_preview_image(response, channel, short_url_id) do
     Task.Supervisor.async_nolink(Sanbase.TaskSupervisor, fn ->
@@ -340,19 +320,6 @@ defimpl Sanbase.Alert, for: Any do
         Logger.error(
           "Response of #{image_url} was expected to be with content type image/jpg, got #{content_type} instead"
         )
-    end
-  end
-
-  defp deactivate_if_telegram_channel_only(user_trigger) do
-    case user_trigger do
-      %{trigger: %{settings: %{channel: channel}}}
-      when channel in ["telegram", ["telegram"], "telegram_channel", ["telegram_channel"]] ->
-        Logger.info("Deactivating user trigger with id #{user_trigger.id} because the user \
-        with id #{user_trigger.user.id} has blocked the telegram bot.")
-        Sanbase.Alert.UserTrigger.update_is_active(user_trigger.id, user_trigger.user_id, false)
-
-      _ ->
-        :ok
     end
   end
 
@@ -497,11 +464,31 @@ defimpl Sanbase.Alert, for: Any do
     end
   end
 
-  defp send_or_limit(channel, %{user: user, trigger: trigger}, limit, send_alert_fun)
+  defp send_or_limit(
+         channel,
+         %{user: user, trigger: trigger} = user_trigger,
+         limit,
+         send_alert_fun
+       )
        when is_function(send_alert_fun, 2) do
+    # Same rounding as the scheduler's end-of-round write, so both produce
+    # the same last_triggered value.
+    now =
+      Timex.now()
+      |> Sanbase.Utils.DateTime.round_datetime(second: 30)
+      |> Timex.set(microsecond: {0, 0})
+
     send_fun = fn {identifier, payload}, list ->
-      elem = {identifier, send_alert_fun.(identifier, payload)}
-      [elem | list]
+      result = send_alert_fun.(identifier, payload)
+
+      # The user already received the alert - persist the cooldown right
+      # away so it is not sent again if the process is killed before the
+      # end-of-round write.
+      if result == :ok do
+        Sanbase.Alert.UserTrigger.stamp_last_triggered(user_trigger.id, identifier, now)
+      end
+
+      [{identifier, result} | list]
     end
 
     limit_fun = fn {identifier, _payload}, list ->

--- a/lib/sanbase/alerts/alert.ex
+++ b/lib/sanbase/alerts/alert.ex
@@ -84,7 +84,7 @@ defimpl Sanbase.Alert, for: Any do
 
     # Alerts created before the https/no-IP restrictions keep failing here
     # and get auto-disabled by the scheduler.
-    case Sanbase.Utils.Validation.valid_webhook_url?(webhook_url) do
+    case webhook_url_send_time_validation(webhook_url) do
       :ok ->
         fun = fn identifier, payload ->
           payload = transform_payload(payload, trigger.id, :webhook)
@@ -93,10 +93,28 @@ defimpl Sanbase.Alert, for: Any do
 
         send_or_limit("webhook", trigger, max_alerts_to_send, fun)
 
-      {:error, reason} ->
+      {:error, reason_atom, message} ->
         %{trigger: %{settings: %{payload: payload_map}}} = trigger
 
-        error_for_each_identifier(payload_map, %{reason: :webhook_url_not_valid, error: reason})
+        error_for_each_identifier(payload_map, %{reason: reason_atom, error: message})
+    end
+  end
+
+  # On top of the URL validation (which checks the host literal), check what
+  # the host currently resolves to, so a domain pointing at a private address
+  # cannot be used for SSRF via DNS.
+  defp webhook_url_send_time_validation(webhook_url) do
+    with :ok <- Sanbase.Utils.Validation.valid_webhook_url?(webhook_url) do
+      host = URI.parse(webhook_url).host
+
+      if Sanbase.Utils.IP.resolves_to_blocked_ip?(host) do
+        {:error, :webhook_url_resolves_to_blocked_ip,
+         "URL host '#{host}' resolves to a private, reserved or otherwise blocked address"}
+      else
+        :ok
+      end
+    else
+      {:error, reason} -> {:error, :webhook_url_not_valid, reason}
     end
   end
 

--- a/lib/sanbase/alerts/alert.ex
+++ b/lib/sanbase/alerts/alert.ex
@@ -61,18 +61,18 @@ defimpl Sanbase.Alert, for: Any do
     )
 
     error_list =
-      Enum.map(payload_map, fn {identifier, _payload} ->
-        {identifier,
-         {:error,
-          %{
-            reason: :unsupported_notification_channel,
-            channel: channel,
-            user_id: user_id,
-            trigger_id: trigger_id
-          }}}
-      end)
+      error_for_each_identifier(payload_map, %{
+        reason: :unsupported_notification_channel,
+        channel: channel,
+        user_id: user_id,
+        trigger_id: trigger_id
+      })
 
     {"unknown", error_list}
+  end
+
+  defp error_for_each_identifier(payload_map, error) do
+    Enum.map(payload_map, fn {identifier, _payload} -> {identifier, {:error, error}} end)
   end
 
   defp send_webhook(
@@ -82,18 +82,22 @@ defimpl Sanbase.Alert, for: Any do
        ) do
     %{id: user_trigger_id} = trigger
 
-    fun = fn identifier, payload ->
-      case Sanbase.Utils.Validation.valid_public_url?(webhook_url) do
-        :ok ->
+    # Alerts created before the https/no-IP restrictions keep failing here
+    # and get auto-disabled by the scheduler.
+    case Sanbase.Utils.Validation.valid_webhook_url?(webhook_url) do
+      :ok ->
+        fun = fn identifier, payload ->
           payload = transform_payload(payload, trigger.id, :webhook)
           do_send_webhook(webhook_url, identifier, payload, user_trigger_id)
+        end
 
-        {:error, reason} ->
-          {:error, %{reason: :webhook_url_not_valid, error: reason}}
-      end
+        send_or_limit("webhook", trigger, max_alerts_to_send, fun)
+
+      {:error, reason} ->
+        %{trigger: %{settings: %{payload: payload_map}}} = trigger
+
+        error_for_each_identifier(payload_map, %{reason: :webhook_url_not_valid, error: reason})
     end
-
-    send_or_limit("webhook", trigger, max_alerts_to_send, fun)
   end
 
   defp send_email(
@@ -129,11 +133,11 @@ defimpl Sanbase.Alert, for: Any do
       trigger
 
     # The emails notifications are disabled
-    Enum.map(payload_map, fn {identifier, _payload} ->
-      {identifier,
-       {:error,
-        %{reason: :email_alert_notifications_disabled, user_id: user_id, trigger_id: trigger_id}}}
-    end)
+    error_for_each_identifier(payload_map, %{
+      reason: :email_alert_notifications_disabled,
+      user_id: user_id,
+      trigger_id: trigger_id
+    })
   end
 
   defp send_email(trigger, _max_alerts_to_send) do
@@ -143,9 +147,11 @@ defimpl Sanbase.Alert, for: Any do
       trigger: %{settings: %{payload: payload_map}}
     } = trigger
 
-    Enum.map(payload_map, fn {identifier, _payload} ->
-      {identifier, {:error, %{reason: :no_email, user_id: user_id, trigger_id: trigger_id}}}
-    end)
+    error_for_each_identifier(payload_map, %{
+      reason: :no_email,
+      user_id: user_id,
+      trigger_id: trigger_id
+    })
   end
 
   defp send_telegram(
@@ -199,15 +205,11 @@ defimpl Sanbase.Alert, for: Any do
       }
     } = user_trigger
 
-    Enum.map(payload_map, fn {identifier, _payload} ->
-      {identifier,
-       {:error,
-        %{
-          reason: :telegram_alert_notifications_disabled,
-          user_id: user_id,
-          trigger_id: trigger_id
-        }}}
-    end)
+    error_for_each_identifier(payload_map, %{
+      reason: :telegram_alert_notifications_disabled,
+      user_id: user_id,
+      trigger_id: trigger_id
+    })
   end
 
   defp send_telegram(user_trigger, _max_alerts_to_send) do
@@ -217,9 +219,11 @@ defimpl Sanbase.Alert, for: Any do
       trigger: %{settings: %{payload: payload_map}}
     } = user_trigger
 
-    Enum.map(payload_map, fn {identifier, _payload} ->
-      {identifier, {:error, %{reason: :no_telegram, user_id: user_id, trigger_id: trigger_id}}}
-    end)
+    error_for_each_identifier(payload_map, %{
+      reason: :no_telegram,
+      user_id: user_id,
+      trigger_id: trigger_id
+    })
   end
 
   defp send_telegram_channel(

--- a/lib/sanbase/alerts/evaluator/scheduler.ex
+++ b/lib/sanbase/alerts/evaluator/scheduler.ex
@@ -60,7 +60,7 @@ defmodule Sanbase.Alert.Scheduler do
     alerts =
       type
       |> UserTrigger.get_active_triggers_by_type()
-      |> deactivate_ip_webhook_triggers(info_map)
+      |> filter_and_deactivate_webhook_bad_url_triggers(info_map)
       |> filter_receivable_triggers(info_map)
       |> filter_not_frozen_triggers(info_map)
 
@@ -178,6 +178,7 @@ defmodule Sanbase.Alert.Scheduler do
 
     fired_alerts =
       updated_user_triggers
+      |> Enum.zip(sent_list_results)
       |> get_fired_alerts_data()
 
     fired_alerts |> persist_historical_activity()
@@ -230,15 +231,18 @@ defmodule Sanbase.Alert.Scheduler do
     filtered
   end
 
-  # IP address webhook destinations are not allowed. Deactivate legacy alerts
-  # that still have one instead of evaluating them.
-  defp deactivate_ip_webhook_triggers(user_triggers, info_map) do
-    {ip_webhook_triggers, rest} = Enum.split_with(user_triggers, &ip_webhook_trigger?/1)
+  # Deactivate legacy alerts whose only destinations are webhooks with invalid
+  # URLs (http scheme, IP address host, malformed) - they cannot deliver
+  # anything. Alerts that also have other channels are kept - the invalid
+  # webhook is refused at send time instead.
+  defp filter_and_deactivate_webhook_bad_url_triggers(user_triggers, info_map) do
+    {bad_url_triggers, rest} =
+      Enum.split_with(user_triggers, &only_bad_webhook_url_channels?/1)
 
-    for %UserTrigger{} = ut <- ip_webhook_triggers do
+    for %UserTrigger{} = ut <- bad_url_triggers do
       Logger.info("""
-      [#{info_map.run_uuid}] Deactivating alert with id #{ut.id} because its webhook \
-      destination host is an IP address, which is not allowed.
+      [#{info_map.run_uuid}] Deactivating alert with id #{ut.id} because its only \
+      destinations are webhooks with invalid URLs.
       """)
 
       UserTrigger.update_is_active(ut.id, ut.user_id, false)
@@ -247,22 +251,24 @@ defmodule Sanbase.Alert.Scheduler do
     rest
   end
 
-  defp ip_webhook_trigger?(%UserTrigger{trigger: %{settings: %{channel: channel}}}) do
-    channel
-    |> List.wrap()
-    |> Enum.any?(fn entry ->
-      case NotificationChannel.webhook_url(entry) do
-        {:ok, url} -> webhook_url_ip_host?(url)
-        :error -> false
-      end
-    end)
+  defp only_bad_webhook_url_channels?(%UserTrigger{trigger: %{settings: %{channel: channel}}}) do
+    case List.wrap(channel) do
+      [] -> false
+      entries -> Enum.all?(entries, &bad_webhook_url_entry?/1)
+    end
   end
 
-  defp ip_webhook_trigger?(_user_trigger), do: false
+  defp only_bad_webhook_url_channels?(_user_trigger), do: false
 
-  defp webhook_url_ip_host?(url) do
-    host = URI.parse(url).host
-    is_binary(host) and Sanbase.Utils.IP.ip_address?(host)
+  # True only for webhook entries whose URL fails validation. Entries of
+  # other channel types are not bad entries.
+  defp bad_webhook_url_entry?(entry) do
+    with {:ok, url} <- NotificationChannel.webhook_url(entry),
+         {:error, _} <- Sanbase.Utils.Validation.valid_webhook_url?(url) do
+      true
+    else
+      _ -> false
+    end
   end
 
   defp filter_receivable_triggers(user_triggers, info_map) do
@@ -349,6 +355,10 @@ defmodule Sanbase.Alert.Scheduler do
       max_concurrency: 15,
       ordered: false,
       map_type: :map,
+      # A killed task loses the not-yet-recorded send results of its in-flight
+      # trigger, which resends on the next run. Keep the timeout a generous
+      # backstop so that does not happen for legitimately slow rounds.
+      timeout: 60_000,
       on_timeout: :kill_task
     )
     |> List.flatten()
@@ -369,7 +379,9 @@ defmodule Sanbase.Alert.Scheduler do
 
           user_trigger = update_trigger_after_send(user_trigger, send_results_map, info_map)
 
-          emit_event({:ok, user_trigger}, :alert_triggered, %{})
+          if send_results_map.any_success? do
+            emit_event({:ok, user_trigger}, :alert_triggered, %{})
+          end
 
           {user_trigger, list}
       end
@@ -394,46 +406,38 @@ defmodule Sanbase.Alert.Scheduler do
         from batch #{index} task for sending them timed out. List of timedout alerts: \
         #{Enum.join(failed_ids, ", ")}
         """)
-
-        # Timed out sends count as failed rounds, so alerts that keep timing
-        # out also get auto-disabled eventually.
-        triggers
-        |> Enum.filter(&(&1.id in failed_ids))
-        |> Enum.each(&record_timed_out_send(&1, info_map))
     end
 
     result
   end
 
-  # The killed task left no per-identifier results - record a single failed
-  # send without touching `last_triggered`.
-  defp record_timed_out_send(%UserTrigger{} = user_trigger, info_map) do
-    send_results_map = %{
-      last_triggered: user_trigger.trigger.last_triggered,
-      any_success?: false,
-      any_delivery_failure?: true,
-      delivery_failures_count: 1
-    }
-
-    update_trigger_after_send(user_trigger, send_results_map, info_map)
-  end
-
   defp update_trigger_after_send(user_trigger, send_results_map, info_map) do
     failing_state = Trigger.FailingState.next(user_trigger.trigger, send_results_map)
-    deactivate? = Trigger.FailingState.deactivate?(failing_state)
+
+    deactivation_reason =
+      cond do
+        Trigger.FailingState.deactivate_now?(send_results_map) ->
+          "of permanent send failures: #{inspect(send_results_map.permanent_failure_reasons)}"
+
+        Trigger.FailingState.deactivate?(failing_state) ->
+          "sending it failed on #{failing_state.consecutive_failed_days} consecutive days " <>
+            "(#{failing_state.failed_attempts} failed sends since #{failing_state.failing_since})"
+
+        true ->
+          nil
+      end
 
     {:ok, updated_user_trigger} =
       UserTrigger.record_send_result(user_trigger, %{
         last_triggered: send_results_map.last_triggered,
         failing_state: failing_state,
-        deactivate?: deactivate?
+        deactivate?: deactivation_reason != nil
       })
 
-    if deactivate? do
+    if deactivation_reason do
       Logger.info("""
       [#{info_map.run_uuid}] Deactivating alert with id #{user_trigger.id} because \
-      sending it failed on #{failing_state.consecutive_failed_days} consecutive days \
-      (#{failing_state.failed_attempts} failed sends since #{failing_state.failing_since}).
+      #{deactivation_reason}.
       """)
     end
 
@@ -454,25 +458,36 @@ defmodule Sanbase.Alert.Scheduler do
 
     # Failed sends are not marked as triggered - the alert fires for them
     # again on the next run.
-    {last_triggered, any_success?, delivery_failures_count} =
+    {last_triggered, any_success?, delivery_failures_count, permanent_failure_reasons} =
       send_results_list
-      |> Enum.reduce({last_triggered, _any_success = false, _delivery_failures = 0}, fn
-        {identifier_or_list, _result = :ok}, {acc, _any_success, delivery_failures} ->
+      |> Enum.reduce({last_triggered, false, 0, []}, fn
+        {identifier_or_list, _result = :ok}, {acc, _any_success, delivery_failures, permanent} ->
           # Example: {["elem1", "elem2"], :ok} or {"0x4efb548a2cb8f0af7c591cef21053f6875b5d38f", :ok}
           # This case happens when multiple identifiers (for example emerging words)
           # are handled in one notification.
           list = identifier_or_list |> List.wrap()
           acc = Enum.reduce(list, acc, &Map.put(&2, &1, now))
 
-          {acc, true, delivery_failures}
+          {acc, true, delivery_failures, permanent}
 
-        {_identifier_or_list, error_result}, {acc, any_success, delivery_failures} ->
+        {_identifier_or_list, error_result}, {acc, any_success, delivery_failures, permanent} ->
           delivery_failures =
             if Trigger.FailingState.delivery_failure?(error_result),
               do: delivery_failures + 1,
               else: delivery_failures
 
-          {acc, any_success, delivery_failures}
+          permanent =
+            case error_result do
+              {:error, %{reason: reason}} ->
+                if Trigger.FailingState.permanent_failure?(error_result),
+                  do: [reason | permanent],
+                  else: permanent
+
+              _ ->
+                permanent
+            end
+
+          {acc, any_success, delivery_failures, permanent}
       end)
 
     {:ok,
@@ -480,36 +495,45 @@ defmodule Sanbase.Alert.Scheduler do
        last_triggered: last_triggered,
        any_success?: any_success?,
        any_delivery_failure?: delivery_failures_count > 0,
-       delivery_failures_count: delivery_failures_count
+       delivery_failures_count: delivery_failures_count,
+       permanent_failure_reasons: Enum.uniq(permanent_failure_reasons),
+       all_permanent_failures?:
+         send_results_list != [] and
+           length(permanent_failure_reasons) == length(send_results_list)
      }}
   end
 
-  defp get_fired_alerts_data(user_triggers) do
-    user_triggers
+  # A trigger can be evaluated while all of its deliveries fail. In that case
+  # `last_triggered` deliberately remains unchanged so it can be retried, but
+  # its old value must not be recorded as a newly fired historical activity.
+  defp get_fired_alerts_data(send_results) do
+    send_results
     |> Enum.map(fn
-      %UserTrigger{
-        trigger: %{
-          settings: %{triggered?: true} = settings,
-          last_triggered: last_triggered
-        }
-      } = ut
-      when is_non_empty_map(last_triggered) ->
-        identifier_kv_map =
-          settings.template_kv
-          |> Enum.into(%{}, fn {identifier, {_, kv}} -> {identifier, kv} end)
-
-        %{
-          user_trigger_id: ut.id,
-          user_id: ut.user_id,
-          payload: settings.payload,
-          triggered_at: max_last_triggered(last_triggered) |> DateTime.to_naive(),
-          data: %{user_trigger_data: identifier_kv_map}
-        }
-
-      _ ->
-        nil
+      {ut, results} when is_list(results) and results != [] -> fired_alert_data(ut, results)
+      _ -> nil
     end)
     |> Enum.reject(&is_nil/1)
+  end
+
+  defp fired_alert_data(%UserTrigger{} = ut, results) do
+    %{trigger: %{settings: settings, last_triggered: last_triggered}} = ut
+
+    delivered? = Enum.any?(results, fn {_identifier, result} -> result == :ok end)
+
+    if match?(%{triggered?: true}, settings) and delivered? and
+         is_non_empty_map(last_triggered) do
+      identifier_kv_map =
+        settings.template_kv
+        |> Enum.into(%{}, fn {identifier, {_, kv}} -> {identifier, kv} end)
+
+      %{
+        user_trigger_id: ut.id,
+        user_id: ut.user_id,
+        payload: settings.payload,
+        triggered_at: max_last_triggered(last_triggered) |> DateTime.to_naive(),
+        data: %{user_trigger_data: identifier_kv_map}
+      }
+    end
   end
 
   # Fixme: remove after frontend migrates to use only Timeline Events

--- a/lib/sanbase/alerts/evaluator/scheduler.ex
+++ b/lib/sanbase/alerts/evaluator/scheduler.ex
@@ -11,8 +11,9 @@ defmodule Sanbase.Alert.Scheduler do
   """
 
   alias Sanbase.Accounts.User
-  alias Sanbase.Alert.{UserTrigger, HistoricalActivity}
+  alias Sanbase.Alert.{Trigger, UserTrigger, HistoricalActivity}
   alias Sanbase.Alert.Evaluator
+  alias Sanbase.Alert.Validation.NotificationChannel
   alias Sanbase.Alert
 
   import Sanbase.Alert.EventEmitter, only: [emit_event: 3]
@@ -59,6 +60,7 @@ defmodule Sanbase.Alert.Scheduler do
     alerts =
       type
       |> UserTrigger.get_active_triggers_by_type()
+      |> deactivate_ip_webhook_triggers(info_map)
       |> filter_receivable_triggers(info_map)
       |> filter_not_frozen_triggers(info_map)
 
@@ -228,6 +230,41 @@ defmodule Sanbase.Alert.Scheduler do
     filtered
   end
 
+  # IP address webhook destinations are not allowed. Deactivate legacy alerts
+  # that still have one instead of evaluating them.
+  defp deactivate_ip_webhook_triggers(user_triggers, info_map) do
+    {ip_webhook_triggers, rest} = Enum.split_with(user_triggers, &ip_webhook_trigger?/1)
+
+    for %UserTrigger{} = ut <- ip_webhook_triggers do
+      Logger.info("""
+      [#{info_map.run_uuid}] Deactivating alert with id #{ut.id} because its webhook \
+      destination host is an IP address, which is not allowed.
+      """)
+
+      UserTrigger.update_is_active(ut.id, ut.user_id, false)
+    end
+
+    rest
+  end
+
+  defp ip_webhook_trigger?(%UserTrigger{trigger: %{settings: %{channel: channel}}}) do
+    channel
+    |> List.wrap()
+    |> Enum.any?(fn entry ->
+      case NotificationChannel.webhook_url(entry) do
+        {:ok, url} -> webhook_url_ip_host?(url)
+        :error -> false
+      end
+    end)
+  end
+
+  defp ip_webhook_trigger?(_user_trigger), do: false
+
+  defp webhook_url_ip_host?(url) do
+    host = URI.parse(url).host
+    is_binary(host) and Sanbase.Utils.IP.ip_address?(host)
+  end
+
   defp filter_receivable_triggers(user_triggers, info_map) do
     %{type: type, run_uuid: run_uuid} = info_map
 
@@ -308,7 +345,7 @@ defmodule Sanbase.Alert.Scheduler do
     # a matching error is raised
     grouped_by_user
     |> Sanbase.Parallel.map(
-      fn {_user_id, triggers} -> send_triggers_sequentially(triggers) end,
+      fn {_user_id, triggers} -> send_triggers_sequentially(triggers, info_map) end,
       max_concurrency: 15,
       ordered: false,
       map_type: :map,
@@ -320,7 +357,7 @@ defmodule Sanbase.Alert.Scheduler do
     |> Enum.unzip()
   end
 
-  def send_triggers_sequentially(triggers) do
+  def send_triggers_sequentially(triggers, info_map) do
     triggers
     |> Enum.map(fn %UserTrigger{} = user_trigger ->
       case Alert.send(user_trigger) do
@@ -328,9 +365,9 @@ defmodule Sanbase.Alert.Scheduler do
           {user_trigger, []}
 
         list when is_list(list) ->
-          {:ok, %{last_triggered: last_triggered}} = handle_send_results_list(user_trigger, list)
+          {:ok, send_results_map} = handle_send_results_list(user_trigger, list)
 
-          user_trigger = update_trigger_last_triggered(user_trigger, last_triggered)
+          user_trigger = update_trigger_after_send(user_trigger, send_results_map, info_map)
 
           emit_event({:ok, user_trigger}, :alert_triggered, %{})
 
@@ -357,23 +394,50 @@ defmodule Sanbase.Alert.Scheduler do
         from batch #{index} task for sending them timed out. List of timedout alerts: \
         #{Enum.join(failed_ids, ", ")}
         """)
+
+        # Timed out sends count as failed rounds, so alerts that keep timing
+        # out also get auto-disabled eventually.
+        triggers
+        |> Enum.filter(&(&1.id in failed_ids))
+        |> Enum.each(&record_timed_out_send(&1, info_map))
     end
 
     result
   end
 
-  defp update_trigger_last_triggered(user_trigger, last_triggered) do
+  # The killed task left no per-identifier results - record a single failed
+  # send without touching `last_triggered`.
+  defp record_timed_out_send(%UserTrigger{} = user_trigger, info_map) do
+    send_results_map = %{
+      last_triggered: user_trigger.trigger.last_triggered,
+      any_success?: false,
+      any_delivery_failure?: true,
+      delivery_failures_count: 1
+    }
+
+    update_trigger_after_send(user_trigger, send_results_map, info_map)
+  end
+
+  defp update_trigger_after_send(user_trigger, send_results_map, info_map) do
+    failing_state = Trigger.FailingState.next(user_trigger.trigger, send_results_map)
+    deactivate? = Trigger.FailingState.deactivate?(failing_state)
+
     {:ok, updated_user_trigger} =
-      UserTrigger.update_user_trigger(user_trigger.user.id, %{
-        id: user_trigger.id,
-        last_triggered: last_triggered,
-        settings: user_trigger.trigger.settings
+      UserTrigger.record_send_result(user_trigger, %{
+        last_triggered: send_results_map.last_triggered,
+        failing_state: failing_state,
+        deactivate?: deactivate?
       })
 
-    put_in(
-      user_trigger.trigger.last_triggered,
-      updated_user_trigger.trigger.last_triggered
-    )
+    if deactivate? do
+      Logger.info("""
+      [#{info_map.run_uuid}] Deactivating alert with id #{user_trigger.id} because \
+      sending it failed on #{failing_state.consecutive_failed_days} consecutive days \
+      (#{failing_state.failed_attempts} failed sends since #{failing_state.failing_since}).
+      """)
+    end
+
+    updated_user_trigger
   end
 
   defp handle_send_results_list(
@@ -388,35 +452,35 @@ defmodule Sanbase.Alert.Scheduler do
       |> Sanbase.Utils.DateTime.round_datetime(second: 30)
       |> Timex.set(microsecond: {0, 0})
 
-    # Update all triggered_at regardless if the send to the channel succeed
-    # because the alert will be stored in the timeline events.
-    # Keep count of the total alerts triggered and the number of alerts
-    # that were not sent successfully. Reasons can be:
-    # - missing email/telegram linked when such channel is chosen;
-    # - webhook failed to be sent;
-    # - daily alerts limit is reached;
-    {last_triggered, total_triggered, total_failed} =
+    # Failed sends are not marked as triggered - the alert fires for them
+    # again on the next run.
+    {last_triggered, any_success?, delivery_failures_count} =
       send_results_list
-      |> Enum.reduce({last_triggered, _total = 0, _failed = 0}, fn
-        {identifier_or_list, _result = :ok}, {acc, total, failed} ->
+      |> Enum.reduce({last_triggered, _any_success = false, _delivery_failures = 0}, fn
+        {identifier_or_list, _result = :ok}, {acc, _any_success, delivery_failures} ->
           # Example: {["elem1", "elem2"], :ok} or {"0x4efb548a2cb8f0af7c591cef21053f6875b5d38f", :ok}
           # This case happens when multiple identifiers (for example emerging words)
           # are handled in one notification.
           list = identifier_or_list |> List.wrap()
           acc = Enum.reduce(list, acc, &Map.put(&2, &1, now))
 
-          {acc, total + 1, failed}
+          {acc, true, delivery_failures}
 
-        {_identifier_or_list, _error_result}, {acc, total, failed} ->
-          {acc, total + 1, failed + 1}
+        {_identifier_or_list, error_result}, {acc, any_success, delivery_failures} ->
+          delivery_failures =
+            if Trigger.FailingState.delivery_failure?(error_result),
+              do: delivery_failures + 1,
+              else: delivery_failures
+
+          {acc, any_success, delivery_failures}
       end)
 
     {:ok,
      %{
        last_triggered: last_triggered,
-       total_triggered: total_triggered,
-       total_sent_succesfully: total_triggered - total_failed,
-       total_sent_failed: total_failed
+       any_success?: any_success?,
+       any_delivery_failure?: delivery_failures_count > 0,
+       delivery_failures_count: delivery_failures_count
      }}
   end
 

--- a/lib/sanbase/alerts/trigger/failing_state.ex
+++ b/lib/sanbase/alerts/trigger/failing_state.ex
@@ -1,0 +1,70 @@
+defmodule Sanbase.Alert.Trigger.FailingState do
+  @moduledoc ~s"""
+  Tracks alerts whose sends keep failing and decides when to auto-disable
+  them. The state lives in the `failing_since`, `failed_attempts`,
+  `consecutive_failed_days` and `last_failed_on` fields of the trigger embed.
+  """
+
+  alias Sanbase.Alert.Trigger
+
+  @consecutive_failed_days_before_deactivation 7
+
+  @doc ~s"""
+  Compute the trigger's next failing state from a send round: a success
+  clears it, delivery failures extend it, anything else keeps it unchanged.
+  """
+  def next(%Trigger{}, %{any_success?: true}) do
+    %{failing_since: nil, failed_attempts: 0, consecutive_failed_days: 0, last_failed_on: nil}
+  end
+
+  def next(%Trigger{} = trigger, %{any_delivery_failure?: true} = results) do
+    today = Date.utc_today()
+
+    consecutive_failed_days =
+      cond do
+        trigger.last_failed_on == today ->
+          max(trigger.consecutive_failed_days || 0, 1)
+
+        trigger.last_failed_on == Date.add(today, -1) ->
+          (trigger.consecutive_failed_days || 0) + 1
+
+        # First failure, or the chain was broken by a day without failures
+        true ->
+          1
+      end
+
+    %{
+      failing_since: trigger.failing_since || DateTime.utc_now() |> DateTime.truncate(:second),
+      failed_attempts: (trigger.failed_attempts || 0) + results.delivery_failures_count,
+      consecutive_failed_days: consecutive_failed_days,
+      last_failed_on: today
+    }
+  end
+
+  # Explicit match instead of a catch-all so a malformed results map crashes
+  # rather than silently keeping the state.
+  def next(%Trigger{} = trigger, %{any_success?: false, any_delivery_failure?: false}) do
+    Map.take(trigger, [
+      :failing_since,
+      :failed_attempts,
+      :consecutive_failed_days,
+      :last_failed_on
+    ])
+  end
+
+  @doc ~s"""
+  Send failures that count towards the failing state. The daily alerts limit
+  does not mean the destination is broken, so it does not count.
+  """
+  def delivery_failure?({:error, %{reason: :alerts_limit_reached}}), do: false
+  def delivery_failure?({:error, _}), do: true
+  def delivery_failure?(_result), do: false
+
+  @doc ~s"""
+  Deactivate an alert that failed on 7+ days in a row with no successful send
+  in between. A day without any failed send breaks the chain.
+  """
+  def deactivate?(%{consecutive_failed_days: consecutive_failed_days}) do
+    (consecutive_failed_days || 0) >= @consecutive_failed_days_before_deactivation
+  end
+end

--- a/lib/sanbase/alerts/trigger/failing_state.ex
+++ b/lib/sanbase/alerts/trigger/failing_state.ex
@@ -52,13 +52,41 @@ defmodule Sanbase.Alert.Trigger.FailingState do
     ])
   end
 
+  # Failures split by how they disable an alert. Email failures and telegram
+  # rate limits count as neither - they can be on our side, not the client's.
+  # :telegram_chat_not_found_404 is also excluded: telegram returns 404 for an
+  # invalid bot token (our misconfiguration), not for a missing chat.
+  @permanent_failure_reasons [
+    :webhook_url_not_valid,
+    :telegram_chat_not_found,
+    :telegram_bot_blocked
+  ]
+
+  @streak_failure_reasons [:webhook_send_fail]
+
   @doc ~s"""
-  Send failures that count towards the failing state. The daily alerts limit
-  does not mean the destination is broken, so it does not count.
+  Failures proving the destination itself is broken - an invalid webhook URL
+  or an unreachable telegram chat. They disable the alert on the spot.
   """
-  def delivery_failure?({:error, %{reason: :alerts_limit_reached}}), do: false
-  def delivery_failure?({:error, _}), do: true
+  def permanent_failure?({:error, %{reason: reason}}), do: reason in @permanent_failure_reasons
+  def permanent_failure?(_result), do: false
+
+  @doc ~s"""
+  Possibly transient failures that count towards the failing state and
+  disable the alert only after failing for 7 days in a row.
+  """
+  def delivery_failure?({:error, %{reason: reason}}), do: reason in @streak_failure_reasons
   def delivery_failure?(_result), do: false
+
+  @doc ~s"""
+  Disable the alert immediately - every send attempt of the round failed with
+  a permanent error, so all its destinations are broken. If any channel
+  delivered or failed transiently (email, rate limit), the alert is kept
+  active.
+  """
+  def deactivate_now?(%{all_permanent_failures?: all_permanent_failures?}) do
+    all_permanent_failures?
+  end
 
   @doc ~s"""
   Deactivate an alert that failed on 7+ days in a row with no successful send

--- a/lib/sanbase/alerts/trigger/failing_state.ex
+++ b/lib/sanbase/alerts/trigger/failing_state.ex
@@ -62,7 +62,10 @@ defmodule Sanbase.Alert.Trigger.FailingState do
     :telegram_bot_blocked
   ]
 
-  @streak_failure_reasons [:webhook_send_fail]
+  # A blocked-IP DNS resolution is a streak failure, not a permanent one -
+  # resolvers can transiently return blocked addresses (e.g. DNS-level
+  # ad blocking resolving to 127.0.0.1).
+  @streak_failure_reasons [:webhook_send_fail, :webhook_url_resolves_to_blocked_ip]
 
   @doc ~s"""
   Failures proving the destination itself is broken - an invalid webhook URL

--- a/lib/sanbase/alerts/trigger/trigger.ex
+++ b/lib/sanbase/alerts/trigger/trigger.ex
@@ -53,6 +53,12 @@ defmodule Sanbase.Alert.Trigger do
     field(:icon_url, :string)
     field(:is_active, :boolean, default: true)
     field(:is_repeating, :boolean, default: true)
+    # Failed-sends streak, used to auto-disable alerts. Set while all send
+    # attempts fail, cleared on the first successful send.
+    field(:failing_since, :utc_datetime)
+    field(:failed_attempts, :integer, default: 0)
+    field(:consecutive_failed_days, :integer, default: 0)
+    field(:last_failed_on, :date)
   end
 
   @type t :: %__MODULE__{
@@ -64,7 +70,11 @@ defmodule Sanbase.Alert.Trigger do
           description: String.t(),
           icon_url: String.t(),
           is_active: boolean(),
-          is_repeating: boolean()
+          is_repeating: boolean(),
+          failing_since: DateTime.t() | nil,
+          failed_attempts: non_neg_integer(),
+          consecutive_failed_days: non_neg_integer(),
+          last_failed_on: Date.t() | nil
         }
 
   @doc false
@@ -78,7 +88,11 @@ defmodule Sanbase.Alert.Trigger do
     :description,
     :icon_url,
     :is_active,
-    :is_repeating
+    :is_repeating,
+    :failing_since,
+    :failed_attempts,
+    :consecutive_failed_days,
+    :last_failed_on
   ]
 
   def create_changeset(%__MODULE__{} = trigger, args \\ %{}) do

--- a/lib/sanbase/alerts/trigger/validation/notification_channel_validation.ex
+++ b/lib/sanbase/alerts/trigger/validation/notification_channel_validation.ex
@@ -12,12 +12,32 @@ defmodule Sanbase.Alert.Validation.NotificationChannel do
   def webhook_url(%{webhook: url}) when is_binary(url), do: {:ok, url}
   def webhook_url(_channel), do: :error
 
+  @doc ~s"""
+  Strict validation of the webhook URLs in a channel definition, applied on
+  alert create/update. It is not part of `valid_notification_channel?/1` on
+  purpose - that one also runs on every evaluation and would auto-disable
+  legacy alerts whose other channels still work.
+  """
+  def validate_webhook_urls(channel) do
+    channel
+    |> List.wrap()
+    |> Enum.reduce_while(:ok, fn entry, :ok ->
+      with {:ok, url} <- webhook_url(entry),
+           {:error, _} = error <- Sanbase.Utils.Validation.valid_webhook_url?(url) do
+        {:halt, error}
+      else
+        _ -> {:cont, :ok}
+      end
+    end)
+  end
+
   # TODO: Check if the key => value checks are needed
+  # The webhook checks are structural only - see validate_webhook_urls/1
   def valid_notification_channel?(%{"webhook" => webhook_url}) when is_binary(webhook_url),
-    do: Sanbase.Utils.Validation.valid_webhook_url?(webhook_url)
+    do: :ok
 
   def valid_notification_channel?(%{webhook: webhook_url}) when is_binary(webhook_url),
-    do: Sanbase.Utils.Validation.valid_webhook_url?(webhook_url)
+    do: :ok
 
   def valid_notification_channel?(%{"telegram_channel" => telegram_channel})
       when is_binary(telegram_channel),

--- a/lib/sanbase/alerts/trigger/validation/notification_channel_validation.ex
+++ b/lib/sanbase/alerts/trigger/validation/notification_channel_validation.ex
@@ -4,12 +4,20 @@ defmodule Sanbase.Alert.Validation.NotificationChannel do
 
   def valid_notification_channels(), do: @notification_channels
 
+  @doc ~s"""
+  Extract the webhook URL from a channel entry, in both its stored
+  (string-key) and loaded (atom-key) shape.
+  """
+  def webhook_url(%{"webhook" => url}) when is_binary(url), do: {:ok, url}
+  def webhook_url(%{webhook: url}) when is_binary(url), do: {:ok, url}
+  def webhook_url(_channel), do: :error
+
   # TODO: Check if the key => value checks are needed
   def valid_notification_channel?(%{"webhook" => webhook_url}) when is_binary(webhook_url),
-    do: Sanbase.Utils.Validation.valid_public_url?(webhook_url)
+    do: Sanbase.Utils.Validation.valid_webhook_url?(webhook_url)
 
   def valid_notification_channel?(%{webhook: webhook_url}) when is_binary(webhook_url),
-    do: Sanbase.Utils.Validation.valid_public_url?(webhook_url)
+    do: Sanbase.Utils.Validation.valid_webhook_url?(webhook_url)
 
   def valid_notification_channel?(%{"telegram_channel" => telegram_channel})
       when is_binary(telegram_channel),

--- a/lib/sanbase/alerts/user_trigger.ex
+++ b/lib/sanbase/alerts/user_trigger.ex
@@ -88,6 +88,45 @@ defmodule Sanbase.Alert.UserTrigger do
   end
 
   @doc ~s"""
+  Persist the `last_triggered` datetime of the given identifier(s) right
+  after a successful send, so an already-received alert is not sent again
+  if the process is killed before the end-of-round write.
+  """
+  def stamp_last_triggered(user_trigger_id, identifier_or_list, %DateTime{} = datetime) do
+    iso = DateTime.to_iso8601(datetime)
+
+    for identifier <- List.wrap(identifier_or_list) do
+      # The inner jsonb_set initializes a missing/null 'last_triggered' parent
+      # (possible on legacy rows) - without it the outer jsonb_set would
+      # silently leave the row unchanged.
+      from(ut in __MODULE__,
+        where: ut.id == ^user_trigger_id,
+        update: [
+          set: [
+            trigger:
+              fragment(
+                """
+                jsonb_set(
+                  jsonb_set(?, '{last_triggered}', COALESCE(NULLIF(? -> 'last_triggered', 'null'::jsonb), '{}'::jsonb)),
+                  ARRAY['last_triggered', ?],
+                  to_jsonb(?::text)
+                )
+                """,
+                ut.trigger,
+                ut.trigger,
+                ^identifier,
+                ^iso
+              )
+          ]
+        ]
+      )
+      |> Repo.update_all([])
+    end
+
+    :ok
+  end
+
+  @doc ~s"""
   Persist the result of an alert send round in a single write. Internal API
   for the scheduler: unlike `update_user_trigger/2` it keeps nil values (so
   the failing state can be cleared) and does not re-validate the settings.
@@ -493,6 +532,11 @@ defmodule Sanbase.Alert.UserTrigger do
   defp validate_settings(settings) do
     with {_, {:ok, trigger_struct}} <- {:load_in_struct?, load_in_struct_if_valid(settings)},
          {_, true} <- {:validate_settings, Vex.valid?(trigger_struct)},
+         {_, :ok} <-
+           {:webhook_urls,
+            Sanbase.Alert.Validation.NotificationChannel.validate_webhook_urls(
+              Map.get(trigger_struct, :channel)
+            )},
          {_, {:ok, _trigger_map}} <- {:map_from_struct, map_from_struct(trigger_struct)} do
       :ok
     else
@@ -511,6 +555,10 @@ defmodule Sanbase.Alert.UserTrigger do
         Logger.warning("UserTrigger struct is not valid. Reason: #{inspect(errors_text)}")
 
         {:error, errors_text}
+
+      {:webhook_urls, {:error, error}} ->
+        Logger.warning("UserTrigger struct is not valid. Reason: #{inspect(error)}")
+        {:error, error}
 
       {:map_from_struct, {:error, error}} ->
         Logger.warning("UserTrigger struct is not valid. Reason: #{inspect(error)}")

--- a/lib/sanbase/alerts/user_trigger.ex
+++ b/lib/sanbase/alerts/user_trigger.ex
@@ -87,6 +87,27 @@ defmodule Sanbase.Alert.UserTrigger do
     })
   end
 
+  @doc ~s"""
+  Persist the result of an alert send round in a single write. Internal API
+  for the scheduler: unlike `update_user_trigger/2` it keeps nil values (so
+  the failing state can be cleared) and does not re-validate the settings.
+  """
+  def record_send_result(%__MODULE__{} = user_trigger, %{
+        last_triggered: last_triggered,
+        failing_state: %{} = failing_state,
+        deactivate?: deactivate?
+      }) do
+    attrs =
+      %{last_triggered: last_triggered, settings: user_trigger.trigger.settings}
+      |> Map.merge(failing_state)
+
+    attrs = if deactivate?, do: Map.put(attrs, :is_active, false), else: attrs
+
+    user_trigger
+    |> update_changeset(%{trigger: attrs})
+    |> Repo.update()
+  end
+
   @impl Sanbase.Entity.Behaviour
   # is_public is virtual (computed from the embedded trigger), so the default
   # helper that selects it directly doesn't work here.

--- a/lib/sanbase/utils/ip_utils.ex
+++ b/lib/sanbase/utils/ip_utils.ex
@@ -25,6 +25,14 @@ defmodule Sanbase.Utils.IP do
   def ip_tuple_to_string(ip), do: ip |> :inet_parse.ntoa() |> to_string()
 
   @doc ~s"""
+  Returns `true` when the string is an IPv4 or IPv6 address literal,
+  including shortened IPv4 forms like "127.1".
+  """
+  def ip_address?(host) when is_binary(host) do
+    match?({:ok, _}, :inet.parse_address(to_charlist(host)))
+  end
+
+  @doc ~s"""
   Returns `true` when the host is private, reserved, loopback, link-local,
   multicast, broadcast, or a known cloud-metadata endpoint. Use this when
   validating user-supplied URLs to prevent SSRF (e.g. webhook destinations

--- a/lib/sanbase/utils/ip_utils.ex
+++ b/lib/sanbase/utils/ip_utils.ex
@@ -33,6 +33,26 @@ defmodule Sanbase.Utils.IP do
   end
 
   @doc ~s"""
+  Returns `true` when the host resolves to a private, reserved or otherwise
+  blocked address. An extra SSRF guard for user-supplied URLs - the URL
+  validation checks the host literal, not what it resolves to (DNS
+  rebinding). Unresolvable hosts return `false` - connecting to them fails
+  on its own.
+  """
+  def resolves_to_blocked_ip?(host) when is_binary(host) do
+    charlist = to_charlist(host)
+
+    [:inet, :inet6]
+    |> Enum.flat_map(fn family ->
+      case :inet.gethostbyname(charlist, family) do
+        {:ok, {:hostent, _name, _aliases, _addrtype, _length, addrs}} -> addrs
+        {:error, _} -> []
+      end
+    end)
+    |> Enum.any?(&private_or_reserved?/1)
+  end
+
+  @doc ~s"""
   Returns `true` when the host is private, reserved, loopback, link-local,
   multicast, broadcast, or a known cloud-metadata endpoint. Use this when
   validating user-supplied URLs to prevent SSRF (e.g. webhook destinations

--- a/lib/sanbase/utils/validation.ex
+++ b/lib/sanbase/utils/validation.ex
@@ -148,6 +148,27 @@ defmodule Sanbase.Utils.Validation do
     end
   end
 
+  @doc ~s"""
+  Like `valid_public_url?/2` but stricter, for webhook destinations: https
+  only and no IP address hosts.
+  """
+  def valid_webhook_url?(url, opts \\ []) do
+    with :ok <- valid_public_url?(url, opts) do
+      uri = URI.parse(url)
+
+      cond do
+        uri.scheme != "https" ->
+          {:error, "URL '#{url}' must use the https scheme"}
+
+        Sanbase.Utils.IP.ip_address?(uri.host) ->
+          {:error, "URL host '#{uri.host}' is an IP address. Webhook URLs must use a domain name"}
+
+        true ->
+          :ok
+      end
+    end
+  end
+
   # Private functions
 
   defp time_window_format_check(time_window) do

--- a/test/sanbase/alerts/failing_state_test.exs
+++ b/test/sanbase/alerts/failing_state_test.exs
@@ -33,6 +33,16 @@ defmodule Sanbase.Alert.Trigger.FailingStateTest do
       assert FailingState.delivery_failure?({:error, %{reason: :webhook_send_fail}})
     end
 
+    test "blocked-IP DNS resolutions count as streak failures, not permanent ones" do
+      assert FailingState.delivery_failure?(
+               {:error, %{reason: :webhook_url_resolves_to_blocked_ip}}
+             )
+
+      refute FailingState.permanent_failure?(
+               {:error, %{reason: :webhook_url_resolves_to_blocked_ip}}
+             )
+    end
+
     test "permanent failures do not count - they disable on the spot instead" do
       refute FailingState.delivery_failure?({:error, %{reason: :webhook_url_not_valid}})
       refute FailingState.delivery_failure?({:error, %{reason: :telegram_bot_blocked}})

--- a/test/sanbase/alerts/failing_state_test.exs
+++ b/test/sanbase/alerts/failing_state_test.exs
@@ -1,0 +1,182 @@
+defmodule Sanbase.Alert.Trigger.FailingStateTest do
+  use ExUnit.Case, async: true
+
+  alias Sanbase.Alert.Trigger
+  alias Sanbase.Alert.Trigger.FailingState
+
+  describe "permanent_failure?/1 - disables the alert on the spot" do
+    test "invalid webhook URL is permanent" do
+      assert FailingState.permanent_failure?({:error, %{reason: :webhook_url_not_valid}})
+    end
+
+    test "unreachable telegram chats are permanent" do
+      assert FailingState.permanent_failure?({:error, %{reason: :telegram_chat_not_found}})
+      assert FailingState.permanent_failure?({:error, %{reason: :telegram_bot_blocked}})
+    end
+
+    test "telegram 404 is not permanent - it means an invalid bot token, which is on us" do
+      refute FailingState.permanent_failure?({:error, %{reason: :telegram_chat_not_found_404}})
+    end
+
+    test "webhook send failures are not permanent - they take the 7-day path" do
+      refute FailingState.permanent_failure?({:error, %{reason: :webhook_send_fail}})
+    end
+
+    test "email failures and rate limits are not permanent" do
+      refute FailingState.permanent_failure?({:error, %{reason: :email_send_fail}})
+      refute FailingState.permanent_failure?({:error, "Too Many Requests: retry after 5"})
+    end
+  end
+
+  describe "delivery_failure?/1 - counts towards the 7-day streak" do
+    test "webhook send failures count" do
+      assert FailingState.delivery_failure?({:error, %{reason: :webhook_send_fail}})
+    end
+
+    test "permanent failures do not count - they disable on the spot instead" do
+      refute FailingState.delivery_failure?({:error, %{reason: :webhook_url_not_valid}})
+      refute FailingState.delivery_failure?({:error, %{reason: :telegram_bot_blocked}})
+    end
+
+    test "email failures do not count - they can be on our provider's side" do
+      refute FailingState.delivery_failure?({:error, %{reason: :email_send_fail}})
+    end
+
+    test "telegram rate limits and other raw errors do not count" do
+      refute FailingState.delivery_failure?({:error, "Too Many Requests: retry after 5"})
+    end
+
+    test "daily alerts limit does not count" do
+      refute FailingState.delivery_failure?({:error, %{reason: :alerts_limit_reached}})
+    end
+
+    test "successful sends do not count" do
+      refute FailingState.delivery_failure?(:ok)
+    end
+  end
+
+  describe "deactivate_now?/1" do
+    test "disables immediately when all sends failed permanently" do
+      assert FailingState.deactivate_now?(%{all_permanent_failures?: true})
+    end
+
+    test "keeps the alert when any channel delivered or failed transiently" do
+      refute FailingState.deactivate_now?(%{all_permanent_failures?: false})
+    end
+  end
+
+  describe "next/2" do
+    test "a success clears the state" do
+      trigger = %Trigger{
+        failing_since: ~U[2026-08-01 00:00:00Z],
+        failed_attempts: 10,
+        consecutive_failed_days: 5,
+        last_failed_on: ~D[2026-08-05]
+      }
+
+      assert FailingState.next(trigger, %{any_success?: true}) == %{
+               failing_since: nil,
+               failed_attempts: 0,
+               consecutive_failed_days: 0,
+               last_failed_on: nil
+             }
+    end
+
+    test "first failure starts the state" do
+      state =
+        FailingState.next(%Trigger{}, %{
+          any_success?: false,
+          any_delivery_failure?: true,
+          delivery_failures_count: 2
+        })
+
+      assert %DateTime{} = state.failing_since
+      assert state.failed_attempts == 2
+      assert state.consecutive_failed_days == 1
+      assert state.last_failed_on == Date.utc_today()
+    end
+
+    test "failure on the next day extends the day chain" do
+      trigger = %Trigger{
+        failing_since: ~U[2026-08-01 00:00:00Z],
+        failed_attempts: 5,
+        consecutive_failed_days: 3,
+        last_failed_on: Date.add(Date.utc_today(), -1)
+      }
+
+      state =
+        FailingState.next(trigger, %{
+          any_success?: false,
+          any_delivery_failure?: true,
+          delivery_failures_count: 1
+        })
+
+      assert state.consecutive_failed_days == 4
+      assert state.failed_attempts == 6
+      assert state.failing_since == trigger.failing_since
+    end
+
+    test "repeated failures within the same day do not extend the day chain" do
+      trigger = %Trigger{
+        failing_since: ~U[2026-08-01 00:00:00Z],
+        failed_attempts: 5,
+        consecutive_failed_days: 3,
+        last_failed_on: Date.utc_today()
+      }
+
+      state =
+        FailingState.next(trigger, %{
+          any_success?: false,
+          any_delivery_failure?: true,
+          delivery_failures_count: 1
+        })
+
+      assert state.consecutive_failed_days == 3
+      assert state.failed_attempts == 6
+    end
+
+    test "a day without failures restarts the day chain" do
+      trigger = %Trigger{
+        failing_since: ~U[2026-08-01 00:00:00Z],
+        failed_attempts: 5,
+        consecutive_failed_days: 6,
+        last_failed_on: Date.add(Date.utc_today(), -3)
+      }
+
+      state =
+        FailingState.next(trigger, %{
+          any_success?: false,
+          any_delivery_failure?: true,
+          delivery_failures_count: 1
+        })
+
+      assert state.consecutive_failed_days == 1
+      assert state.failing_since == trigger.failing_since
+    end
+
+    test "a round with neither success nor delivery failure keeps the state" do
+      trigger = %Trigger{
+        failing_since: ~U[2026-08-01 00:00:00Z],
+        failed_attempts: 5,
+        consecutive_failed_days: 3,
+        last_failed_on: ~D[2026-08-05]
+      }
+
+      assert FailingState.next(trigger, %{any_success?: false, any_delivery_failure?: false}) ==
+               %{
+                 failing_since: trigger.failing_since,
+                 failed_attempts: 5,
+                 consecutive_failed_days: 3,
+                 last_failed_on: trigger.last_failed_on
+               }
+    end
+  end
+
+  describe "deactivate?/1" do
+    test "deactivates at 7 consecutive failed days" do
+      refute FailingState.deactivate?(%{consecutive_failed_days: 6})
+      assert FailingState.deactivate?(%{consecutive_failed_days: 7})
+      assert FailingState.deactivate?(%{consecutive_failed_days: 8})
+    end
+  end
+end

--- a/test/sanbase/alerts/notification_channel_validation_test.exs
+++ b/test/sanbase/alerts/notification_channel_validation_test.exs
@@ -55,36 +55,58 @@ defmodule Sanbase.Alert.Validation.NotificationChannelTest do
       assert {:error, _} = NotificationChannel.valid_notification_channel?(%{webhook: 123})
     end
 
-    test "webhook with http URL is rejected" do
+    test "webhook URL policy is not checked here - it runs on create/update only" do
+      assert NotificationChannel.valid_notification_channel?(%{webhook: "http://example.com/x"}) ==
+               :ok
+    end
+  end
+
+  describe "validate_webhook_urls/1" do
+    test "valid https domain URLs are accepted" do
+      assert NotificationChannel.validate_webhook_urls(%{webhook: "https://example.com/x"}) == :ok
+
+      assert NotificationChannel.validate_webhook_urls([
+               "telegram",
+               %{"webhook" => "https://example.com/x"}
+             ]) == :ok
+    end
+
+    test "non-webhook channels are ignored" do
+      assert NotificationChannel.validate_webhook_urls(["telegram", "email"]) == :ok
+      assert NotificationChannel.validate_webhook_urls(nil) == :ok
+    end
+
+    test "http URL is rejected" do
       assert {:error, error} =
-               NotificationChannel.valid_notification_channel?(%{webhook: "http://example.com/x"})
+               NotificationChannel.validate_webhook_urls(%{webhook: "http://example.com/x"})
 
       assert error =~ "must use the https scheme"
 
       assert {:error, _} =
-               NotificationChannel.valid_notification_channel?(%{
-                 "webhook" => "http://example.com/x"
-               })
+               NotificationChannel.validate_webhook_urls([
+                 "telegram",
+                 %{"webhook" => "http://example.com/x"}
+               ])
     end
 
-    test "webhook with IP address host is rejected" do
+    test "IP address host is rejected" do
       assert {:error, error} =
-               NotificationChannel.valid_notification_channel?(%{webhook: "https://8.8.8.8/x"})
+               NotificationChannel.validate_webhook_urls(%{webhook: "https://8.8.8.8/x"})
 
       assert error =~ "is an IP address"
 
       assert {:error, _} =
-               NotificationChannel.valid_notification_channel?(%{
+               NotificationChannel.validate_webhook_urls(%{
                  "webhook" => "https://[2606:4700::1111]/x"
                })
     end
 
-    test "webhook with private IP or localhost is rejected" do
+    test "private IP or localhost is rejected" do
       assert {:error, _} =
-               NotificationChannel.valid_notification_channel?(%{webhook: "https://127.0.0.1/x"})
+               NotificationChannel.validate_webhook_urls(%{webhook: "https://127.0.0.1/x"})
 
       assert {:error, _} =
-               NotificationChannel.valid_notification_channel?(%{webhook: "https://localhost/x"})
+               NotificationChannel.validate_webhook_urls(%{webhook: "https://localhost/x"})
     end
 
     test "telegram_channel map with non-binary id is rejected" do

--- a/test/sanbase/alerts/notification_channel_validation_test.exs
+++ b/test/sanbase/alerts/notification_channel_validation_test.exs
@@ -55,6 +55,38 @@ defmodule Sanbase.Alert.Validation.NotificationChannelTest do
       assert {:error, _} = NotificationChannel.valid_notification_channel?(%{webhook: 123})
     end
 
+    test "webhook with http URL is rejected" do
+      assert {:error, error} =
+               NotificationChannel.valid_notification_channel?(%{webhook: "http://example.com/x"})
+
+      assert error =~ "must use the https scheme"
+
+      assert {:error, _} =
+               NotificationChannel.valid_notification_channel?(%{
+                 "webhook" => "http://example.com/x"
+               })
+    end
+
+    test "webhook with IP address host is rejected" do
+      assert {:error, error} =
+               NotificationChannel.valid_notification_channel?(%{webhook: "https://8.8.8.8/x"})
+
+      assert error =~ "is an IP address"
+
+      assert {:error, _} =
+               NotificationChannel.valid_notification_channel?(%{
+                 "webhook" => "https://[2606:4700::1111]/x"
+               })
+    end
+
+    test "webhook with private IP or localhost is rejected" do
+      assert {:error, _} =
+               NotificationChannel.valid_notification_channel?(%{webhook: "https://127.0.0.1/x"})
+
+      assert {:error, _} =
+               NotificationChannel.valid_notification_channel?(%{webhook: "https://localhost/x"})
+    end
+
     test "telegram_channel map with non-binary id is rejected" do
       assert {:error, _} =
                NotificationChannel.valid_notification_channel?(%{telegram_channel: nil})

--- a/test/sanbase/alerts/trigger_sending_test.exs
+++ b/test/sanbase/alerts/trigger_sending_test.exs
@@ -190,6 +190,233 @@ defmodule Sanbase.Alert.TriggerSendingTest do
     end
   end
 
+  describe "IP webhook destinations at runtime" do
+    @tag capture_log: true
+    test "scheduler deactivates alert whose webhook host is an IP address", context do
+      %{user: user, project: project} = context
+
+      # Create-time validation rejects IP hosts, so plant a legacy trigger by
+      # updating the embed directly, bypassing the validation.
+      {:ok, trigger} =
+        create_trigger(user, project.slug, channel: [%{"webhook" => "https://example.com/hook"}])
+
+      plant_ip_webhook!(trigger.id, "https://8.8.8.8/hook")
+
+      Sanbase.Mock.prepare_mock2(
+        &HTTPoison.post/3,
+        {:ok, %HTTPoison.Response{status_code: 200, body: "OK"}}
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        Scheduler.run_alert(MetricTriggerSettings)
+
+        {:ok, user_trigger} = UserTrigger.by_user_and_id(user.id, trigger.id)
+        assert user_trigger.trigger.is_active == false
+      end)
+    end
+
+    @tag capture_log: true
+    test "send/1 rejects webhook URL with a public IP host", context do
+      user_trigger = build_webhook_user_trigger(context.user, "https://8.8.8.8/hook")
+
+      assert [{"santiment", {:error, error}}] = Sanbase.Alert.Any.send(user_trigger)
+      assert %{reason: :webhook_url_not_valid, error: reason} = error
+      assert reason =~ "is an IP address"
+    end
+
+    @tag capture_log: true
+    test "send/1 rejects legacy http webhook URL", context do
+      user_trigger = build_webhook_user_trigger(context.user, "http://example.com/hook")
+
+      assert [{"santiment", {:error, error}}] = Sanbase.Alert.Any.send(user_trigger)
+      assert %{reason: :webhook_url_not_valid, error: reason} = error
+      assert reason =~ "must use the https scheme"
+    end
+  end
+
+  describe "failing alerts auto-disable" do
+    @tag capture_log: true
+    test "failed webhook send starts the failing streak", context do
+      %{user: user, project: project} = context
+
+      {:ok, trigger} =
+        create_trigger(user, project.slug, channel: [%{"webhook" => "https://example.com/hook"}])
+
+      run_scheduler_with_webhook_response(project, 500)
+
+      {:ok, user_trigger} = UserTrigger.by_user_and_id(user.id, trigger.id)
+
+      assert %DateTime{} = user_trigger.trigger.failing_since
+
+      assert Sanbase.TestUtils.datetime_close_to(
+               Timex.now(),
+               user_trigger.trigger.failing_since,
+               60,
+               :seconds
+             )
+
+      assert user_trigger.trigger.failed_attempts == 1
+      assert user_trigger.trigger.consecutive_failed_days == 1
+      assert user_trigger.trigger.last_failed_on == Date.utc_today()
+      assert user_trigger.trigger.is_active == true
+    end
+
+    @tag capture_log: true
+    test "successful send clears the failing streak", context do
+      %{user: user, project: project} = context
+
+      {:ok, trigger} =
+        create_trigger(user, project.slug, channel: [%{"webhook" => "https://example.com/hook"}])
+
+      plant_trigger_state!(trigger.id, %{
+        failing_since: days_ago(3),
+        failed_attempts: 42,
+        consecutive_failed_days: 3,
+        last_failed_on: Date.add(Date.utc_today(), -1)
+      })
+
+      run_scheduler_with_webhook_response(project, 200)
+
+      {:ok, user_trigger} = UserTrigger.by_user_and_id(user.id, trigger.id)
+
+      assert user_trigger.trigger.failing_since == nil
+      assert user_trigger.trigger.failed_attempts == 0
+      assert user_trigger.trigger.consecutive_failed_days == 0
+      assert user_trigger.trigger.last_failed_on == nil
+      assert user_trigger.trigger.is_active == true
+    end
+
+    @tag capture_log: true
+    test "alert failing on 7 days in a row is deactivated", context do
+      %{user: user, project: project} = context
+
+      {:ok, trigger} =
+        create_trigger(user, project.slug, channel: [%{"webhook" => "https://example.com/hook"}])
+
+      plant_trigger_state!(trigger.id, %{
+        failing_since: days_ago(7),
+        failed_attempts: 60,
+        consecutive_failed_days: 6,
+        last_failed_on: Date.add(Date.utc_today(), -1)
+      })
+
+      run_scheduler_with_webhook_response(project, 500)
+
+      {:ok, user_trigger} = UserTrigger.by_user_and_id(user.id, trigger.id)
+
+      assert user_trigger.trigger.consecutive_failed_days == 7
+      assert user_trigger.trigger.is_active == false
+    end
+
+    @tag capture_log: true
+    test "a day without failures breaks the chain", context do
+      %{user: user, project: project} = context
+
+      {:ok, trigger} =
+        create_trigger(user, project.slug, channel: [%{"webhook" => "https://example.com/hook"}])
+
+      # Last failure 3 days ago - the failure-free days in between restart
+      # the chain from 1 instead of reaching 7.
+      plant_trigger_state!(trigger.id, %{
+        failing_since: days_ago(10),
+        failed_attempts: 60,
+        consecutive_failed_days: 6,
+        last_failed_on: Date.add(Date.utc_today(), -3)
+      })
+
+      run_scheduler_with_webhook_response(project, 500)
+
+      {:ok, user_trigger} = UserTrigger.by_user_and_id(user.id, trigger.id)
+
+      assert user_trigger.trigger.consecutive_failed_days == 1
+      assert user_trigger.trigger.failed_attempts == 61
+      assert user_trigger.trigger.is_active == true
+
+      # The failing_since marker is preserved - there was still no success
+      assert Sanbase.TestUtils.datetime_close_to(
+               days_ago(10),
+               user_trigger.trigger.failing_since,
+               60,
+               :seconds
+             )
+    end
+
+    @tag capture_log: true
+    test "multiple failures within the same day count as one day", context do
+      %{user: user, project: project} = context
+
+      {:ok, trigger} =
+        create_trigger(user, project.slug, channel: [%{"webhook" => "https://example.com/hook"}])
+
+      plant_trigger_state!(trigger.id, %{
+        failing_since: days_ago(6),
+        failed_attempts: 40,
+        consecutive_failed_days: 6,
+        last_failed_on: Date.utc_today()
+      })
+
+      run_scheduler_with_webhook_response(project, 500)
+
+      {:ok, user_trigger} = UserTrigger.by_user_and_id(user.id, trigger.id)
+
+      assert user_trigger.trigger.consecutive_failed_days == 6
+      assert user_trigger.trigger.failed_attempts == 41
+      assert user_trigger.trigger.is_active == true
+    end
+  end
+
+  defp run_scheduler_with_webhook_response(project, status_code) do
+    mock_fun =
+      [
+        fn -> {:ok, %{project.slug => 10}} end,
+        fn -> {:ok, %{project.slug => 15}} end
+      ]
+      |> Sanbase.Mock.wrap_consecutives(arity: 4)
+
+    Sanbase.Mock.prepare_mock(Sanbase.Metric, :aggregated_timeseries_data, mock_fun)
+    |> Sanbase.Mock.prepare_mock2(
+      &HTTPoison.post/3,
+      {:ok, %HTTPoison.Response{status_code: status_code, body: ""}}
+    )
+    |> Sanbase.Mock.run_with_mocks(fn ->
+      Scheduler.run_alert(MetricTriggerSettings)
+    end)
+  end
+
+  defp build_webhook_user_trigger(user, webhook_url) do
+    %{
+      id: 555,
+      user_id: user.id,
+      user: user,
+      trigger: %{
+        id: 555,
+        settings: %{
+          channel: %{webhook: webhook_url},
+          payload: %{"santiment" => "some payload"}
+        }
+      }
+    }
+  end
+
+  defp plant_ip_webhook!(user_trigger_id, url) do
+    ut = Sanbase.Repo.get(UserTrigger, user_trigger_id)
+    settings = Map.put(ut.trigger.settings, "channel", [%{"webhook" => url}])
+
+    plant_trigger_state!(user_trigger_id, %{settings: settings})
+  end
+
+  # Update the embedded trigger directly, bypassing the create/update
+  # validations, to simulate legacy DB state.
+  defp plant_trigger_state!(user_trigger_id, %{} = trigger_attrs) do
+    Sanbase.Repo.get(UserTrigger, user_trigger_id)
+    |> Sanbase.Repo.preload([:tags])
+    |> UserTrigger.update_changeset(%{trigger: trigger_attrs})
+    |> Sanbase.Repo.update!()
+  end
+
+  defp days_ago(days) do
+    Sanbase.Utils.DateTime.days_ago(days) |> DateTime.truncate(:second)
+  end
+
   defp create_trigger(user, slug, opts) do
     metric = Keyword.get(opts, :metric, "active_addresses_24h")
     time_window = Keyword.get(opts, :time_window, "1d")

--- a/test/sanbase/alerts/trigger_sending_test.exs
+++ b/test/sanbase/alerts/trigger_sending_test.exs
@@ -270,6 +270,18 @@ defmodule Sanbase.Alert.TriggerSendingTest do
     end
 
     @tag capture_log: true
+    test "send/1 rejects webhook URL whose host resolves to a blocked IP", context do
+      user_trigger = build_webhook_user_trigger(context.user, "https://example.com/hook")
+
+      Sanbase.Mock.prepare_mock2(&Sanbase.Utils.IP.resolves_to_blocked_ip?/1, true)
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        assert [{"santiment", {:error, error}}] = Sanbase.Alert.Any.send(user_trigger)
+        assert %{reason: :webhook_url_resolves_to_blocked_ip, error: message} = error
+        assert message =~ "resolves to a private, reserved or otherwise blocked address"
+      end)
+    end
+
+    @tag capture_log: true
     test "send/1 rejects legacy http webhook URL", context do
       user_trigger = build_webhook_user_trigger(context.user, "http://example.com/hook")
 

--- a/test/sanbase/alerts/trigger_sending_test.exs
+++ b/test/sanbase/alerts/trigger_sending_test.exs
@@ -4,7 +4,7 @@ defmodule Sanbase.Alert.TriggerSendingTest do
   import Sanbase.Factory
   import ExUnit.CaptureLog
 
-  alias Sanbase.Alert.{UserTrigger, Scheduler}
+  alias Sanbase.Alert.{HistoricalActivity, UserTrigger, Scheduler}
   alias Sanbase.Alert.Trigger.MetricTriggerSettings
 
   setup do
@@ -200,7 +200,7 @@ defmodule Sanbase.Alert.TriggerSendingTest do
       {:ok, trigger} =
         create_trigger(user, project.slug, channel: [%{"webhook" => "https://example.com/hook"}])
 
-      plant_ip_webhook!(trigger.id, "https://8.8.8.8/hook")
+      plant_webhook_url!(trigger.id, "https://8.8.8.8/hook")
 
       Sanbase.Mock.prepare_mock2(
         &HTTPoison.post/3,
@@ -215,12 +215,58 @@ defmodule Sanbase.Alert.TriggerSendingTest do
     end
 
     @tag capture_log: true
+    test "alert with a bad webhook URL and another channel stays active", context do
+      %{user: user, project: project} = context
+
+      {:ok, trigger} =
+        create_trigger(user, project.slug,
+          channel: ["telegram", %{"webhook" => "https://example.com/hook"}]
+        )
+
+      plant_webhook_url_keeping_channels!(trigger.id, "https://8.8.8.8/hook")
+
+      mock_fun =
+        [
+          fn -> {:ok, %{project.slug => 10}} end,
+          fn -> {:ok, %{project.slug => 15}} end
+        ]
+        |> Sanbase.Mock.wrap_consecutives(arity: 4)
+
+      Sanbase.Mock.prepare_mock(Sanbase.Metric, :aggregated_timeseries_data, mock_fun)
+      |> Sanbase.Mock.prepare_mock2(
+        &Sanbase.Telegram.send_message/2,
+        {:ok, ~s({"result": {}})}
+      )
+      |> Sanbase.Mock.run_with_mocks(fn ->
+        Scheduler.run_alert(MetricTriggerSettings)
+
+        {:ok, user_trigger} = UserTrigger.by_user_and_id(user.id, trigger.id)
+        assert user_trigger.trigger.is_active == true
+      end)
+    end
+
+    @tag capture_log: true
     test "send/1 rejects webhook URL with a public IP host", context do
       user_trigger = build_webhook_user_trigger(context.user, "https://8.8.8.8/hook")
 
       assert [{"santiment", {:error, error}}] = Sanbase.Alert.Any.send(user_trigger)
       assert %{reason: :webhook_url_not_valid, error: reason} = error
       assert reason =~ "is an IP address"
+    end
+
+    @tag capture_log: true
+    test "alert with invalid legacy webhook URL is deactivated on the first send", context do
+      %{user: user, project: project} = context
+
+      {:ok, trigger} =
+        create_trigger(user, project.slug, channel: [%{"webhook" => "https://example.com/hook"}])
+
+      plant_webhook_url!(trigger.id, "http://example.com/hook")
+
+      run_scheduler_with_webhook_response(project, 200)
+
+      {:ok, user_trigger} = UserTrigger.by_user_and_id(user.id, trigger.id)
+      assert user_trigger.trigger.is_active == false
     end
 
     @tag capture_log: true
@@ -258,6 +304,28 @@ defmodule Sanbase.Alert.TriggerSendingTest do
       assert user_trigger.trigger.consecutive_failed_days == 1
       assert user_trigger.trigger.last_failed_on == Date.utc_today()
       assert user_trigger.trigger.is_active == true
+    end
+
+    @tag capture_log: true
+    test "failed retry does not create activity from a stale successful delivery", context do
+      %{user: user, project: project} = context
+
+      {:ok, trigger} =
+        create_trigger(user, project.slug, channel: [%{"webhook" => "https://example.com/hook"}])
+
+      # The old delivery must remain outside the cooldown so this run evaluates
+      # and attempts another send, but it is not a new historical activity.
+      previous_delivery =
+        DateTime.utc_now()
+        |> DateTime.add(-24 * 60 * 60, :second)
+        |> DateTime.truncate(:second)
+        |> DateTime.to_iso8601()
+
+      plant_trigger_state!(trigger.id, %{last_triggered: %{project.slug => previous_delivery}})
+
+      run_scheduler_with_webhook_response(project, 500)
+
+      assert Sanbase.Repo.aggregate(HistoricalActivity, :count) == 0
     end
 
     @tag capture_log: true
@@ -382,6 +450,47 @@ defmodule Sanbase.Alert.TriggerSendingTest do
     end)
   end
 
+  describe "stamp_last_triggered/3" do
+    test "stamps identifiers without touching existing ones", context do
+      %{user: user, project: project} = context
+
+      {:ok, trigger} = create_trigger(user, project.slug, channel: ["telegram"])
+
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+      :ok = UserTrigger.stamp_last_triggered(trigger.id, "santiment", now)
+      :ok = UserTrigger.stamp_last_triggered(trigger.id, ["ethereum", "bitcoin"], now)
+
+      {:ok, user_trigger} = UserTrigger.by_user_and_id(user.id, trigger.id)
+
+      assert user_trigger.trigger.last_triggered |> Map.keys() |> Enum.sort() ==
+               ["bitcoin", "ethereum", "santiment"]
+
+      stamped_dt =
+        user_trigger.trigger.last_triggered
+        |> Map.get("santiment")
+        |> Sanbase.Utils.DateTime.from_iso8601!()
+
+      assert Sanbase.TestUtils.datetime_close_to(Timex.now(), stamped_dt, 60, :seconds)
+    end
+
+    test "stamps legacy rows missing the last_triggered key", context do
+      %{user: user, project: project} = context
+
+      {:ok, trigger} = create_trigger(user, project.slug, channel: ["telegram"])
+
+      Sanbase.Repo.query!(
+        "UPDATE user_triggers SET trigger = trigger - 'last_triggered' WHERE id = $1",
+        [trigger.id]
+      )
+
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+      :ok = UserTrigger.stamp_last_triggered(trigger.id, "santiment", now)
+
+      {:ok, user_trigger} = UserTrigger.by_user_and_id(user.id, trigger.id)
+      assert Map.has_key?(user_trigger.trigger.last_triggered, "santiment")
+    end
+  end
+
   defp build_webhook_user_trigger(user, webhook_url) do
     %{
       id: 555,
@@ -397,10 +506,25 @@ defmodule Sanbase.Alert.TriggerSendingTest do
     }
   end
 
-  defp plant_ip_webhook!(user_trigger_id, url) do
+  defp plant_webhook_url!(user_trigger_id, url) do
     ut = Sanbase.Repo.get(UserTrigger, user_trigger_id)
     settings = Map.put(ut.trigger.settings, "channel", [%{"webhook" => url}])
 
+    plant_trigger_state!(user_trigger_id, %{settings: settings})
+  end
+
+  defp plant_webhook_url_keeping_channels!(user_trigger_id, url) do
+    ut = Sanbase.Repo.get(UserTrigger, user_trigger_id)
+
+    channel =
+      ut.trigger.settings
+      |> Map.get("channel")
+      |> Enum.map(fn
+        %{"webhook" => _} -> %{"webhook" => url}
+        other -> other
+      end)
+
+    settings = Map.put(ut.trigger.settings, "channel", channel)
     plant_trigger_state!(user_trigger_id, %{settings: settings})
   end
 

--- a/test/sanbase/utils/validation_test.exs
+++ b/test/sanbase/utils/validation_test.exs
@@ -197,4 +197,48 @@ defmodule Sanbase.Utils.ValidationTest do
       assert {:error, _} = Validation.valid_public_url?("not-a-url")
     end
   end
+
+  describe "valid_webhook_url?/1" do
+    test "accepts https URLs with a domain name host" do
+      assert Validation.valid_webhook_url?("https://example.com/hook") == :ok
+      assert Validation.valid_webhook_url?("https://hooks.slack.com/services/x") == :ok
+    end
+
+    test "rejects http URLs" do
+      assert {:error, error} = Validation.valid_webhook_url?("http://example.com/hook")
+      assert error =~ "must use the https scheme"
+    end
+
+    test "rejects non-http(s) schemes" do
+      assert {:error, _} = Validation.valid_webhook_url?("ftp://example.com/hook")
+    end
+
+    test "rejects public IPv4 literal hosts" do
+      assert {:error, error} = Validation.valid_webhook_url?("https://8.8.8.8/hook")
+      assert error =~ "is an IP address"
+
+      assert {:error, _} = Validation.valid_webhook_url?("https://1.1.1.1/hook")
+    end
+
+    test "rejects shortened IPv4 literal hosts" do
+      assert {:error, _} = Validation.valid_webhook_url?("https://8.8/hook")
+    end
+
+    test "rejects public IPv6 literal hosts" do
+      assert {:error, error} = Validation.valid_webhook_url?("https://[2606:4700::1111]/hook")
+      assert error =~ "is an IP address"
+    end
+
+    test "rejects private / reserved hosts even over https" do
+      assert {:error, _} = Validation.valid_webhook_url?("https://127.0.0.1/hook")
+      assert {:error, _} = Validation.valid_webhook_url?("https://169.254.169.254/hook")
+      assert {:error, _} = Validation.valid_webhook_url?("https://localhost/hook")
+      assert {:error, _} = Validation.valid_webhook_url?("https://[::1]/hook")
+    end
+
+    test "rejects empty / scheme-less URLs" do
+      assert {:error, _} = Validation.valid_webhook_url?("")
+      assert {:error, _} = Validation.valid_webhook_url?("example.com/hook")
+    end
+  end
 end

--- a/test/sanbase/utils/validation_test.exs
+++ b/test/sanbase/utils/validation_test.exs
@@ -241,4 +241,14 @@ defmodule Sanbase.Utils.ValidationTest do
       assert {:error, _} = Validation.valid_webhook_url?("example.com/hook")
     end
   end
+
+  describe "IP.resolves_to_blocked_ip?/1" do
+    test "hosts resolving to loopback are blocked" do
+      assert Sanbase.Utils.IP.resolves_to_blocked_ip?("localhost") == true
+    end
+
+    test "public IP literals are not blocked" do
+      assert Sanbase.Utils.IP.resolves_to_blocked_ip?("8.8.8.8") == false
+    end
+  end
 end


### PR DESCRIPTION
- **Harden alert webhook destinations and auto-disable failing alerts**
- **Further alert improvements**

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved webhook validation by requiring secure HTTPS URLs and rejecting IP-based, private, reserved, and localhost addresses.
  - Added delivery failure tracking with automatic alert deactivation after permanent failures or seven consecutive failed days.
  - Successful deliveries now update the alert’s last-triggered timestamp immediately.

- **Bug Fixes**
  - Prevented unsuccessful deliveries from creating historical activity.
  - Improved per-identifier error reporting and Telegram error handling.
  - Disabled legacy alerts configured with invalid webhook destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->