### PR TITLE
Improve DRA session durability

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -68,15 +68,16 @@ config :sanbase, Sanbase.DeepResearch,
   openrouter_api_key: System.get_env("OPENROUTER_API_KEY"),
   tavily_api_key: System.get_env("TAVILY_API_KEY"),
   # Catalog of MCP servers the research UI can connect to. Each entry:
-  # %{key, label, url, auth}. auth: :user_apikey sends the caller's Santiment
-  # API key as `Authorization: Apikey <key>`. Add more entries (local or remote)
-  # here — no code changes needed.
+  # %{key, label, url, auth}, where auth says how THAT server authenticates —
+  # :santiment_apikey (only ours accepts a Santiment key), :bearer (with a
+  # token: field) or :none. Add more entries (local or remote) here — no code
+  # changes needed. See Sanbase.DeepResearch.McpServers.
   mcp_servers: [
     %{
       key: "santiment",
       label: "Santiment",
       url: System.get_env("DRA_MCP_URL", "http://localhost:4000/mcp"),
-      auth: :user_apikey,
+      auth: :santiment_apikey,
       # Dev override: send this fixed key instead of the logged-in user's key.
       # Needed when a local UI points at a remote MCP (the local user's key is
       # unknown to the remote DB). Unset (the default) = current user's key.

--- a/lib/sanbase/application/application.ex
+++ b/lib/sanbase/application/application.ex
@@ -326,6 +326,10 @@ defmodule Sanbase.Application do
       # Start the Task Supervisor
       {Task.Supervisor, [name: Sanbase.TaskSupervisor]},
 
+      # Deep research runners keep a run alive across LiveView disconnects.
+      {Registry, [keys: :unique, name: Sanbase.DeepResearch.Registry]},
+      {DynamicSupervisor, [name: Sanbase.DeepResearch.RunnerSupervisor, strategy: :one_for_one]},
+
       # Star the API call service
       Sanbase.ApiCallLimit.ETS,
 

--- a/lib/sanbase/deep_research/client.ex
+++ b/lib/sanbase/deep_research/client.ex
@@ -16,66 +16,126 @@ defmodule Sanbase.DeepResearch.Client do
 
   Thread creation, cancellation and the state-poll fallback are plain request/
   response calls.
+
+  Every call fails with `{:error, %Sanbase.DeepResearch.Failure{}}` — a message
+  naming the call, the agent and the reason, plus whether the turn is worth
+  resuming. Failures are logged here too: the turn's copy can be closed with the
+  tab, and a run that broke with nobody watching still has to be findable.
+
+  ## Timeouts
+
+  **Nothing here caps how long a run may take.** A research run that thinks, calls
+  tools and loops for twenty minutes or two hours is expected, and no timeout in
+  this module counts against it. The stream has no total-duration limit at all:
+  Finch's `:request_timeout` is left at its `:infinity` default.
+
+  What is bounded, and what each bound means:
+
+    * **Connecting to the agent** (5s, every call including the stream). A host
+      that is down or unreachable never completes the TCP connect; failing fast
+      there is what makes "the agent is unreachable" readable instead of arriving
+      as a slow, unexplained `"timeout"`.
+
+    * **The stream's silence** (15 min). Finch applies `:receive_timeout` *per
+      chunk*, restarting the clock on every byte, so this is the longest the run
+      may send NOTHING — not the longest it may run. It exists only because a
+      half-open connection (killed pod, dropped NAT entry) never announces itself:
+      without it a dead socket would hang the run forever with the UI spinning.
+      Hitting it is treated as a lost connection, so the turn parks `:paused` and
+      Continue resumes it on the same thread — the agent's work is not thrown away.
+
+    * **The one-shot calls** (15s per attempt, one retry): create a thread, cancel
+      a run, poll thread state. These are answered from the agent's own store, so
+      slower than that means a sick server. None of them is in the research path.
+
+  A reverse proxy in front of the agent has idle timeouts of its own, and those we
+  cannot see from here: a run cut at a suspiciously round number of seconds with
+  the agent still healthy is a proxy, not this module.
   """
 
-  alias Sanbase.DeepResearch.{Config, EventParser, SSE}
+  alias Sanbase.DeepResearch.{Config, EventParser, Failure, SSE}
 
   require Logger
 
-  # Generous gap between SSE chunks — a research run can pause for a while while
-  # the model thinks before emitting the next event.
-  @stream_receive_timeout 300_000
-  @request_timeout 30_000
+  # -- the stream's budget (see the "Timeouts" section of the moduledoc) ----------
+
+  # How long the stream may stay SILENT, not how long a run may take. Finch applies
+  # `:receive_timeout` per chunk and restarts the clock on every byte that arrives
+  # (`Mint.HTTP.recv/3` inside its receive loop), and the total-duration timeout
+  # (`:request_timeout`) is left at its `:infinity` default, so a run is free to
+  # take hours as long as it keeps emitting.
+  #
+  # A silent stretch is the model thinking, or a tool call that reports nothing
+  # until it returns. 15 minutes is well past both; past that we assume a dead
+  # socket, which a half-open connection (no FIN — killed pod, dropped NAT entry)
+  # never tells us about. Not `:infinity` for exactly that reason: the run would
+  # hang forever with the UI spinning on it.
+  @stream_idle_timeout 900_000
+
+  # -- the one-shot calls' budget -------------------------------------------------
+
+  # Separate from the read timeout on purpose: a host that is down or unreachable
+  # (agent not running, VPN off, wrong address) never completes the TCP connect,
+  # and spending the full read timeout on that hides a connectivity problem behind
+  # a slow, unexplained "timeout". Fails in seconds instead. Applies to the stream's
+  # own connect too — only reaching the agent is bounded, never the research.
+  @connect_timeout 5_000
+
+  # One-shot calls (create, cancel, state poll) are answered from the agent's own
+  # store, so anything slower than this is a sick server, not a slow one. Retried
+  # once on a transport blip, which keeps the worst case at what a single attempt
+  # used to cost.
+  @request_timeout 15_000
+  @request_retries 1
+
+  # Fixed, rather than Req's exponential default, so the worst case below is
+  # arithmetic instead of a guess: one quick retry is all a transport blip needs.
+  @retry_delay 500
+
+  # What ONE one-shot call can cost at worst: every attempt spending its connect
+  # budget and then its read budget, plus the backoff between attempts. A caller
+  # that wraps such a call in a task of its own has to outlast this, or it kills a
+  # call that was still going. Nothing here bounds a run — see `@stream_idle_timeout`.
+  @oneshot_worst_case (@request_retries + 1) * (@connect_timeout + @request_timeout) +
+                        @request_retries * @retry_delay + 1_000
 
   @buffer_key :dra_sse_buffer
 
-  @doc "Create a new thread. Returns `{:ok, thread_id}` or `{:error, reason}`."
-  @spec create_thread() :: {:ok, String.t()} | {:error, String.t()}
+  @doc "Create a new thread. Returns `{:ok, thread_id}` or `{:error, failure}`."
+  @spec create_thread() :: {:ok, String.t()} | {:error, Failure.t()}
   def create_thread() do
-    case Req.post(
-           url("/threads"),
-           request_opts(json: %{}, receive_timeout: @request_timeout, retry: false)
-         ) do
+    case Req.post(url("/threads"), oneshot_opts(json: %{})) do
       {:ok, %{status: status, body: %{"thread_id" => thread_id}}} when status in 200..299 ->
         {:ok, thread_id}
 
       {:ok, %{status: status, body: body}} ->
-        {:error, "create_thread failed (HTTP #{status}): #{inspect(body)}"}
+        {:error, response_failure("create_thread", status, body)}
 
       {:error, error} ->
-        {:error, error_message(error)}
+        {:error, connection_failure("create_thread", error)}
     end
   end
 
   @doc """
-  Cancel an in-flight run. Returns `{:error, reason}` on failure (also logged) —
-  the thread is reused for later turns, so a failed cancel leaving the previous
-  run alive is worth surfacing. The LiveView fires cancels from a supervised
-  task and treats them as best-effort, but callers that care can react.
+  Cancel an in-flight run. Returns `{:error, failure}` on failure — the thread is
+  reused for later turns, so a failed cancel leaving the previous run alive is
+  worth surfacing. The LiveView fires cancels from a supervised task and treats
+  them as best-effort, but callers that care can react.
   """
-  @spec cancel_run(String.t(), String.t()) :: :ok | {:error, String.t()}
+  @spec cancel_run(String.t(), String.t()) :: :ok | {:error, Failure.t()}
   def cancel_run(thread_id, run_id) do
-    case Req.post(
-           url("/threads/#{thread_id}/runs/#{run_id}/cancel"),
-           request_opts(json: %{}, receive_timeout: @request_timeout, retry: false)
-         ) do
+    case Req.post(url("/threads/#{thread_id}/runs/#{run_id}/cancel"), oneshot_opts(json: %{})) do
       {:ok, %{status: status}} when status in 200..299 ->
         :ok
 
       {:ok, %{status: status, body: body}} ->
-        Logger.warning("DeepResearch cancel_run failed (HTTP #{status}): #{inspect(body)}")
-        {:error, "cancel_run failed (HTTP #{status})"}
+        {:error, response_failure("cancel_run", status, body)}
 
       {:error, error} ->
-        message = error_message(error)
-        Logger.warning("DeepResearch cancel_run failed: #{message}")
-        {:error, message}
+        {:error, connection_failure("cancel_run", error)}
     end
   rescue
-    error ->
-      message = Exception.message(error)
-      Logger.warning("DeepResearch cancel_run failed: #{message}")
-      {:error, message}
+    error -> {:error, log(Failure.crashed(error))}
   end
 
   @doc """
@@ -87,10 +147,7 @@ defmodule Sanbase.DeepResearch.Client do
   """
   @spec cancel_active_runs(String.t()) :: :ok
   def cancel_active_runs(thread_id) do
-    case Req.get(
-           url("/threads/#{thread_id}/runs"),
-           request_opts(receive_timeout: @request_timeout, retry: false)
-         ) do
+    case Req.get(url("/threads/#{thread_id}/runs"), oneshot_opts([])) do
       {:ok, %{status: status, body: runs}} when status in 200..299 and is_list(runs) ->
         # Cancel concurrently: sequential cancels stack their HTTP timeouts,
         # and a Stop should take effect on every run at once.
@@ -99,52 +156,53 @@ defmodule Sanbase.DeepResearch.Client do
         |> Task.async_stream(&cancel_run(thread_id, &1["run_id"]),
           max_concurrency: 5,
           ordered: false,
-          timeout: @request_timeout + 1_000,
+          timeout: @oneshot_worst_case,
           on_timeout: :kill_task
         )
         |> Stream.run()
 
       {:ok, %{status: status, body: body}} ->
-        Logger.warning(
-          "DeepResearch cancel_active_runs failed (HTTP #{status}): #{inspect(body)}"
-        )
-
+        response_failure("cancel_active_runs", status, body)
         :ok
 
       {:error, error} ->
-        Logger.warning("DeepResearch cancel_active_runs failed: #{error_message(error)}")
+        connection_failure("cancel_active_runs", error)
         :ok
     end
   rescue
     error ->
-      Logger.warning("DeepResearch cancel_active_runs failed: #{Exception.message(error)}")
+      log(Failure.crashed(error))
       :ok
   end
 
   @doc "Fetch the thread state (poll fallback after the stream closes)."
-  @spec get_state(String.t()) :: {:ok, map()} | {:error, String.t()}
+  @spec get_state(String.t()) :: {:ok, map()} | {:error, Failure.t()}
   def get_state(thread_id) do
-    case Req.get(
-           url("/threads/#{thread_id}/state"),
-           request_opts(receive_timeout: @request_timeout, retry: false)
-         ) do
-      {:ok, %{status: status, body: body}} when status in 200..299 -> {:ok, body}
-      {:ok, %{status: status}} -> {:error, "get_state failed (HTTP #{status})"}
-      {:error, error} -> {:error, error_message(error)}
+    case Req.get(url("/threads/#{thread_id}/state"), oneshot_opts([])) do
+      {:ok, %{status: status, body: body}} when status in 200..299 ->
+        {:ok, body}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, response_failure("get_state", status, body)}
+
+      {:error, error} ->
+        {:error, connection_failure("get_state", error)}
     end
   end
 
   @doc """
   Stream a run on `thread_id`, forwarding parsed events to `lv_pid` as
   `{:dra_event, ref, result}` messages during the stream. Blocks the calling
-  process until the stream ends — run it via `start_async/3` so the LiveView keeps
-  serving heartbeats. Returns the terminal status for `handle_async/3`.
+  process for as long as the run takes — hours, if the research takes hours; the
+  only limit is how long it may stay silent (see "Timeouts" above). Run it via
+  `start_async/3` so the LiveView keeps serving heartbeats. Returns the terminal
+  status for `handle_async/3`.
 
   `opts[:ref]` is echoed back in every event message (see the moduledoc); the
   rest are forwarded to `Config.run_payload/2`: `:mcp_servers` (list of agent MCP
   server maps) and `:model_tier` (the price-tier name picked in the UI).
   """
-  @spec stream_run(String.t(), String.t(), pid(), keyword()) :: :ok | {:error, String.t()}
+  @spec stream_run(String.t(), String.t(), pid(), keyword()) :: :ok | {:error, Failure.t()}
   def stream_run(thread_id, message, lv_pid, opts \\ []) do
     with :ok <- check_base_url_security() do
       do_stream_run(thread_id, message, lv_pid, opts)
@@ -160,7 +218,9 @@ defmodule Sanbase.DeepResearch.Client do
         url("/threads/#{thread_id}/runs/stream"),
         request_opts(
           json: payload,
-          receive_timeout: @stream_receive_timeout,
+          receive_timeout: @stream_idle_timeout,
+          # Never retried, unlike the one-shot calls: a retry replays the request
+          # and would start a SECOND run whose events interleave with the first's.
           retry: false,
           # The partial-line buffer rides along on the response's private map, so
           # the framing state is explicit and scoped to this request rather than
@@ -179,8 +239,8 @@ defmodule Sanbase.DeepResearch.Client do
 
     case result do
       {:ok, %{status: status}} when status in 200..299 -> :ok
-      {:ok, %{status: status}} -> {:error, "Research stream failed (HTTP #{status})"}
-      {:error, error} -> {:error, error_message(error)}
+      {:ok, %{status: status, body: body}} -> {:error, response_failure("The run", status, body)}
+      {:error, error} -> {:error, connection_failure("the research stream", error)}
     end
   end
 
@@ -210,8 +270,26 @@ defmodule Sanbase.DeepResearch.Client do
 
   defp url(path), do: Config.base_url() <> path
 
-  # Attach the deploy's bearer token (if configured) to a request's options.
+  # The shared shape of every non-streaming call: bounded, retried once.
+  # `:transient` (rather than the default `:safe_transient`) retries the POSTs
+  # too, which is safe for the calls we make with it — a retried create leaves at
+  # most one unused empty thread behind, a repeated cancel is idempotent.
+  defp oneshot_opts(opts) do
+    opts
+    |> Keyword.merge(
+      receive_timeout: @request_timeout,
+      retry: :transient,
+      max_retries: @request_retries,
+      retry_delay: @retry_delay
+    )
+    |> request_opts()
+  end
+
+  # Attach the deploy's bearer token (if configured) and the connect timeout to a
+  # request's options.
   defp request_opts(opts) do
+    opts = Keyword.put(opts, :connect_options, timeout: @connect_timeout)
+
     case Config.auth_token() do
       nil -> opts
       token -> Keyword.put(opts, :auth, {:bearer, token})
@@ -233,7 +311,7 @@ defmodule Sanbase.DeepResearch.Client do
 
         if deployed_env?() and not cluster_internal_host?(host) do
           Logger.error(message)
-          {:error, message}
+          {:error, Failure.refused(message)}
         else
           Logger.warning(message)
           :ok
@@ -252,7 +330,14 @@ defmodule Sanbase.DeepResearch.Client do
     Sanbase.Utils.Config.module_get(Sanbase, :deployment_env) in ["stage", "prod"]
   end
 
-  defp error_message(%{__exception__: true} = error), do: Exception.message(error)
-  defp error_message(error) when is_binary(error), do: error
-  defp error_message(error), do: inspect(error)
+  defp connection_failure(operation, error),
+    do: log(Failure.connection(operation, Config.base_url(), error))
+
+  defp response_failure(operation, status, body),
+    do: log(Failure.response(operation, status, body))
+
+  defp log(%Failure{} = failure) do
+    Logger.warning("DeepResearch: #{failure.message}")
+    failure
+  end
 end

--- a/lib/sanbase/deep_research/config.ex
+++ b/lib/sanbase/deep_research/config.ex
@@ -23,6 +23,7 @@ defmodule Sanbase.DeepResearch.Config do
 
   @default_base_url "http://127.0.0.1:2024"
   @default_assistant_id "deep_research_agent"
+  @default_pause_after_disconnect_ms 60_000
 
   @doc "Base URL of the LangGraph server (no trailing slash)."
   @spec base_url() :: String.t()
@@ -33,6 +34,14 @@ defmodule Sanbase.DeepResearch.Config do
   @doc "Graph id / assistant id to run."
   @spec assistant_id() :: String.t()
   def assistant_id(), do: get(:assistant_id) || @default_assistant_id
+
+  @doc """
+  How long a runner keeps a run alive with no LiveView attached: long enough for a
+  websocket reconnect, short enough that a closed tab stops burning tokens.
+  """
+  @spec pause_after_disconnect_ms() :: non_neg_integer()
+  def pause_after_disconnect_ms(),
+    do: get(:pause_after_disconnect_ms, @default_pause_after_disconnect_ms)
 
   @doc """
   Optional bearer token sent as `Authorization: Bearer <token>` on every request
@@ -120,10 +129,11 @@ defmodule Sanbase.DeepResearch.Config do
 
   @doc """
   The catalog of MCP servers the UI can offer. Each entry is
-  `%{key, label, url, auth}` (`auth: :user_apikey` resolves to the caller's
-  Santiment API key). Defined in `runtime.exs` under `:mcp_servers`, so more
-  servers (local or remote) can be added without code changes; an empty or
-  missing list simply means the UI offers no data sources.
+  `%{key, label, url, auth}`, where `auth` names how THAT server is
+  authenticated — `:none`, `:santiment_apikey` (sanbase's own MCP) or `:bearer`;
+  see `Sanbase.DeepResearch.McpServers`. Defined in `runtime.exs` under
+  `:mcp_servers`, so more servers (local or remote) can be added without code
+  changes; an empty or missing list simply means the UI offers no data sources.
 
   Entries missing any of the required keys are dropped (with a warning) rather
   than handed to the LiveView, where a malformed map would crash the mount.

--- a/lib/sanbase/deep_research/config.ex
+++ b/lib/sanbase/deep_research/config.ex
@@ -24,6 +24,7 @@ defmodule Sanbase.DeepResearch.Config do
   @default_base_url "http://127.0.0.1:2024"
   @default_assistant_id "deep_research_agent"
   @default_pause_after_disconnect_ms 60_000
+  @default_checkpoint_every_ms 10_000
 
   @doc "Base URL of the LangGraph server (no trailing slash)."
   @spec base_url() :: String.t()
@@ -42,6 +43,16 @@ defmodule Sanbase.DeepResearch.Config do
   @spec pause_after_disconnect_ms() :: non_neg_integer()
   def pause_after_disconnect_ms(),
     do: get(:pause_after_disconnect_ms, @default_pause_after_disconnect_ms)
+
+  @doc """
+  How often a runner rewrites the row of the turn it is streaming.
+
+  Between two checkpoints a killed runner (pod eviction, VM kill) loses the events
+  it has not written, so this trades database churn — each write serializes the
+  whole timeline — against how much of an interrupted turn survives.
+  """
+  @spec checkpoint_every_ms() :: non_neg_integer()
+  def checkpoint_every_ms(), do: get(:checkpoint_every_ms, @default_checkpoint_every_ms)
 
   @doc """
   Optional bearer token sent as `Authorization: Bearer <token>` on every request

--- a/lib/sanbase/deep_research/failure.ex
+++ b/lib/sanbase/deep_research/failure.ex
@@ -1,0 +1,107 @@
+defmodule Sanbase.DeepResearch.Failure do
+  @moduledoc """
+  A failed call to the research agent, in the two shapes the rest of the stack
+  needs.
+
+    * `:message` — what the turn is persisted with and what the research UI
+      shows. That UI is admin-only, so the message names the call, the agent's
+      URL and the reason: an agent nobody can reach should read as one, instead
+      of being guessed at from the timing of a bare `"timeout"`.
+
+    * `:resumable?` — whether the run is worth picking back up. A connection that
+      timed out, was refused or dropped says nothing about the research itself:
+      the thread and the work already on it live on the agent side, so the turn
+      is parked `:paused` and Continue resumes it. An answer FROM the agent (an
+      HTTP status) or a call we refused to make is not fixed by retrying, and
+      settles the turn `:failed`.
+
+  Constructed by `Sanbase.DeepResearch.Client` (which knows the call and the
+  URL); consumed by `Sanbase.DeepResearch.Runner.fail_run/2`.
+  """
+
+  defstruct [:message, resumable?: false]
+
+  @type t :: %__MODULE__{message: String.t(), resumable?: boolean()}
+
+  @retry_hint "Nothing was lost — Continue retries the turn."
+
+  @doc """
+  `operation` against `url` never got an answer: DNS, connect or read failed.
+  Resumable — nothing on the agent side went wrong, we just could not talk to it.
+
+  `operation` is read inside parentheses, so name the call as a noun:
+  `"create_thread"`, `"the research stream"`.
+  """
+  @spec connection(String.t(), String.t(), Exception.t() | term()) :: t()
+  def connection(operation, url, error) do
+    %__MODULE__{
+      message:
+        "Connection to the research agent failed: #{reason(error)} " <>
+          "(#{operation}, #{url}). #{@retry_hint}",
+      resumable?: true
+    }
+  end
+
+  @doc """
+  The agent answered `operation` with a status we cannot use. Not resumable: the
+  same call gets the same answer until someone changes the agent's side.
+
+  `operation` opens the sentence — `"create_thread failed (HTTP 401): ..."`.
+  """
+  @spec response(String.t(), non_neg_integer(), term()) :: t()
+  def response(operation, status, body \\ nil) do
+    %__MODULE__{message: "#{operation} failed (HTTP #{status})#{explain(status, body)}"}
+  end
+
+  @doc """
+  Our side stopped mid-run — the stream task crashed, an unexpected exception.
+  Resumable for the same reason a lost connection is: the agent kept working and
+  the thread is still there.
+  """
+  @spec crashed(term()) :: t()
+  def crashed(reason) do
+    %__MODULE__{
+      message: "The research run stopped unexpectedly: #{describe(reason)}. #{@retry_hint}",
+      resumable?: true
+    }
+  end
+
+  @doc "The call was never made — a misconfiguration only a human can clear."
+  @spec refused(String.t()) :: t()
+  def refused(message), do: %__MODULE__{message: message}
+
+  # Transport reasons arrive as `%Req.TransportError{reason: atom}` and carry a
+  # one-word message ("timeout", "closed") that reads as nothing in the UI. Name
+  # what each one means for whoever has to fix it.
+  defp reason(%{reason: :timeout}), do: "the request timed out"
+  defp reason(%{reason: :econnrefused}), do: "connection refused, nothing is listening there"
+  defp reason(%{reason: :closed}), do: "the connection closed mid-request"
+  defp reason(%{reason: :econnreset}), do: "the connection was reset"
+  defp reason(%{reason: :nxdomain}), do: "the host could not be resolved (DNS)"
+
+  defp reason(%{reason: unreachable}) when unreachable in [:ehostunreach, :enetunreach],
+    do: "the host is unreachable from this network (VPN?)"
+
+  defp reason(%{__exception__: true} = error), do: Exception.message(error)
+  defp reason(other), do: inspect(other)
+
+  defp explain(status, _body) when status in [401, 403],
+    do: ": the agent rejected our credentials — check its auth token (DRA_AUTH_TOKEN)."
+
+  defp explain(404, _body), do: ": the agent has no such thread — start a new session."
+
+  defp explain(status, body) when status >= 500,
+    do: ": the agent itself errored." <> summarize(body)
+
+  defp explain(_status, body), do: "." <> summarize(body)
+
+  # Bodies range from a plain string to a decoded map to nothing at all, and a
+  # stack trace from the agent would swamp the UI.
+  defp summarize(nil), do: ""
+  defp summarize(""), do: ""
+  defp summarize(body) when is_binary(body), do: " " <> String.slice(body, 0, 300)
+  defp summarize(body), do: " " <> (body |> inspect() |> String.slice(0, 300))
+
+  defp describe(%{__exception__: true} = error), do: Exception.message(error)
+  defp describe(reason), do: inspect(reason)
+end

--- a/lib/sanbase/deep_research/mcp_servers.ex
+++ b/lib/sanbase/deep_research/mcp_servers.ex
@@ -13,8 +13,9 @@ defmodule Sanbase.DeepResearch.McpServers do
     * `:bearer` — `Authorization: Bearer <token>` with the entry's `:token`, for a
       third-party server we hold a static credential for.
 
-  An entry is dropped rather than sent unauthenticated when its credential does
-  not resolve, or when its `:auth` is one this module does not implement.
+  An entry is dropped (with a warning) rather than sent unauthenticated when its
+  credential does not resolve, when its `:auth` is one this module does not
+  implement, or when the entry itself is malformed — no `:label`/`:url` strings.
   """
 
   require Logger
@@ -80,11 +81,27 @@ defmodule Sanbase.DeepResearch.McpServers do
   defp authenticated(_server, _scheme, credential) when credential in [nil, ""], do: nil
 
   defp authenticated(server, scheme, credential) do
-    Map.put(base_config(server), "headers", %{"Authorization" => "#{scheme} #{credential}"})
+    case base_config(server) do
+      nil -> nil
+      config -> Map.put(config, "headers", %{"Authorization" => "#{scheme} #{credential}"})
+    end
   end
 
+  defp base_config(%{label: label, url: url}) when is_binary(label) and is_binary(url) do
+    %{"name" => label, "label" => label, "url" => url, "tools" => []}
+  end
+
+  # A catalog entry comes from `runtime.exs`, so it can be malformed (an env var
+  # nobody set leaves `url: nil`). Dropping it with a warning keeps the run going
+  # without that server; reading the keys blind would raise inside the stream task,
+  # which parks the turn `:paused` and makes Continue repeat the same crash.
   defp base_config(server) do
-    %{"name" => server.label, "label" => server.label, "url" => server.url, "tools" => []}
+    Logger.warning(
+      "DeepResearch dropping MCP server #{inspect(server[:key])}: " <>
+        "label and url must both be strings, got #{inspect(Map.take(server, [:label, :url]))}"
+    )
+
+    nil
   end
 
   defp apikey_override(server) do

--- a/lib/sanbase/deep_research/mcp_servers.ex
+++ b/lib/sanbase/deep_research/mcp_servers.ex
@@ -1,0 +1,96 @@
+defmodule Sanbase.DeepResearch.McpServers do
+  @moduledoc """
+  Maps enabled MCP catalog entries (see `Sanbase.DeepResearch.Config.mcp_catalog/0`)
+  to the server configs the agent expects.
+
+  Auth is a property of the server, so every entry declares its own `:auth`:
+
+    * `:none` — a public server; no `Authorization` header.
+    * `:santiment_apikey` — `Authorization: Apikey <key>` with the caller's
+      Santiment API key (generated on demand) or the entry's `:apikey_override`.
+      Only sanbase's own MCP server accepts a Santiment key, so this mode belongs
+      to that entry alone.
+    * `:bearer` — `Authorization: Bearer <token>` with the entry's `:token`, for a
+      third-party server we hold a static credential for.
+
+  An entry is dropped rather than sent unauthenticated when its credential does
+  not resolve, or when its `:auth` is one this module does not implement.
+  """
+
+  require Logger
+
+  alias Sanbase.Accounts.{Apikey, User}
+
+  @doc """
+  Configs for the `enabled` catalog entries. May read and create the caller's
+  Santiment API key, so call it from the stream task, not from a GenServer callback.
+  """
+  @spec build([map()], User.t() | nil) :: [map()]
+  def build([], _user), do: []
+
+  def build(enabled, user) do
+    # One lookup covers every entry (a user has one Santiment key), and it is
+    # skipped when no entry needs it — resolving one can CREATE a key.
+    santiment_key = if Enum.any?(enabled, &needs_santiment_apikey?/1), do: santiment_apikey(user)
+
+    enabled |> Enum.map(&server_config(&1, santiment_key)) |> Enum.reject(&is_nil/1)
+  end
+
+  defp needs_santiment_apikey?(%{auth: :santiment_apikey} = server),
+    do: is_nil(apikey_override(server))
+
+  defp needs_santiment_apikey?(_server), do: false
+
+  defp santiment_apikey(%User{} = user) do
+    case Apikey.apikeys_list(user) do
+      {:ok, [apikey | _]} -> apikey
+      {:ok, []} -> generate_santiment_apikey(user)
+      _ -> nil
+    end
+  end
+
+  defp santiment_apikey(_no_user), do: nil
+
+  defp generate_santiment_apikey(user) do
+    case Apikey.generate_apikey(user) do
+      {:ok, apikey} -> apikey
+      _ -> nil
+    end
+  end
+
+  defp server_config(%{auth: :none} = server, _santiment_key), do: base_config(server)
+
+  defp server_config(%{auth: :santiment_apikey} = server, santiment_key),
+    do: authenticated(server, "Apikey", apikey_override(server) || santiment_key)
+
+  defp server_config(%{auth: :bearer} = server, _santiment_key),
+    do: authenticated(server, "Bearer", Map.get(server, :token))
+
+  defp server_config(server, _santiment_key) do
+    Logger.warning(
+      "DeepResearch dropping MCP server #{inspect(server[:key])}: " <>
+        "unsupported auth #{inspect(server[:auth])}"
+    )
+
+    nil
+  end
+
+  # No credential (e.g. an anonymous caller has no api key): drop the server
+  # instead of connecting to it unauthenticated.
+  defp authenticated(_server, _scheme, credential) when credential in [nil, ""], do: nil
+
+  defp authenticated(server, scheme, credential) do
+    Map.put(base_config(server), "headers", %{"Authorization" => "#{scheme} #{credential}"})
+  end
+
+  defp base_config(server) do
+    %{"name" => server.label, "label" => server.label, "url" => server.url, "tools" => []}
+  end
+
+  defp apikey_override(server) do
+    case Map.get(server, :apikey_override) do
+      override when is_binary(override) and override != "" -> override
+      _ -> nil
+    end
+  end
+end

--- a/lib/sanbase/deep_research/runner.ex
+++ b/lib/sanbase/deep_research/runner.ex
@@ -3,7 +3,8 @@ defmodule Sanbase.DeepResearch.Runner do
   Run engine of a deep research session, detached from any LiveView. One runner per
   session in `Sanbase.DeepResearch.Registry`: it streams the run, folds events into
   the current `Turn` (`ref` = turn id; others are stale), persists settled turns
-  and pushes `{:dra_runner, key, snapshot}` to watchers.
+  (plus a periodic checkpoint of the one in flight) and pushes
+  `{:dra_runner, key, snapshot}` to watchers.
 
   It outlives its watchers, so a reconnect reattaches mid-stream. Unwatched for
   `Config.pause_after_disconnect_ms/0` it parks the turn `:paused` (resume with
@@ -15,7 +16,16 @@ defmodule Sanbase.DeepResearch.Runner do
 
   require Logger
 
-  alias Sanbase.DeepResearch.{Client, Config, EventParser, McpServers, Sessions, Timeline, Turn}
+  alias Sanbase.DeepResearch.{
+    Client,
+    Config,
+    EventParser,
+    Failure,
+    McpServers,
+    Sessions,
+    Timeline,
+    Turn
+  }
 
   @registry Sanbase.DeepResearch.Registry
   @supervisor Sanbase.DeepResearch.RunnerSupervisor
@@ -37,6 +47,7 @@ defmodule Sanbase.DeepResearch.Runner do
     :current_turn,
     :task,
     :pause_timer,
+    :checkpointed_at,
     running: false,
     mcp_warning: nil,
     next_id: 1,
@@ -68,6 +79,10 @@ defmodule Sanbase.DeepResearch.Runner do
     end
   end
 
+  # Called by the supervisor through `ensure_started/1`, never directly: a runner
+  # started outside the supervisor is not restarted and not found by `whereis/1`.
+  @doc false
+  @spec start_link(map()) :: GenServer.on_start()
   def start_link(init_arg) do
     GenServer.start_link(__MODULE__, init_arg, name: via(init_arg.key))
   end
@@ -265,6 +280,14 @@ defmodule Sanbase.DeepResearch.Runner do
     end
   end
 
+  # The poll could not be made. That says nothing about the run, so the turn is
+  # settled from the failure instead of being blamed for delivering no report.
+  def handle_info({:dra_poll, ref, %Failure{} = failure}, %{current_turn: %{id: ref}} = state) do
+    state = update_current_turn(state, &settle_failure(&1, failure, now_ms()))
+
+    maybe_wind_down(state)
+  end
+
   def handle_info({:dra_poll, ref, result}, %{current_turn: %{id: ref}} = state) do
     state =
       update_current_turn(state, fn turn ->
@@ -287,7 +310,7 @@ defmodule Sanbase.DeepResearch.Runner do
     state =
       case result do
         :ok -> finalize_run(state)
-        {:error, reason} -> fail_run(state, reason)
+        {:error, failure} -> fail_run(state, failure)
       end
 
     maybe_wind_down(state)
@@ -296,7 +319,7 @@ defmodule Sanbase.DeepResearch.Runner do
   def handle_info({:DOWN, ref, :process, _pid, reason}, %{task: %Task{ref: ref}} = state) do
     state =
       %{state | task: nil}
-      |> fail_run("Research stopped unexpectedly (#{inspect(reason)})")
+      |> fail_run(Failure.crashed(reason))
 
     maybe_wind_down(state)
   end
@@ -384,12 +407,22 @@ defmodule Sanbase.DeepResearch.Runner do
     end
   end
 
-  defp fail_run(%{running: false} = state, _reason), do: state
+  defp fail_run(%{running: false} = state, _failure), do: state
 
-  defp fail_run(state, reason) do
+  defp fail_run(state, %Failure{} = failure) do
     %{state | running: false}
-    |> update_current_turn(&Timeline.fail_turn(&1, reason, now_ms()))
+    |> update_current_turn(&settle_failure(&1, failure, now_ms()))
   end
+
+  # A turn the connection broke under is parked `:paused`, not `:failed`: the agent
+  # kept the thread and the work on it, so the turn stays resumable with
+  # `continue/3` — the same treatment a runner that died mid-run gets. Only the
+  # agent's own refusals settle a turn as failed. See `DeepResearch.Failure`.
+  defp settle_failure(turn, %Failure{resumable?: true} = failure, now_ms),
+    do: Timeline.pause_turn(turn, now_ms, failure.message)
+
+  defp settle_failure(turn, %Failure{} = failure, now_ms),
+    do: Timeline.fail_turn(turn, failure.message, now_ms)
 
   # The agent stopped without ever delivering a report.
   defp fail_no_report(turn), do: Timeline.fail_turn(turn, @no_report_error, now_ms())
@@ -468,17 +501,47 @@ defmodule Sanbase.DeepResearch.Runner do
     prev = state.current_turn
     next = fun.(prev)
 
-    maybe_persist_settled(state, prev, next)
-    broadcast(%{state | current_turn: next})
+    %{state | current_turn: next}
+    |> persist_turn(prev, next)
+    |> broadcast()
   end
 
-  defp maybe_persist_settled(state, prev, next) do
-    if state.session_id && Timeline.settled_phase?(next.phase) && next != prev do
-      with {:error, error} <- Sessions.update_turn(state.session_id, next.id, next) do
-        log_persist_error("update_turn", error)
-      end
+  # Two reasons to write a turn's row — and neither of them is "every event": the
+  # settling write, which is the row's final state, and a checkpoint while the turn
+  # is still streaming.
+  defp persist_turn(%{session_id: nil} = state, _prev, _next), do: state
+  defp persist_turn(state, prev, next) when next == prev, do: state
 
-      Sessions.touch_session(state.session_id)
+  defp persist_turn(state, _prev, next) do
+    cond do
+      Timeline.settled_phase?(next.phase) ->
+        write_turn(state, next)
+        Sessions.touch_session(state.session_id)
+
+        # Reset, so the next turn's checkpoint clock starts from its own first event.
+        %{state | checkpointed_at: nil}
+
+      # The first event of a turn needs no write — `persist_new_turn/2` just made the
+      # row. It only starts the clock.
+      is_nil(state.checkpointed_at) ->
+        %{state | checkpointed_at: now_ms()}
+
+      # Bounds what an abrupt node loss (pod eviction, VM kill) can take with it:
+      # nothing settles the turn then, so without checkpoints the row keeps only the
+      # question and the turn comes back with an empty timeline. Timed rather than
+      # per-event, because each write serializes the whole timeline.
+      now_ms() - state.checkpointed_at >= Config.checkpoint_every_ms() ->
+        write_turn(state, next)
+        %{state | checkpointed_at: now_ms()}
+
+      true ->
+        state
+    end
+  end
+
+  defp write_turn(state, turn) do
+    with {:error, error} <- Sessions.update_turn(state.session_id, turn.id, turn) do
+      log_persist_error("update_turn", error)
     end
 
     :ok
@@ -525,14 +588,15 @@ defmodule Sanbase.DeepResearch.Runner do
 
   defp poll_state_async(thread_id, sink, ref) do
     Task.Supervisor.start_child(Sanbase.TaskSupervisor, fn ->
-      result =
-        case Client.get_state(thread_id) do
-          {:ok, state} -> EventParser.parse_thread_state(state)
-          _ -> %{}
-        end
-
-      send(sink, {:dra_poll, ref, result})
+      send(sink, {:dra_poll, ref, poll_result(thread_id)})
     end)
+  end
+
+  defp poll_result(thread_id) do
+    case Client.get_state(thread_id) do
+      {:ok, state} -> EventParser.parse_thread_state(state)
+      {:error, failure} -> failure
+    end
   end
 
   # No run_id yet (the stream never reported one) — cancel whatever the thread has active.

--- a/lib/sanbase/deep_research/runner.ex
+++ b/lib/sanbase/deep_research/runner.ex
@@ -1,0 +1,554 @@
+defmodule Sanbase.DeepResearch.Runner do
+  @moduledoc """
+  Run engine of a deep research session, detached from any LiveView. One runner per
+  session in `Sanbase.DeepResearch.Registry`: it streams the run, folds events into
+  the current `Turn` (`ref` = turn id; others are stale), persists settled turns
+  and pushes `{:dra_runner, key, snapshot}` to watchers.
+
+  It outlives its watchers, so a reconnect reattaches mid-stream. Unwatched for
+  `Config.pause_after_disconnect_ms/0` it parks the turn `:paused` (resume with
+  `continue/3`) and stops; idle it stops at once. The registry is node-local — a
+  reconnect on another node sees `:paused`.
+  """
+
+  use GenServer, restart: :temporary
+
+  require Logger
+
+  alias Sanbase.DeepResearch.{Client, Config, EventParser, McpServers, Sessions, Timeline, Turn}
+
+  @registry Sanbase.DeepResearch.Registry
+  @supervisor Sanbase.DeepResearch.RunnerSupervisor
+
+  @continue_message "Continue the interrupted research. Pick up where you left off, reuse the " <>
+                      "work already done on this thread, and deliver the final report."
+
+  @no_report_error "The research run finished without producing a report — the agent stopped " <>
+                     "before delivering one (it may have hit a tool/iteration budget or been " <>
+                     "unable to complete the task). Try rephrasing or narrowing your question."
+
+  defstruct [
+    :key,
+    :session_id,
+    :user,
+    :model_tier,
+    :thread_id,
+    :run_id,
+    :current_turn,
+    :task,
+    :pause_timer,
+    running: false,
+    mcp_warning: nil,
+    next_id: 1,
+    watchers: %{}
+  ]
+
+  @type snapshot :: %{
+          key: String.t(),
+          session_id: Ecto.UUID.t() | nil,
+          thread_id: String.t() | nil,
+          current_turn: Turn.t() | nil,
+          running: boolean(),
+          mcp_warning: String.t() | nil,
+          next_id: pos_integer()
+        }
+
+  # -- public API ----------------------------------------------------------------
+
+  @doc """
+  Start (or find) the runner for `init_arg.key`. Keys: `:key`, `:session_id`
+  (nil = unpersisted), `:user`, `:model_tier`, `:thread_id`, `:next_id`.
+  """
+  @spec ensure_started(map()) :: {:ok, pid()} | {:error, term()}
+  def ensure_started(init_arg) do
+    case DynamicSupervisor.start_child(@supervisor, {__MODULE__, init_arg}) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:ok, pid}
+      other -> other
+    end
+  end
+
+  def start_link(init_arg) do
+    GenServer.start_link(__MODULE__, init_arg, name: via(init_arg.key))
+  end
+
+  @doc "The runner registered under `key`, or nil."
+  @spec whereis(String.t() | nil) :: pid() | nil
+  def whereis(nil), do: nil
+
+  def whereis(key) do
+    case Registry.lookup(@registry, key) do
+      [{pid, _}] -> pid
+      [] -> nil
+    end
+  end
+
+  @doc "Attach `watcher` (monitored); returns the current snapshot."
+  @spec attach(pid(), pid()) :: {:ok, snapshot()} | {:error, :not_alive}
+  def attach(pid, watcher), do: safe_call(pid, {:attach, watcher})
+
+  @doc "Detach `watcher`. With none left the runner pauses after a grace period."
+  @spec detach(pid(), pid()) :: :ok
+  def detach(pid, watcher), do: GenServer.cast(pid, {:detach, watcher})
+
+  @doc """
+  Ask `text` — how every turn starts, the session's first and every follow-up on
+  the same thread.
+
+  Before replying it settles the previous turn if a run left it unsettled (nothing
+  else will, once `:current_turn` moves on), opens turn `next_id` in `:planning`,
+  inserts its row when the session is persisted — so a tab closed mid-run still
+  leaves the question behind — and starts the supervised stream task. The rest is
+  asynchronous: the task creates the thread if there is none and streams
+  `{:dra_event, turn_id, _}` back, which the runner folds into the turn.
+
+  `opts`:
+
+    * `:enabled_mcp` — catalog entries to connect for this run (turned into agent
+      configs inside the task, see `Sanbase.DeepResearch.McpServers`);
+    * `:model_tier` — price tier, remembered for later turns and persisted rows
+      until the next `ask/3` changes it.
+
+  Replies with the post-start snapshot and broadcasts the same one, so a second
+  tab renders the new turn without having asked. `{:error, :busy}` while a run is
+  already streaming — one run per session, and the caller keeps its view.
+  """
+  @spec ask(pid(), String.t(), keyword()) ::
+          {:ok, snapshot()} | {:error, :busy | :not_alive}
+  def ask(pid, text, opts \\ []), do: safe_call(pid, {:ask, text, opts})
+
+  @doc """
+  Resume a `:paused` `turn` rather than asking a new one: streams a continue-run on
+  the same thread INTO that turn (same id, phase back to `:planning`, error
+  cleared), so its partial timeline keeps growing instead of restarting.
+
+  Any run still live server-side is cancelled first — the runner that crashed
+  never got to. With no thread yet there is nothing to pick up, so the turn's
+  question is simply re-asked. Same `opts` as `ask/3`; `{:error, :not_paused}` for
+  a turn in any other phase.
+  """
+  @spec continue(pid(), Turn.t(), keyword()) ::
+          {:ok, snapshot()} | {:error, :busy | :not_paused | :not_alive}
+  def continue(pid, %Turn{} = turn, opts \\ []), do: safe_call(pid, {:continue, turn, opts})
+
+  @doc "Cancel the in-flight run (the user's Stop button)."
+  @spec cancel(pid()) :: {:ok, snapshot()} | {:error, :not_alive}
+  def cancel(pid), do: safe_call(pid, :cancel)
+
+  @doc "Cancel any in-flight run and stop the runner (session deleted)."
+  @spec shutdown(pid()) :: :ok
+  def shutdown(pid), do: GenServer.cast(pid, :shutdown)
+
+  # A runner can stop between lookup and call — don't take the caller down.
+  defp safe_call(pid, msg) do
+    GenServer.call(pid, msg)
+  catch
+    :exit, _ -> {:error, :not_alive}
+  end
+
+  defp via(key), do: {:via, Registry, {@registry, key}}
+
+  # -- GenServer -------------------------------------------------------------------
+
+  @impl true
+  def init(init_arg) do
+    # So terminate/2 runs and stops the stream task.
+    Process.flag(:trap_exit, true)
+
+    {:ok,
+     %__MODULE__{
+       key: init_arg.key,
+       session_id: init_arg[:session_id],
+       user: init_arg[:user],
+       model_tier: init_arg[:model_tier],
+       thread_id: init_arg[:thread_id],
+       next_id: init_arg[:next_id] || 1
+     }}
+  end
+
+  @impl true
+  def handle_call({:attach, watcher}, _from, state) do
+    watchers = Map.put_new_lazy(state.watchers, watcher, fn -> Process.monitor(watcher) end)
+    state = cancel_pause_timer(%{state | watchers: watchers})
+
+    {:reply, {:ok, snapshot(state)}, state}
+  end
+
+  def handle_call({:ask, _text, _opts}, _from, %{running: true} = state),
+    do: {:reply, {:error, :busy}, state}
+
+  def handle_call({:ask, text, opts}, _from, state) do
+    # Nothing settles the old turn once :current_turn changes.
+    state = settle_abandoned_turn(state)
+
+    # Before persist_new_turn, so the row records the tier the run uses.
+    state = %{state | model_tier: Keyword.get(opts, :model_tier, state.model_tier)}
+
+    turn = Timeline.new_turn(text, state.next_id, now_ms())
+    persist_new_turn(state, turn)
+
+    state =
+      state
+      |> start_run(turn, text, opts)
+      |> Map.update!(:next_id, &(&1 + 1))
+
+    {:reply, {:ok, snapshot(state)}, broadcast(state)}
+  end
+
+  def handle_call({:continue, _turn, _opts}, _from, %{running: true} = state),
+    do: {:reply, {:error, :busy}, state}
+
+  def handle_call({:continue, %Turn{phase: :paused} = turn, opts}, _from, state) do
+    # Resuming a DIFFERENT turn strands the current one exactly as :ask would: once
+    # :current_turn moves on, a pending poll reply no longer matches its id.
+    state =
+      if state.current_turn && state.current_turn.id != turn.id,
+        do: settle_abandoned_turn(state),
+        else: state
+
+    resumed = %{turn | phase: :planning, finished_at: nil, error: nil}
+
+    # No thread: nothing to resume, so re-ask the question.
+    message = if state.thread_id, do: @continue_message, else: turn.question
+
+    # A crash never cancelled the old run — it may still be live server-side.
+    state =
+      %{state | next_id: max(state.next_id, turn.id + 1)}
+      |> start_run(resumed, message, opts, cancel_active_first: true)
+
+    {:reply, {:ok, snapshot(state)}, broadcast(state)}
+  end
+
+  def handle_call({:continue, _turn, _opts}, _from, state),
+    do: {:reply, {:error, :not_paused}, state}
+
+  def handle_call(:cancel, _from, %{running: false} = state),
+    do: {:reply, {:ok, snapshot(state)}, state}
+
+  def handle_call(:cancel, _from, state) do
+    state = cancel_current_run(state)
+    {:reply, {:ok, snapshot(state)}, state}
+  end
+
+  @impl true
+  def handle_cast({:detach, watcher}, state) do
+    state = remove_watcher(state, watcher)
+    maybe_wind_down(state)
+  end
+
+  def handle_cast(:shutdown, %{running: true} = state),
+    do: {:stop, :normal, cancel_current_run(state)}
+
+  def handle_cast(:shutdown, state), do: {:stop, :normal, state}
+
+  # -- streamed messages -----------------------------------------------------------
+
+  # The thread id arrives once, from the run that created the thread.
+  @impl true
+  def handle_info({:dra_thread, thread_id}, %{thread_id: nil} = state) do
+    if state.session_id, do: Sessions.set_thread_id(state.session_id, thread_id)
+
+    {:noreply, broadcast(%{state | thread_id: thread_id})}
+  end
+
+  def handle_info({:dra_thread, _thread_id}, state), do: {:noreply, state}
+
+  # `ref` is the turn id — an event for any other turn belongs to a superseded run
+  # and falls through to the catch-all clause below. A terminal turn ignores events
+  # as well; it is already settled and persisted.
+  def handle_info({:dra_event, ref, result}, %{current_turn: %{id: ref, phase: phase}} = state) do
+    if Timeline.terminal_phase?(phase) do
+      {:noreply, state}
+    else
+      state = apply_run_level(state, result)
+      {:noreply, update_current_turn(state, &Timeline.apply_result(&1, result))}
+    end
+  end
+
+  def handle_info({:dra_poll, ref, result}, %{current_turn: %{id: ref}} = state) do
+    state =
+      update_current_turn(state, fn turn ->
+        report = turn.report || result[:report]
+
+        cond do
+          Timeline.settled_phase?(turn.phase) -> turn
+          is_binary(report) -> Timeline.complete_turn(%{turn | report: report}, now_ms())
+          true -> fail_no_report(turn)
+        end
+      end)
+
+    maybe_wind_down(state)
+  end
+
+  def handle_info({task_ref, result}, %{task: %Task{ref: task_ref}} = state) do
+    Process.demonitor(task_ref, [:flush])
+    state = %{state | task: nil}
+
+    state =
+      case result do
+        :ok -> finalize_run(state)
+        {:error, reason} -> fail_run(state, reason)
+      end
+
+    maybe_wind_down(state)
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, reason}, %{task: %Task{ref: ref}} = state) do
+    state =
+      %{state | task: nil}
+      |> fail_run("Research stopped unexpectedly (#{inspect(reason)})")
+
+    maybe_wind_down(state)
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    state = remove_watcher(state, pid)
+    maybe_wind_down(state)
+  end
+
+  def handle_info(:pause_timeout, state) do
+    if map_size(state.watchers) == 0 do
+      {:stop, :normal, pause(state)}
+    else
+      # Re-attached as the timer fired.
+      {:noreply, %{state | pause_timer: nil}}
+    end
+  end
+
+  # Events for a superseded turn, and late replies from superseded tasks.
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, state) do
+    stop_task(state)
+    :ok
+  end
+
+  # -- run lifecycle ----------------------------------------------------------------
+
+  defp start_run(state, turn, message, opts, run_opts \\ []) do
+    sink = self()
+    thread_id = state.thread_id
+    enabled_mcp = Keyword.get(opts, :enabled_mcp, [])
+    user = state.user
+    model_tier = Keyword.get(opts, :model_tier, state.model_tier)
+    ref = turn.id
+    cancel_first? = Keyword.get(run_opts, :cancel_active_first, false)
+
+    task =
+      Task.Supervisor.async_nolink(Sanbase.TaskSupervisor, fn ->
+        if cancel_first? and is_binary(thread_id), do: Client.cancel_active_runs(thread_id)
+
+        # Inside the task: resolving MCP servers does a DB read.
+        stream_opts = [
+          mcp_servers: McpServers.build(enabled_mcp, user),
+          model_tier: model_tier,
+          ref: ref
+        ]
+
+        stream_run(thread_id, message, sink, stream_opts)
+      end)
+
+    %{state | current_turn: turn, running: true, run_id: nil, mcp_warning: nil, task: task}
+  end
+
+  # First run of a session: the thread has to exist before anything can stream.
+  defp stream_run(nil, text, sink, opts) do
+    with {:ok, thread_id} <- Client.create_thread() do
+      send(sink, {:dra_thread, thread_id})
+      Client.stream_run(thread_id, text, sink, opts)
+    end
+  end
+
+  defp stream_run(thread_id, text, sink, opts) when is_binary(thread_id) do
+    Client.stream_run(thread_id, text, sink, opts)
+  end
+
+  defp finalize_run(%{running: false} = state), do: state
+  defp finalize_run(%{current_turn: nil} = state), do: broadcast(%{state | running: false})
+
+  defp finalize_run(%{current_turn: turn} = state) do
+    state = %{state | running: false}
+
+    cond do
+      turn.report || Timeline.settled_phase?(turn.phase) || Timeline.direct_answer?(turn) ->
+        update_current_turn(state, &Timeline.complete_turn(&1, now_ms()))
+
+      # No report, no error — {:dra_poll, _, _} settles it.
+      state.thread_id ->
+        poll_state_async(state.thread_id, self(), turn.id)
+        update_current_turn(state, &Timeline.stamp_finished_at(&1, now_ms()))
+
+      true ->
+        update_current_turn(state, &fail_no_report/1)
+    end
+  end
+
+  defp fail_run(%{running: false} = state, _reason), do: state
+
+  defp fail_run(state, reason) do
+    %{state | running: false}
+    |> update_current_turn(&Timeline.fail_turn(&1, reason, now_ms()))
+  end
+
+  # The agent stopped without ever delivering a report.
+  defp fail_no_report(turn), do: Timeline.fail_turn(turn, @no_report_error, now_ms())
+
+  defp settle_abandoned_turn(%{current_turn: %{phase: phase}} = state) do
+    if Timeline.settled_phase?(phase),
+      do: state,
+      else: update_current_turn(state, &fail_no_report/1)
+  end
+
+  defp settle_abandoned_turn(state), do: state
+
+  defp cancel_current_run(state), do: stop_run(state, &Timeline.cancel_turn(&1, now_ms()))
+
+  # Stop what is in flight (locally and server-side), then settle the turn.
+  defp stop_run(state, settle_fun) do
+    if state.running, do: cancel_run_async(state.thread_id, state.run_id)
+
+    %{stop_task(state) | running: false}
+    |> update_current_turn(settle_fun)
+  end
+
+  # Its SSE connection would otherwise outlive the run.
+  defp stop_task(%{task: nil} = state), do: state
+
+  defp stop_task(state) do
+    Task.shutdown(state.task, :brutal_kill)
+    %{state | task: nil}
+  end
+
+  # -- pausing / winding down --------------------------------------------------------
+
+  defp remove_watcher(state, watcher) do
+    case Map.pop(state.watchers, watcher) do
+      {nil, _} ->
+        state
+
+      {ref, watchers} ->
+        Process.demonitor(ref, [:flush])
+        %{state | watchers: watchers}
+    end
+  end
+
+  # Nobody watching: an unfinished run gets the grace period, a settled one stops.
+  defp maybe_wind_down(%{watchers: watchers} = state) when map_size(watchers) > 0,
+    do: {:noreply, state}
+
+  defp maybe_wind_down(%{current_turn: turn} = state) do
+    if state.running or (turn && not Timeline.settled_phase?(turn.phase)),
+      do: {:noreply, schedule_pause(state)},
+      else: {:stop, :normal, state}
+  end
+
+  defp schedule_pause(%{pause_timer: nil} = state) do
+    timer = Process.send_after(self(), :pause_timeout, Config.pause_after_disconnect_ms())
+    %{state | pause_timer: timer}
+  end
+
+  defp schedule_pause(state), do: state
+
+  defp cancel_pause_timer(%{pause_timer: nil} = state), do: state
+
+  defp cancel_pause_timer(state) do
+    Process.cancel_timer(state.pause_timer)
+    %{state | pause_timer: nil}
+  end
+
+  defp pause(state), do: stop_run(state, &Timeline.pause_turn(&1, now_ms()))
+
+  # -- turn state / persistence / broadcast ------------------------------------------
+
+  # The choke point for turn mutations: persistence and broadcast hang off it.
+  defp update_current_turn(%{current_turn: nil} = state, _fun), do: broadcast(state)
+
+  defp update_current_turn(state, fun) do
+    prev = state.current_turn
+    next = fun.(prev)
+
+    maybe_persist_settled(state, prev, next)
+    broadcast(%{state | current_turn: next})
+  end
+
+  defp maybe_persist_settled(state, prev, next) do
+    if state.session_id && Timeline.settled_phase?(next.phase) && next != prev do
+      with {:error, error} <- Sessions.update_turn(state.session_id, next.id, next) do
+        log_persist_error("update_turn", error)
+      end
+
+      Sessions.touch_session(state.session_id)
+    end
+
+    :ok
+  end
+
+  # Before the run, so a browser closed mid-run still leaves the question behind.
+  defp persist_new_turn(%{session_id: session_id} = state, turn) when is_binary(session_id) do
+    with {:error, error} <- Sessions.create_turn(session_id, turn, state.model_tier) do
+      log_persist_error("create_turn", error)
+    end
+
+    :ok
+  end
+
+  defp persist_new_turn(_state, _turn), do: :ok
+
+  defp apply_run_level(state, result) do
+    %{
+      state
+      | run_id: result[:run_id] || state.run_id,
+        mcp_warning: get_in(result, [:meta, :mcp_warning]) || state.mcp_warning
+    }
+  end
+
+  defp snapshot(state) do
+    %{
+      key: state.key,
+      session_id: state.session_id,
+      thread_id: state.thread_id,
+      current_turn: state.current_turn,
+      running: state.running,
+      mcp_warning: state.mcp_warning,
+      next_id: state.next_id
+    }
+  end
+
+  defp broadcast(state) do
+    snap = snapshot(state)
+    Enum.each(Map.keys(state.watchers), &send(&1, {:dra_runner, state.key, snap}))
+    state
+  end
+
+  # -- side-call tasks (fire-and-forget) ----------------------------------------------
+
+  defp poll_state_async(thread_id, sink, ref) do
+    Task.Supervisor.start_child(Sanbase.TaskSupervisor, fn ->
+      result =
+        case Client.get_state(thread_id) do
+          {:ok, state} -> EventParser.parse_thread_state(state)
+          _ -> %{}
+        end
+
+      send(sink, {:dra_poll, ref, result})
+    end)
+  end
+
+  # No run_id yet (the stream never reported one) — cancel whatever the thread has active.
+  defp cancel_run_async(thread_id, run_id) when is_binary(thread_id) do
+    Task.Supervisor.start_child(Sanbase.TaskSupervisor, fn ->
+      if is_binary(run_id),
+        do: Client.cancel_run(thread_id, run_id),
+        else: Client.cancel_active_runs(thread_id)
+    end)
+  end
+
+  defp cancel_run_async(_thread_id, _run_id), do: :ok
+
+  defp log_persist_error(operation, error) do
+    Logger.warning("Deep research session persistence failed in #{operation}: #{inspect(error)}")
+  end
+
+  defp now_ms(), do: System.system_time(:millisecond)
+end

--- a/lib/sanbase/deep_research/sessions.ex
+++ b/lib/sanbase/deep_research/sessions.ex
@@ -1,16 +1,12 @@
 defmodule Sanbase.DeepResearch.Sessions do
   @moduledoc """
-  Persistence for deep research conversations: sessions (author, model tier,
-  share flag) and their turns, stored as one row per turn.
+  Persistence for deep research sessions and their turns (one row per turn); the
+  only Repo access for the feature. Reads decode rows back into
+  `Sanbase.DeepResearch.Turn` structs, so history renders like a live transcript.
 
-  All Repo access for the feature lives here. Reads decode rows back into
-  `Sanbase.DeepResearch.Turn` structs (via `TurnCodec`), so callers render
-  persisted history exactly like a live transcript.
-
-  Authorization: mutations and `get_session_for_user/2` are owner-only;
-  `get_public_session/1` only requires `is_public` — "must be logged in" is the
-  router's concern. `:forbidden` and `:not_found` are distinct here for tests;
-  the UI collapses both so a session id never leaks its existence.
+  Mutations and `get_session_for_user/2` are owner-only; `get_public_session/1`
+  needs only `is_public`. `:forbidden` vs `:not_found` matters to tests; the UI
+  collapses both so an id never leaks its existence.
   """
 
   import Ecto.Query
@@ -20,23 +16,28 @@ defmodule Sanbase.DeepResearch.Sessions do
   alias Sanbase.Repo
 
   @title_max_length 80
-  @interrupted_error "Interrupted — the research run did not finish (connection lost or the app restarted)."
 
   @type session_with_turns :: %{session: Session.t(), turns: [Turn.t()]}
+
+  @doc "Create a session row owned by `user_id`, titled after its first question."
+  @spec create_session(integer(), String.t(), String.t()) ::
+          {:ok, Session.t()} | {:error, Ecto.Changeset.t()}
+  def create_session(user_id, model_tier, question) do
+    %Session{}
+    |> Session.changeset(%{
+      user_id: user_id,
+      model_tier: model_tier,
+      title: generate_title(question)
+    })
+    |> Repo.insert()
+  end
 
   @doc "Create a session owned by `user_id` plus the row for its first turn."
   @spec start_session(integer(), String.t(), Turn.t()) ::
           {:ok, %{session: Session.t(), turn: SessionTurn.t()}} | {:error, Ecto.Changeset.t()}
   def start_session(user_id, model_tier, %Turn{} = turn) do
     Repo.transaction(fn ->
-      with {:ok, session} <-
-             %Session{}
-             |> Session.changeset(%{
-               user_id: user_id,
-               model_tier: model_tier,
-               title: generate_title(turn.question)
-             })
-             |> Repo.insert(),
+      with {:ok, session} <- create_session(user_id, model_tier, turn.question),
            {:ok, row} <- create_turn(session.id, turn, model_tier) do
         %{session: session, turn: row}
       else
@@ -162,33 +163,19 @@ defmodule Sanbase.DeepResearch.Sessions do
   end
 
   defp load_turns(session) do
-    rows =
+    turns =
       from(t in SessionTurn, where: t.session_id == ^session.id, order_by: [asc: t.position])
       |> Repo.all()
-      |> Enum.map(&reconcile_interrupted_turn/1)
+      |> Enum.map(&(&1 |> pause_if_interrupted() |> TurnCodec.from_row()))
 
-    %{session: session, turns: Enum.map(rows, &TurnCodec.from_row/1)}
+    %{session: session, turns: turns}
   end
 
-  # A row still unsettled at read time means the LiveView died mid-run (the
-  # settling write never happened). Coerce it to a stable failed state and
-  # PERSIST the coercion, so every later viewer sees the same thing. A second
-  # tab peeking at a session still streaming in another tab would mark it
-  # failed early — accepted: the real settling write self-heals the row.
-  defp reconcile_interrupted_turn(row) do
-    if Timeline.settled_phase?(row.phase) do
-      row
-    else
-      attrs = %{
-        phase: :failed,
-        error: row.error || @interrupted_error,
-        finished_at: row.finished_at || DateTime.utc_now()
-      }
-
-      case row |> SessionTurn.changeset(attrs) |> Repo.update() do
-        {:ok, updated} -> updated
-        {:error, _} -> row
-      end
-    end
+  # Unsettled at read time = the runner died mid-run; show :paused, resumable since
+  # the thread survives. Never written back: another node's runner may still own it.
+  defp pause_if_interrupted(row) do
+    if Timeline.settled_phase?(row.phase),
+      do: row,
+      else: %{row | phase: :paused, finished_at: row.finished_at || DateTime.utc_now()}
   end
 end

--- a/lib/sanbase/deep_research/sessions.ex
+++ b/lib/sanbase/deep_research/sessions.ex
@@ -58,7 +58,7 @@ defmodule Sanbase.DeepResearch.Sessions do
     %SessionTurn{} |> SessionTurn.changeset(attrs) |> Repo.insert()
   end
 
-  @doc "Patch the turn at `position` with the turn's current state (the terminal write)."
+  @doc "Patch the turn at `position` with its current state (a checkpoint, or the settling write)."
   @spec update_turn(Ecto.UUID.t(), integer(), Turn.t()) ::
           {:ok, SessionTurn.t()} | {:error, :not_found | Ecto.Changeset.t()}
   def update_turn(session_id, position, %Turn{} = turn) do

--- a/lib/sanbase/deep_research/timeline.ex
+++ b/lib/sanbase/deep_research/timeline.ex
@@ -73,10 +73,18 @@ defmodule Sanbase.DeepResearch.Timeline do
 
   def cancel_turn(turn, now_ms), do: settle(turn, :cancelled, now_ms)
 
-  @doc "Park an unfinished turn as `:paused`; a settled turn is returned as is."
-  @spec pause_turn(turn(), non_neg_integer()) :: turn()
-  def pause_turn(turn, now_ms) do
-    if settled_phase?(turn.phase), do: turn, else: settle(turn, :paused, now_ms)
+  @doc """
+  Park an unfinished turn as `:paused`; a settled turn is returned as is.
+
+  `reason` (why it stopped — a lost connection, a crashed run) is kept alongside
+  the resumable phase, so the UI can say what interrupted the turn while still
+  offering Continue. Nothing to say (the ordinary disconnect pause): `nil`.
+  """
+  @spec pause_turn(turn(), non_neg_integer(), String.t() | nil) :: turn()
+  def pause_turn(turn, now_ms, reason \\ nil) do
+    if settled_phase?(turn.phase),
+      do: turn,
+      else: %{settle(turn, :paused, now_ms) | error: turn.error || reason}
   end
 
   @doc "Stamp the finish time without settling the phase (a run awaiting its poll)."
@@ -93,6 +101,7 @@ defmodule Sanbase.DeepResearch.Timeline do
   def all_phases(), do: @phases ++ [:paused] ++ @terminal_phases
 
   @doc "Is `phase` a terminal (sticky) phase?"
+  @spec terminal_phase?(phase()) :: boolean()
   def terminal_phase?(phase), do: phase in @terminal_phases
 
   @doc """

--- a/lib/sanbase/deep_research/timeline.ex
+++ b/lib/sanbase/deep_research/timeline.ex
@@ -1,8 +1,9 @@
 defmodule Sanbase.DeepResearch.Timeline do
   @moduledoc """
   Pure state reducer for a research transcript: folds parsed stream events into
-  per-turn timeline state (`reduce_timeline`, `upsert_thinking`, `merge_phase`)
-  and groups it for rendering (`segment`, `coalesce`).
+  per-turn timeline state (`reduce_timeline`, `upsert_thinking`, `merge_phase`),
+  settles a turn once its run ends (`complete_turn`, `fail_turn`, `cancel_turn`,
+  `pause_turn`) and groups it for rendering (`segment`, `coalesce`).
 
   Shaping the *finished* report markdown (source reflow, in-report chart specs)
   is a separate concern — see `Sanbase.DeepResearch.ReportMarkdown`.
@@ -32,6 +33,7 @@ defmodule Sanbase.DeepResearch.Timeline do
           | :researching
           | :writing
           | :awaiting_user
+          | :paused
           | :completed
           | :failed
           | :cancelled
@@ -46,20 +48,66 @@ defmodule Sanbase.DeepResearch.Timeline do
     %Turn{id: id, question: question, started_at: started_at_ms}
   end
 
+  # -- settling a turn -----------------------------------------------------------
+  # One rule for all of these: `finished_at` is stamped once (the first settling
+  # write owns it) and an already-terminal phase is never downgraded.
+
+  @doc "Mark a finished run `:completed`; an already settled turn keeps its phase."
+  @spec complete_turn(turn(), non_neg_integer()) :: turn()
+  def complete_turn(turn, now_ms) do
+    phase = if settled_phase?(turn.phase), do: turn.phase, else: :completed
+
+    settle(turn, phase, now_ms)
+  end
+
+  @doc "Fail a turn with `reason`, keeping any error it already carries."
+  @spec fail_turn(turn(), String.t(), non_neg_integer()) :: turn()
+  def fail_turn(turn, reason, now_ms) do
+    %{settle(turn, merge_phase(turn.phase, :failed), now_ms) | error: turn.error || reason}
+  end
+
+  @doc "Cancel a turn (the user's Stop). One that already has a report completes instead."
+  @spec cancel_turn(turn(), non_neg_integer()) :: turn()
+  def cancel_turn(%{report: report} = turn, now_ms) when is_binary(report),
+    do: complete_turn(turn, now_ms)
+
+  def cancel_turn(turn, now_ms), do: settle(turn, :cancelled, now_ms)
+
+  @doc "Park an unfinished turn as `:paused`; a settled turn is returned as is."
+  @spec pause_turn(turn(), non_neg_integer()) :: turn()
+  def pause_turn(turn, now_ms) do
+    if settled_phase?(turn.phase), do: turn, else: settle(turn, :paused, now_ms)
+  end
+
+  @doc "Stamp the finish time without settling the phase (a run awaiting its poll)."
+  @spec stamp_finished_at(turn(), non_neg_integer()) :: turn()
+  def stamp_finished_at(turn, now_ms), do: settle(turn, turn.phase, now_ms)
+
+  defp settle(turn, phase, now_ms),
+    do: %{turn | phase: phase, finished_at: turn.finished_at || now_ms}
+
+  # -- phases --------------------------------------------------------------------
+
   @doc "Every phase a turn can be in, running and terminal."
   @spec all_phases() :: [phase()]
-  def all_phases(), do: @phases ++ @terminal_phases
+  def all_phases(), do: @phases ++ [:paused] ++ @terminal_phases
 
   @doc "Is `phase` a terminal (sticky) phase?"
   def terminal_phase?(phase), do: phase in @terminal_phases
 
   @doc """
-  A settled turn needs no further work: any terminal phase, plus
-  `:awaiting_user` — a clarification request is a finished exchange (the reply
-  arrives as a new turn), not an interrupted run.
+  Needs no further work: any terminal phase, plus `:awaiting_user` (a finished
+  exchange, not an interrupted run) and `:paused` (interrupted but resumable).
   """
   @spec settled_phase?(phase()) :: boolean()
-  def settled_phase?(phase), do: terminal_phase?(phase) or phase == :awaiting_user
+  def settled_phase?(phase), do: terminal_phase?(phase) or phase in [:awaiting_user, :paused]
+
+  @doc """
+  Nothing left in flight to render: terminal or `:paused`. Settles spinners the
+  interrupted run never closed. `:awaiting_user` is live, so not inactive.
+  """
+  @spec inactive_phase?(phase()) :: boolean()
+  def inactive_phase?(phase), do: terminal_phase?(phase) or phase == :paused
 
   @doc "Is `phase` an in-progress (running) phase?"
   def running_phase?(phase), do: phase in @running_phases
@@ -254,11 +302,14 @@ defmodule Sanbase.DeepResearch.Timeline do
 
     * terminal phases are sticky (never moved by a later update);
     * reaching a terminal phase always wins over the in-progress phases;
+    * `:paused` leaves via a running phase (a resumed run's first events). No
+      event moves a turn INTO `:paused`, so it has no phase-order index;
     * otherwise advance monotonically through the in-progress order.
   """
   @spec merge_phase(phase(), phase() | nil) :: phase()
   def merge_phase(current, nil), do: current
   def merge_phase(current, current), do: current
+  def merge_phase(:paused, next) when next in @running_phases, do: next
 
   def merge_phase(current, next) do
     cond do

--- a/lib/sanbase_web/live/deep_research/components.ex
+++ b/lib/sanbase_web/live/deep_research/components.ex
@@ -200,14 +200,35 @@ defmodule SanbaseWeb.DeepResearch.Components do
         questions={@turn.clarification}
       />
 
-      <div
-        :if={@turn.error}
-        class="flex items-start gap-2 rounded-xl border border-error/30 bg-error/5 px-4 py-3 text-sm text-error"
-        role="alert"
-      >
-        <.icon name="hero-exclamation-triangle" class="mt-0.5 size-4 shrink-0" />
-        <span>{@turn.error}</span>
-      </div>
+      <.turn_error :if={@turn.error} turn={@turn} />
+    </div>
+    """
+  end
+
+  attr :turn, :map, required: true
+
+  # A `:paused` turn stopped for a reason it can be picked up from — a lost
+  # connection, a run that crashed — with a Continue offered right above it. That
+  # is a warning, not the red of research that failed and is going nowhere.
+  defp turn_error(assigns) do
+    assigns = assign(assigns, :resumable?, assigns.turn.phase == :paused)
+
+    ~H"""
+    <div
+      class={[
+        "flex items-start gap-2 rounded-xl border px-4 py-3 text-sm",
+        if(@resumable?,
+          do: "border-warning/30 bg-warning/5 text-warning",
+          else: "border-error/30 bg-error/5 text-error"
+        )
+      ]}
+      role={if @resumable?, do: "status", else: "alert"}
+    >
+      <.icon
+        name={if @resumable?, do: "hero-pause-circle", else: "hero-exclamation-triangle"}
+        class="mt-0.5 size-4 shrink-0"
+      />
+      <span>{@turn.error}</span>
     </div>
     """
   end

--- a/lib/sanbase_web/live/deep_research/components.ex
+++ b/lib/sanbase_web/live/deep_research/components.ex
@@ -60,17 +60,18 @@ defmodule SanbaseWeb.DeepResearch.Components do
 
   attr :sessions, :list, required: true, doc: "the user's sessions, most recent first"
   attr :current_session_id, :string, default: nil
-  attr :running, :boolean, required: true, doc: "navigation is disabled while a run streams"
 
-  @doc "Past-sessions sidebar: open / share / delete a session, start a new one."
+  @doc """
+  Past-sessions sidebar: open / share / delete a session, start a new one.
+  Navigation stays enabled mid-run — leaving only detaches from the runner.
+  """
   def sidebar(assigns) do
     ~H"""
     <aside class="hidden w-72 shrink-0 flex-col lg:flex">
       <button
         type="button"
         phx-click="new_session"
-        disabled={@running}
-        class="mb-3 inline-flex cursor-pointer items-center justify-center gap-2 rounded-xl border border-base-300 bg-base-100 px-3 py-2 text-sm font-medium text-base-content/80 transition hover:border-base-content/20 hover:bg-base-200 disabled:cursor-not-allowed disabled:opacity-40"
+        class="mb-3 inline-flex cursor-pointer items-center justify-center gap-2 rounded-xl border border-base-300 bg-base-100 px-3 py-2 text-sm font-medium text-base-content/80 transition hover:border-base-content/20 hover:bg-base-200"
       >
         <.icon name="hero-plus" class="size-4" /> New session
       </button>
@@ -87,12 +88,11 @@ defmodule SanbaseWeb.DeepResearch.Components do
               text selection instead of navigating. --%>
         <div
           :for={session <- @sessions}
-          phx-click={!@running && "open_session"}
+          phx-click="open_session"
           phx-value-id={session.id}
           title={session.title}
           class={[
-            "group select-none rounded-xl border px-3 py-2 transition",
-            if(@running, do: "cursor-not-allowed opacity-60", else: "cursor-pointer"),
+            "group cursor-pointer select-none rounded-xl border px-3 py-2 transition",
             if(session.id == @current_session_id,
               do: "border-primary/40 bg-primary/5",
               else: "border-transparent hover:border-base-300 hover:bg-base-200/60"
@@ -174,6 +174,10 @@ defmodule SanbaseWeb.DeepResearch.Components do
     doc:
       "wall clock for the live elapsed counter; nil for a finished turn, whose own finished_at is authoritative"
 
+  attr :can_continue, :boolean,
+    default: false,
+    doc: "offer Continue on a :paused turn (owner, last turn, nothing running)"
+
   @doc "One question/answer exchange: the asked question, its research timeline, and any error."
   def turn_view(assigns) do
     ~H"""
@@ -184,7 +188,12 @@ defmodule SanbaseWeb.DeepResearch.Components do
         </div>
       </div>
 
-      <.research_timeline turn={@turn} running={@running} now_ms={@now_ms} />
+      <.research_timeline
+        turn={@turn}
+        running={@running}
+        now_ms={@now_ms}
+        can_continue={@can_continue}
+      />
 
       <.clarification_card
         :if={@turn.clarification && @turn.clarification != []}
@@ -225,15 +234,14 @@ defmodule SanbaseWeb.DeepResearch.Components do
   attr :turn, :map, required: true
   attr :running, :boolean, required: true
   attr :now_ms, :integer, default: nil
+  attr :can_continue, :boolean, default: false
 
   defp research_timeline(assigns) do
     turn = assigns.turn
     proc_items = visible_items(turn.timeline, turn.report, turn.clarification)
-    # A terminal turn has nothing in flight — settle any tool item still marked
-    # running so it shows a final state, not a perpetual spinner (e.g. when a run was
-    # interrupted before a call returned, like a dev hot-reload killing the workers).
+    # Nothing in flight: an item left marked running would spin forever.
     proc_items =
-      if Timeline.terminal_phase?(turn.phase),
+      if Timeline.inactive_phase?(turn.phase),
         do: Enum.map(proc_items, &settle_item/1),
         else: proc_items
 
@@ -248,7 +256,8 @@ defmodule SanbaseWeb.DeepResearch.Components do
       )
 
     ~H"""
-    <div :if={not (@empty? and not @running)} class="space-y-3">
+    <%!-- A paused turn renders even when empty, to keep Continue reachable. --%>
+    <div :if={not (@empty? and not @running) or @turn.phase == :paused} class="space-y-3">
       <%= for {block, index} <- Enum.with_index(@blocks) do %>
         <.timeline_block block={block} index={index} turn_id={@turn.id} />
       <% end %>
@@ -278,6 +287,22 @@ defmodule SanbaseWeb.DeepResearch.Components do
       >
         <.icon name="hero-no-symbol" class="size-3.5" />
         Stopped after {format_duration(elapsed_seconds(@turn, @now_ms))}
+      </div>
+      <div
+        :if={@turn.phase == :paused}
+        class="flex items-center gap-2 text-xs text-base-content/50"
+      >
+        <.icon name="hero-pause-circle" class="size-3.5 text-warning" />
+        <span>Research paused — the connection was lost while it was running.</span>
+        <button
+          :if={@can_continue}
+          type="button"
+          phx-click="continue_turn"
+          phx-value-id={@turn.id}
+          class="inline-flex cursor-pointer items-center gap-1 rounded-full border border-primary/40 bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary transition hover:bg-primary/20"
+        >
+          <.icon name="hero-play" class="size-3" /> Continue
+        </button>
       </div>
     </div>
     """
@@ -840,5 +865,6 @@ defmodule SanbaseWeb.DeepResearch.Components do
   defp phase_label(:planning), do: "Planning research"
   defp phase_label(:researching), do: "Researching"
   defp phase_label(:writing), do: "Writing report"
+  defp phase_label(:paused), do: "Paused"
   defp phase_label(_), do: "Working"
 end

--- a/lib/sanbase_web/live/deep_research_live.ex
+++ b/lib/sanbase_web/live/deep_research_live.ex
@@ -14,7 +14,7 @@ defmodule SanbaseWeb.DeepResearchLive do
 
   import SanbaseWeb.DeepResearch.Components, only: [composer: 1, turn_view: 1, sidebar: 1]
 
-  alias Sanbase.DeepResearch.{Config, Runner, Sessions, Timeline, Turn}
+  alias Sanbase.DeepResearch.{Config, Failure, Runner, Sessions, Timeline, Turn}
 
   @impl true
   def mount(_params, _session, socket) do
@@ -390,13 +390,16 @@ defmodule SanbaseWeb.DeepResearchLive do
   def handle_info({:DOWN, ref, :process, _pid, :normal}, %{assigns: %{runner_ref: ref}} = socket),
     do: {:noreply, forget_runner(socket)}
 
-  # A crash settled nothing, so park the turn :paused locally.
-  def handle_info({:DOWN, ref, :process, _pid, _reason}, %{assigns: %{runner_ref: ref}} = socket) do
+  # A crash settled nothing, so park the turn :paused locally — with the reason, so
+  # the tab says what interrupted the research instead of silently going quiet.
+  def handle_info({:DOWN, ref, :process, _pid, reason}, %{assigns: %{runner_ref: ref}} = socket) do
+    why = Failure.crashed(reason).message
+
     socket =
       socket
       |> forget_runner()
       |> assign(:running, false)
-      |> update(:current_turn, &(&1 && Timeline.pause_turn(&1, now_ms())))
+      |> update(:current_turn, &(&1 && Timeline.pause_turn(&1, now_ms(), why)))
 
     {:noreply, socket}
   end

--- a/lib/sanbase_web/live/deep_research_live.ex
+++ b/lib/sanbase_web/live/deep_research_live.ex
@@ -1,29 +1,12 @@
 defmodule SanbaseWeb.DeepResearchLive do
   @moduledoc """
-  Deep research agent UI, implemented as a Phoenix LiveView.
+  Deep research agent UI. Holds only socket/UI state; the run lifecycle lives in a
+  detached `Sanbase.DeepResearch.Runner` (one per session) that this LiveView
+  attaches to and mirrors — so a websocket drop leaves the run streaming, to be
+  reattached on remount or left `:paused` for the owner to Continue.
 
-  The LiveView connects directly to a LangGraph deep research agent over SSE
-  (`Sanbase.DeepResearch.Client`), streams the typed event protocol, reduces it
-  into per-turn state (`Sanbase.DeepResearch.Timeline`) and renders it through
-  `SanbaseWeb.DeepResearch.Components`. This module owns only the socket state
-  and the async plumbing; all markup lives in the components module.
-
-  The streaming run is driven by `start_async/3` (like `AskLive`) so the LiveView
-  process keeps serving websocket heartbeats during long runs and the task is
-  auto-cancelled if the LiveView goes down.
-
-  ## Turn state
-
-  The transcript is split in two assigns on purpose:
-
-    * `:turns` — finished turns, oldest first. Never touched while a run streams,
-      so LiveView re-renders none of them per event or per one-second tick.
-    * `:current_turn` — the turn being streamed into (or the most recent finished
-      one, until the next question pushes it onto `:turns`).
-
-  Every message from the async work carries the turn id as an opaque `ref`.
-  Anything whose ref is not the current turn's is dropped: a slow state poll or a
-  late event from a cancelled run must never land on a turn that started after it.
+  `:turns` (finished, untouched mid-run) is split from `:current_turn` so a stream
+  event re-renders one turn, not the transcript.
   """
   use SanbaseWeb, :live_view
 
@@ -31,11 +14,7 @@ defmodule SanbaseWeb.DeepResearchLive do
 
   import SanbaseWeb.DeepResearch.Components, only: [composer: 1, turn_view: 1, sidebar: 1]
 
-  alias Sanbase.DeepResearch.{Client, Config, EventParser, Sessions, Timeline}
-
-  @no_report_error "The research run finished without producing a report — the agent stopped " <>
-                     "before delivering one (it may have hit a tool/iteration budget or been " <>
-                     "unable to complete the task). Try rephrasing or narrowing your question."
+  alias Sanbase.DeepResearch.{Config, Runner, Sessions, Timeline, Turn}
 
   @impl true
   def mount(_params, _session, socket) do
@@ -45,16 +24,12 @@ defmodule SanbaseWeb.DeepResearchLive do
       socket
       |> assign(
         mcp_catalog: catalog,
-        # All configured MCP servers are enabled (connected) by default.
         mcp_enabled: MapSet.new(Enum.map(catalog, & &1.key)),
-        # Model price tier (the only model knob the agent exposes per run). The
-        # dropdown is feature-flagged; when off, every run uses the deploy default.
+        # Price tier, the only per-run model knob. Flagged off = deploy default.
         tiering_dropdown_enabled: Config.tiering_dropdown_enabled?(),
         model_tiers: Config.model_tiers(),
         model_tier: Config.default_model_tier(),
-        # Whether a :tick timer is already pending. Lives outside
-        # reset_conversation/1 on purpose: a pending timer survives a
-        # conversation reset, and forgetting it would let a second loop start.
+        # Outside reset_conversation/1: a pending timer survives a reset.
         tick_scheduled?: false
       )
       |> reset_conversation()
@@ -63,19 +38,14 @@ defmodule SanbaseWeb.DeepResearchLive do
     {:ok, socket}
   end
 
-  # Fires on mount and on every push_patch. Navigating away from a streaming
-  # run cancels it first — a reused LiveView process must not keep an orphaned
-  # run streaming (and billing) into state the user just left.
+  # Mount and every push_patch. Navigating away only DETACHES; the run keeps going.
   @impl true
   def handle_params(params, _uri, socket) do
     if params["id"] && params["id"] == socket.assigns.session_id do
-      # Our own patch announcing the session the process already holds — the
-      # permalink issued on first submit, or a sidebar click on the open
-      # session. The state (possibly a streaming run) is current; reloading
-      # would destroy it.
+      # Our own patch for the session already held — reloading destroys a live run.
       {:noreply, socket}
     else
-      socket = if socket.assigns.running, do: cancel_current_run(socket), else: socket
+      socket = detach_runner(socket)
 
       case socket.assigns.live_action do
         :show -> open_session(socket, params["id"])
@@ -84,27 +54,26 @@ defmodule SanbaseWeb.DeepResearchLive do
     end
   end
 
-  # Reopen a past session: the owner can keep chatting with it. Restoring the
-  # session's thread_id resumes the same LangGraph thread, so the agent keeps
-  # its context; new turns append after the last persisted position.
+  # A live runner (reconnect, second tab) is reattached in the same call, so its
+  # snapshot replaces the loaded row of the turn it is still streaming.
   defp open_session(socket, session_id) do
     user = socket.assigns[:current_user]
 
     case user && Sessions.get_session_for_user(session_id, user.id) do
       {:ok, %{session: session, turns: turns}} ->
-        {:noreply,
-         socket
-         |> reset_conversation()
-         |> assign(
-           turns: turns,
-           session_id: session.id,
-           thread_id: session.thread_id,
-           next_id: next_position(turns)
-         )}
+        socket =
+          socket
+          |> reset_conversation()
+          |> assign(
+            turns: turns,
+            session_id: session.id,
+            thread_id: session.thread_id,
+            next_id: next_position(turns)
+          )
 
-      # :forbidden collapses into "not found" so a session id never leaks
-      # whether it exists. push_navigate (not patch): this branch can run
-      # during mount, where patching is not allowed.
+        {:noreply, attach_runner(socket, session.id, Runner.whereis(session.id))}
+
+      # :forbidden collapses into "not found". push_navigate: this runs on mount too.
       _ ->
         {:noreply,
          socket
@@ -121,12 +90,14 @@ defmodule SanbaseWeb.DeepResearchLive do
       turns: [],
       current_turn: nil,
       thread_id: nil,
-      run_id: nil,
       running: false,
       query: "",
       mcp_warning: nil,
       next_id: 1,
       session_id: nil,
+      runner_pid: nil,
+      runner_ref: nil,
+      runner_key: nil,
       now_ms: now_ms()
     )
   end
@@ -143,8 +114,7 @@ defmodule SanbaseWeb.DeepResearchLive do
   end
 
   def handle_event("select_tier", %{"model_tier" => tier}, socket) do
-    # Whitelist against the catalog (and the feature flag — a crafted event must
-    # not change the tier when the dropdown is off). Anything else keeps current.
+    # A crafted event must not change the tier when the dropdown is off.
     valid? =
       socket.assigns.tiering_dropdown_enabled and
         Enum.any?(socket.assigns.model_tiers, fn {value, _, _} -> value == tier end)
@@ -173,13 +143,25 @@ defmodule SanbaseWeb.DeepResearchLive do
     end
   end
 
-  # A cancel with no run in flight (double click, crafted event) must not touch
-  # the finished turn or fire a cancel request at the agent server.
+  # A cancel with nothing in flight must not touch the finished turn.
   def handle_event("cancel", _params, %{assigns: %{running: false}} = socket),
     do: {:noreply, socket}
 
   def handle_event("cancel", _params, socket) do
-    {:noreply, cancel_current_run(socket)}
+    case socket.assigns.runner_pid && Runner.cancel(socket.assigns.runner_pid) do
+      {:ok, snapshot} -> {:noreply, apply_snapshot(socket, snapshot)}
+      _ -> {:noreply, assign(socket, :running, false)}
+    end
+  end
+
+  def handle_event("continue_turn", _params, %{assigns: %{running: true}} = socket),
+    do: {:noreply, socket}
+
+  def handle_event("continue_turn", %{"id" => id}, socket) do
+    case continuable_turn(socket, id) do
+      %Turn{} = turn -> {:noreply, resume_research(socket, turn)}
+      nil -> {:noreply, socket}
+    end
   end
 
   # -- sidebar events ------------------------------------------------------------
@@ -201,14 +183,15 @@ defmodule SanbaseWeb.DeepResearchLive do
   end
 
   def handle_event("delete_session", %{"id" => id}, socket) do
-    with %{} = user <- socket.assigns[:current_user] do
-      Sessions.delete_session(id, user.id)
+    # Stop the runner only AFTER delete_session's owner check.
+    with %{} = user <- socket.assigns[:current_user],
+         {:ok, _session} <- Sessions.delete_session(id, user.id),
+         pid when is_pid(pid) <- Runner.whereis(id) do
+      Runner.shutdown(pid)
     end
 
     socket = refresh_sessions(socket)
 
-    # Deleting the session that is open (or streaming into) leaves nothing to
-    # show — navigate to a fresh conversation.
     if socket.assigns.session_id == id do
       {:noreply, push_patch(socket, to: ~p"/admin/deep_research")}
     else
@@ -216,143 +199,175 @@ defmodule SanbaseWeb.DeepResearchLive do
     end
   end
 
-  defp cancel_current_run(socket) do
-    cancel_run_async(socket.assigns.thread_id, socket.assigns.run_id)
+  # -- runner plumbing -----------------------------------------------------------
 
-    socket
-    |> cancel_async(:research)
-    |> update_current_turn(&cancel_turn/1)
-    |> assign(running: false)
+  # Only the LAST turn can be continued — the thread has moved past earlier ones.
+  defp continuable_turn(socket, id_param) do
+    last = socket.assigns.current_turn || List.last(socket.assigns.turns)
+
+    with %Turn{phase: :paused} = turn <- last,
+         {id, ""} <- Integer.parse(to_string(id_param)),
+         true <- turn.id == id do
+      turn
+    else
+      _ -> nil
+    end
   end
-
-  # A Stop that races the report is a race the report already won: the stream
-  # stays open a little after delivering it, so a cancel in that window must
-  # finalize the turn as completed — not mark (and persist) a delivered report
-  # as :cancelled.
-  defp cancel_turn(%{report: report} = turn) when is_binary(report), do: finalize_turn(turn)
-
-  defp cancel_turn(turn),
-    do: %{turn | phase: :cancelled, finished_at: turn.finished_at || now_ms()}
 
   defp start_research(socket, text) do
-    id = socket.assigns.next_id
-    now = now_ms()
-    turn = Timeline.new_turn(text, id, now)
-    lv = self()
-    thread_id = socket.assigns.thread_id
-    # Pure, in-memory: which MCP servers are toggled on. Auth resolution (a DB
-    # read) is deferred into the async task so the LiveView process never blocks.
-    enabled_mcp = enabled_mcp_servers(socket)
-    model_tier = socket.assigns.model_tier
+    socket = socket |> ensure_session(text) |> ensure_runner()
+
+    case socket.assigns.runner_pid &&
+           Runner.ask(socket.assigns.runner_pid, text, run_opts(socket)) do
+      {:ok, snapshot} ->
+        socket |> assign(:query, "") |> apply_snapshot(snapshot)
+
+      # Another tab already started a run on this session.
+      {:error, :busy} ->
+        socket
+
+      _ ->
+        put_flash(socket, :error, "Could not start the research run — please retry.")
+    end
+  end
+
+  defp resume_research(socket, turn) do
+    socket = ensure_runner(socket)
+
+    case socket.assigns.runner_pid &&
+           Runner.continue(socket.assigns.runner_pid, turn, run_opts(socket)) do
+      {:ok, snapshot} -> apply_snapshot(socket, snapshot)
+      {:error, :busy} -> socket
+      _ -> put_flash(socket, :error, "Could not resume the research — please retry.")
+    end
+  end
+
+  defp run_opts(socket) do
+    [
+      enabled_mcp: enabled_mcp_servers(socket),
+      model_tier: socket.assigns.model_tier
+    ]
+  end
+
+  # The first question creates the row: registry key, persistence, permalink. A
+  # failure must not block research — the conversation continues unpersisted.
+  defp ensure_session(%{assigns: %{session_id: id}} = socket, _text) when is_binary(id),
+    do: socket
+
+  defp ensure_session(socket, text) do
     user = socket.assigns[:current_user]
 
-    # A new question can arrive while the previous turn's no-report poll is
-    # still in flight (running is already false then). Once :current_turn
-    # changes, that poll result is dropped as stale and nothing would ever
-    # settle the old turn — fail it before it is archived.
-    socket = settle_abandoned_turn(socket)
+    case user && Sessions.create_session(user.id, socket.assigns.model_tier, text) do
+      {:ok, session} ->
+        socket
+        |> assign(:session_id, session.id)
+        |> refresh_sessions()
+        |> push_patch(to: ~p"/admin/deep_research/#{session.id}")
 
-    # Everything network/DB-bound runs off the socket via start_async/3 (like
-    # AskLive) so the LiveView keeps serving heartbeats; incremental events
-    # arrive as {:dra_event, ref, _} messages, the terminal status via handle_async/3.
-    socket
-    |> persist_new_turn(turn)
-    |> assign(
-      # The turn that just finished (if any) is now history — moving it out of
-      # :current_turn is what stops it re-rendering for the rest of the session.
-      turns: archive_current_turn(socket),
-      current_turn: turn,
-      running: true,
-      query: "",
-      run_id: nil,
-      # A warning belongs to the run that produced it; a new run starts clean.
-      mcp_warning: nil,
-      next_id: id + 1,
-      now_ms: now
-    )
-    |> schedule_tick()
-    |> start_async(:research, fn ->
-      run_stream(thread_id, text, lv, enabled_mcp, user, model_tier, id)
-    end)
-  end
-
-  defp archive_current_turn(%{assigns: %{current_turn: nil, turns: turns}}), do: turns
-  defp archive_current_turn(%{assigns: %{current_turn: turn, turns: turns}}), do: turns ++ [turn]
-
-  defp settle_abandoned_turn(%{assigns: %{current_turn: %{phase: phase}}} = socket) do
-    if Timeline.settled_phase?(phase),
-      do: socket,
-      else: update_current_turn(socket, &fail_no_report/1)
-  end
-
-  defp settle_abandoned_turn(socket), do: socket
-
-  # Persist the new turn (and, on the first turn, the session row) before the
-  # run starts, so a browser closed mid-run still leaves the question behind.
-  # A persistence failure must never block research — log and carry on.
-  defp persist_new_turn(socket, turn) do
-    case {socket.assigns[:current_user], socket.assigns.session_id} do
-      {nil, _} ->
+      {:error, error} ->
+        Logger.warning("Deep research session creation failed: #{inspect(error)}")
         socket
 
-      {_user, session_id} when is_binary(session_id) ->
-        with {:error, error} <- Sessions.create_turn(session_id, turn, socket.assigns.model_tier) do
-          log_persist_error("create_turn", error)
-        end
-
+      nil ->
         socket
-
-      {user, nil} ->
-        case Sessions.start_session(user.id, socket.assigns.model_tier, turn) do
-          {:ok, %{session: session}} ->
-            # The URL becomes the session's permalink the moment it exists, so
-            # it can be copied mid-run. handle_params recognizes the id it
-            # already holds and leaves the streaming state alone.
-            socket
-            |> assign(:session_id, session.id)
-            |> refresh_sessions()
-            |> push_patch(to: ~p"/admin/deep_research/#{session.id}")
-
-          {:error, error} ->
-            log_persist_error("start_session", error)
-            socket
-        end
     end
   end
 
-  # Write the turn's row once it settles (terminal phase or :awaiting_user); a
-  # follow-up settled change (e.g. finalize stamping finished_at after a
-  # clarification) re-writes, an unchanged turn never does.
-  defp maybe_persist_settled(socket, prev, next) do
-    if socket.assigns.session_id && Timeline.settled_phase?(next.phase) && next != prev do
-      with {:error, error} <- Sessions.update_turn(socket.assigns.session_id, next.id, next) do
-        log_persist_error("update_turn", error)
-      end
+  defp ensure_runner(%{assigns: %{runner_pid: pid}} = socket) when is_pid(pid), do: socket
 
-      Sessions.touch_session(socket.assigns.session_id)
-      # touch_session just changed the sidebar ordering.
-      refresh_sessions(socket)
-    else
-      socket
+  defp ensure_runner(socket) do
+    key = socket.assigns.session_id || ephemeral_key()
+
+    init_arg = %{
+      key: key,
+      session_id: socket.assigns.session_id,
+      user: socket.assigns[:current_user],
+      model_tier: socket.assigns.model_tier,
+      thread_id: socket.assigns.thread_id,
+      next_id: socket.assigns.next_id
+    }
+
+    case Runner.ensure_started(init_arg) do
+      {:ok, pid} ->
+        attach_runner(socket, key, pid)
+
+      {:error, error} ->
+        Logger.warning("Deep research runner failed to start: #{inspect(error)}")
+        socket
     end
+  end
+
+  # No runner, or it stopped between lookup and attach — the transcript is authoritative.
+  defp attach_runner(socket, _key, nil), do: socket
+
+  defp attach_runner(socket, key, pid) do
+    case Runner.attach(pid, self()) do
+      {:ok, snapshot} ->
+        socket
+        |> assign(runner_pid: pid, runner_ref: Process.monitor(pid), runner_key: key)
+        |> apply_snapshot(snapshot)
+
+      {:error, :not_alive} ->
+        socket
+    end
+  end
+
+  defp detach_runner(%{assigns: %{runner_pid: nil}} = socket), do: socket
+
+  defp detach_runner(socket) do
+    Process.demonitor(socket.assigns.runner_ref, [:flush])
+    Runner.detach(socket.assigns.runner_pid, self())
+    forget_runner(socket)
+  end
+
+  defp forget_runner(socket) do
+    assign(socket, runner_pid: nil, runner_ref: nil, runner_key: nil)
+  end
+
+  # An anonymous conversation gets a runner too, under a key no URL can find again.
+  defp ephemeral_key(), do: "ephemeral-#{System.unique_integer([:positive])}"
+
+  defp apply_snapshot(socket, snapshot) do
+    was_running = socket.assigns.running
+
+    socket =
+      assign(socket,
+        turns: settled_turns(socket, snapshot.current_turn),
+        current_turn: snapshot.current_turn || socket.assigns.current_turn,
+        running: snapshot.running,
+        mcp_warning: snapshot.mcp_warning,
+        thread_id: snapshot.thread_id || socket.assigns.thread_id,
+        next_id: max(socket.assigns.next_id, snapshot.next_id),
+        now_ms: now_ms()
+      )
+
+    socket = if snapshot.running, do: schedule_tick(socket), else: socket
+
+    # A run just settled: touch_session changed the sidebar ordering.
+    if was_running and not snapshot.running, do: refresh_sessions(socket), else: socket
+  end
+
+  # The transcript minus the turn the runner owns — a reattach loaded its row too.
+  # A turn the runner has moved past (a follow-up started elsewhere) joins the transcript.
+  defp settled_turns(socket, nil), do: socket.assigns.turns
+
+  defp settled_turns(socket, runner_turn) do
+    prev = socket.assigns.current_turn
+    kept = Enum.reject(socket.assigns.turns, &(&1.id == runner_turn.id))
+
+    if prev && prev.id != runner_turn.id, do: kept ++ [prev], else: kept
   end
 
   defp refresh_sessions(socket) do
     user = socket.assigns[:current_user]
 
-    # Skip the query on the static (disconnected) render — the connected mount
-    # runs it again anyway.
+    # Skip the query on the static render; the connected mount runs it anyway.
     sessions =
       if user && connected?(socket), do: Sessions.list_user_sessions(user.id), else: []
 
     assign(socket, :sessions, sessions)
   end
 
-  defp log_persist_error(operation, error) do
-    Logger.warning("Deep research session persistence failed in #{operation}: #{inspect(error)}")
-  end
-
-  # The enabled catalog entries — pure, runs in the LiveView process (no DB/IO).
   defp enabled_mcp_servers(socket) do
     Enum.filter(socket.assigns.mcp_catalog, &MapSet.member?(socket.assigns.mcp_enabled, &1.key))
   end
@@ -364,156 +379,26 @@ defmodule SanbaseWeb.DeepResearchLive do
     end
   end
 
-  # Runs INSIDE the async task (off the LiveView process): resolve MCP auth (a
-  # DB read), create the thread on the first turn, then stream. Returns the
-  # terminal status, handled by handle_async/3.
-  defp run_stream(thread_id, text, lv, enabled_mcp, user, model_tier, ref) do
-    mcp_servers = build_mcp_servers(enabled_mcp, user)
+  # -- runner messages -----------------------------------------------------------
 
-    do_run_stream(thread_id, text, lv,
-      mcp_servers: mcp_servers,
-      model_tier: model_tier,
-      ref: ref
-    )
-  end
-
-  defp do_run_stream(nil, text, lv, opts) do
-    case Client.create_thread() do
-      {:ok, thread_id} ->
-        send(lv, {:dra_thread, thread_id})
-        Client.stream_run(thread_id, text, lv, opts)
-
-      {:error, reason} ->
-        {:error, reason}
-    end
-  end
-
-  defp do_run_stream(thread_id, text, lv, opts) when is_binary(thread_id) do
-    Client.stream_run(thread_id, text, lv, opts)
-  end
-
-  # Build agent MCP server maps from the enabled catalog entries, resolving
-  # `:user_apikey` auth to the user's Santiment API key. Runs in the async task.
-  defp build_mcp_servers([], _user), do: []
-
-  defp build_mcp_servers(enabled, user) do
-    api_key = resolve_api_key(enabled, user)
-    enabled |> Enum.map(&agent_server(&1, api_key)) |> Enum.reject(&is_nil/1)
-  end
-
-  defp resolve_api_key(enabled, user) do
-    if Enum.any?(enabled, &(&1.auth == :user_apikey)) do
-      case fetch_api_key(user) do
-        {:ok, key} -> key
-        _ -> nil
-      end
-    end
-  end
-
-  defp agent_server(%{auth: :user_apikey} = server, api_key) do
-    case apikey_override(server) || api_key do
-      key when is_binary(key) ->
-        %{
-          "name" => server.label,
-          "label" => server.label,
-          "url" => server.url,
-          "tools" => [],
-          "headers" => %{"Authorization" => "Apikey #{key}"}
-        }
-
-      # No API key available — skip a server that needs one.
-      _ ->
-        nil
-    end
-  end
-
-  defp agent_server(server, _api_key) do
-    %{"name" => server.label, "label" => server.label, "url" => server.url, "tools" => []}
-  end
-
-  defp apikey_override(server) do
-    case Map.get(server, :apikey_override) do
-      override when is_binary(override) and override != "" -> override
-      _ -> nil
-    end
-  end
-
-  defp fetch_api_key(%Sanbase.Accounts.User{} = user) do
-    case Sanbase.Accounts.Apikey.apikeys_list(user) do
-      {:ok, [key | _]} -> {:ok, key}
-      {:ok, []} -> Sanbase.Accounts.Apikey.generate_apikey(user)
-      other -> other
-    end
-  end
-
-  defp fetch_api_key(_), do: {:error, :no_user}
-
-  # -- streamed messages -------------------------------------------------------
-
+  # A snapshot from a runner we no longer follow falls through to the catch-all below.
   @impl true
-  def handle_info({:dra_thread, thread_id}, socket) do
-    socket =
-      if is_nil(socket.assigns.thread_id) do
-        if socket.assigns.session_id,
-          do: Sessions.set_thread_id(socket.assigns.session_id, thread_id)
+  def handle_info({:dra_runner, key, snapshot}, %{assigns: %{runner_key: key}} = socket),
+    do: {:noreply, apply_snapshot(socket, snapshot)}
 
-        assign(socket, :thread_id, thread_id)
-      else
-        socket
-      end
+  # A clean stop already settled the turn.
+  def handle_info({:DOWN, ref, :process, _pid, :normal}, %{assigns: %{runner_ref: ref}} = socket),
+    do: {:noreply, forget_runner(socket)}
+
+  # A crash settled nothing, so park the turn :paused locally.
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, %{assigns: %{runner_ref: ref}} = socket) do
+    socket =
+      socket
+      |> forget_runner()
+      |> assign(:running, false)
+      |> update(:current_turn, &(&1 && Timeline.pause_turn(&1, now_ms())))
 
     {:noreply, socket}
-  end
-
-  def handle_info({:dra_event, ref, result}, socket) do
-    # Two ways an event can be stale, both of which would corrupt a live turn:
-    # a ref from a superseded run (see the moduledoc), or an event queued behind
-    # a terminal status — dropping the latter stops a cancelled turn from
-    # growing new thinking/tools or being handed a late report.
-    if stale_ref?(socket, ref) or current_turn_terminal?(socket) do
-      {:noreply, socket}
-    else
-      socket =
-        socket
-        |> apply_socket_level(result)
-        |> update_current_turn(&Timeline.apply_result(&1, result))
-
-      {:noreply, socket}
-    end
-  end
-
-  # Poll-state fallback after a no-report stream close: recover a report from the
-  # thread state if present, otherwise fail the turn with an explanation. The poll
-  # can take up to 30s, by which time the user may have asked something else —
-  # hence the ref check, without which this would fail the *new* turn.
-  def handle_info({:dra_poll, ref, result}, socket) do
-    if stale_ref?(socket, ref) do
-      {:noreply, socket}
-    else
-      socket =
-        update_current_turn(socket, fn turn ->
-          cond do
-            turn.phase in [:failed, :cancelled, :awaiting_user] ->
-              turn
-
-            turn.report ->
-              %{turn | phase: :completed, finished_at: turn.finished_at || now_ms()}
-
-            is_binary(result[:report]) ->
-              %{
-                turn
-                | report: result[:report],
-                  phase: :completed,
-                  finished_at: turn.finished_at || now_ms()
-              }
-
-            true ->
-              fail_no_report(turn)
-          end
-        end)
-
-      {:noreply, socket}
-    end
   end
 
   def handle_info(:tick, socket) do
@@ -526,159 +411,11 @@ defmodule SanbaseWeb.DeepResearchLive do
     end
   end
 
-  # Terminal status of the streaming run (start_async/3). The async task is
-  # automatically cancelled if the LiveView process goes down.
-  @impl true
-  def handle_async(:research, {:ok, :ok}, socket) do
-    {:noreply, finalize_run(socket)}
-  end
+  # A snapshot or :DOWN from a runner we dropped, and late replies to a timed-out
+  # Runner.safe_call/2 (they land as {ref, reply}).
+  def handle_info(_msg, socket), do: {:noreply, socket}
 
-  def handle_async(:research, {:ok, {:error, reason}}, socket) do
-    {:noreply, fail_run(socket, reason)}
-  end
-
-  def handle_async(:research, {:exit, reason}, socket) do
-    {:noreply, fail_run(socket, "Research stopped unexpectedly (#{inspect(reason)})")}
-  end
-
-  # -- state helpers -----------------------------------------------------------
-
-  defp finalize_run(%{assigns: %{running: false}} = socket), do: socket
-
-  defp finalize_run(socket) do
-    socket = assign(socket, running: false)
-    turn = socket.assigns.current_turn
-
-    cond do
-      is_nil(turn) ->
-        socket
-
-      # A report was delivered, the turn already ended in a known state (failed
-      # via a `status: error`, cancelled, or awaiting a clarification), or the
-      # agent answered conversationally in plain text (a follow-up/simple
-      # question — no report is expected, so it is NOT a missing-report failure).
-      turn.report || turn.phase in [:failed, :cancelled, :awaiting_user] ||
-          Timeline.direct_answer?(turn) ->
-        update_current_turn(socket, &finalize_turn/1)
-
-      # The stream closed with NO report and no explicit error. Poll the thread
-      # state as a fallback; the {:dra_poll, _, _} handler then either completes
-      # the turn (report recovered) or fails it with an explanation.
-      socket.assigns.thread_id ->
-        poll_state_async(socket.assigns.thread_id, self(), turn.id)
-        update_current_turn(socket, fn t -> %{t | finished_at: t.finished_at || now_ms()} end)
-
-      true ->
-        update_current_turn(socket, &fail_no_report/1)
-    end
-  end
-
-  # A run that ends without ever delivering a report is a failure — show why.
-  # Keep any error reason the agent already surfaced (e.g. a `status: error`
-  # detail); otherwise explain the missing report.
-  defp fail_no_report(turn) do
-    %{
-      turn
-      | phase: :failed,
-        error: turn.error || @no_report_error,
-        finished_at: turn.finished_at || now_ms()
-    }
-  end
-
-  defp fail_run(socket, reason) do
-    if socket.assigns.running do
-      socket
-      |> update_current_turn(fn turn ->
-        %{
-          turn
-          | phase: Timeline.merge_phase(turn.phase, :failed),
-            error: turn.error || reason,
-            finished_at: turn.finished_at || now_ms()
-        }
-      end)
-      |> assign(running: false)
-    else
-      socket
-    end
-  end
-
-  defp apply_socket_level(socket, result) do
-    socket =
-      case result do
-        %{run_id: id} -> assign(socket, :run_id, id)
-        _ -> socket
-      end
-
-    case result do
-      %{meta: %{mcp_warning: warning}} -> assign(socket, :mcp_warning, warning)
-      _ -> socket
-    end
-  end
-
-  defp finalize_turn(turn) do
-    phase =
-      if turn.phase in [:failed, :cancelled, :awaiting_user], do: turn.phase, else: :completed
-
-    %{turn | phase: phase, finished_at: turn.finished_at || now_ms()}
-  end
-
-  # A message is stale when it belongs to any turn other than the current one.
-  defp stale_ref?(%{assigns: %{current_turn: %{id: id}}}, ref), do: ref != id
-  defp stale_ref?(_socket, _ref), do: true
-
-  defp current_turn_terminal?(%{assigns: %{current_turn: %{phase: phase}}}),
-    do: Timeline.terminal_phase?(phase)
-
-  defp current_turn_terminal?(_socket), do: false
-
-  defp update_current_turn(%{assigns: %{current_turn: nil}} = socket, _fun), do: socket
-
-  # The single choke point every turn mutation flows through (stream events,
-  # poll, cancel, finalize, fail) — which makes it the one place persistence
-  # has to watch for a turn settling.
-  defp update_current_turn(socket, fun) do
-    prev = socket.assigns.current_turn
-    next = fun.(prev)
-
-    socket
-    |> assign(:current_turn, next)
-    |> maybe_persist_settled(prev, next)
-  end
-
-  defp poll_state_async(thread_id, lv, ref) do
-    Task.Supervisor.start_child(Sanbase.TaskSupervisor, fn ->
-      result =
-        case Client.get_state(thread_id) do
-          {:ok, state} -> EventParser.parse_thread_state(state)
-          _ -> %{}
-        end
-
-      # Always reply so the LiveView can finalize (recover report or fail).
-      send(lv, {:dra_poll, ref, result})
-    end)
-  end
-
-  defp cancel_run_async(thread_id, run_id) when is_binary(thread_id) and is_binary(run_id) do
-    Task.Supervisor.start_child(Sanbase.TaskSupervisor, fn ->
-      Client.cancel_run(thread_id, run_id)
-    end)
-  end
-
-  # Cancel arrived before the stream delivered a run_id: the server-side run
-  # already exists, so cancel whatever is active on the thread — otherwise it
-  # keeps running (and billing) invisibly after the UI shows "cancelled".
-  defp cancel_run_async(thread_id, nil) when is_binary(thread_id) do
-    Task.Supervisor.start_child(Sanbase.TaskSupervisor, fn ->
-      Client.cancel_active_runs(thread_id)
-    end)
-  end
-
-  # No thread yet (cancel raced thread creation) — nothing server-side to cancel.
-  defp cancel_run_async(_thread_id, _run_id), do: :ok
-
-  # At most one :tick is ever in flight. Without the guard, a timer left over
-  # from a run that just ended can fire after a new run has scheduled its own,
-  # leaving two loops that each re-render every second for the session's rest.
+  # At most one :tick in flight; a leftover timer would start a second loop.
   defp schedule_tick(%{assigns: %{tick_scheduled?: true}} = socket), do: socket
 
   defp schedule_tick(socket) do
@@ -694,7 +431,7 @@ defmodule SanbaseWeb.DeepResearchLive do
   def render(assigns) do
     ~H"""
     <div class="mx-auto flex h-[calc(100vh-10rem)] w-full max-w-7xl gap-6 px-4">
-      <.sidebar sessions={@sessions} current_session_id={@session_id} running={@running} />
+      <.sidebar sessions={@sessions} current_session_id={@session_id} />
       <div class="flex min-h-0 min-w-0 flex-1 flex-col">
         <div
           :if={@turns == [] and is_nil(@current_turn)}
@@ -727,10 +464,19 @@ defmodule SanbaseWeb.DeepResearchLive do
           :if={@turns != [] or @current_turn}
           class="min-h-0 flex-1 space-y-8 overflow-y-auto py-4"
         >
-          <%!-- Finished turns carry their own finished_at, so they take no now_ms and
-                stay untouched while the current turn streams. --%>
-          <.turn_view :for={turn <- @turns} turn={turn} running={false} />
-          <.turn_view :if={@current_turn} turn={@current_turn} running={@running} now_ms={@now_ms} />
+          <.turn_view
+            :for={turn <- @turns}
+            turn={turn}
+            running={false}
+            can_continue={is_nil(@current_turn) and not @running and turn == List.last(@turns)}
+          />
+          <.turn_view
+            :if={@current_turn}
+            turn={@current_turn}
+            running={@running}
+            now_ms={@now_ms}
+            can_continue={not @running}
+          />
         </div>
 
         <div class="shrink-0 pt-2">

--- a/priv/repo/migrations/20260812120000_add_paused_deep_research_phase.exs
+++ b/priv/repo/migrations/20260812120000_add_paused_deep_research_phase.exs
@@ -1,0 +1,31 @@
+defmodule Sanbase.Repo.Migrations.AddPausedDeepResearchPhase do
+  use Ecto.Migration
+
+  @moduledoc "Adds the `paused` phase: an interrupted run the user can continue."
+
+  def up() do
+    drop(constraint(:deep_research_turns, :valid_phase))
+
+    create(
+      constraint(:deep_research_turns, :valid_phase,
+        check:
+          "phase IN ('idle','planning','researching','writing','awaiting_user','paused','completed','failed','cancelled')"
+      )
+    )
+  end
+
+  def down() do
+    # Lock first: a 'paused' row written after the UPDATE would fail the constraint.
+    execute("LOCK TABLE deep_research_turns IN ACCESS EXCLUSIVE MODE")
+    execute("UPDATE deep_research_turns SET phase = 'failed' WHERE phase = 'paused'")
+
+    drop(constraint(:deep_research_turns, :valid_phase))
+
+    create(
+      constraint(:deep_research_turns, :valid_phase,
+        check:
+          "phase IN ('idle','planning','researching','writing','awaiting_user','completed','failed','cancelled')"
+      )
+    )
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -1411,7 +1411,7 @@ CREATE TABLE public.deep_research_turns (
     finished_at timestamp without time zone,
     inserted_at timestamp(0) without time zone NOT NULL,
     updated_at timestamp(0) without time zone NOT NULL,
-    CONSTRAINT valid_phase CHECK (((phase)::text = ANY ((ARRAY['idle'::character varying, 'planning'::character varying, 'researching'::character varying, 'writing'::character varying, 'awaiting_user'::character varying, 'completed'::character varying, 'failed'::character varying, 'cancelled'::character varying])::text[])))
+    CONSTRAINT valid_phase CHECK (((phase)::text = ANY ((ARRAY['idle'::character varying, 'planning'::character varying, 'researching'::character varying, 'writing'::character varying, 'awaiting_user'::character varying, 'paused'::character varying, 'completed'::character varying, 'failed'::character varying, 'cancelled'::character varying])::text[])))
 );
 
 
@@ -12915,4 +12915,5 @@ INSERT INTO public."schema_migrations" (version) VALUES (20260806120000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260810120000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260810121347);
 INSERT INTO public."schema_migrations" (version) VALUES (20260810121612);
+INSERT INTO public."schema_migrations" (version) VALUES (20260812120000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260813090000);

--- a/test/sanbase/deep_research/config_test.exs
+++ b/test/sanbase/deep_research/config_test.exs
@@ -198,7 +198,10 @@ defmodule Sanbase.DeepResearch.ConfigTest do
     end
 
     test "the configured list is returned as-is" do
-      catalog = [%{key: "santiment", label: "Santiment", url: "http://x/mcp", auth: :user_apikey}]
+      catalog = [
+        %{key: "santiment", label: "Santiment", url: "http://x/mcp", auth: :santiment_apikey}
+      ]
+
       put_env(mcp_servers: catalog)
       assert Config.mcp_catalog() == catalog
     end

--- a/test/sanbase/deep_research/failure_test.exs
+++ b/test/sanbase/deep_research/failure_test.exs
@@ -1,0 +1,75 @@
+defmodule Sanbase.DeepResearch.FailureTest do
+  use ExUnit.Case, async: true
+
+  alias Sanbase.DeepResearch.Failure
+
+  @url "http://127.0.0.1:2024"
+
+  defp transport(reason), do: %Req.TransportError{reason: reason}
+
+  describe "connection/3" do
+    test "names the call, the agent and what the reason means" do
+      failure = Failure.connection("create_thread", @url, transport(:timeout))
+
+      assert failure.resumable?
+      assert failure.message =~ "the request timed out"
+      assert failure.message =~ "create_thread"
+      assert failure.message =~ @url
+    end
+
+    test "translates the transport reasons that read as nothing on their own" do
+      for {reason, text} <- [
+            econnrefused: "nothing is listening",
+            closed: "closed mid-request",
+            econnreset: "was reset",
+            nxdomain: "could not be resolved",
+            ehostunreach: "unreachable from this network",
+            enetunreach: "unreachable from this network"
+          ] do
+        assert Failure.connection("get_state", @url, transport(reason)).message =~ text
+      end
+    end
+
+    test "an unrecognized error still carries its own message" do
+      error = %Req.HTTPError{protocol: :http2, reason: :unprocessed}
+
+      assert Failure.connection("the research stream", @url, error).message =~
+               Exception.message(error)
+    end
+  end
+
+  describe "response/3" do
+    test "an answer from the agent is not resumable — retrying gets the same answer" do
+      refute Failure.response("create_thread", 500, "boom").resumable?
+    end
+
+    test "the statuses with a known cause say what to look at" do
+      assert Failure.response("create_thread", 401, nil).message =~ "DRA_AUTH_TOKEN"
+      assert Failure.response("create_thread", 403, nil).message =~ "DRA_AUTH_TOKEN"
+      assert Failure.response("get_state", 404, nil).message =~ "no such thread"
+      assert Failure.response("The run", 502, nil).message =~ "the agent itself errored"
+    end
+
+    test "the body is carried along, trimmed — an agent stack trace would swamp the UI" do
+      failure = Failure.response("The run", 500, String.duplicate("stack trace ", 200))
+
+      assert failure.message =~ "stack trace"
+      assert String.length(failure.message) < 400
+    end
+
+    test "an empty body leaves no dangling punctuation" do
+      assert Failure.response("cancel_run", 409, "").message == "cancel_run failed (HTTP 409)."
+    end
+  end
+
+  test "crashed/1 is resumable — our side stopped, the agent kept the thread" do
+    failure = Failure.crashed(:killed)
+
+    assert failure.resumable?
+    assert failure.message =~ ":killed"
+  end
+
+  test "refused/1 is not resumable — a human has to change the configuration" do
+    refute Failure.refused("base_url is plain HTTP").resumable?
+  end
+end

--- a/test/sanbase/deep_research/mcp_servers_test.exs
+++ b/test/sanbase/deep_research/mcp_servers_test.exs
@@ -1,0 +1,75 @@
+defmodule Sanbase.DeepResearch.McpServersTest do
+  use Sanbase.DataCase, async: true
+
+  import ExUnit.CaptureLog
+  import Sanbase.Factory
+
+  alias Sanbase.Accounts.Apikey
+  alias Sanbase.DeepResearch.McpServers
+
+  defp entry(attrs \\ %{}) do
+    Map.merge(%{key: "santiment", label: "Santiment", url: "http://x/mcp", auth: :none}, attrs)
+  end
+
+  test "nothing enabled, nothing configured" do
+    assert McpServers.build([], nil) == []
+  end
+
+  test "a server needing no auth carries no headers" do
+    assert [config] = McpServers.build([entry()], nil)
+
+    assert config == %{
+             "name" => "Santiment",
+             "label" => "Santiment",
+             "url" => "http://x/mcp",
+             "tools" => []
+           }
+  end
+
+  describe ":santiment_apikey (only sanbase's own MCP)" do
+    test "is authenticated with the caller's Santiment api key" do
+      user = insert(:user)
+
+      assert [%{"headers" => %{"Authorization" => header}}] =
+               McpServers.build([entry(%{auth: :santiment_apikey})], user)
+
+      assert header =~ "Apikey "
+    end
+
+    test "a catalog override wins, and no key is generated for the user" do
+      user = insert(:user)
+      server = entry(%{auth: :santiment_apikey, apikey_override: "override-key"})
+
+      assert [%{"headers" => headers}] = McpServers.build([server], user)
+      assert headers == %{"Authorization" => "Apikey override-key"}
+
+      assert {:ok, []} = Apikey.apikeys_list(user)
+    end
+
+    test "is dropped when there is no user to resolve a key for" do
+      assert McpServers.build([entry(%{auth: :santiment_apikey})], nil) == []
+    end
+  end
+
+  describe ":bearer (a third-party server we hold a token for)" do
+    test "sends the entry's token" do
+      server = entry(%{auth: :bearer, token: "third-party-token"})
+
+      assert [%{"headers" => headers}] = McpServers.build([server], nil)
+      assert headers == %{"Authorization" => "Bearer third-party-token"}
+    end
+
+    test "is dropped when the entry carries no token" do
+      assert McpServers.build([entry(%{auth: :bearer})], insert(:user)) == []
+    end
+  end
+
+  test "an auth mode this module does not implement is dropped, not sent open" do
+    log =
+      capture_log(fn ->
+        assert McpServers.build([entry(%{auth: :oauth})], insert(:user)) == []
+      end)
+
+    assert log =~ "unsupported auth :oauth"
+  end
+end

--- a/test/sanbase/deep_research/mcp_servers_test.exs
+++ b/test/sanbase/deep_research/mcp_servers_test.exs
@@ -27,13 +27,26 @@ defmodule Sanbase.DeepResearch.McpServersTest do
   end
 
   describe ":santiment_apikey (only sanbase's own MCP)" do
-    test "is authenticated with the caller's Santiment api key" do
+    test "sends the key the caller already has" do
       user = insert(:user)
+      {:ok, apikey} = Apikey.generate_apikey(user)
 
-      assert [%{"headers" => %{"Authorization" => header}}] =
+      assert [%{"headers" => headers}] =
                McpServers.build([entry(%{auth: :santiment_apikey})], user)
 
-      assert header =~ "Apikey "
+      assert headers == %{"Authorization" => "Apikey #{apikey}"}
+    end
+
+    test "generates a key for a caller who has none, and sends that one" do
+      user = insert(:user)
+      assert {:ok, []} = Apikey.apikeys_list(user)
+
+      assert [%{"headers" => headers}] =
+               McpServers.build([entry(%{auth: :santiment_apikey})], user)
+
+      # The key the user now owns is the key that was sent — not merely "an Apikey".
+      assert {:ok, [apikey]} = Apikey.apikeys_list(user)
+      assert headers == %{"Authorization" => "Apikey #{apikey}"}
     end
 
     test "a catalog override wins, and no key is generated for the user" do
@@ -71,5 +84,26 @@ defmodule Sanbase.DeepResearch.McpServersTest do
       end)
 
     assert log =~ "unsupported auth :oauth"
+  end
+
+  describe "a malformed catalog entry" do
+    # Entries come from runtime.exs, so an unset env var can leave :url nil. Raising
+    # here would crash the stream task, park the turn :paused, and make Continue
+    # repeat the crash — drop the server and run without it instead.
+    test "is dropped, whichever of label/url is missing" do
+      for attrs <- [%{url: nil}, %{label: nil}, %{auth: :bearer, token: "t", url: nil}] do
+        log = capture_log(fn -> assert McpServers.build([entry(attrs)], insert(:user)) == [] end)
+
+        assert log =~ "dropping MCP server \"santiment\""
+        assert log =~ "label and url must both be strings"
+      end
+    end
+
+    test "does not take the well-formed entries with it" do
+      capture_log(fn ->
+        assert [%{"label" => "Santiment"}] =
+                 McpServers.build([entry(%{key: "broken", url: nil}), entry()], nil)
+      end)
+    end
   end
 end

--- a/test/sanbase/deep_research/runner_test.exs
+++ b/test/sanbase/deep_research/runner_test.exs
@@ -9,9 +9,10 @@ defmodule Sanbase.DeepResearch.RunnerTest do
 
   use ExUnit.Case, async: false
 
-  alias Sanbase.DeepResearch.{Runner, Timeline, Turn}
+  alias Sanbase.DeepResearch.{Failure, Runner, Timeline, Turn}
 
   @supervisor Sanbase.DeepResearch.RunnerSupervisor
+  @started_key :runner_test_started
 
   setup do
     original = Application.get_env(:sanbase, Sanbase.DeepResearch)
@@ -24,12 +25,20 @@ defmodule Sanbase.DeepResearch.RunnerTest do
       mcp_servers: []
     )
 
+    # Unlinked on purpose: `on_exit` runs after the test process is gone, so the
+    # list of runners to clean up cannot live in the test process itself.
+    {:ok, started} = Agent.start(fn -> [] end)
+    Process.put(@started_key, started)
+
     on_exit(fn ->
-      # Runners first: one still holding the port would outlive the test.
-      for {_, pid, _, _} <- DynamicSupervisor.which_children(@supervisor), is_pid(pid) do
+      # Only this test's runners: the supervisor is shared, so any other child of it
+      # belongs to someone else. Runners first — one still holding the port would
+      # outlive the test.
+      for pid <- Agent.get(started, & &1), Process.alive?(pid) do
         DynamicSupervisor.terminate_child(@supervisor, pid)
       end
 
+      Agent.stop(started)
       :gen_tcp.close(listen)
 
       case original do
@@ -63,6 +72,8 @@ defmodule Sanbase.DeepResearch.RunnerTest do
         thread_id: nil,
         next_id: 1
       })
+
+    Agent.update(Process.get(@started_key), &[pid | &1])
 
     {key, pid}
   end
@@ -141,6 +152,8 @@ defmodule Sanbase.DeepResearch.RunnerTest do
   end
 
   test "reattaching within the grace period cancels the pause" do
+    # Explicit, so shortening the default grace cannot make this race.
+    put_pause_grace(60_000)
     {_key, pid} = start_runner()
     {:ok, _} = Runner.attach(pid, self())
     {:ok, _} = Runner.ask(pid, "q")
@@ -166,6 +179,67 @@ defmodule Sanbase.DeepResearch.RunnerTest do
     Process.exit(watcher, :kill)
 
     assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 2_000
+  end
+
+  describe "a run that ends in a failure" do
+    defp end_run(pid, failure) do
+      send(pid, {:sys.get_state(pid).task.ref, {:error, failure}})
+    end
+
+    defp timeout(), do: %Req.TransportError{reason: :timeout}
+    defp refused(), do: %Req.TransportError{reason: :econnrefused}
+
+    test "parks the turn :paused when the connection broke — it is resumable" do
+      {key, pid} = start_runner()
+      {:ok, _} = Runner.attach(pid, self())
+      {:ok, _} = Runner.ask(pid, "q")
+
+      end_run(pid, Failure.connection("create_thread", "http://127.0.0.1:1", refused()))
+
+      assert_receive {:dra_runner, ^key, %{running: false, current_turn: turn}}
+      assert %Turn{phase: :paused, error: error} = turn
+      assert error =~ "nothing is listening"
+    end
+
+    test "fails the turn when the agent itself answered" do
+      {key, pid} = start_runner()
+      {:ok, _} = Runner.attach(pid, self())
+      {:ok, _} = Runner.ask(pid, "q")
+
+      end_run(pid, Failure.response("The run", 500, "boom"))
+
+      assert_receive {:dra_runner, ^key, %{current_turn: %Turn{phase: :failed, error: error}}}
+      assert error =~ "HTTP 500"
+    end
+
+    test "parks the turn :paused when the state poll could not be made" do
+      {key, pid} = start_runner()
+      {:ok, _} = Runner.attach(pid, self())
+      {:ok, _} = Runner.ask(pid, "q")
+
+      # The stream ended with no report, so the turn waits on the thread's state.
+      send(pid, {:dra_thread, "th1"})
+      send(pid, {:sys.get_state(pid).task.ref, :ok})
+
+      send(pid, {:dra_poll, 1, Failure.connection("get_state", "http://x", timeout())})
+
+      assert_receive {:dra_runner, ^key, %{current_turn: %Turn{phase: :paused, error: error}}}
+      assert error =~ "timed out"
+      # NOT the "finished without producing a report" verdict — we never asked.
+      refute error =~ "without producing a report"
+    end
+
+    test "parks the turn :paused when the stream task itself died" do
+      {key, pid} = start_runner()
+      {:ok, _} = Runner.attach(pid, self())
+      {:ok, _} = Runner.ask(pid, "q")
+
+      task = :sys.get_state(pid).task
+      Process.exit(task.pid, :kill)
+
+      assert_receive {:dra_runner, ^key, %{current_turn: %Turn{phase: :paused, error: error}}}
+      assert error =~ "stopped unexpectedly"
+    end
   end
 
   test "continue resumes a paused turn in place" do

--- a/test/sanbase/deep_research/runner_test.exs
+++ b/test/sanbase/deep_research/runner_test.exs
@@ -1,0 +1,227 @@
+defmodule Sanbase.DeepResearch.RunnerTest do
+  @moduledoc """
+  Runner unit tests: attach/detach, the pause grace period, continue.
+
+  Every runner is EPHEMERAL (no session_id), so nothing touches the DB —
+  persistence is covered in `SanbaseWeb.DeepResearchLiveTest`. The base URL points
+  at a listener that never answers, so a run stays in flight until settled.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Sanbase.DeepResearch.{Runner, Timeline, Turn}
+
+  @supervisor Sanbase.DeepResearch.RunnerSupervisor
+
+  setup do
+    original = Application.get_env(:sanbase, Sanbase.DeepResearch)
+
+    {:ok, listen} = :gen_tcp.listen(0, [:binary, active: false])
+    {:ok, port} = :inet.port(listen)
+
+    Application.put_env(:sanbase, Sanbase.DeepResearch,
+      base_url: "http://127.0.0.1:#{port}",
+      mcp_servers: []
+    )
+
+    on_exit(fn ->
+      # Runners first: one still holding the port would outlive the test.
+      for {_, pid, _, _} <- DynamicSupervisor.which_children(@supervisor), is_pid(pid) do
+        DynamicSupervisor.terminate_child(@supervisor, pid)
+      end
+
+      :gen_tcp.close(listen)
+
+      case original do
+        nil -> Application.delete_env(:sanbase, Sanbase.DeepResearch)
+        env -> Application.put_env(:sanbase, Sanbase.DeepResearch, env)
+      end
+    end)
+
+    :ok
+  end
+
+  defp put_pause_grace(ms) do
+    env = Application.get_env(:sanbase, Sanbase.DeepResearch)
+
+    Application.put_env(
+      :sanbase,
+      Sanbase.DeepResearch,
+      Keyword.put(env, :pause_after_disconnect_ms, ms)
+    )
+  end
+
+  defp start_runner() do
+    key = "runner-test-#{System.unique_integer([:positive])}"
+
+    {:ok, pid} =
+      Runner.ensure_started(%{
+        key: key,
+        session_id: nil,
+        user: nil,
+        model_tier: "mid",
+        thread_id: nil,
+        next_id: 1
+      })
+
+    {key, pid}
+  end
+
+  test "ensure_started is idempotent per key" do
+    {key, pid} = start_runner()
+
+    assert {:ok, ^pid} =
+             Runner.ensure_started(%{key: key, session_id: nil, user: nil, next_id: 1})
+
+    assert Runner.whereis(key) == pid
+  end
+
+  test "attach returns the current snapshot; ask starts a run and broadcasts" do
+    {key, pid} = start_runner()
+
+    assert {:ok, snapshot} = Runner.attach(pid, self())
+    assert snapshot.key == key
+    assert snapshot.running == false
+    assert snapshot.current_turn == nil
+
+    assert {:ok, snapshot} = Runner.ask(pid, "What is driving ETH?")
+    assert snapshot.running == true
+
+    assert %Turn{id: 1, question: "What is driving ETH?", phase: :planning} =
+             snapshot.current_turn
+
+    send(pid, {:dra_event, 1, %{thinking: %{id: "m1", text: "Scanning"}}})
+
+    assert_receive {:dra_runner, ^key, %{current_turn: %Turn{timeline: [%{text: "Scanning"}]}}}
+  end
+
+  test "ask while a run streams is busy" do
+    {_key, pid} = start_runner()
+    {:ok, _} = Runner.attach(pid, self())
+    {:ok, _} = Runner.ask(pid, "first")
+
+    assert {:error, :busy} = Runner.ask(pid, "second")
+  end
+
+  test "cancel settles the turn; later events are dropped" do
+    {key, pid} = start_runner()
+    {:ok, _} = Runner.attach(pid, self())
+    {:ok, _} = Runner.ask(pid, "q")
+
+    assert {:ok, snapshot} = Runner.cancel(pid)
+    assert snapshot.running == false
+    assert snapshot.current_turn.phase == :cancelled
+
+    send(pid, {:dra_event, 1, %{thinking: %{id: "m1", text: "late event"}}})
+    :sys.get_state(pid)
+
+    refute_receive {:dra_runner, ^key, %{current_turn: %Turn{timeline: [_ | _]}}}
+  end
+
+  test "an idle runner stops as soon as its last watcher detaches" do
+    {_key, pid} = start_runner()
+    {:ok, _} = Runner.attach(pid, self())
+    ref = Process.monitor(pid)
+
+    Runner.detach(pid, self())
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1_000
+  end
+
+  test "a streaming runner pauses (and stops) once the grace period expires" do
+    put_pause_grace(1)
+    {_key, pid} = start_runner()
+    {:ok, _} = Runner.attach(pid, self())
+    {:ok, _} = Runner.ask(pid, "q")
+    ref = Process.monitor(pid)
+
+    Runner.detach(pid, self())
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 2_000
+  end
+
+  test "reattaching within the grace period cancels the pause" do
+    {_key, pid} = start_runner()
+    {:ok, _} = Runner.attach(pid, self())
+    {:ok, _} = Runner.ask(pid, "q")
+
+    Runner.detach(pid, self())
+    assert :sys.get_state(pid).pause_timer != nil
+
+    {:ok, snapshot} = Runner.attach(pid, self())
+    assert :sys.get_state(pid).pause_timer == nil
+    assert snapshot.running == true
+    assert Process.alive?(pid)
+  end
+
+  test "a watcher dying counts as a detach" do
+    put_pause_grace(1)
+    {_key, pid} = start_runner()
+
+    watcher = spawn(fn -> Process.sleep(:infinity) end)
+    {:ok, _} = Runner.attach(pid, watcher)
+    {:ok, _} = Runner.ask(pid, "q")
+    ref = Process.monitor(pid)
+
+    Process.exit(watcher, :kill)
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 2_000
+  end
+
+  test "continue resumes a paused turn in place" do
+    {_key, pid} = start_runner()
+    {:ok, _} = Runner.attach(pid, self())
+
+    paused = %{Timeline.new_turn("ETH drivers?", 1, 123) | phase: :paused, finished_at: 456}
+
+    assert {:ok, snapshot} = Runner.continue(pid, paused)
+    assert snapshot.running == true
+    assert %Turn{id: 1, phase: :planning, finished_at: nil, error: nil} = snapshot.current_turn
+
+    # The resume run streams into the SAME turn id.
+    send(pid, {:dra_event, 1, %{thinking: %{id: "m1", text: "Resumed"}}})
+    :sys.get_state(pid)
+    assert_receive {:dra_runner, _key, %{current_turn: %Turn{timeline: [%{text: "Resumed"}]}}}
+  end
+
+  test "continue settles the unrelated turn it replaces" do
+    {key, pid} = start_runner()
+    {:ok, _} = Runner.attach(pid, self())
+    {:ok, _} = Runner.ask(pid, "first")
+
+    # Land the first turn in "not running, not settled": its stream ended and it
+    # waits for a state poll that never answers.
+    send(pid, {:dra_thread, "th1"})
+    task_ref = :sys.get_state(pid).task.ref
+    send(pid, {task_ref, :ok})
+    refute :sys.get_state(pid).running
+
+    paused = %{Timeline.new_turn("another question", 7, 123) | phase: :paused}
+    assert {:ok, %{current_turn: %Turn{id: 7}}} = Runner.continue(pid, paused)
+
+    # Nothing else would have settled turn 1 once :current_turn moved on.
+    assert_receive {:dra_runner, ^key, %{current_turn: %Turn{id: 1, phase: :failed}}}
+  end
+
+  test "continue rejects a turn that is not paused" do
+    {_key, pid} = start_runner()
+    {:ok, _} = Runner.attach(pid, self())
+
+    settled = %{Timeline.new_turn("q", 1, 123) | phase: :completed}
+
+    assert {:error, :not_paused} = Runner.continue(pid, settled)
+    assert {:ok, %{running: false}} = Runner.attach(pid, self())
+  end
+
+  test "calls against a dead runner return not_alive instead of exiting" do
+    {_key, pid} = start_runner()
+    {:ok, _} = Runner.attach(pid, self())
+    ref = Process.monitor(pid)
+    Runner.shutdown(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _}, 1_000
+
+    assert {:error, :not_alive} = Runner.ask(pid, "q")
+    assert {:error, :not_alive} = Runner.attach(pid, self())
+    assert {:error, :not_alive} = Runner.cancel(pid)
+  end
+end

--- a/test/sanbase/deep_research/sessions_test.exs
+++ b/test/sanbase/deep_research/sessions_test.exs
@@ -181,20 +181,36 @@ defmodule Sanbase.DeepResearch.SessionsTest do
   end
 
   describe "interrupted turn reconciliation" do
-    test "a non-terminal turn loads as failed and the coercion is persisted" do
+    test "a non-terminal turn loads as paused (resumable), without touching the row" do
       user = insert(:user)
       {:ok, %{session: session}} = Sessions.start_session(user.id, "mid", new_turn())
 
-      # The row is stuck in :planning — the LiveView died before the terminal write.
+      # The row is stuck in :planning — the runner died before the settling write.
       assert {:ok, %{turns: [turn]}} = Sessions.get_session_for_user(session.id, user.id)
 
-      assert turn.phase == :failed
-      assert turn.error =~ "Interrupted"
+      assert turn.phase == :paused
+      assert turn.error == nil
+      assert turn.finished_at
+
+      # Not persisted: the row may belong to a runner on another node.
+      row = Repo.one!(from(t in SessionTurn, where: t.session_id == ^session.id))
+      assert row.phase == :planning
+      assert row.finished_at == nil
+    end
+
+    test "a public read shows an interrupted turn as paused, without touching the row" do
+      user = insert(:user)
+      {:ok, %{session: session}} = Sessions.start_session(user.id, "mid", new_turn())
+      {:ok, _} = Sessions.toggle_public(session.id, user.id)
+
+      assert {:ok, %{turns: [turn]}} = Sessions.get_public_session(session.id)
+
+      assert turn.phase == :paused
       assert turn.finished_at
 
       row = Repo.one!(from(t in SessionTurn, where: t.session_id == ^session.id))
-      assert row.phase == :failed
-      assert row.error =~ "Interrupted"
+      assert row.phase == :planning
+      assert row.finished_at == nil
     end
 
     test "a terminal turn is left untouched" do

--- a/test/sanbase/deep_research/timeline_test.exs
+++ b/test/sanbase/deep_research/timeline_test.exs
@@ -172,6 +172,76 @@ defmodule Sanbase.DeepResearch.TimelineTest do
     test "reaching terminal wins over in-progress" do
       assert Timeline.merge_phase(:researching, :completed) == :completed
     end
+
+    test "a resumed run moves a paused turn forward again" do
+      assert Timeline.merge_phase(:paused, :planning) == :planning
+      assert Timeline.merge_phase(:paused, :researching) == :researching
+    end
+  end
+
+  describe "phase predicates for :paused" do
+    test "paused is settled and inactive, but NOT terminal (it is resumable)" do
+      assert Timeline.settled_phase?(:paused)
+      assert Timeline.inactive_phase?(:paused)
+      refute Timeline.terminal_phase?(:paused)
+    end
+
+    test "running phases are neither settled nor inactive" do
+      for phase <- [:planning, :researching, :writing] do
+        refute Timeline.settled_phase?(phase)
+        refute Timeline.inactive_phase?(phase)
+      end
+    end
+  end
+
+  describe "settling a turn" do
+    test "complete_turn completes a running turn, keeps a settled phase" do
+      completed = Timeline.complete_turn(turn(), 500)
+
+      assert completed.phase == :completed
+      assert completed.finished_at == 500
+
+      awaiting = %{turn() | phase: :awaiting_user}
+      assert Timeline.complete_turn(awaiting, 500).phase == :awaiting_user
+    end
+
+    test "fail_turn records the reason and keeps an earlier error" do
+      failed = Timeline.fail_turn(turn(), "boom", 500)
+
+      assert failed.phase == :failed
+      assert failed.error == "boom"
+      assert Timeline.fail_turn(failed, "later", 900) == failed
+    end
+
+    test "cancel_turn cancels, unless a report already arrived" do
+      assert Timeline.cancel_turn(turn(), 500).phase == :cancelled
+      assert Timeline.cancel_turn(%{turn() | report: "## Done"}, 500).phase == :completed
+    end
+
+    test "pause_turn parks an unfinished turn, returns a settled one as is" do
+      paused = Timeline.pause_turn(turn(), 500)
+
+      assert paused.phase == :paused
+      assert paused.finished_at == 500
+
+      settled = %{turn() | phase: :completed, finished_at: 10}
+      assert Timeline.pause_turn(settled, 500) == settled
+    end
+
+    test "stamp_finished_at records the finish time without settling the phase" do
+      stamped = Timeline.stamp_finished_at(turn(), 500)
+
+      assert stamped.phase == :planning
+      assert stamped.finished_at == 500
+    end
+
+    test "the first finish time wins" do
+      finished = %{turn() | finished_at: 10}
+
+      assert Timeline.complete_turn(finished, 500).finished_at == 10
+      assert Timeline.cancel_turn(finished, 500).finished_at == 10
+      assert Timeline.stamp_finished_at(finished, 500).finished_at == 10
+    end
   end
 
   describe "segment" do

--- a/test/sanbase/deep_research/timeline_test.exs
+++ b/test/sanbase/deep_research/timeline_test.exs
@@ -223,9 +223,20 @@ defmodule Sanbase.DeepResearch.TimelineTest do
 
       assert paused.phase == :paused
       assert paused.finished_at == 500
+      assert paused.error == nil
 
       settled = %{turn() | phase: :completed, finished_at: 10}
       assert Timeline.pause_turn(settled, 500) == settled
+    end
+
+    test "pause_turn keeps why the turn stopped, without overwriting an earlier error" do
+      paused = Timeline.pause_turn(turn(), 500, "the connection closed mid-request")
+
+      assert paused.phase == :paused
+      assert paused.error == "the connection closed mid-request"
+
+      # A turn that already knows what went wrong keeps its own account of it.
+      assert Timeline.pause_turn(%{turn() | error: "first"}, 500, "second").error == "first"
     end
 
     test "stamp_finished_at records the finish time without settling the phase" do

--- a/test/sanbase_web/live/deep_research/components_test.exs
+++ b/test/sanbase_web/live/deep_research/components_test.exs
@@ -26,7 +26,8 @@ defmodule SanbaseWeb.DeepResearch.ComponentsTest do
     render_component(&turn_view/1,
       turn: turn,
       running: Keyword.get(opts, :running, false),
-      now_ms: Keyword.get(opts, :now_ms)
+      now_ms: Keyword.get(opts, :now_ms),
+      can_continue: Keyword.get(opts, :can_continue, false)
     )
   end
 
@@ -55,6 +56,32 @@ defmodule SanbaseWeb.DeepResearch.ComponentsTest do
       html = render_turn(turn([%{thinking: %{id: "m1", text: "Planning the research"}}]))
 
       assert html =~ "Planning the research"
+    end
+
+    test "a paused turn shows the pause footer even with an empty timeline" do
+      html = render_turn(turn([], %{phase: :paused, finished_at: @now + 5_000}))
+
+      assert html =~ "Research paused"
+      # Not the owner's resumable view — no Continue button.
+      refute html =~ "phx-click=\"continue_turn\""
+      refute html =~ "loading-spinner"
+    end
+
+    test "a continuable paused turn offers the Continue button" do
+      html =
+        render_turn(
+          turn([%{thinking: %{id: "m1", text: "Scanning"}}], %{
+            phase: :paused,
+            finished_at: @now + 5_000
+          }),
+          can_continue: true
+        )
+
+      assert html =~ "Research paused"
+      assert html =~ "phx-click=\"continue_turn\""
+      assert html =~ "phx-value-id=\"1\""
+      # The interrupted tool spinner settles — paused is inactive.
+      refute html =~ "loading-spinner"
     end
 
     test "renders a search query with its results, linking only safe http(s) urls" do

--- a/test/sanbase_web/live/deep_research/components_test.exs
+++ b/test/sanbase_web/live/deep_research/components_test.exs
@@ -253,8 +253,25 @@ defmodule SanbaseWeb.DeepResearch.ComponentsTest do
 
     test "renders the error of a failed turn" do
       turn = turn([], %{phase: :failed, error: "Agent budget exhausted", finished_at: @now})
+      html = render_turn(turn)
 
-      assert render_turn(turn) =~ "Agent budget exhausted"
+      assert html =~ "Agent budget exhausted"
+      assert html =~ "bg-error/5"
+    end
+
+    test "why a paused turn stopped reads as a warning — it is still resumable" do
+      turn =
+        turn([], %{
+          phase: :paused,
+          error: "Connection to the research agent failed: the request timed out",
+          finished_at: @now
+        })
+
+      html = render_turn(turn)
+
+      assert html =~ "the request timed out"
+      assert html =~ "bg-warning/5"
+      refute html =~ "bg-error/5"
     end
 
     test "a finished turn needs no wall clock — it renders with now_ms nil" do

--- a/test/sanbase_web/live/deep_research/deep_research_live_test.exs
+++ b/test/sanbase_web/live/deep_research/deep_research_live_test.exs
@@ -1,39 +1,36 @@
 defmodule SanbaseWeb.DeepResearchLiveTest do
   @moduledoc """
-  LiveView-level tests for the deep research UI: mount, the submit → streamed
-  events → report flow, ref staleness, and cancellation.
+  LiveView-level tests: mount, submit → streamed events → report, ref staleness,
+  cancellation and the runner lifecycle (detach/reattach, pause, continue).
 
-  No agent server is involved. The base URL points at a local TCP socket that
-  accepts and never answers, so the async `create_thread` call blocks for the
-  duration of each test — the current turn stays alive and the streamed-event
-  handlers are driven deterministically with hand-sent `{:dra_event, ref, result}`
-  / `{:dra_poll, ref, result}` messages (exactly what `Client.stream_run` and the
-  poll task send).
+  No agent server: the base URL points at a socket that accepts and never answers,
+  so the stream task blocks in `create_thread` while events are sent to the
+  `Runner` directly. `:sys.get_state(runner)` after each send forces a broadcast.
   """
 
-  # Not async: rewrites the Sanbase.DeepResearch app env.
+  # Not async: rewrites app env, and the runners need the shared sandbox mode.
   use SanbaseWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
-  import Sanbase.DeepResearch.Fixtures, only: [completed_session: 1]
+  import Sanbase.DeepResearch.Fixtures, only: [completed_session: 1, paused_session: 1]
 
-  alias Sanbase.DeepResearch.Sessions
+  alias Sanbase.DeepResearch.{Runner, Sessions}
   alias Sanbase.DeepResearch.Sessions.SessionTurn
   alias Sanbase.Repo
 
   @path "/admin/deep_research"
+  @runner_supervisor Sanbase.DeepResearch.RunnerSupervisor
 
   setup do
     original = Application.get_env(:sanbase, Sanbase.DeepResearch)
 
-    # A listener that accepts connections (into the backlog) but never responds.
+    # Accepts connections into the backlog, never responds.
     {:ok, listen} = :gen_tcp.listen(0, [:binary, active: false])
     {:ok, port} = :inet.port(listen)
 
     Application.put_env(:sanbase, Sanbase.DeepResearch,
       base_url: "http://127.0.0.1:#{port}",
-      # No MCP catalog: the async task must not resolve API keys (a DB read from
-      # a process outside the sandbox owner's tree).
+      # No catalog: the stream task's API key lookup would race the sandbox owner.
       mcp_servers: []
     )
 
@@ -45,6 +42,9 @@ defmodule SanbaseWeb.DeepResearchLiveTest do
         env -> Application.put_env(:sanbase, Sanbase.DeepResearch, env)
       end
     end)
+
+    # Registered last, so it runs FIRST: runners must die before the sandbox does.
+    on_exit(fn -> stop_all_runners() end)
 
     {conn, user} = admin_conn()
     {:ok, conn: conn, user: user}
@@ -59,14 +59,42 @@ defmodule SanbaseWeb.DeepResearchLiveTest do
     {Plug.Test.init_test_session(Phoenix.ConnTest.build_conn(), jwt_tokens), user}
   end
 
-  # The first turn of a fresh LiveView always gets id 1 — the ref echoed back in
-  # every {:dra_event, ref, _} message.
+  # Runners outlive their watchers by design, so they outlive the test too.
+  defp stop_all_runners() do
+    for {_, pid, _, _} <- DynamicSupervisor.which_children(@runner_supervisor), is_pid(pid) do
+      DynamicSupervisor.terminate_child(@runner_supervisor, pid)
+    end
+  end
+
+  defp put_pause_grace(ms) do
+    env = Application.get_env(:sanbase, Sanbase.DeepResearch)
+
+    Application.put_env(
+      :sanbase,
+      Sanbase.DeepResearch,
+      Keyword.put(env, :pause_after_disconnect_ms, ms)
+    )
+  end
+
+  # A fresh session's first turn is id 1, echoed as the ref in every event.
   @ref 1
 
   defp submit(view, query) do
     view
     |> element("#dr-composer")
     |> render_submit(%{"query" => query})
+  end
+
+  defp runner_of(user) do
+    [session] = Sessions.list_user_sessions(user.id)
+    pid = Runner.whereis(session.id)
+    assert is_pid(pid)
+    {session, pid}
+  end
+
+  defp send_sync(runner, message) do
+    send(runner, message)
+    :sys.get_state(runner)
   end
 
   test "mounts with the empty state", %{conn: conn} do
@@ -85,15 +113,23 @@ defmodule SanbaseWeb.DeepResearchLiveTest do
     assert html =~ "phx-click=\"cancel\""
   end
 
-  test "streamed events fold into the current turn, ending in a report", %{conn: conn} do
+  test "streamed events fold into the current turn, ending in a report", %{
+    conn: conn,
+    user: user
+  } do
     {:ok, view, _html} = live(conn, @path)
     submit(view, "What is driving ETH?")
+    {_session, runner} = runner_of(user)
 
-    send(view.pid, {:dra_event, @ref, %{thinking: %{id: "m1", text: "Scanning on-chain data"}}})
+    send_sync(
+      runner,
+      {:dra_event, @ref, %{thinking: %{id: "m1", text: "Scanning on-chain data"}}}
+    )
+
     assert render(view) =~ "Scanning on-chain data"
 
-    send(
-      view.pid,
+    send_sync(
+      runner,
       {:dra_event, @ref, %{activity: %{kind: :search_query, id: "s1", query: "eth gas fees"}}}
     )
 
@@ -101,48 +137,55 @@ defmodule SanbaseWeb.DeepResearchLiveTest do
     assert html =~ "Research"
     assert html =~ "eth gas fees"
 
-    send(view.pid, {:dra_event, @ref, %{report: "## Findings\n\nFees fell.", phase: :writing}})
+    send_sync(runner, {:dra_event, @ref, %{report: "## Findings\n\nFees fell.", phase: :writing}})
     html = render(view)
     assert html =~ "Research report"
     assert html =~ "Fees fell."
   end
 
-  test "events with a stale ref are dropped", %{conn: conn} do
+  test "events with a stale ref are dropped", %{conn: conn, user: user} do
     {:ok, view, _html} = live(conn, @path)
     submit(view, "q")
+    {_session, runner} = runner_of(user)
 
-    send(view.pid, {:dra_event, @ref + 1, %{thinking: %{id: "m1", text: "stale text"}}})
+    send_sync(runner, {:dra_event, @ref + 1, %{thinking: %{id: "m1", text: "stale text"}}})
 
     refute render(view) =~ "stale text"
   end
 
-  test "a state-poll result can complete the turn with a recovered report", %{conn: conn} do
+  test "a state-poll result can complete the turn with a recovered report", %{
+    conn: conn,
+    user: user
+  } do
     {:ok, view, _html} = live(conn, @path)
     submit(view, "q")
+    {_session, runner} = runner_of(user)
 
-    send(view.pid, {:dra_poll, @ref, %{report: "## Recovered report"}})
+    send_sync(runner, {:dra_poll, @ref, %{report: "## Recovered report"}})
 
     assert render(view) =~ "Recovered report"
   end
 
-  test "a stale state-poll result is dropped", %{conn: conn} do
+  test "a stale state-poll result is dropped", %{conn: conn, user: user} do
     {:ok, view, _html} = live(conn, @path)
     submit(view, "q")
+    {_session, runner} = runner_of(user)
 
-    send(view.pid, {:dra_poll, @ref + 1, %{report: "stale poll report"}})
+    send_sync(runner, {:dra_poll, @ref + 1, %{report: "stale poll report"}})
 
     refute render(view) =~ "stale poll report"
   end
 
-  test "cancel stops the run and later events are dropped", %{conn: conn} do
+  test "cancel stops the run and later events are dropped", %{conn: conn, user: user} do
     {:ok, view, _html} = live(conn, @path)
     submit(view, "q")
+    {_session, runner} = runner_of(user)
 
     html = render_click(view, "cancel", %{})
     refute html =~ "phx-click=\"cancel\""
 
     # Events queued behind the cancel must not grow the cancelled turn.
-    send(view.pid, {:dra_event, @ref, %{thinking: %{id: "m1", text: "late event"}}})
+    send_sync(runner, {:dra_event, @ref, %{thinking: %{id: "m1", text: "late event"}}})
     refute render(view) =~ "late event"
   end
 
@@ -180,23 +223,23 @@ defmodule SanbaseWeb.DeepResearchLiveTest do
 
       submit(view, "What is driving ETH?")
 
-      assert [session] = Sessions.list_user_sessions(user.id)
+      {session, runner} = runner_of(user)
       assert_patch(view, "#{@path}/#{session.id}")
 
-      # The patch must NOT reset the conversation: the live run keeps
-      # streaming into the same process.
-      send(view.pid, {:dra_event, @ref, %{thinking: %{id: "m1", text: "Scanning"}}})
+      # The patch must not reset the conversation — still attached, same turn.
+      send_sync(runner, {:dra_event, @ref, %{thinking: %{id: "m1", text: "Scanning"}}})
       html = render(view)
       assert html =~ "Scanning"
       assert html =~ "dr-composer"
     end
 
-    test "a poll-completed turn is persisted with its report", %{conn: conn} do
+    test "a poll-completed turn is persisted with its report", %{conn: conn, user: user} do
       {:ok, view, _html} = live(conn, @path)
       submit(view, "q")
+      {_session, runner} = runner_of(user)
 
-      send(view.pid, {:dra_event, @ref, %{thinking: %{id: "m1", text: "Scanning"}}})
-      send(view.pid, {:dra_poll, @ref, %{report: "## Recovered report"}})
+      send_sync(runner, {:dra_event, @ref, %{thinking: %{id: "m1", text: "Scanning"}}})
+      send_sync(runner, {:dra_poll, @ref, %{report: "## Recovered report"}})
       render(view)
 
       assert [row] = Repo.all(SessionTurn)
@@ -230,6 +273,103 @@ defmodule SanbaseWeb.DeepResearchLiveTest do
       rows = SessionTurn |> Repo.all() |> Enum.sort_by(& &1.position)
       assert [%{position: 1, phase: :cancelled}, %{position: 2, phase: :planning}] = rows
       assert Enum.all?(rows, &(&1.session_id == session.id))
+    end
+  end
+
+  describe "runner lifecycle across the LiveView" do
+    test "a run survives navigating away and reattaches on return", %{conn: conn, user: user} do
+      {:ok, view, _html} = live(conn, @path)
+      submit(view, "long question")
+      {session, runner} = runner_of(user)
+
+      # Leaving only detaches — within the grace period the runner keeps going.
+      render_click(view, "new_session", %{})
+      assert render(view) =~ "What do you want to research?"
+      assert Process.alive?(runner)
+
+      render_click(view, "open_session", %{"id" => session.id})
+      assert_patch(view, "#{@path}/#{session.id}")
+
+      send_sync(runner, {:dra_event, @ref, %{thinking: %{id: "m1", text: "Still going"}}})
+      html = render(view)
+      assert html =~ "Still going"
+      assert html =~ "phx-click=\"cancel\""
+
+      assert [%{phase: :planning}] = Repo.all(SessionTurn)
+    end
+
+    test "a second LiveView on the session URL attaches to the streaming run", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, view, _html} = live(conn, @path)
+      submit(view, "q")
+      {session, runner} = runner_of(user)
+
+      {:ok, reconnected, html} = live(conn, "#{@path}/#{session.id}")
+      assert html =~ "loading-spinner"
+
+      send_sync(runner, {:dra_event, @ref, %{thinking: %{id: "m1", text: "Scanning"}}})
+      assert render(reconnected) =~ "Scanning"
+      assert render(view) =~ "Scanning"
+    end
+
+    test "with nobody attached the run is paused after the grace period", %{
+      conn: conn,
+      user: user
+    } do
+      put_pause_grace(1)
+      {:ok, view, _html} = live(conn, @path)
+      submit(view, "long question")
+      {_session, runner} = runner_of(user)
+      ref = Process.monitor(runner)
+
+      render_click(view, "new_session", %{})
+      assert render(view) =~ "What do you want to research?"
+
+      assert_receive {:DOWN, ^ref, :process, ^runner, :normal}, 2_000
+
+      assert [row] = Repo.all(SessionTurn)
+      assert row.phase == :paused
+      assert row.error == nil
+      assert row.finished_at
+    end
+
+    test "a paused turn offers Continue, which resumes it in place", %{conn: conn, user: user} do
+      session = paused_session(user)
+
+      {:ok, view, html} = live(conn, "#{@path}/#{session.id}")
+
+      assert html =~ "Research paused"
+      assert html =~ "phx-click=\"continue_turn\""
+
+      html = render_click(view, "continue_turn", %{"id" => "1"})
+
+      assert html =~ "loading-spinner"
+      assert html =~ "phx-click=\"cancel\""
+      refute html =~ "phx-click=\"continue_turn\""
+      # The partial timeline keeps growing in the SAME turn.
+      assert html =~ "Scanning on-chain data"
+
+      runner = Runner.whereis(session.id)
+      assert is_pid(runner)
+      assert :sys.get_state(runner).running
+
+      send_sync(runner, {:dra_event, @ref, %{thinking: %{id: "m2", text: "Resumed research"}}})
+      assert render(view) =~ "Resumed research"
+    end
+
+    test "continue_turn on a settled turn is a no-op", %{conn: conn, user: user} do
+      session = completed_session(user)
+
+      {:ok, view, html} = live(conn, "#{@path}/#{session.id}")
+      refute html =~ "phx-click=\"continue_turn\""
+
+      # A crafted event must not start a run on a completed turn.
+      html = render_click(view, "continue_turn", %{"id" => "1"})
+
+      refute html =~ "loading-spinner"
+      assert Runner.whereis(session.id) == nil
     end
   end
 
@@ -273,7 +413,6 @@ defmodule SanbaseWeb.DeepResearchLiveTest do
 
       submit(view, "And what about SOL?")
 
-      # The follow-up appends to the same session — no new session is created.
       assert [%{id: id}] = Sessions.list_user_sessions(user.id)
       assert id == session.id
 
@@ -308,6 +447,19 @@ defmodule SanbaseWeb.DeepResearchLiveTest do
       assert Sessions.list_user_sessions(user.id) == []
     end
 
+    test "deleting the streaming session also stops its runner", %{conn: conn, user: user} do
+      {:ok, view, _html} = live(conn, @path)
+      submit(view, "q")
+      {session, runner} = runner_of(user)
+      ref = Process.monitor(runner)
+
+      render_click(view, "delete_session", %{"id" => session.id})
+
+      assert_receive {:DOWN, ^ref, :process, ^runner, _}, 2_000
+      assert Sessions.list_user_sessions(user.id) == []
+      assert render(view) =~ "What do you want to research?"
+    end
+
     test "toggle_public flips the share flag and reveals the share link", %{
       conn: conn,
       user: user
@@ -324,17 +476,6 @@ defmodule SanbaseWeb.DeepResearchLiveTest do
 
       html = render_click(view, "toggle_public", %{"id" => session.id})
       refute html =~ "copy-share-link-#{session.id}"
-    end
-
-    test "navigating away from a streaming run cancels and persists it", %{conn: conn} do
-      {:ok, view, _html} = live(conn, @path)
-      submit(view, "long question")
-
-      render_click(view, "new_session", %{})
-
-      assert [row] = Repo.all(SessionTurn)
-      assert row.phase == :cancelled
-      assert render(view) =~ "What do you want to research?"
     end
   end
 end

--- a/test/sanbase_web/live/deep_research/deep_research_live_test.exs
+++ b/test/sanbase_web/live/deep_research/deep_research_live_test.exs
@@ -66,14 +66,13 @@ defmodule SanbaseWeb.DeepResearchLiveTest do
     end
   end
 
-  defp put_pause_grace(ms) do
+  defp put_pause_grace(ms), do: put_env(:pause_after_disconnect_ms, ms)
+  defp put_checkpoint_every(ms), do: put_env(:checkpoint_every_ms, ms)
+
+  defp put_env(key, value) do
     env = Application.get_env(:sanbase, Sanbase.DeepResearch)
 
-    Application.put_env(
-      :sanbase,
-      Sanbase.DeepResearch,
-      Keyword.put(env, :pause_after_disconnect_ms, ms)
-    )
+    Application.put_env(:sanbase, Sanbase.DeepResearch, Keyword.put(env, key, value))
   end
 
   # A fresh session's first turn is id 1, echoed as the ref in every event.
@@ -258,6 +257,45 @@ defmodule SanbaseWeb.DeepResearchLiveTest do
       assert [row] = Repo.all(SessionTurn)
       assert row.phase == :cancelled
       assert row.finished_at
+    end
+
+    test "a streaming turn is checkpointed, so an abrupt loss keeps its timeline", %{
+      conn: conn,
+      user: user
+    } do
+      # Checkpoint on every event: the interval is what keeps writes off the hot path,
+      # not anything about which events deserve one.
+      put_checkpoint_every(0)
+
+      {:ok, view, _html} = live(conn, @path)
+      submit(view, "q")
+      {_session, runner} = runner_of(user)
+
+      send_sync(runner, {:dra_event, @ref, %{thinking: %{id: "m1", text: "Scanning"}}})
+      send_sync(runner, {:dra_event, @ref, %{thinking: %{id: "m2", text: "Reading"}}})
+      render(view)
+
+      assert [row] = Repo.all(SessionTurn)
+      # A checkpoint, not the settling write: the turn is still in flight.
+      assert row.phase == :planning
+      refute row.finished_at
+      assert [_scanning, %{"kind" => "thinking", "text" => "Reading"}] = row.timeline
+    end
+
+    test "the first event of a turn writes nothing — the row was just created", %{
+      conn: conn,
+      user: user
+    } do
+      put_checkpoint_every(0)
+
+      {:ok, view, _html} = live(conn, @path)
+      submit(view, "q")
+      {_session, runner} = runner_of(user)
+
+      send_sync(runner, {:dra_event, @ref, %{thinking: %{id: "m1", text: "Scanning"}}})
+      render(view)
+
+      assert [%{timeline: []}] = Repo.all(SessionTurn)
     end
 
     test "a follow-up question lands in the same session", %{conn: conn, user: user} do

--- a/test/support/deep_research_fixtures.ex
+++ b/test/support/deep_research_fixtures.ex
@@ -21,7 +21,15 @@ defmodule Sanbase.DeepResearch.Fixtures do
     end
   end
 
-  @doc "A one-turn session owned by `user`, its turn left `:paused` mid-timeline."
+  @doc """
+  A one-turn session owned by `user`, its turn left `:paused` mid-timeline — what a
+  runner interrupted mid-run leaves behind, and what Continue resumes from.
+
+      session = paused_session(user)
+
+      {:ok, %{turns: [%{phase: :paused, timeline: [_scanning]}]}} =
+        Sessions.get_session_for_user(session.id, user.id)
+  """
   def paused_session(user) do
     one_turn_session(user,
       phase: :paused,

--- a/test/support/deep_research_fixtures.ex
+++ b/test/support/deep_research_fixtures.ex
@@ -6,24 +6,12 @@ defmodule Sanbase.DeepResearch.Fixtures do
 
   alias Sanbase.DeepResearch.{Sessions, Turn}
 
+  @started_at 1_754_820_000_000
+  @finished_at 1_754_820_090_000
+
   @doc "A completed one-turn session owned by `user`. Pass `public?: true` to share it."
   def completed_session(user, opts \\ []) do
-    {:ok, %{session: session}} =
-      Sessions.start_session(user.id, "mid", %Turn{
-        id: 1,
-        question: "ETH drivers?",
-        started_at: 1_754_820_000_000
-      })
-
-    {:ok, _} =
-      Sessions.update_turn(session.id, 1, %Turn{
-        id: 1,
-        question: "ETH drivers?",
-        report: "## Findings\n\nFees fell.",
-        phase: :completed,
-        started_at: 1_754_820_000_000,
-        finished_at: 1_754_820_090_000
-      })
+    session = one_turn_session(user, phase: :completed, report: "## Findings\n\nFees fell.")
 
     if opts[:public?] do
       {:ok, session} = Sessions.toggle_public(session.id, user.id)
@@ -31,5 +19,24 @@ defmodule Sanbase.DeepResearch.Fixtures do
     else
       session
     end
+  end
+
+  @doc "A one-turn session owned by `user`, its turn left `:paused` mid-timeline."
+  def paused_session(user) do
+    one_turn_session(user,
+      phase: :paused,
+      timeline: [%{kind: :thinking, id: "m1", text: "Scanning on-chain data"}]
+    )
+  end
+
+  # The two writes the live path makes: the asked turn, then the settled one.
+  defp one_turn_session(user, settled_attrs) do
+    asked = %Turn{id: 1, question: "ETH drivers?", started_at: @started_at}
+    {:ok, %{session: session}} = Sessions.start_session(user.id, "mid", asked)
+
+    settled = struct!(%{asked | finished_at: @finished_at}, settled_attrs)
+    {:ok, _} = Sessions.update_turn(session.id, 1, settled)
+
+    session
   end
 end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deep Research sessions continue running through brief disconnects.
  * Disconnected sessions pause after a configurable timeout and can be continued later.
  * Session navigation and new-session creation remain available during active research.
  * Authenticated research tools can be configured automatically.
  * Improved connection and request error messages indicate whether a run can resume.

* **Bug Fixes**
  * Interrupted research is now represented as paused rather than failed, preserving the ability to resume.
  * Research cancellations, failures, and paused states are handled more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->