### PR TITLE
mcp improvements

### DIFF
--- a/lib/sanbase/mcp/http_plugs.ex
+++ b/lib/sanbase/mcp/http_plugs.ex
@@ -3,12 +3,20 @@ defmodule Sanbase.MCP.AuthPlug do
   Plug that enforces authentication for MCP endpoints.
   Supports both OAuth Bearer tokens and API key authentication.
   Rejects unauthenticated requests with 401 before they reach the MCP server.
+
+  The MCP handshake and tool-surface introspection (`initialize`, `tools/list`,
+  `ping`, the `notifications/initialized` notification) are allowed without
+  credentials so MCP directory probes and anonymous clients can discover the
+  available tools. No data is reachable this way: `Sanbase.MCP.Server` rejects
+  `tools/call` and `prompts/get` when there is no `current_user`.
   """
   @behaviour Plug
 
   import Plug.Conn
 
   alias Boruta.Oauth.Authorization
+
+  @public_methods ["initialize", "notifications/initialized", "ping", "tools/list"]
 
   @doc "Returns the given options unchanged."
   @spec init(opts :: term()) :: term()
@@ -21,15 +29,41 @@ defmodule Sanbase.MCP.AuthPlug do
   def call(conn, _opts) do
     case get_authorization_value(conn) do
       nil ->
-        reject(conn, "Authorization header required")
+        if public_request?(conn) do
+          conn
+        else
+          reject(conn, "Authorization header required")
+        end
 
       header_value ->
+        # Credentials that fail validation are rejected even for public
+        # methods, so clients with expired tokens get the 401 + www-authenticate
+        # that restarts their OAuth flow instead of silently degrading to
+        # an anonymous session.
         case try_oauth(header_value) || try_apikey(header_value) do
           {:ok, user} -> assign(conn, :current_user, user)
           nil -> reject(conn, "Invalid credentials")
         end
     end
   end
+
+  defp public_request?(%Plug.Conn{method: "POST", body_params: body_params}) do
+    case body_params do
+      %{"method" => method} ->
+        method in @public_methods
+
+      # JSON-RPC batch requests: Plug.Parsers wraps top-level arrays in "_json"
+      %{"_json" => requests} when is_list(requests) and requests != [] ->
+        Enum.all?(requests, fn request ->
+          is_map(request) and request["method"] in @public_methods
+        end)
+
+      _ ->
+        false
+    end
+  end
+
+  defp public_request?(_conn), do: false
 
   defp get_authorization_value(conn) do
     case get_req_header(conn, "authorization") do

--- a/lib/sanbase_web/controllers/well_known_controller.ex
+++ b/lib/sanbase_web/controllers/well_known_controller.ex
@@ -1,0 +1,24 @@
+defmodule SanbaseWeb.WellKnownController do
+  use SanbaseWeb, :controller
+
+  @doc """
+  Returns the ownership proof for the Glama MCP directory listing
+  (https://glama.ai/mcp/connectors/io.github.santiment/santiment-mcp).
+
+  Glama re-verifies this URL continuously — removing the endpoint lapses
+  the claim on the listing.
+
+  ## Example
+
+      GET /.well-known/glama.json
+      {"$schema": "https://glama.ai/mcp/schemas/connector.json",
+       "maintainers": [{"email": "team@santiment.net"}]}
+  """
+  @spec glama(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def glama(conn, _params) do
+    json(conn, %{
+      "$schema" => "https://glama.ai/mcp/schemas/connector.json",
+      "maintainers" => [%{"email" => "team@santiment.net"}]
+    })
+  end
+end

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -72,6 +72,7 @@ defmodule SanbaseWeb.Router do
   scope "/.well-known" do
     get("/oauth-authorization-server", SanbaseWeb.OAuthController, :metadata)
     get("/oauth-protected-resource", SanbaseWeb.OAuthController, :protected_resource)
+    get("/glama.json", SanbaseWeb.WellKnownController, :glama)
     options("/oauth-authorization-server", SanbaseWeb.OAuthController, :preflight)
     options("/oauth-protected-resource", SanbaseWeb.OAuthController, :preflight)
   end

--- a/test/sanbase/mcp/mcp_auth_test.exs
+++ b/test/sanbase/mcp/mcp_auth_test.exs
@@ -271,11 +271,9 @@ defmodule SanbaseWeb.Graphql.MCPAuthTest do
     assert String.slice(obfuscated_apikey, -3, 3) == String.slice(context.apikey, -3, 3)
   end
 
-  test "unauthenticated - no authorization header returns 401", _context do
+  test "unauthenticated - initialize and tools/list are public, tools/call is rejected",
+       _context do
     port = Sanbase.Utils.Config.module_get(SanbaseWeb.Endpoint, [:http, :port])
-
-    # The client process starts but crashes when the initialize request gets 401
-    Process.flag(:trap_exit, true)
 
     {:ok, client} =
       Sanbase.MCP.Client.start_link(
@@ -293,8 +291,23 @@ defmodule SanbaseWeb.Graphql.MCPAuthTest do
         protocol_version: "2025-03-26"
       )
 
-    # The client should shut down because the 401 prevents initialization
-    assert_receive {:EXIT, ^client, :shutdown}, 5000
+    # The handshake succeeds without credentials so directory probes can
+    # introspect the tool surface
+    assert Process.alive?(client)
+    wait_for_mcp_initialization()
+
+    assert {:ok, %Anubis.MCP.Response{result: %{"tools" => tools}}} =
+             try_few_times(fn -> Anubis.Client.list_tools(Sanbase.MCP.Client) end,
+               attempts: 3,
+               sleep: 250
+             )
+
+    assert is_list(tools)
+    assert length(tools) > 0
+    assert Enum.all?(tools, fn tool -> is_binary(tool["name"]) end)
+
+    # Data-returning methods are still rejected with 401 at the HTTP layer
+    assert {:error, _} = Sanbase.MCP.Client.call_tool("check_authentication", %{})
   end
 
   test "unauthenticated - invalid bearer token returns 401", _context do

--- a/test/sanbase/mcp/mcp_auth_test.exs
+++ b/test/sanbase/mcp/mcp_auth_test.exs
@@ -307,7 +307,52 @@ defmodule SanbaseWeb.Graphql.MCPAuthTest do
     assert Enum.all?(tools, fn tool -> is_binary(tool["name"]) end)
 
     # Data-returning methods are still rejected with 401 at the HTTP layer
-    assert {:error, _} = Sanbase.MCP.Client.call_tool("check_authentication", %{})
+    assert {:error,
+            %Anubis.MCP.Error{
+              reason: :send_failure,
+              data: %{original_reason: {:http_error, 401, _}}
+            }} = Sanbase.MCP.Client.call_tool("check_authentication", %{})
+  end
+
+  test "unauthenticated - direct tools/call POST returns 401 with www-authenticate", %{
+    conn: conn
+  } do
+    body =
+      Jason.encode!(%{
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: %{name: "check_authentication", arguments: %{}}
+      })
+
+    conn =
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> post("/mcp", body)
+
+    assert conn.status == 401
+    assert [www_authenticate] = get_resp_header(conn, "www-authenticate")
+    assert www_authenticate =~ "resource_metadata"
+  end
+
+  test "unauthenticated - batch mixing public and private methods returns 401", %{conn: conn} do
+    body =
+      Jason.encode!([
+        %{jsonrpc: "2.0", id: 1, method: "tools/list"},
+        %{
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: %{name: "check_authentication", arguments: %{}}
+        }
+      ])
+
+    conn =
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> post("/mcp", body)
+
+    assert conn.status == 401
   end
 
   test "unauthenticated - invalid bearer token returns 401", _context do

--- a/test/sanbase_web/controllers/well_known_controller_test.exs
+++ b/test/sanbase_web/controllers/well_known_controller_test.exs
@@ -1,0 +1,15 @@
+defmodule SanbaseWeb.WellKnownControllerTest do
+  use SanbaseWeb.ConnCase, async: true
+
+  test "GET /.well-known/glama.json returns the Glama ownership proof", %{conn: conn} do
+    response =
+      conn
+      |> get("/.well-known/glama.json")
+      |> json_response(200)
+
+    assert response == %{
+             "$schema" => "https://glama.ai/mcp/schemas/connector.json",
+             "maintainers" => [%{"email" => "team@santiment.net"}]
+           }
+  end
+end


### PR DESCRIPTION
- **Allow unauthenticated MCP handshake and tools/list**
- **Serve /.well-known/glama.json to claim the Glama MCP listing**

## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Glama ownership metadata at `/.well-known/glama.json`.
  * MCP clients can now perform handshake, discovery, ping, and initialization notifications without credentials.
* **Security**
  * Requests requiring authentication remain protected.
  * Invalid credentials continue to be rejected, including for public MCP methods.
* **Bug Fixes**
  * Improved unauthenticated MCP initialization and tool-listing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->