### PR TITLE
Allow more MCP calls to be made without auth

### DIFF
--- a/lib/sanbase/mcp/http_plugs.ex
+++ b/lib/sanbase/mcp/http_plugs.ex
@@ -4,11 +4,12 @@ defmodule Sanbase.MCP.AuthPlug do
   Supports both OAuth Bearer tokens and API key authentication.
   Rejects unauthenticated requests with 401 before they reach the MCP server.
 
-  The MCP handshake and tool-surface introspection (`initialize`, `tools/list`,
-  `ping`, the `notifications/initialized` notification) are allowed without
-  credentials so MCP directory probes and anonymous clients can discover the
-  available tools. No data is reachable this way: `Sanbase.MCP.Server` rejects
-  `tools/call` and `prompts/get` when there is no `current_user`.
+  The MCP handshake and surface introspection (`initialize`, `ping`, the
+  `notifications/initialized` notification and the `*/list` methods) are
+  allowed without credentials so MCP directory probes and anonymous clients
+  can discover the available tools, prompts and resources. No data is
+  reachable this way: `Sanbase.MCP.Server` rejects `tools/call` and
+  `prompts/get` when there is no `current_user`.
   """
   @behaviour Plug
 
@@ -16,7 +17,16 @@ defmodule Sanbase.MCP.AuthPlug do
 
   alias Boruta.Oauth.Authorization
 
-  @public_methods ["initialize", "notifications/initialized", "ping", "tools/list"]
+  @public_methods [
+    "initialize",
+    "notifications/initialized",
+    "ping",
+    "tools/list",
+    "prompts/list",
+    "resources/list",
+    "resources/templates/list",
+    "tasks/list"
+  ]
 
   @doc "Returns the given options unchanged."
   @spec init(opts :: term()) :: term()

--- a/test/sanbase/mcp/mcp_auth_test.exs
+++ b/test/sanbase/mcp/mcp_auth_test.exs
@@ -271,7 +271,7 @@ defmodule SanbaseWeb.Graphql.MCPAuthTest do
     assert String.slice(obfuscated_apikey, -3, 3) == String.slice(context.apikey, -3, 3)
   end
 
-  test "unauthenticated - initialize and tools/list are public, tools/call is rejected",
+  test "unauthenticated - initialize and list methods are public, tools/call is rejected",
        _context do
     port = Sanbase.Utils.Config.module_get(SanbaseWeb.Endpoint, [:http, :port])
 
@@ -305,6 +305,17 @@ defmodule SanbaseWeb.Graphql.MCPAuthTest do
     assert is_list(tools)
     assert length(tools) > 0
     assert Enum.all?(tools, fn tool -> is_binary(tool["name"]) end)
+
+    # Prompt and resource introspection is public as well
+    assert {:ok, %Anubis.MCP.Response{result: %{"prompts" => prompts}}} =
+             Anubis.Client.list_prompts(Sanbase.MCP.Client)
+
+    assert is_list(prompts)
+
+    assert {:ok, %Anubis.MCP.Response{result: %{"resources" => resources}}} =
+             Anubis.Client.list_resources(Sanbase.MCP.Client)
+
+    assert is_list(resources)
 
     # Data-returning methods are still rejected with 401 at the HTTP layer
     assert {:error,


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled unauthenticated discovery of MCP prompts, resources, resource templates, and tasks.
  * Kept data-returning tool requests protected by authentication.

* **Bug Fixes**
  * Corrected public access handling for MCP listing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->