### PR TITLE
Add institutional plan

### DIFF
--- a/docs/composable-api-plans-handover.md
+++ b/docs/composable-api-plans-handover.md
@@ -59,7 +59,7 @@ The public "Pricing & Packages" surface (mock; amounts provisional) is **not** p
 | Column | Product name | Commercial model | Billing model in this epic |
 |--------|--------------|------------------|----------------------------|
 | Left | **API · by data type** | Pick 1..N of 5 data packages (+ optional API-call add-on). Full history, 100k req/mo base, MCP. | **`BUNDLE`** — multi-item entitlement path (tasks PD…SL) |
-| Middle | **Institutional · flagship** | Fixed SKU: Full Sanbase + Full SanAPI + MCP. 3 seats, 50k req/mo, 3-year history. ~$799/mo · ~$9,500/yr. | **`INSTITUTIONAL`** — fixed standard plan (task **IN**) |
+| Middle | **Institutional · flagship** | Fixed SKU: Full Sanbase + Full SanAPI + MCP. 3 seats, 50k req/mo, 3-year history. ~$799/mo · ~$9,500/yr. | **`INSTITUTIONAL`** — fixed standard plan (task **IN**, ✅ built; **seats not implemented** — Q6) |
 | Right | **Enterprise · custom** | Sales-led: Institutional baseline + full history all pillars + S3 + 300k calls + dedicated AM / DPA. From ~$19,999/yr. | **`CUSTOM_*` / sales** — not self-serve cart (task **EP**) |
 
 **Prices are not final** and must stay changeable (catalog data + Stripe Price replace — §9). Provisional figures from the mock do not block implementation; only the *list of SKUs / plan shapes* does.
@@ -456,6 +456,11 @@ items rather than adjusted in place.
 | `cancel/2` | `cancel_at_period_end` | synced from the response | unchanged until the period ends |
 | `ItemExpiry.run/1` (hourly) | deletes items past `remove_at`, no proration | deletes the rows | package finally goes away |
 
+**What the interval switch charges, verified on stage 2026-08-06.** Switching a month-old Market + Social bundle to yearly produced one invoice of $9,031.14: `+7,000.00` and `+3,500.00` for the two yearly items, `-699.97` and `-349.98` crediting the unused monthly ones, and `-418.91` crediting the legacy BUSINESS_PRO the bundle had replaced. Two things to know from that:
+
+- **Every credited item is re-charged in the same invoice.** The monthly items are deleted, so Stripe credits their unused time; the yearly items are new, so they are charged in full. Net is the yearly price minus what was actually consumed, which was $1.14 across all three subscriptions. Nothing is credited without being replaced, and nothing is charged twice.
+- **The legacy plan's credit lands on the *bundle's* invoice, not on its own.** `cancel_subscription_with_proration/1` writes a negative *pending invoice item* against the customer rather than against a subscription, so Stripe attaches it to whatever invoice that customer generates next. Economically right — the customer gets their unused legacy time back as a discount on the new plan — but it reads oddly in the dashboard, where a line called "Unused time on SANapi" appears on a bundle invoice. Expect support to ask.
+
 Four rules hold this together, and each is the answer to a way it went wrong:
 
 * **Removal is a date, not a flag.** `subscription_items.remove_at` holds the
@@ -808,6 +813,24 @@ Changing a priced amount after Stripe exists = `Price.replace/1` + new Stripe Pr
 **Depends on:** LC, EN. **Critical for BC.**
 **Not covered:** §7.3 #4 (`stripe_sync.ex`) and #5 (`timeseries.ex`) are separate work — they are first-item *read* assumptions, not the webhook write path.
 
