### PR TITLE
Improve failed telegram sent alert error msg

### DIFF
--- a/lib/sanbase/alerts/alert.ex
+++ b/lib/sanbase/alerts/alert.ex
@@ -278,35 +278,32 @@ defimpl Sanbase.Alert, for: Any do
 
   defp maybe_send_preview_image_as_reply(_, _, _, _), do: :ok
 
-  # Convert known telegram API errors to reason maps. The scheduler
-  # deactivates alerts whose reason marks a permanently broken destination.
-  defp normalize_telegram_response({:error, error}, user_trigger) do
-    cond do
-      not is_binary(error) ->
-        # If the error is not binary, for example :closed, do not alerts_template
-        # the other functions
-        :ok
+  defp normalize_telegram_response({:error, error}, user_trigger) when is_binary(error) do
+    %{id: trigger_id, user: %User{id: user_id}} = user_trigger
 
-      String.contains?(error, "chat not found") ->
-        %{user: %User{id: user_id}, trigger: %{id: trigger_id}} = user_trigger
-        {:error, %{reason: :telegram_chat_not_found, user_id: user_id, trigger_id: trigger_id}}
+    reason =
+      cond do
+        String.contains?(error, "chat not found") -> :telegram_chat_not_found
+        String.contains?(error, "blocked the telegram bot") -> :telegram_bot_blocked
+        String.contains?(error, "status 404") -> :telegram_chat_not_found_404
+        true -> nil
+      end
 
-      String.contains?(error, "blocked the telegram bot") ->
-        %{user: %User{id: user_id}, trigger: %{id: trigger_id}} = user_trigger
-        {:error, %{reason: :telegram_bot_blocked, user_id: user_id, trigger_id: trigger_id}}
-
-      String.contains?(error, "error 404. Reason: Not Found") ->
-        %{user: %User{id: user_id}, trigger: %{id: trigger_id}} = user_trigger
-
-        {:error,
-         %{reason: :telegram_chat_not_found_404, user_id: user_id, trigger_id: trigger_id}}
-
-      true ->
+    case reason do
+      nil ->
         {:error, error}
+
+      reason ->
+        Logger.info(
+          "Failed to deliver telegram alert with user_trigger_id=#{trigger_id} " <>
+            "user_id=#{user_id}. Reason: #{reason}"
+        )
+
+        {:error, %{reason: reason, user_id: user_id, trigger_id: trigger_id}}
     end
   end
 
-  defp normalize_telegram_response(_response, _trigger), do: :ok
+  defp normalize_telegram_response({:ok, _response}, _user_trigger), do: :ok
 
   defp send_preview_image(response, channel, short_url_id) do
     Task.Supervisor.async_nolink(Sanbase.TaskSupervisor, fn ->

--- a/lib/sanbase/telegram/telegram.ex
+++ b/lib/sanbase/telegram/telegram.ex
@@ -101,7 +101,7 @@ defmodule Sanbase.Telegram do
   The chat_id is the `@<alias name>` of a channel when the channel is pubic
   The chat_id is `-100<chat id>` when the channel is private
   """
-  @spec send_message_to_chat_id(non_neg_integer(), message, nil | %User{}) ::
+  @spec send_message_to_chat_id(integer() | String.t(), message, nil | %User{}) ::
           {:ok, any()} | {:error, String.t()}
   def send_message_to_chat_id(chat_id, text, user \\ nil) do
     content =
@@ -113,6 +113,8 @@ defmodule Sanbase.Telegram do
       }
       |> Jason.encode!()
 
+    recipient = describe_recipient(chat_id, user)
+
     case post("sendMessage", content) do
       {:ok, %Tesla.Env{status: 200, body: body}} ->
         {:ok, body}
@@ -121,16 +123,14 @@ defmodule Sanbase.Telegram do
         body = Jason.decode!(json_body)
 
         error_msg =
-          "Telegram message not senterror 400. Reason: #{Map.get(body, "description", "Bad request")}"
+          "Telegram message not sent (#{recipient}). Error status 400. Reason: #{Map.get(body, "description", "Bad request")}"
 
         Logger.info(error_msg)
         {:error, error_msg}
 
       {:ok, %Tesla.Env{status: 403}} ->
-        user_data = if user, do: "User with id #{user.id}", else: "User"
-
         error_msg =
-          "Telegram message not sent error 403. Reason: #{user_data} has blocked the telegram bot."
+          "Telegram message not sent (#{recipient}). Error status 403. Reason: The recipient has blocked the telegram bot."
 
         Logger.info(error_msg)
         {:error, error_msg}
@@ -139,15 +139,26 @@ defmodule Sanbase.Telegram do
         body = Jason.decode!(json_body)
 
         error_msg =
-          "Telegram message not sent error 404. Reason: #{Map.get(body, "description", "Chat ID not found")}"
+          "Telegram message not sent (#{recipient}). Error status 404. Reason: #{Map.get(body, "description", "Chat ID not found")}"
 
         Logger.info(error_msg)
         {:error, error_msg}
 
-      error ->
-        Logger.warning("Telegram message not sent. Reason: #{inspect(error)}")
-        {:error, "Telegram message not sent."}
-        error
+      # Do not inspect Tesla.Env/Tesla.Error - their request URL embeds the bot token
+      {:ok, %Tesla.Env{status: status}} ->
+        error_msg = "Telegram message not sent (#{recipient}). Error status #{status}."
+        Logger.warning(error_msg)
+        {:error, error_msg}
+
+      %Tesla.Error{reason: reason} ->
+        error_msg = "Telegram message not sent (#{recipient}). Reason: #{inspect(reason)}"
+        Logger.warning(error_msg)
+        {:error, error_msg}
+
+      {:error, reason} ->
+        error_msg = "Telegram message not sent (#{recipient}). Reason: #{inspect(reason)}"
+        Logger.warning(error_msg)
+        {:error, error_msg}
     end
   end
 
@@ -251,4 +262,9 @@ defmodule Sanbase.Telegram do
   defp generate_link(user_token) do
     "https://telegram.me/#{Config.module_get(__MODULE__, :bot_username)}?start=#{user_token}"
   end
+
+  defp describe_recipient(chat_id, %User{id: user_id}),
+    do: "chat_id=#{chat_id} user_id=#{user_id}"
+
+  defp describe_recipient(chat_id, _user), do: "chat_id=#{chat_id}"
 end

--- a/test/sanbase/telegram/telegram_test.exs
+++ b/test/sanbase/telegram/telegram_test.exs
@@ -123,6 +123,21 @@ defmodule Sanbase.TelegramTest do
     assert has_telegram_connected == true
   end
 
+  test "unhandled telegram API response does not leak the bot token" do
+    Tesla.Mock.mock(fn %Tesla.Env{method: :post} = env ->
+      %Tesla.Env{env | status: 500, body: "Internal Server Error"}
+    end)
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:error, error_msg} = Telegram.send_message_to_chat_id(123, "test message")
+        assert error_msg == "Telegram message not sent (chat_id=123). Error status 500."
+        refute error_msg =~ "api.telegram.org"
+      end)
+
+    refute log =~ "api.telegram.org"
+  end
+
   # Private functions
 
   defp get_telegram_deep_link(context) do


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Telegram delivery failures, including clearer errors for invalid, inaccessible, or missing destinations.
  * Preserved unexpected transport errors instead of incorrectly treating them as successful operations.
  * Added recipient details to Telegram error messages to make delivery issues easier to diagnose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->