+**⚠️ Nothing retries an event left `is_processed = false`.** There is no sweep, no backoff, no dead-letter queue — a row that fails once stays unprocessed forever, and the only signal is the row itself. Two consequences worth knowing before reading `stripe_events` on stage or production:
+
+- **A `false` row is not evidence of a live bug.** Every bundle bought before this task landed left its `customer.subscription.created` unprocessed (that is the §7.3 #3 bug this fixed), and those rows are still there. Distinguish by timestamp, not by assumption:
+
+  ```sql
+  SELECT event_id, type, is_processed, inserted_at,
+         payload->'data'->'object'->>'id' AS stripe_sub
+  FROM stripe_events
+  WHERE type = 'customer.subscription.created'
+  ORDER BY inserted_at DESC LIMIT 10;
+  ```
+
+  The newest row must be `true`. Older `false` rows predate the fix. Verified on stage 2026-08-06: `evt_1U1PFQ` (11:14:04) and `evt_1U1PI6` (11:16:51) are `false` and are the two bundle purchases from the declined-card incident; `evt_1U1RaW` (13:44:01), the first bundle bought after the deploy, is `true`. The deploy landed between 11:16:51 and 11:48:29 UTC, and both stale rows sit on the earlier side of it. Their subscription (1639) has its items and entitlement regardless — the rows are cosmetic, not missing state.
+
+- **`switchBundleInterval` never produces a `created` event.** It swaps items on the existing Stripe subscription (`swap_stripe_items/4`), so it emits `customer.subscription.updated` only. An unprocessed `created` row appearing around the time of a switch therefore belongs to something else.
+
+Building the retry sweep is not in this epic. If it is wanted, the shape is a Quantum job over `is_processed = false` rows younger than Stripe's own 3-day retry window, replaying them through `StripeEvent.handle_event/1` — which is already idempotent for every branch above, which is what makes a replay safe.
+
 **One correction to the original description:** it says the `deleted` branch must "reset the `ApiCallLimit` record" because nothing else would. Not quite — `Subscription.update_subscription_db/2` emits `:update_subscription`, and `EventBus.BillingEventSubscriber` already calls `ApiCallLimit.update_user_plan/1` for it, so the quota does drop today. But that path is asynchronous and wrapped in `try/rescue` (`billing_event_subscriber.ex:50-57`), and it is disabled outright in the test config. The webhook now calls `update_user_plan/1` synchronously as well — idempotent, so the two together are harmless, and it is what makes the drop deterministic and testable.
 
 ### AM. `available_metrics` by entitlement — ✅ done
@@ -825,29 +848,44 @@ Three testers answer the question a ticket actually asks:
 **Deliverable:** ✅ two LiveViews + `Subscription.list_bundle_subscriptions/1` / `get_bundle_subscription/1`.
 **Depends on:** EN. Small, high value — do not defer it to "later".
 
-### IN. Institutional flagship plan — ⬜ not started
+### IN. Institutional flagship plan — ✅ done (seats excluded)
 **What:** The middle pricing-page column — a **fixed** SanAPI (+ Sanbase) plan, **not** assembled from packages (Q10). Distinct from `BUNDLE` and from bespoke `CUSTOM_*`.
 
-**Product shape (provisional prices; changeable):**
-- **Price:** $799 / mo · $9,500 / yr (⚠️ yearly discount looks wrong vs ~2 months free — Q11)
-- **Access:** Full Sanbase + Full SanAPI + MCP
-- **Quota:** 50,000 API requests / month (intentional; lower than a single package — §9)
-- **History:** 3-year window on API data (confirmed intentional while packages get full history — §9)
-- **Seats:** "3 seats" on Sanbase — ⚠️ **Q6** still open; no seats concept exists today
-- **Add-ons:** "Add-ons for full history per pillar" — ⚠️ product detail TBD; packages already include full history in v1, so this may mean something else for Institutional
+**Implemented as:** two `INSTITUTIONAL` `plans` rows on SanAPI (ids 311 month / 312 year, `priv/repo/migrations/20260806120000_add_institutional_plans.exs` plus the dev seed), classified `:standard` by `Plan.type/1`, and one clause added at each plan-dependent dispatch site. No `subscription_items`, no entitlement blob, no multi-item Stripe subscription — the whole point of the shape is that Institutional is an ordinary plan row that happens to belong to the new offering commercially.
 
-**Implementation shape (recommended):**
-- New `plans` rows named `INSTITUTIONAL` (month + year), product SanAPI — same two-row pattern as `PRO`. Likely also Sanbase rows if "Full Sanbase" is sold as part of the same SKU vs a coupled Sanbase sub.
-- `Plan.type/1` → `:standard` (or a dedicated `:institutional` atom if we want exhaustiveness separate from PRO) — **not** `:bundle`. No `subscription_items`, no entitlement blob.
-- Access via the **standard** path: metric access = all (or equivalent to union of five packages), `historical_data_in_days: ~1095` (3 years), `realtime_data_cut_off_in_days: 0`, `api_call_limits` month = 50_000.
-- Stripe: one Product + month/year Prices; wire into existing `subscribe` / plan sync — **not** multi-item SC.
-- Exclude from sale coexistence with `BUNDLE` / legacy PRO the same way §7.3 #6 blocks dual SanAPI subs.
+**What it grants, and why each number is what it is:**
 
-**Why not a five-package BUNDLE at $799?** Cheaper to maintain as a fixed plan; Institutional's 3-year history and 50k calls already diverge from "five packages × full history × 100k". Encoding it as packages would fight the product.
+| Dimension | Value | Why |
+|---|---|---|
+| Metric / query / signal access | everything a paid SanAPI plan gets | "Full SanAPI". No `min_plan` in the schema is above `PRO`, so the standard ladder already answers this correctly with no allow-list |
+| History window | **1095 days** (3 years) | The product's figure. BUSINESS_PRO gets 730 and BUSINESS_MAX unlimited, so this sits deliberately between them — full history is what the packages sell |
+| Realtime cut-off | 0 | Realtime included |
+| Calls / month | **50,000** | The product's figure, and the lowest of any paid SanAPI plan — lower than a single package. Institutional sells breadth, not volume (§9) |
+| Calls / hour · minute | 30,000 · 600 | Burst limits, taken from `sanapi_pro` — the same numbers a bundle gets. Deliberately *not* scaled down with the month: the monthly cap is the constraint being sold, and throttling an institutional customer harder than a package customer inside their own allowance would be a worse plan for more money |
+| Response size / month | 50,000 MB | BUSINESS_PRO's figure. Not a dimension Institutional sells |
+| Sanbase side | **MAX**-equivalent (alerts 50, paywalled insights, SanGraphs) | "Full Sanbase" is part of the SKU. A bundle answers as PRO here; that difference is the point |
+| MCP | `:max` tier | MCP is listed in what Institutional includes. `MCP.Restrictions.classify/2` has a catch-all returning `:free`, so a missing clause would have sold MCP and then served 15 calls a minute |
+| Clickhouse repo · credits · query executions · complexity divider | as **BUSINESS_MAX** | None of these is a dimension Institutional sells. Inventing separate numbers for each would be a set of values nobody decided |
+| 14-day API trial | **excluded**, like the Business plans | A trial of the flagship is a decision for product to make deliberately (task **TR**), not something it inherits by being new |
 
-**Deliverable:** plan rows + access/quota clauses + Stripe prices + BC fixture still green for FREE/PRO/CUSTOM.
+**Who may buy it.** `Bundle.Lifecycle.ensure_can_subscribe_institutional/1`, called from `Subscription.subscribe/4` and `subscribe2/4` *before* the Stripe customer or subscription is created. Two rules, both shared with bundles because they are about the offering rather than about items:
+- not for sale until `/admin/bundle_offering` is switched on — staff can still buy it while it is off, which is how it gets tested;
+- never a customer's second live SanAPI subscription. `has_active_subscriptions/2` cannot enforce this: it compares plan *ids*, so without the gate a bundle customer could buy Institutional and be billed for both at once.
+
+A replaceable legacy SanAPI subscription is allowed to be present and is **not** canceled at purchase. `cancel_stale_replaced_subscriptions/0` already matches `INSTITUTIONAL%` and does that within the hour, once the new subscription is actually live — the same treatment a bundle gets, and for the same reason: a declined first invoice must not cost the customer the plan they are still paying for (§10.1 item 3).
+
+**Stripe.** Nothing new. The rows carry real amounts and a NULL `stripe_id`; `Sanbase.Billing.sync_products_with_stripe/0` creates the Stripe plan on first run and writes the id back, exactly as for every other `plans` row. Prices are the provisional $799 / $9,500 — changing them is an UPDATE plus a new Stripe price, not a schema change.
+
+**Sale controls.** `SaleControls` already toggled `INSTITUTIONAL%` alongside `BUNDLE%`, and `product_with_plans/0` already excluded it, so one switch activates the whole offering and the Institutional column is rendered from its own copy rather than from a plans listing. No new admin surface was needed.
+
+**Deliverable:** ✅ plan rows + migration + seed, clauses at every dispatch site, the sale gate, `test/sanbase/billing/plan/institutional_test.exs` (22 tests), `INSTITUTIONAL` added to `AccessMatrix.standard_plan_names/0` so the BC fixture now pins it too — that fixture diff is **542 insertions, 0 deletions**, i.e. no existing plan's behavior moved.
 **Depends on:** DP (dispatch seam already landed). Parallel to SC — does **not** block package checkout.
-**Open before coding seats / history add-ons:** Q6, and the "full history per pillar add-on" wording.
+
+**Deliberately left out:**
+- **Seats.** "3 seats on Sanbase" (Q6) is not implemented and no seats concept exists anywhere in the codebase. Product's call was to ship without it.
+- **"Add-ons for full history per pillar."** Wording still unresolved; packages already include full history in v1, so this means something else for Institutional and nobody has said what.
+- **Cancelling a customer's separate Sanbase subscription.** Buying `BUSINESS_PRO`/`BUSINESS_MAX` immediately cancels any Sanbase subscription the customer holds (`maybe_cancel_subscriptions/2`); Institutional does **not**, and neither does a bundle. Left alone on purpose — the alternative is destroying a paid Sanbase year on a button press — but it does mean an Institutional customer with a separate Sanbase subscription pays twice for Sanbase. New question in §15.
+- **The yearly price.** $9,500 against $799/mo is ~1 month free where the other plans give ~2 (Q11). Seeded as given.
 
 ### EP. Enterprise custom tier — ⬜ not started
 **What:** The right pricing-page column — sales-led contracting, **not** self-serve checkout.
@@ -1142,7 +1180,7 @@ release day.
 | **SC** — Stripe catalog | ✅ done | `Bundle.Catalog` via `Billing.sync_bundle_catalog_with_stripe/0` (also in `@reboot` `sync_products_with_stripe`). 12 local rows; package Stripe Prices via Price API; `api_calls_500k` amount still TBD. |
 | **SL** — subscribe lifecycle | ✅ done | `Bundle.Lifecycle` + GraphQL mutations; SaleControls activate/deactivate; legacy auto-replace; `upgrade_downgrade` guard. |
 | **UI** | ⬜ not started | Three-column pricing / checkout (webapp). |
-| **IN** — Institutional | ⬜ not started | Fixed flagship plan (§1.1 middle column). Specced in §8 **IN**; not a BUNDLE. |
+| **IN** — Institutional | ✅ done (no seats) | `INSTITUTIONAL` month/year rows on SanAPI, `Plan.type/1` → `:standard`. 1095-day history, realtime, 50k calls/month, full Sanbase (MAX-equivalent), MCP `:max`; everything else answers as BUSINESS_MAX. Sold through the ordinary `subscribe`, behind the new-offering gate. Seats (Q6) deliberately out. |
 | **EP** — Enterprise | ⬜ not started | Sales-led custom tier (§1.1 right column). Specced in §8 **EP**; prefer CUSTOM path. |
 
 **Admin pages.** `/admin/bundle_packages` shows what each package contains live vs
@@ -1196,11 +1234,12 @@ covers only the webhook write path; those two are tracked on their own.
 
 ### 13.1 Next
 
-1. **`IN`** — Institutional as a fixed standard plan. Does not share the multi-item path; uses offering gate + standard `subscribe`.
-2. **`EP`** — confirm Enterprise = CUSTOM sales path; thin plan/admin work only.
-3. **`UI`** — three-column pricing / checkout once SL (packages) and IN (flagship CTA) exist; use `bundleCatalog` + plan flags (`is_private` / `is_deprecated`).
-4. When product prices `api_calls_500k`: set amounts + `Sanbase.Billing.sync_bundle_catalog_with_stripe()` (or wait for `@reboot`) — no code change.
-5. Use `/admin/bundle_offering` to activate bundle plans and/or deactivate Business Pro/Max when ready.
+1. **`EP`** — confirm Enterprise = CUSTOM sales path; thin plan/admin work only.
+2. **`UI`** — three-column pricing / checkout. Both dependencies now exist: SL for the package builder, IN for the flagship CTA. Use `bundleCatalog` + plan flags (`is_private` / `is_deprecated`). ⚠️ Also carries the §10.2 launch blocker, which gates withdrawal of the Business plans on its own.
+3. **`TR`** — trial & dunning. Sharpened by IN and SL both shipping: `past_due` currently grants roughly three weeks of full access, and the exposure now scales to $1,050/month bundles and $799/month Institutional (§10.1 item 8).
+4. Verify on stage: run `Sanbase.Billing.sync_products_with_stripe()` once so the two `INSTITUTIONAL` rows get their Stripe plans, then activate the offering from `/admin/bundle_offering` and buy one.
+5. When product prices `api_calls_500k`: set amounts + `Sanbase.Billing.sync_bundle_catalog_with_stripe()` (or wait for `@reboot`) — no code change.
+6. Use `/admin/bundle_offering` to activate bundle plans and/or deactivate Business Pro/Max when ready.
 
 Prices on the mock are **not final** and must not gate further work.
 
@@ -1282,6 +1321,24 @@ Left over, and cosmetic: a bundle subscriber's account page renders the literal 
 **Q6. Does Institutional's "3 seats" ship in the first version?**
 
 We have no concept of seats today — one subscription belongs to one account. Adding seats is a separate piece of work from packages. If it has to be there at launch, it needs planning now rather than later.
+
+*Answer:* **no, not in v1.** Institutional shipped without seats (task **IN**). Everything else about the plan is built and sellable; a seat is still one account. If the pricing page is going to say "3 seats", either that line comes off the page or seats become their own piece of work with its own plan — nothing in the current build enforces or even records a seat count.
+
+---
+
+**Q14. Should Institutional cancel a customer's separate Sanbase subscription?**
+
+Institutional includes full Sanbase. A customer who already pays for Sanbase separately and then buys Institutional currently keeps both subscriptions and pays for Sanbase twice.
+
+The existing behavior for the Business plans is the opposite and quite blunt: buying `BUSINESS_PRO` or `BUSINESS_MAX` cancels any Sanbase subscription the customer holds, immediately. We deliberately did not copy that for Institutional, because "immediately" can mean destroying most of a paid Sanbase year on a button press, and because bundles do not do it either.
+
+So one of three answers is needed:
+
+1. leave it — the customer double-pays until they cancel Sanbase themselves (today's behavior);
+2. cancel the Sanbase subscription at the end of its paid period, so nothing is thrown away;
+3. copy the Business behavior and cancel it immediately.
+
+Not blocking. It becomes visible with the first Institutional customer who already has Sanbase.
 
 *Answer:* pending
 

--- a/docs/composable-api-plans-handover.md
+++ b/docs/composable-api-plans-handover.md
@@ -906,6 +906,13 @@ A replaceable legacy SanAPI subscription is allowed to be present and is **not**
 
 ### UI. Self-serve purchase surface
 **What:** Pricing page / checkout reflecting the three-column offering (§1.1): composable package builder (left), Institutional CTA (middle), Enterprise contact CTA (right). Package checkout needs SC + SL. Institutional can use existing single-plan subscribe once **IN** lands. Enterprise is contact/sales, not cart.
+
+⚠️ **The Institutional plan ids have to be hardcoded, or a query has to be added.** Institutional is bought with `subscribe(plan_id:)` — id **311** monthly, **312** yearly, fixed by the migration so identical in every environment. But `productsWithPlans` excludes `INSTITUTIONAL%` by name unconditionally (the same exclusion `BUNDLE%` has), so there is no query the frontend can use to *discover* those ids. Two ways out, and the choice belongs to whoever builds the page:
+
+- hardcode 311 / 312, which works because the ids are pinned by the migration, or
+- add a small `institutionalPlans` query returning the two rows, gated on `SaleControls.bundle_plans_visible?/1` so it only answers once the offering is on — the counterpart of what `bundleCatalog` does for packages.
+
+Note that the `/admin/bundle_offering` switch controls *purchasability*, not visibility: activating the offering makes Institutional buyable while leaving it entirely absent from the pricing page. Rendering that column is frontend work either way.
 **Depends on:** SC, SL for packages; IN for Institutional button; EP only for copy/CTA. ⚠️ **Confirm ownership** — if this is a frontend-team deliverable, say so explicitly in the epic rather than leaving it unassigned.
 **Blocks the launch on its own:** the SanAPI pricing page crashes when the Business plans are withdrawn (§10.2). That fix is needed even if the package builder ships later, because it gates the moment we stop selling the old plans — and until the builder does ship, withdrawal leaves the "For Business" tab as a single contact-sales card.
 
@@ -1326,7 +1333,7 @@ We have no concept of seats today — one subscription belongs to one account. A
 
 ---
 
-**Q14. Should Institutional cancel a customer's separate Sanbase subscription?**
+**Q15. Should Institutional cancel a customer's separate Sanbase subscription?**
 
 Institutional includes full Sanbase. A customer who already pays for Sanbase separately and then buys Institutional currently keeps both subscriptions and pays for Sanbase twice.
 

--- a/lib/sanbase/api_call_limit/restrictions.ex
+++ b/lib/sanbase/api_call_limit/restrictions.ex
@@ -1,4 +1,23 @@
 defmodule Sanbase.ApiCallLimit.Restrictions do
+  @moduledoc ~s"""
+  The per-plan call and response-size allowances, keyed by the product-prefixed,
+  downcased plan name stored in `api_call_limits.api_calls_limit_plan`.
+
+  ## `sanapi_institutional`
+
+  Its monthly allowance is 50,000 - lower than every other paid SanAPI plan, and
+  lower than a single composable package. That is the product's intent, not an
+  oversight: Institutional sells breadth of access and a 3-year history window
+  rather than volume, and volume is what the packages and their add-ons sell. See
+  `docs/composable-api-plans-handover.md` §8 task IN and §9.
+
+  The hour and minute figures are burst limits and are taken from `sanapi_pro`,
+  the same numbers a bundle gets. They are deliberately not scaled down in
+  proportion to the month: the monthly figure is the constraint being sold, and an
+  institutional customer backfilling a dataset should not be throttled harder than
+  a package customer while still inside their monthly allowance.
+  """
+
   def call_limits_per_month() do
     %{
       "sanbase_basic" => 1000,
@@ -9,7 +28,8 @@ defmodule Sanbase.ApiCallLimit.Restrictions do
       "sanapi_basic" => 300_000,
       "sanapi_pro" => 600_000,
       "sanapi_business_pro" => 600_000,
-      "sanapi_business_max" => 1_200_000
+      "sanapi_business_max" => 1_200_000,
+      "sanapi_institutional" => 50_000
     }
   end
 
@@ -23,7 +43,8 @@ defmodule Sanbase.ApiCallLimit.Restrictions do
       "sanapi_basic" => 20_000,
       "sanapi_pro" => 30_000,
       "sanapi_business_pro" => 30_000,
-      "sanapi_business_max" => 60_000
+      "sanapi_business_max" => 60_000,
+      "sanapi_institutional" => 30_000
     }
   end
 
@@ -37,7 +58,8 @@ defmodule Sanbase.ApiCallLimit.Restrictions do
       "sanapi_basic" => 300,
       "sanapi_pro" => 600,
       "sanapi_business_pro" => 600,
-      "sanapi_business_max" => 1200
+      "sanapi_business_max" => 1200,
+      "sanapi_institutional" => 600
     }
   end
 
@@ -53,7 +75,8 @@ defmodule Sanbase.ApiCallLimit.Restrictions do
       "sanapi_basic" => 20_000,
       "sanapi_pro" => 40_000,
       "sanapi_business_pro" => 50_000,
-      "sanapi_business_max" => 100_000
+      "sanapi_business_max" => 100_000,
+      "sanapi_institutional" => 50_000
     }
   end
 end

--- a/lib/sanbase/billing/plan.ex
+++ b/lib/sanbase/billing/plan.ex
@@ -157,6 +157,7 @@ defmodule Sanbase.Billing.Plan do
       "ESSENTIAL" -> "BASIC"
       "CUSTOM_" <> _ = name -> name
       @bundle_prefix <> _ = name -> name
+      @institutional_prefix <> _ = name -> name
     end
   end
 
@@ -174,7 +175,10 @@ defmodule Sanbase.Billing.Plan do
       subscription's items. See `docs/composable-api-plans-handover.md`.
 
   Note that the plan named exactly `"CUSTOM"` is `:standard` - it is a rung on
-  the ladder, not a bespoke plan.
+  the ladder, not a bespoke plan. `INSTITUTIONAL` is `:standard` too: it belongs
+  to the same new offering as `BUNDLE` commercially, but it is a fixed plan whose
+  access and quota are declared in code like every other rung, not assembled from
+  purchased items. Nothing about it needs the item or entitlement machinery.
   """
   @type plan_type :: :standard | :custom | :bundle
 
@@ -202,6 +206,9 @@ defmodule Sanbase.Billing.Plan do
 
       iex> Sanbase.Billing.Plan.type("BUNDLE")
       :bundle
+
+      iex> Sanbase.Billing.Plan.type("INSTITUTIONAL")
+      :standard
 
   ## Non-binary input
 

--- a/lib/sanbase/billing/plan/bundle/lifecycle.ex
+++ b/lib/sanbase/billing/plan/bundle/lifecycle.ex
@@ -263,11 +263,29 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
   """
   @spec ensure_can_subscribe_institutional(User.t()) :: :ok | {:error, String.t()}
   def ensure_can_subscribe_institutional(%User{} = user) do
-    with :ok <- ensure_institutional_visible(user),
+    with :ok <- ensure_institutional_for_sale(user),
          {:ok, _replaceable} <- classify_for_subscribe(user) do
       :ok
     end
   end
+
+  @doc ~s"""
+  Whether the Institutional plan may be sold to this user at all.
+
+  The sale switch on its own, without the one-live-SanAPI-subscription rule. Moving
+  an *existing* subscription onto Institutional (`updateSubscription`) replaces
+  rather than adds, so it cannot produce a second live subscription and must not be
+  refused for having one - but it is still a sale, and a plan that is not for sale
+  must not be reachable through it.
+
+  Nothing else stops that path: `is_private` is not enforced anywhere as a purchase
+  gate, and deliberately so (§15 Q14 - `FREE` and the Sanbase tiers are all private
+  on production while being sold every day). This check is the only thing keeping
+  Institutional off sale before launch, so every route to it has to call one of
+  these two functions.
+  """
+  @spec ensure_institutional_for_sale(User.t()) :: :ok | {:error, String.t()}
+  def ensure_institutional_for_sale(%User{} = user), do: ensure_institutional_visible(user)
 
   @spec list_replaceable_sanapi_subs(User.t()) :: [Subscription.t()]
   def list_replaceable_sanapi_subs(%User{} = user) do

--- a/lib/sanbase/billing/plan/bundle/lifecycle.ex
+++ b/lib/sanbase/billing/plan/bundle/lifecycle.ex
@@ -242,6 +242,33 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
     end
   end
 
+  @doc ~s"""
+  Whether the user may purchase the Institutional plan.
+
+  Institutional is sold through the ordinary `Sanbase.Billing.Subscription.subscribe/4`
+  path rather than through `subscribe/2` here - it is a fixed plan with one Stripe
+  price, so none of the multi-item machinery applies to it. What it does share with
+  a bundle is the two commercial rules, and they live here because they are about
+  the offering rather than about items:
+
+    * it is not for sale until the admin switch is on (staff can still buy it while
+      it is off, which is how it gets tested), and
+    * it never becomes a customer's second live SanAPI subscription.
+
+  A replaceable legacy SanAPI subscription is allowed to be present and is not
+  canceled here. `cancel_stale_replaced_subscriptions/0` does that within the hour,
+  once the new subscription is actually live - the same treatment a bundle gets, and
+  for the same reason: a declined first invoice must not cost the customer the plan
+  they are still paying for.
+  """
+  @spec ensure_can_subscribe_institutional(User.t()) :: :ok | {:error, String.t()}
+  def ensure_can_subscribe_institutional(%User{} = user) do
+    with :ok <- ensure_institutional_visible(user),
+         {:ok, _replaceable} <- classify_for_subscribe(user) do
+      :ok
+    end
+  end
+
   @spec list_replaceable_sanapi_subs(User.t()) :: [Subscription.t()]
   def list_replaceable_sanapi_subs(%User{} = user) do
     case classify_active_sanapi(user) do
@@ -257,6 +284,18 @@ defmodule Sanbase.Billing.Plan.Bundle.Lifecycle do
       :ok
     else
       {:error, "Bundle plans are not available for purchase yet"}
+    end
+  end
+
+  # Same switch, different wording. `SaleControls` activates the whole new offering
+  # at once, so there is no state in which one of the two is for sale and the other
+  # is not - but a customer told "Bundle plans are not available" after clicking
+  # Institutional would reasonably think they had hit the wrong button.
+  defp ensure_institutional_visible(user) do
+    if SaleControls.bundle_plans_visible?(user) do
+      :ok
+    else
+      {:error, "The Institutional plan is not available for purchase yet"}
     end
   end
 

--- a/lib/sanbase/billing/plan/standard_access_checker/api_access_checker.ex
+++ b/lib/sanbase/billing/plan/standard_access_checker/api_access_checker.ex
@@ -57,6 +57,17 @@ defmodule Sanbase.Billing.Plan.ApiAccessChecker do
 
   @custom_plan_stats Plan.upgrade_plan(@business_max_plan_stats, extends: %{})
 
+  # The Institutional flagship. Its history window is a deliberate 3 years rather
+  # than the unlimited one BUSINESS_MAX gets: composable packages are what sell
+  # full history, and Institutional is priced against a fixed, broad plan instead.
+  # See `docs/composable-api-plans-handover.md` §8 task IN.
+  @institutional_plan_stats Plan.upgrade_plan(@free_plan_stats,
+                              extends: %{
+                                historical_data_in_days: 3 * 365,
+                                realtime_data_cut_off_in_days: 0
+                              }
+                            )
+
   def historical_data_in_days(subscription_product, plan) do
     case subscription_product do
       nil -> historical_data_in_days_api(plan)
@@ -74,6 +85,7 @@ defmodule Sanbase.Billing.Plan.ApiAccessChecker do
       "MAX" -> @sanbase_max_plan_stats[:historical_data_in_days]
       "BUSINESS_PRO" -> @business_pro_plan_stats[:historical_data_in_days]
       "BUSINESS_MAX" -> @business_max_plan_stats[:historical_data_in_days]
+      "INSTITUTIONAL" -> @institutional_plan_stats[:historical_data_in_days]
       "CUSTOM" -> @custom_plan_stats[:historical_data_in_days]
     end
   end
@@ -104,6 +116,7 @@ defmodule Sanbase.Billing.Plan.ApiAccessChecker do
       "MAX" -> @sanbase_max_plan_stats[:realtime_data_cut_off_in_days]
       "BUSINESS_PRO" -> @business_pro_plan_stats[:realtime_data_cut_off_in_days]
       "BUSINESS_MAX" -> @business_max_plan_stats[:realtime_data_cut_off_in_days]
+      "INSTITUTIONAL" -> @institutional_plan_stats[:realtime_data_cut_off_in_days]
       "CUSTOM" -> @custom_plan_stats[:realtime_data_cut_off_in_days]
     end
   end

--- a/lib/sanbase/billing/plan/standard_access_checker/sanbase_access_checker.ex
+++ b/lib/sanbase/billing/plan/standard_access_checker/sanbase_access_checker.ex
@@ -35,6 +35,12 @@ defmodule Sanbase.Billing.Plan.SanbaseAccessChecker do
   @business_max_plan_stats Plan.upgrade_plan(@business_pro_plan_stats, extends: %{})
   @custom_plan_stats Plan.upgrade_plan(@business_max_plan_stats, extends: %{})
 
+  # Institutional includes the full Sanbase experience, which is what MAX is. It
+  # is a SanAPI plan, so this is reached whenever such a customer opens Sanbase
+  # without a separate Sanbase subscription - the same route a bundle takes, only
+  # answering as MAX instead of PRO because Sanbase is part of what was sold.
+  @institutional_plan_stats Plan.upgrade_plan(@sanbase_max_plan_stats, extends: %{})
+
   def historical_data_in_days(_subscription_product, plan) do
     plan_stats(plan)
     |> Map.get(:historical_data_in_days)
@@ -83,6 +89,7 @@ defmodule Sanbase.Billing.Plan.SanbaseAccessChecker do
       "MAX" -> @sanbase_max_plan_stats
       "BUSINESS_PRO" -> @business_pro_plan_stats
       "BUSINESS_MAX" -> @business_max_plan_stats
+      "INSTITUTIONAL" -> @institutional_plan_stats
       "CUSTOM" -> @custom_plan_stats
       "CUSTOM_" <> _ -> @custom_plan_stats
     end

--- a/lib/sanbase/billing/subscription/subscription.ex
+++ b/lib/sanbase/billing/subscription/subscription.ex
@@ -296,6 +296,7 @@ defmodule Sanbase.Billing.Subscription do
   def subscribe(user, plan, card_token \\ nil, coupon \\ nil) do
     with {:ok, coupon} <- maybe_validate_san_holder_coupon(user, coupon),
          :ok <- has_active_subscriptions(user, plan),
+         :ok <- ensure_plan_is_for_sale(user, plan),
          {:ok, user} <- Billing.create_or_update_stripe_customer(user, card_token),
          {:ok, stripe_subscription} <- create_stripe_subscription(user, plan, coupon),
          {:ok, db_subscription} <- create_subscription_db(stripe_subscription, user, plan) do
@@ -313,6 +314,7 @@ defmodule Sanbase.Billing.Subscription do
   def subscribe2(user, plan, payment_method_id, coupon \\ nil) do
     with {:ok, coupon} <- maybe_validate_san_holder_coupon(user, coupon),
          :ok <- has_active_subscriptions(user, plan),
+         :ok <- ensure_plan_is_for_sale(user, plan),
          {:ok, user} <- StripeApi.attach_payment_method_to_customer(user, payment_method_id),
          {:ok, stripe_subscription} <- create_stripe_subscription(user, plan, coupon),
          {:ok, db_subscription} <- create_subscription_db(stripe_subscription, user, plan) do
@@ -734,6 +736,21 @@ defmodule Sanbase.Billing.Subscription do
     end
   end
 
+  # Institutional belongs to the new SanAPI offering, so it answers to that
+  # offering's two commercial rules rather than only to `has_active_subscriptions/2`
+  # above - which compares plan ids and would happily sell it to a customer who is
+  # already on a bundle, leaving two live SanAPI subscriptions billing at once.
+  #
+  # Every other plan keeps exactly the behavior it had before this clause existed.
+  defp ensure_plan_is_for_sale(user, %Plan{name: "INSTITUTIONAL" <> _}) do
+    case Sanbase.Billing.Plan.Bundle.Lifecycle.ensure_can_subscribe_institutional(user) do
+      :ok -> :ok
+      {:error, message} -> {:error, %__MODULE__.Error{message: message}}
+    end
+  end
+
+  defp ensure_plan_is_for_sale(_user, _plan), do: :ok
+
   # Add 80% off Sanbase Basic subscription for first month
   defp create_stripe_subscription(user, %Plan{id: plan_id} = plan, _)
        when plan_id == @sanbase_basic_plan_id do
@@ -789,8 +806,11 @@ defmodule Sanbase.Billing.Subscription do
       product_id == @product_sanbase and Billing.eligible_for_sanbase_trial?(user.id, plan) ->
         Map.put(defaults, :trial_end, trial_end_unix)
 
-      # BUSINESS plans are excluded from API trial
-      product_id == @product_api and plan.name not in ~w(BUSINESS_PRO BUSINESS_MAX) and
+      # BUSINESS plans are excluded from API trial. So is INSTITUTIONAL: it is the
+      # flagship SanAPI plan, and a 14-day trial of it is a decision for product to
+      # make deliberately (task TR) rather than something it inherits by being new.
+      product_id == @product_api and
+        plan.name not in ~w(BUSINESS_PRO BUSINESS_MAX INSTITUTIONAL) and
           Billing.eligible_for_api_trial?(user.id) ->
         Map.put(defaults, :trial_end, trial_end_unix)
 

--- a/lib/sanbase/mcp/restrictions.ex
+++ b/lib/sanbase/mcp/restrictions.ex
@@ -8,7 +8,7 @@ defmodule Sanbase.MCP.Restrictions do
     * `:pro`  — Sanbase PRO
     * `:max`  — Sanbase MAX (incl. legacy PRO_PLUS / BUSINESS_* / CUSTOM*)
                 and every paid SanAPI plan (PRO, BUSINESS_PRO, BUSINESS_MAX,
-                CUSTOM, CUSTOM_*).
+                INSTITUTIONAL, CUSTOM, CUSTOM_*).
 
   When a user has subscriptions across both products, the highest tier wins.
 
@@ -52,8 +52,8 @@ defmodule Sanbase.MCP.Restrictions do
       |         | PREMIUM                            |       |
       | SANAPI  | FREE                               | free  |
       | SANAPI  | BASIC, PRO, BUSINESS_PRO,          | max   |
-      |         | BUSINESS_MAX, CUSTOM, CUSTOM_*,    |       |
-      |         | PREMIUM                            |       |
+      |         | BUSINESS_MAX, INSTITUTIONAL,       |       |
+      |         | CUSTOM, CUSTOM_*, PREMIUM          |       |
       +---------+------------------------------------+-------+
 
   Unauthenticated users are blocked at the server layer before reaching
@@ -151,6 +151,7 @@ defmodule Sanbase.MCP.Restrictions do
   defp classify("SANAPI", "PRO"), do: :max
   defp classify("SANAPI", "BUSINESS_PRO"), do: :max
   defp classify("SANAPI", "BUSINESS_MAX"), do: :max
+  defp classify("SANAPI", "INSTITUTIONAL"), do: :max
   defp classify("SANAPI", "CUSTOM"), do: :max
   defp classify("SANAPI", "PREMIUM"), do: :max
   defp classify("SANAPI", "CUSTOM_" <> _), do: :max

--- a/lib/sanbase/queries/authorization.ex
+++ b/lib/sanbase/queries/authorization.ex
@@ -123,6 +123,9 @@ defmodule Sanbase.Queries.Authorization do
       {"SANAPI", "BUSINESS_MAX"} ->
         Sanbase.ClickhouseRepo.BusinessMaxUser
 
+      {"SANAPI", "INSTITUTIONAL"} ->
+        Sanbase.ClickhouseRepo.BusinessMaxUser
+
       {"SANAPI", "CUSTOM"} ->
         Sanbase.ClickhouseRepo.ReadOnly
 
@@ -173,6 +176,9 @@ defmodule Sanbase.Queries.Authorization do
       {"SANAPI", "BUSINESS_MAX"} ->
         %{minute: 100, hour: 3000, day: 15_000}
 
+      {"SANAPI", "INSTITUTIONAL"} ->
+        %{minute: 100, hour: 3000, day: 15_000}
+
       {"SANAPI", "CUSTOM"} ->
         %{minute: 200, hour: 3000, day: 20_000}
 
@@ -215,6 +221,9 @@ defmodule Sanbase.Queries.Authorization do
         50_000
 
       {"SANAPI", "BUSINESS_MAX"} ->
+        500_000
+
+      {"SANAPI", "INSTITUTIONAL"} ->
         500_000
 
       {"SANAPI", "CUSTOM"} ->

--- a/lib/sanbase_web/graphql/complexity/complexity.ex
+++ b/lib/sanbase_web/graphql/complexity/complexity.ex
@@ -90,6 +90,7 @@ defmodule SanbaseWeb.Graphql.Complexity do
       "MAX" -> 5
       "BUSINESS_PRO" -> 6
       "BUSINESS_MAX" -> 7
+      "INSTITUTIONAL" -> 7
       "CUSTOM" -> 7
       # TODO: Move complexity reducer to restrictions map
       "CUSTOM_" <> _ -> 7

--- a/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
@@ -173,6 +173,7 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
            {:not_cancelled?, subscription},
          {_, %Plan{is_deprecated: false} = new_plan} <- {:plan?, Plan.by_id(plan_id)},
          :ok <- ensure_standard_subscribe_allowed(new_plan),
+         :ok <- ensure_new_offering_for_sale(current_user, new_plan),
          :ok <- ensure_not_bundle_subscription(subscription),
          {:ok, subscription} <- Billing.update_subscription(subscription, new_plan) do
       {:ok, subscription}
@@ -618,6 +619,20 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
       :ok
     end
   end
+
+  # `updateSubscription` is a second route onto a plan, and it needs the sale switch
+  # as much as `subscribe` does. Without this, any customer holding a legacy SanAPI
+  # subscription could move themselves onto Institutional while the offering is
+  # still deactivated - `is_private` is not a purchase gate anywhere in the codebase
+  # (§15 Q14), so nothing else would stop them.
+  #
+  # Only the switch is checked, not the one-live-subscription rule: this path
+  # replaces the subscription it is called on, so it cannot create a second one.
+  defp ensure_new_offering_for_sale(%User{} = user, %Plan{name: "INSTITUTIONAL" <> _}) do
+    Sanbase.Billing.Plan.Bundle.Lifecycle.ensure_institutional_for_sale(user)
+  end
+
+  defp ensure_new_offering_for_sale(_user, _plan), do: :ok
 
   defp ensure_not_bundle_subscription(%Subscription{} = subscription) do
     subscription = Sanbase.Repo.preload(subscription, :plan)

--- a/lib/sanbase_web/graphql/schema/types/metric_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/metric_types.ex
@@ -21,6 +21,7 @@ defmodule SanbaseWeb.Graphql.MetricTypes do
     value(:max)
     value(:business_pro)
     value(:business_max)
+    value(:institutional)
     value(:custom)
     value(:bundle)
   end

--- a/lib/sanbase_web/live/admin/bundle_subscriptions_live.ex
+++ b/lib/sanbase_web/live/admin/bundle_subscriptions_live.ex
@@ -1340,7 +1340,10 @@ defmodule SanbaseWeb.Admin.BundleSubscriptionsLive do
                 class="select select-sm w-32"
               >
                 <option
-                  :for={plan <- ~w(FREE BASIC PRO PRO_PLUS MAX BUSINESS_PRO BUSINESS_MAX)}
+                  :for={
+                    plan <-
+                      ~w(FREE BASIC PRO PRO_PLUS MAX BUSINESS_PRO BUSINESS_MAX INSTITUTIONAL)
+                  }
                   value={plan}
                   selected={@compare_plan == plan}
                 >

--- a/priv/repo/migrations/20260806120000_add_institutional_plans.exs
+++ b/priv/repo/migrations/20260806120000_add_institutional_plans.exs
@@ -1,0 +1,65 @@
+defmodule Sanbase.Repo.Migrations.AddInstitutionalPlans do
+  use Ecto.Migration
+
+  @moduledoc ~s"""
+  The `INSTITUTIONAL` plan rows on SanAPI, one per interval.
+
+  Unlike the `BUNDLE` marker rows added alongside them, these are real priced
+  plans: Institutional is a fixed tier bought with one Stripe price through the
+  ordinary `subscribe` mutation, not a set of items assembled at checkout. So the
+  amounts live here, and `Sanbase.Billing.Plan.type/1` classifies them
+  `:standard` - no `subscription_items`, no entitlement blob.
+
+  `is_private` starts `true`, which is what keeps the plan out of sale until
+  someone turns the new offering on from `/admin/bundle_offering`. Both rows are
+  toggled together with the `BUNDLE` rows by
+  `Sanbase.Billing.Plan.SaleControls`, and both are excluded from
+  `Sanbase.Billing.Plan.product_with_plans/0` - the pricing page renders the
+  Institutional column from its own copy rather than from a plans listing.
+
+  `stripe_id` is left NULL. `Sanbase.Billing.sync_products_with_stripe/0` creates
+  the Stripe plan on first run and writes the id back, the same way every other
+  plans row gets one.
+
+  Prices are the provisional ones from the product brief and are expected to
+  change before launch (see §8 task IN and Q11 in
+  docs/composable-api-plans-handover.md). Changing them later is an UPDATE here
+  plus a new Stripe price - not a schema change.
+
+  See task IN of docs/composable-api-plans-handover.md.
+  """
+
+  # Continuing the block the BUNDLE markers started (301, 302), with a gap left
+  # in case more marker rows are needed for the composable side.
+  @institutional_monthly_plan_id 311
+  @institutional_yearly_plan_id 312
+
+  # In cents. $799 / month, $9,500 / year.
+  @monthly_amount 79_900
+  @yearly_amount 950_000
+
+  @sanapi_product_id 1
+
+  def up do
+    execute("""
+    INSERT INTO plans (id, name, product_id, amount, currency, interval, "order", is_private, is_deprecated, has_custom_restrictions)
+    SELECT #{@institutional_monthly_plan_id}, 'INSTITUTIONAL', p.id, #{@monthly_amount}, 'USD', 'month', 32, true, false, false
+    FROM products p WHERE p.id = #{@sanapi_product_id}
+    ON CONFLICT DO NOTHING
+    """)
+
+    execute("""
+    INSERT INTO plans (id, name, product_id, amount, currency, interval, "order", is_private, is_deprecated, has_custom_restrictions)
+    SELECT #{@institutional_yearly_plan_id}, 'INSTITUTIONAL', p.id, #{@yearly_amount}, 'USD', 'year', 33, true, false, false
+    FROM products p WHERE p.id = #{@sanapi_product_id}
+    ON CONFLICT DO NOTHING
+    """)
+  end
+
+  def down do
+    execute("""
+    DELETE FROM plans
+    WHERE id IN (#{@institutional_monthly_plan_id}, #{@institutional_yearly_plan_id})
+    """)
+  end
+end

--- a/priv/repo/seed_plans_and_products.exs
+++ b/priv/repo/seed_plans_and_products.exs
@@ -48,6 +48,18 @@ INSERT INTO plans (id, name, product_id, amount, currency, interval, "order", is
   ON CONFLICT DO NOTHING
 """)
 
+# The INSTITUTIONAL rows. A fixed tier rather than a marker, so these carry real
+# amounts and are bought through the ordinary `subscribe` mutation. Private until
+# the new offering is activated, and excluded from product_with_plans for the same
+# reason the BUNDLE rows are - the pricing page renders this column from its own
+# copy.
+Sanbase.Repo.query!("""
+INSERT INTO plans (id, name, product_id, amount, currency, interval, "order", is_private) VALUES
+  (311,'INSTITUTIONAL',1,79900,'USD','month',32,'t'),
+  (312,'INSTITUTIONAL',1,950000,'USD','year',33,'t')
+  ON CONFLICT DO NOTHING
+""")
+
 # Local bundle catalog only (12 rows). Stripe Prices are created by
 # Sanbase.Billing.sync_bundle_catalog_with_stripe/0 (also on @reboot via
 # sync_products_with_stripe/0).

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict vRvBMnR6yeJFcSDUdBWjzLeQF7FFNGEPxze7qTAgNFZoPss3b43lQy2k6FPwHmJ
+\restrict DU13wkKFgO6KfQBf3LBObP8aAk7FUjW3LwAnnjZP0ZOTKJnrDHgfj6WeazDACvK
 
 -- Dumped from database version 17.10 (Homebrew)
 -- Dumped by pg_dump version 17.10 (Homebrew)
@@ -12227,7 +12227,7 @@ ALTER TABLE ONLY public.webinar_registrations
 -- PostgreSQL database dump complete
 --
 
-\unrestrict vRvBMnR6yeJFcSDUdBWjzLeQF7FFNGEPxze7qTAgNFZoPss3b43lQy2k6FPwHmJ
+\unrestrict DU13wkKFgO6KfQBf3LBObP8aAk7FUjW3LwAnnjZP0ZOTKJnrDHgfj6WeazDACvK
 
 INSERT INTO public."schema_migrations" (version) VALUES (20171008200815);
 INSERT INTO public."schema_migrations" (version) VALUES (20171008203355);
@@ -12824,3 +12824,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20260804140000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260804145231);
 INSERT INTO public."schema_migrations" (version) VALUES (20260805111145);
 INSERT INTO public."schema_migrations" (version) VALUES (20260805125543);
+INSERT INTO public."schema_migrations" (version) VALUES (20260806120000);

--- a/test/fixtures/billing/access_matrix.json
+++ b/test/fixtures/billing/access_matrix.json
@@ -1670,6 +1670,299 @@
         }
       }
     },
+    "INSTITUTIONAL": {
+      "items": {
+        "metric:active_addresses_24h": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": false,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": null
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": null
+            }
+          }
+        },
+        "metric:daily_active_addresses": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": false,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": null
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": null
+            }
+          }
+        },
+        "metric:dev_activity": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": false,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": null
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": null
+            }
+          }
+        },
+        "metric:mvrv_usd": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": true,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": 1095,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": {
+                "__raise__": "CaseClauseError"
+              },
+              "realtime_data_cut_off_in_days": {
+                "__raise__": "CaseClauseError"
+              }
+            }
+          }
+        },
+        "metric:nft_market_volume": {
+          "access?": true,
+          "min_plan": "PRO",
+          "restricted?": true,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": 1095,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": {
+                "__raise__": "CaseClauseError"
+              },
+              "realtime_data_cut_off_in_days": {
+                "__raise__": "CaseClauseError"
+              }
+            }
+          }
+        },
+        "metric:price_usd": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": false,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": null
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": null
+            }
+          }
+        },
+        "metric:social_volume_total": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": true,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": 1095,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": {
+                "__raise__": "CaseClauseError"
+              },
+              "realtime_data_cut_off_in_days": {
+                "__raise__": "CaseClauseError"
+              }
+            }
+          }
+        },
+        "query:all_projects": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": false,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": 1095,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": {
+                "__raise__": "CaseClauseError"
+              },
+              "realtime_data_cut_off_in_days": {
+                "__raise__": "CaseClauseError"
+              }
+            }
+          }
+        },
+        "query:current_user": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": false,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": 1095,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": {
+                "__raise__": "CaseClauseError"
+              },
+              "realtime_data_cut_off_in_days": {
+                "__raise__": "CaseClauseError"
+              }
+            }
+          }
+        },
+        "query:gas_used": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": true,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": 1095,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": {
+                "__raise__": "CaseClauseError"
+              },
+              "realtime_data_cut_off_in_days": {
+                "__raise__": "CaseClauseError"
+              }
+            }
+          }
+        },
+        "query:history_price": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": false,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": 1095,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": {
+                "__raise__": "CaseClauseError"
+              },
+              "realtime_data_cut_off_in_days": {
+                "__raise__": "CaseClauseError"
+              }
+            }
+          }
+        },
+        "query:miners_balance": {
+          "access?": true,
+          "min_plan": "PRO",
+          "restricted?": true,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": 1095,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": {
+                "__raise__": "CaseClauseError"
+              },
+              "realtime_data_cut_off_in_days": {
+                "__raise__": "CaseClauseError"
+              }
+            }
+          }
+        },
+        "query:project_by_slug": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": false,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": 1095,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": {
+                "__raise__": "CaseClauseError"
+              },
+              "realtime_data_cut_off_in_days": {
+                "__raise__": "CaseClauseError"
+              }
+            }
+          }
+        },
+        "query:realtime_top_holders": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": true,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": 1095,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": {
+                "__raise__": "CaseClauseError"
+              },
+              "realtime_data_cut_off_in_days": {
+                "__raise__": "CaseClauseError"
+              }
+            }
+          }
+        },
+        "query:top_holders": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": true,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": 1095,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": {
+                "__raise__": "CaseClauseError"
+              },
+              "realtime_data_cut_off_in_days": {
+                "__raise__": "CaseClauseError"
+              }
+            }
+          }
+        }
+      },
+      "plan_level": {
+        "acl_plan": "sanapi_institutional",
+        "alerts_limit": 50,
+        "api_call_limits": {
+          "hour": 30000,
+          "minute": 600,
+          "month": 50000
+        },
+        "clickhouse_repo": "Sanbase.ClickhouseRepo.BusinessMaxUser",
+        "credits_limit": 500000,
+        "plan_has_limits?": true,
+        "query_executions_limit": {
+          "day": 15000,
+          "hour": 3000,
+          "minute": 100
+        },
+        "response_size_limits": {
+          "month": 50000
+        }
+      }
+    },
     "MAX": {
       "items": {
         "metric:active_addresses_24h": {
@@ -4246,6 +4539,255 @@
           "day": 500,
           "hour": 200,
           "minute": 20
+        },
+        "response_size_limits": {
+          "month": null
+        }
+      }
+    },
+    "INSTITUTIONAL": {
+      "items": {
+        "metric:active_addresses_24h": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": false,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": null
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": null
+            }
+          }
+        },
+        "metric:daily_active_addresses": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": false,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": null
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": null
+            }
+          }
+        },
+        "metric:dev_activity": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": false,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": null
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": null
+            }
+          }
+        },
+        "metric:mvrv_usd": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": true,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            }
+          }
+        },
+        "metric:nft_market_volume": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": true,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            }
+          }
+        },
+        "metric:price_usd": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": false,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": null
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": null
+            }
+          }
+        },
+        "metric:social_volume_total": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": true,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            }
+          }
+        },
+        "query:all_projects": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": false,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            }
+          }
+        },
+        "query:current_user": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": false,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            }
+          }
+        },
+        "query:gas_used": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": true,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            }
+          }
+        },
+        "query:history_price": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": false,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            }
+          }
+        },
+        "query:miners_balance": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": true,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            }
+          }
+        },
+        "query:project_by_slug": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": false,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            }
+          }
+        },
+        "query:realtime_top_holders": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": true,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            }
+          }
+        },
+        "query:top_holders": {
+          "access?": true,
+          "min_plan": "FREE",
+          "restricted?": true,
+          "windows": {
+            "subscription_product=SANAPI": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            },
+            "subscription_product=SANBASE": {
+              "historical_data_in_days": null,
+              "realtime_data_cut_off_in_days": 0
+            }
+          }
+        }
+      },
+      "plan_level": {
+        "acl_plan": "sanbase_institutional",
+        "alerts_limit": 50,
+        "api_call_limits": {
+          "hour": null,
+          "minute": null,
+          "month": null
+        },
+        "clickhouse_repo": "Sanbase.ClickhouseRepo.FreeUser",
+        "credits_limit": {
+          "__raise__": "CaseClauseError"
+        },
+        "plan_has_limits?": true,
+        "query_executions_limit": {
+          "__raise__": "CaseClauseError"
         },
         "response_size_limits": {
           "month": null

--- a/test/sanbase/billing/plan/institutional_test.exs
+++ b/test/sanbase/billing/plan/institutional_test.exs
@@ -1,0 +1,366 @@
+defmodule Sanbase.Billing.Plan.InstitutionalTest do
+  @moduledoc ~s"""
+  What the `INSTITUTIONAL` plan grants, and who is allowed to buy it.
+
+  Institutional is the middle column of the new SanAPI offering (§1.1), but it is
+  deliberately *not* built out of packages: it is a fixed plan on the standard
+  path, so its access and quota are declared in code rather than assembled from
+  purchased items. That makes almost everything about it a matter of adding one
+  clause to each plan-dependent `case`, and the failure mode of that is a missing
+  clause - either a `CaseClauseError` on the first real request, or a catch-all
+  quietly answering as if the customer were on FREE.
+
+  `Sanbase.Billing.PlanTypeDispatchTest` and the access-matrix fixture already
+  catch a missing clause. This file pins the *values*, because several of them are
+  intentionally not what the neighbouring tier gets and would otherwise look like
+  mistakes to whoever reads them next:
+
+    * 50,000 calls a month - lower than every other paid SanAPI plan, and lower
+      than a single package. Institutional sells breadth and a 3-year history;
+      volume is what packages and their add-ons sell (§9).
+    * a 3-year history window, where BUSINESS_MAX has no limit at all.
+    * full Sanbase, so the Sanbase-side answers are MAX's rather than PRO's - a
+      bundle gets PRO's, and that difference is the point.
+
+  See `docs/composable-api-plans-handover.md` §8 task IN.
+  """
+
+  use Sanbase.DataCase, async: false
+
+  import Mock
+  import Sanbase.Factory
+
+  alias Sanbase.Accounts.Role
+  alias Sanbase.Accounts.UserRole
+  alias Sanbase.ApiCallLimit
+  alias Sanbase.Billing.Plan
+  alias Sanbase.Billing.Plan.AccessChecker
+  alias Sanbase.Billing.Plan.Bundle.Lifecycle
+  alias Sanbase.Billing.Plan.SanbaseAccessChecker
+  alias Sanbase.Billing.Subscription
+  alias Sanbase.Queries.Authorization
+  alias Sanbase.Repo
+  alias Sanbase.StripeApi
+
+  @plan "INSTITUTIONAL"
+  @acl_plan "sanapi_institutional"
+
+  # A metric and a query that a FREE user cannot have in full, so "full SanAPI"
+  # is actually being asserted rather than a free-for-all answer.
+  @restricted_metric {:metric, "mvrv_usd"}
+  @pro_only_query {:query, :miners_balance}
+
+  describe "plan classification" do
+    test "is a standard plan, not a bundle" do
+      # It shares the offering with BUNDLE commercially and nothing else
+      # technically: no items, no entitlement, no multi-item Stripe subscription.
+      assert Plan.type(@plan) == :standard
+      assert Plan.type_of_api_call_limit_plan(@acl_plan) == :standard
+    end
+
+    test "reaches the access layer under its own name" do
+      # plan_name/1 is the first function an authenticated request hits. Without a
+      # clause it raises CaseClauseError before any other code runs.
+      assert Plan.plan_name(%Plan{name: @plan}) == @plan
+    end
+  end
+
+  describe "SanAPI access" do
+    test "grants the metrics and queries a paid API plan grants" do
+      assert AccessChecker.plan_has_access?(@restricted_metric, "SANAPI", @plan)
+      assert AccessChecker.plan_has_access?(@pro_only_query, "SANAPI", @plan)
+    end
+
+    test "history is three years, where BUSINESS_MAX has no limit" do
+      # The window is the product's, not an inherited one. BUSINESS_MAX answers nil
+      # (unlimited) and BUSINESS_PRO 730 - this sits between them on purpose.
+      assert data_windows(@restricted_metric, "SANAPI") == %{history: 3 * 365, cut_off: 0}
+
+      assert AccessChecker.historical_data_in_days(
+               @restricted_metric,
+               "SANAPI",
+               "SANAPI",
+               "BUSINESS_MAX"
+             ) == nil
+    end
+
+    test "the window does not depend on which item is asked about" do
+      # One window for the whole plan. A per-item answer would mean the 3-year
+      # limit could be missing on whichever item nobody thought to check.
+      assert data_windows(@pro_only_query, "SANAPI") == %{history: 3 * 365, cut_off: 0}
+    end
+
+    test "realtime data is included" do
+      assert data_windows(@restricted_metric, "SANAPI").cut_off == 0
+    end
+
+    test "the metric catalog can be browsed by plan name alone" do
+      # `getAvailableMetrics(plan: INSTITUTIONAL)` reaches here. A bundle cannot be
+      # answered this way - every bundle is named BUNDLE and each allows something
+      # different - but Institutional is a fixed plan, so the name is the whole
+      # question.
+      metrics = AccessChecker.get_available_metrics_for_plan(@plan, "SANAPI", :all)
+
+      assert {:metric, metric} = @restricted_metric
+      assert metric in metrics
+    end
+  end
+
+  describe "Sanbase access" do
+    test "answers as MAX, because full Sanbase is part of what was sold" do
+      # A bundle answers as PRO here. Institutional includes Sanbase outright, so
+      # it gets the top Sanbase tier instead.
+      assert SanbaseAccessChecker.alerts_limit(@plan) == SanbaseAccessChecker.alerts_limit("MAX")
+
+      assert SanbaseAccessChecker.can_access_paywalled_insights?(%Subscription{
+               plan: %Plan{name: @plan}
+             })
+    end
+  end
+
+  describe "call quota" do
+    test "50,000 calls a month - deliberately the lowest of the paid API plans" do
+      assert ApiCallLimit.plan_to_api_call_limits(@acl_plan) == %{
+               month: 50_000,
+               hour: 30_000,
+               minute: 600
+             }
+    end
+
+    test "the burst limits are not scaled down with the month" do
+      # The monthly figure is what is being sold; the hour and minute are there to
+      # stop a single client saturating the cluster. Throttling an institutional
+      # customer harder than a package customer inside their own allowance would
+      # be a worse plan for more money.
+      assert ApiCallLimit.plan_to_api_call_limits(@acl_plan)
+             |> Map.take([:hour, :minute]) ==
+               ApiCallLimit.plan_to_api_call_limits("sanapi_pro")
+               |> Map.take([:hour, :minute])
+    end
+
+    test "has limits at all" do
+      # Not on the unlimited list. A flagship plan with no quota row would be
+      # discovered as an unmetered customer, not as a bug.
+      assert ApiCallLimit.plan_has_limits?(@acl_plan)
+    end
+
+    test "response size is capped" do
+      assert ApiCallLimit.plan_to_response_size_limits(@acl_plan) == %{month: 50_000}
+    end
+  end
+
+  describe "Queries and complexity" do
+    test "gets the widest table access and the BUSINESS_MAX query allowances" do
+      # Everything that is neither metric access nor call volume answers as the
+      # top standard tier: these are not dimensions Institutional sells, and
+      # inventing separate numbers for each would be a set of values nobody
+      # decided.
+      for site <- [:repo, :credits, :executions] do
+        assert authorization(site, @plan) == authorization(site, "BUSINESS_MAX"),
+               "#{site} should answer as BUSINESS_MAX"
+      end
+    end
+
+    test "query complexity is divided as for BUSINESS_MAX" do
+      # This site runs in Absinthe's document phase rather than through
+      # AccessChecker, which is how it was missed for bundles and raised
+      # CaseClauseError on the first real request.
+      args = %{from: ~U[2026-01-01 00:00:00Z], to: ~U[2026-02-01 00:00:00Z], interval: "1d"}
+
+      assert complexity(args, @plan) == complexity(args, "BUSINESS_MAX")
+    end
+  end
+
+  describe "MCP" do
+    test "an Institutional subscriber is MAX tier" do
+      # MCP is listed in what Institutional includes, and classify/2 has a
+      # catch-all returning :free - so a missing clause here would not raise, it
+      # would silently sell MCP and then serve 15 calls a minute.
+      user = insert(:user)
+
+      insert(:subscription_pro,
+        user_id: user.id,
+        plan_id: institutional_plan("month").id,
+        status: :active,
+        stripe_id: "sub_inst_" <> Ecto.UUID.generate()
+      )
+
+      assert Sanbase.MCP.Restrictions.tier_for_user(user) == :max
+    end
+  end
+
+  describe "who may buy it" do
+    setup do
+      insert(:role_san_team)
+      institutional_plan("month")
+      bundle_plan("month")
+
+      %{user: insert(:user, stripe_customer_id: "cus_inst_" <> Ecto.UUID.generate())}
+    end
+
+    test "not for sale while the new offering is deactivated", %{user: user} do
+      assert {:error, "The Institutional plan is not available for purchase yet"} =
+               Lifecycle.ensure_can_subscribe_institutional(user)
+    end
+
+    test "a team member can buy it while it is deactivated", %{user: user} do
+      # How it gets tested before launch, and the same exemption bundles have.
+      {:ok, _} = UserRole.create(user.id, Role.san_team_role_id())
+
+      assert :ok = Lifecycle.ensure_can_subscribe_institutional(user)
+    end
+
+    test "for sale once the offering is activated", %{user: user} do
+      activate_offering()
+
+      assert :ok = Lifecycle.ensure_can_subscribe_institutional(user)
+    end
+
+    test "refused to a customer who already has a bundle", %{user: user} do
+      # The rule that has_active_subscriptions/2 cannot enforce: it compares plan
+      # ids, so without this the customer ends up with two live SanAPI
+      # subscriptions billing at once.
+      activate_offering()
+
+      insert(:subscription_pro,
+        user_id: user.id,
+        plan_id: bundle_plan("month").id,
+        status: :active,
+        stripe_id: "sub_bundle_" <> Ecto.UUID.generate()
+      )
+
+      assert {:error, "You already have an active SanAPI subscription on the new offering"} =
+               Lifecycle.ensure_can_subscribe_institutional(user)
+    end
+
+    test "allowed while a replaceable legacy subscription is still live", %{user: user} do
+      # The legacy subscription is not canceled here. It is canceled with proration
+      # by cancel_stale_replaced_subscriptions/0 once the new one is actually live -
+      # so a declined first invoice cannot cost the customer the plan they are
+      # still paying for.
+      activate_offering()
+
+      legacy =
+        insert(:subscription_pro,
+          user_id: user.id,
+          plan_id: business_pro_plan().id,
+          status: :active,
+          stripe_id: "sub_legacy_" <> Ecto.UUID.generate()
+        )
+
+      assert :ok = Lifecycle.ensure_can_subscribe_institutional(user)
+      assert Repo.reload!(legacy).status == :active
+    end
+
+    test "subscribe refuses before charging anything", %{user: user} do
+      # The gate is only worth having if it runs before Stripe does. If it moved
+      # below the charge, the customer would be billed and then told no.
+      with_mocks([
+        {StripeApi, [:passthrough],
+         [
+           create_customer_with_card: fn _, _ ->
+             {:ok, %Stripe.Customer{id: "cus_never_created"}}
+           end,
+           create_subscription: fn _ -> {:ok, %Stripe.Subscription{id: "sub_never_created"}} end
+         ]}
+      ]) do
+        assert {:error, %Subscription.Error{message: message}} =
+                 Subscription.subscribe(user, institutional_plan("month"), "card_token")
+
+        assert message == "The Institutional plan is not available for purchase yet"
+
+        assert_not_called(StripeApi.create_customer_with_card(:_, :_))
+        assert_not_called(StripeApi.create_subscription(:_))
+      end
+    end
+  end
+
+  describe "the plan rows" do
+    test "are kept out of the pricing page listing" do
+      # Same reason the BUNDLE markers are: the Institutional column is rendered
+      # from its own copy, and listing the row would offer subscribe(plan_id:) a
+      # plan the pricing page does not drive.
+      institutional_plan("month")
+
+      assert {:ok, products} = Plan.product_with_plans()
+
+      refute @plan in Enum.flat_map(products, fn product ->
+               Enum.map(product.plans, & &1.name)
+             end)
+    end
+
+    test "are toggled by the same switch as the bundle rows" do
+      # One switch for the whole offering. Two would allow a state where the
+      # pricing page shows a column nobody can buy.
+      monthly = institutional_plan("month")
+      bundle_plan("month")
+
+      assert {:ok, ids} = Sanbase.Billing.Plan.SaleControls.activate_bundle_plans()
+      assert monthly.id in ids
+      refute Repo.reload!(monthly).is_private
+    end
+  end
+
+  # --- helpers ---
+
+  # Not `windows/2`: DataCase imports Ecto.Query, which exports a macro by that
+  # name, and the clash is a compile error rather than a shadowing warning.
+  defp data_windows(item, product) do
+    %{
+      history: AccessChecker.historical_data_in_days(item, product, product, @plan),
+      cut_off: AccessChecker.realtime_data_cut_off_in_days(item, product, product, @plan)
+    }
+  end
+
+  defp authorization(:repo, plan), do: Authorization.user_plan_to_dynamic_repo("SANAPI", plan)
+  defp authorization(:credits, plan), do: Authorization.credits_limit("SANAPI", plan)
+
+  defp authorization(:executions, plan),
+    do: Authorization.query_executions_limit("SANAPI", plan)
+
+  defp complexity(args, plan_name) do
+    subscription = %Subscription{plan: %Plan{name: plan_name}}
+
+    SanbaseWeb.Graphql.Complexity.from_to_interval(args, 5, %{
+      context: %{auth: %{subscription: subscription}}
+    })
+  end
+
+  defp activate_offering do
+    {:ok, _} = Sanbase.Billing.Plan.SaleControls.activate_bundle_plans()
+    :ok
+  end
+
+  defp institutional_plan(interval), do: new_offering_plan(@plan, interval, 9701)
+  defp bundle_plan(interval), do: new_offering_plan("BUNDLE", interval, 9711)
+
+  # The migration seeds these rows against products.id = 1, which does not exist
+  # when the test database is migrated - so in tests they have to be created here.
+  defp new_offering_plan(name, interval, base_id) do
+    product_api_id = Sanbase.Billing.Product.product_api()
+
+    case Repo.get_by(Plan, name: name, interval: interval, product_id: product_api_id) do
+      %Plan{} = plan ->
+        plan
+
+      nil ->
+        id = base_id + if interval == "month", do: 0, else: 1
+        Repo.query!("ALTER SEQUENCE plans_id_seq RESTART WITH #{base_id + 100}")
+
+        insert(:plan_pro,
+          id: id,
+          name: name,
+          product_id: product_api_id,
+          interval: interval,
+          amount: if(name == @plan, do: 79_900, else: 0),
+          is_private: true,
+          is_deprecated: false,
+          stripe_id: "plan_#{String.downcase(name)}_#{interval}_" <> Ecto.UUID.generate()
+        )
+    end
+  end
+
+  defp business_pro_plan do
+    Repo.get_by(Plan, name: "BUSINESS_PRO", interval: "month")
+  end
+end

--- a/test/sanbase/billing/plan/institutional_test.exs
+++ b/test/sanbase/billing/plan/institutional_test.exs
@@ -252,6 +252,27 @@ defmodule Sanbase.Billing.Plan.InstitutionalTest do
       assert Repo.reload!(legacy).status == :active
     end
 
+    test "the sale switch is checked on its own, without the one-subscription rule" do
+      # What `updateSubscription` needs. That path replaces the subscription it is
+      # called on, so a customer who already has a live SanAPI subscription must not
+      # be refused for having one - but the plan still has to be for sale.
+      user = insert(:user)
+
+      insert(:subscription_pro,
+        user_id: user.id,
+        plan_id: business_pro_plan().id,
+        status: :active,
+        stripe_id: "sub_legacy_" <> Ecto.UUID.generate()
+      )
+
+      assert {:error, "The Institutional plan is not available for purchase yet"} =
+               Lifecycle.ensure_institutional_for_sale(user)
+
+      activate_offering()
+
+      assert :ok = Lifecycle.ensure_institutional_for_sale(user)
+    end
+
     test "subscribe refuses before charging anything", %{user: user} do
       # The gate is only worth having if it runs before Stripe does. If it moved
       # below the charge, the customer would be billed and then told no.

--- a/test/sanbase/billing/plan_type_dispatch_test.exs
+++ b/test/sanbase/billing/plan_type_dispatch_test.exs
@@ -365,6 +365,13 @@ defmodule Sanbase.Billing.PlanTypeDispatchTest do
       assert Plan.plan_name(%Plan{name: @bundle_plan}) == @bundle_plan
     end
 
+    test "accepts an INSTITUTIONAL plan without raising" do
+      # Same reason as the BUNDLE clause above. Institutional is dispatched as a
+      # standard plan, but it still needs its own clause here because plan_name/1
+      # matches on names rather than on Plan.type/1.
+      assert Plan.plan_name(%Plan{name: "INSTITUTIONAL"}) == "INSTITUTIONAL"
+    end
+
     test "still normalises and passes through existing names" do
       assert Plan.plan_name(%Plan{name: "ESSENTIAL"}) == "BASIC"
       assert Plan.plan_name(%Plan{name: "PRO"}) == "PRO"

--- a/test/support/billing/access_matrix.ex
+++ b/test/support/billing/access_matrix.ex
@@ -52,6 +52,7 @@ defmodule Sanbase.Billing.AccessMatrix do
       "MAX",
       "BUSINESS_PRO",
       "BUSINESS_MAX",
+      "INSTITUTIONAL",
       "CUSTOM",
       "PREMIUM"
     ]


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

```
┌───────────────────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                       │                                                                                                                  │
├───────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ History                               │ 1095 days — between BUSINESS_PRO's 730 and BUSINESS_MAX's unlimited, on purpose                                  │
├───────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Realtime                              │ included (cut-off 0)                                                                                             │
├───────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Calls                                 │ 50,000/month — lowest of any paid API plan, per product; burst stays at PRO's 30,000/hour · 600/min              │
├───────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Metrics                               │ everything a paid API plan gets; no min_plan in the schema is above PRO, so the ladder already answers correctly │
├───────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Sanbase                               │ MAX-equivalent — a bundle gets PRO here, and that difference is the point                                        │
├───────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ MCP                                   │ :max. classify/2 catch-alls to :free, so a missing clause would have sold MCP then served 15 calls/minute        │
├───────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Repo, credits, executions, complexity │ as BUSINESS_MAX — none of these is a dimension Institutional sells                                               │
├───────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ 14-day API trial                      │ excluded, like the Business plans                                                                                │
└───────────────────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Institutional plan for SanAPI and Sanbase, with monthly and yearly pricing options.
  - Institutional access includes three years of historical data, realtime access, expanded query allowances, and higher API quotas.
  - Added Institutional plan support across plan selection, comparisons, authorization, and GraphQL.
- **Access & Billing**
  - Institutional subscriptions are available only when activated for sale.
  - Prevented incompatible existing subscriptions from being combined with Institutional plans.
  - Institutional plans are excluded from API trials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->