### PR TITLE
Add apiCalls to productsWithPlans

### DIFF
--- a/lib/sanbase/api_call_limit/api_call_limit.ex
+++ b/lib/sanbase/api_call_limit/api_call_limit.ex
@@ -387,12 +387,9 @@ defmodule Sanbase.ApiCallLimit do
     }
   end
 
-  def subscription_to_plan_name(%Subscription{plan: %{product: %{id: @product_api_id}}} = sub) do
-    "sanapi_#{Subscription.plan_name(sub)}" |> String.downcase()
-  end
-
-  def subscription_to_plan_name(%Subscription{plan: %{product: %{id: @product_sanbase_id}}} = sub) do
-    "sanbase_#{Subscription.plan_name(sub)}" |> String.downcase()
+  def subscription_to_plan_name(%Subscription{plan: %{product: %{id: id}}} = sub)
+      when id in [@product_api_id, @product_sanbase_id] do
+    Restrictions.key(Product.code_by_id(id), Subscription.plan_name(sub))
   end
 
   def subscription_to_plan_name(_sub), do: "sanapi_free"

--- a/lib/sanbase/api_call_limit/restrictions.ex
+++ b/lib/sanbase/api_call_limit/restrictions.ex
@@ -35,6 +35,17 @@ defmodule Sanbase.ApiCallLimit.Restrictions do
   `docs/composable-api-plans-handover.md` §8 task EP.
   """
 
+  @doc ~s"""
+  Build the key into this module's maps from a product code (`"SANAPI"`) and a
+  canonical plan name (`"PRO"`). The single owner of the key format - quota
+  enforcement (`Sanbase.ApiCallLimit`) and catalog display
+  (`Sanbase.Billing.Plan.api_call_limits/1`) must produce identical strings.
+  Total: a `nil` part interpolates to `""`, yielding a key no map contains.
+  """
+  def key(product_code, plan_name) do
+    String.downcase("#{product_code}_#{plan_name}")
+  end
+
   def call_limits_per_month() do
     %{
       "sanbase_basic" => 1000,

--- a/lib/sanbase/billing/plan.ex
+++ b/lib/sanbase/billing/plan.ex
@@ -140,6 +140,11 @@ defmodule Sanbase.Billing.Plan do
     "PREMIUM"
   ]
 
+  # Names that canonicalize to another rung. Shared by `plan_name/1` and
+  # `api_call_limits/1` so a future alias cannot update one and silently miss
+  # the other.
+  @plan_name_aliases %{"ESSENTIAL" => "BASIC"}
+
   @bundle_prefix "BUNDLE"
   @custom_prefix "CUSTOM_"
   @institutional_prefix "INSTITUTIONAL"
@@ -170,9 +175,8 @@ defmodule Sanbase.Billing.Plan do
   def business_plan_names, do: @business_plan_names
 
   def plan_name(%__MODULE__{} = plan) do
-    case plan.name do
+    case Map.get(@plan_name_aliases, plan.name, plan.name) do
       name when name in @same_name_plans -> name
-      "ESSENTIAL" -> "BASIC"
       "CUSTOM_" <> _ = name -> name
       @bundle_prefix <> _ = name -> name
       @institutional_prefix <> _ = name -> name
@@ -287,6 +291,72 @@ defmodule Sanbase.Billing.Plan do
   end
 
   def type_of_api_call_limit_plan(_plan), do: :standard
+
+  @doc ~s"""
+  The API call allowance a subscription on this plan grants, as a
+  `%{month: _, hour: _, minute: _}` map, or `nil` when the row itself does not
+  fix the numbers: `BUNDLE` rows (per-customer, resolved from the subscription's
+  entitlement), `CUSTOM_*` rows sold without a ceiling, and rows with no entry
+  in `Sanbase.ApiCallLimit.Restrictions` (e.g. Sanbase `FREE`, whose users are
+  metered as `sanapi_free` because quota is keyed on the subscription, and a
+  free plan means no subscription).
+
+  `ESSENTIAL` answers as `BASIC` - the same mapping `plan_name/1` applies when a
+  subscription is metered. `plan_name/1` itself is not called here because it is
+  partial (it raises on `RETIRED_*` names), and this must answer for any row.
+
+  ## Examples
+
+      iex> Sanbase.Billing.Plan.api_call_limits(%Sanbase.Billing.Plan{name: "PRO", product_id: 1})
+      %{month: 600_000, hour: 30_000, minute: 600}
+
+      iex> Sanbase.Billing.Plan.api_call_limits(%Sanbase.Billing.Plan{name: "BUNDLE", product_id: 1})
+      nil
+  """
+  @spec api_call_limits(%__MODULE__{}) ::
+          %{month: pos_integer(), hour: pos_integer(), minute: pos_integer()} | nil
+  def api_call_limits(%__MODULE__{} = plan) do
+    case type(plan.name) do
+      # TODO: A bundle's numbers are per-customer - every bundle subscription
+      # points to the same BUNDLE marker row, and the real limits are decoded
+      # from the subscription's items. Exposing them needs a field on the
+      # subscription (Subscription.bundle_entitlement/1 +
+      # Bundle.Access.api_call_limits/1), not on the plan.
+      :bundle -> nil
+      :custom -> custom_api_call_limits(plan)
+      :standard -> standard_api_call_limits(plan)
+    end
+  end
+
+  defp custom_api_call_limits(%__MODULE__{
+         restrictions: %CustomPlan.Restrictions{
+           api_call_limits: %{"month" => month, "hour" => hour, "minute" => minute}
+         }
+       }) do
+    %{month: month, hour: hour, minute: minute}
+  end
+
+  # Matches both a missing restrictions embed and the %{"has_limits" => false}
+  # shape a bespoke contract with no ceiling stores.
+  defp custom_api_call_limits(_plan), do: nil
+
+  defp standard_api_call_limits(%__MODULE__{} = plan) do
+    name = Map.get(@plan_name_aliases, plan.name, plan.name)
+    code = Product.code_by_id(plan.product_id)
+    key = Sanbase.ApiCallLimit.Restrictions.key(code, name)
+
+    case Map.get(Sanbase.ApiCallLimit.Restrictions.call_limits_per_month(), key) do
+      nil ->
+        nil
+
+      month ->
+        %{
+          month: month,
+          hour: Map.fetch!(Sanbase.ApiCallLimit.Restrictions.call_limits_per_hour(), key),
+          minute: Map.fetch!(Sanbase.ApiCallLimit.Restrictions.call_limits_per_minute(), key)
+        }
+    end
+  end
 
   def plan_full_name(plan) do
     plan = plan |> Repo.preload(:product)

--- a/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
@@ -14,6 +14,10 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
     Plan.product_with_plans()
   end
 
+  def plan_api_call_limits(%Plan{} = plan, _args, _resolution) do
+    {:ok, Plan.api_call_limits(plan)}
+  end
+
   def bundle_catalog(_root, %{interval: interval}, resolution) do
     user = current_user(resolution)
 

--- a/lib/sanbase_web/graphql/schema/types/billing_types.ex
+++ b/lib/sanbase_web/graphql/schema/types/billing_types.ex
@@ -1,6 +1,8 @@
 defmodule SanbaseWeb.Graphql.BillingTypes do
   use Absinthe.Schema.Notation
 
+  alias SanbaseWeb.Graphql.Resolvers.BillingResolver
+
   enum :restriction_types_enum do
     value(:free)
     value(:restricted)
@@ -56,6 +58,21 @@ defmodule SanbaseWeb.Graphql.BillingTypes do
     field(:amount, :integer)
     field(:is_deprecated, :boolean)
     field(:is_private, :boolean)
+
+    @desc ~s"""
+    The API call allowance a subscription on this plan grants. `null` when the
+    plan does not fix the numbers itself - `BUNDLE` allowances are per-customer,
+    and some bespoke plans are sold without a ceiling.
+    """
+    field :api_call_limits, :plan_api_call_limits do
+      resolve(&BillingResolver.plan_api_call_limits/3)
+    end
+  end
+
+  object :plan_api_call_limits do
+    field(:month, non_null(:integer))
+    field(:hour, non_null(:integer))
+    field(:minute, non_null(:integer))
   end
 
   object :bundle_catalog_price do

--- a/test/sanbase/billing/plan_test.exs
+++ b/test/sanbase/billing/plan_test.exs
@@ -38,4 +38,62 @@ defmodule Sanbase.Billing.PlanTest do
       end
     end
   end
+
+  describe "#api_call_limits" do
+    test "standard SanAPI plans answer from the restrictions maps" do
+      assert Plan.api_call_limits(%Plan{name: "PRO", product_id: 1}) ==
+               %{month: 600_000, hour: 30_000, minute: 600}
+
+      assert Plan.api_call_limits(%Plan{name: "FREE", product_id: 1}) ==
+               %{month: 1000, hour: 500, minute: 100}
+
+      assert Plan.api_call_limits(%Plan{name: "BUSINESS_MAX", product_id: 1}) ==
+               %{month: 1_200_000, hour: 60_000, minute: 1200}
+
+      assert Plan.api_call_limits(%Plan{name: "INSTITUTIONAL", product_id: 1}) ==
+               %{month: 50_000, hour: 30_000, minute: 600}
+
+      assert Plan.api_call_limits(%Plan{name: "ENTERPRISE", product_id: 1}) ==
+               %{month: 300_000, hour: 60_000, minute: 1200}
+    end
+
+    test "ESSENTIAL answers as BASIC, the plan it is metered as" do
+      assert Plan.api_call_limits(%Plan{name: "ESSENTIAL", product_id: 1}) ==
+               %{month: 300_000, hour: 20_000, minute: 300}
+    end
+
+    test "standard Sanbase plans answer from the restrictions maps" do
+      assert Plan.api_call_limits(%Plan{name: "PRO", product_id: 2}) ==
+               %{month: 5000, hour: 1000, minute: 100}
+    end
+
+    test "plans with no restrictions entry answer nil" do
+      # Sanbase FREE means no subscription, so its users are metered as sanapi_free
+      assert Plan.api_call_limits(%Plan{name: "FREE", product_id: 2}) == nil
+      # the CUSTOM rung has no published numbers - each contract sets its own
+      assert Plan.api_call_limits(%Plan{name: "CUSTOM", product_id: 1}) == nil
+      assert Plan.api_call_limits(%Plan{name: "RETIRED_ENTERPRISE_BASIC", product_id: 1}) == nil
+    end
+
+    test "BUNDLE answers nil - the numbers are per-customer" do
+      assert Plan.api_call_limits(%Plan{name: "BUNDLE", product_id: 1}) == nil
+    end
+
+    test "CUSTOM_* plans answer from their embedded restrictions" do
+      restrictions = %Plan.CustomPlan.Restrictions{
+        api_call_limits: %{"month" => 1_000_000, "hour" => 50_000, "minute" => 1000}
+      }
+
+      plan = %Plan{name: "CUSTOM_ACME", product_id: 1, restrictions: restrictions}
+
+      assert Plan.api_call_limits(plan) == %{month: 1_000_000, hour: 50_000, minute: 1000}
+    end
+
+    test "CUSTOM_* plans sold without a ceiling answer nil" do
+      restrictions = %Plan.CustomPlan.Restrictions{api_call_limits: %{"has_limits" => false}}
+      plan = %Plan{name: "CUSTOM_ACME", product_id: 1, restrictions: restrictions}
+
+      assert Plan.api_call_limits(plan) == nil
+    end
+  end
 end

--- a/test/sanbase_web/graphql/billing/subscribe_api_test.exs
+++ b/test/sanbase_web/graphql/billing/subscribe_api_test.exs
@@ -138,6 +138,18 @@ defmodule SanbaseWeb.Graphql.Billing.SubscribeApiTest do
 
     assert result["name"] == "Sanapi by Santiment"
     assert length(result["plans"]) == 11
+
+    limits_by_name =
+      Map.new(result["plans"], fn plan -> {plan["name"], plan["apiCallLimits"]} end)
+
+    assert limits_by_name["FREE"] == %{"month" => 1000, "hour" => 500, "minute" => 100}
+    assert limits_by_name["PRO"] == %{"month" => 600_000, "hour" => 30_000, "minute" => 600}
+
+    # ESSENTIAL is metered as BASIC
+    assert limits_by_name["ESSENTIAL"] == %{"month" => 300_000, "hour" => 20_000, "minute" => 300}
+
+    # the CUSTOM rung publishes no numbers - each contract sets its own
+    assert limits_by_name["CUSTOM"] == nil
   end
 
   describe "#currentUser[subscriptions]" do
@@ -698,6 +710,11 @@ defmodule SanbaseWeb.Graphql.Billing.SubscribeApiTest do
         name
         plans {
           name
+          apiCallLimits {
+            month
+            hour
+            minute
+          }
         }
       }
     }


### PR DESCRIPTION
## Changes

Add apiCallLimits to the productWithPlans API

```graphql
{
  productsWithPlans {
    name
    plans {
      name
      interval
      apiCallLimits {
        month
        hour
        minute
      }
    }
  }
}
```

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API call limits to billing plan information.
  * Limits are available by month, hour, and minute for applicable plans.
  * Supports standard, custom, bundle, and unrestricted plans, including ESSENTIAL plan mapping.
  * Exposes limits through the billing GraphQL API for supported plans.
  * Improved consistency when resolving limits across API and platform plans.

* **Tests**
  * Added coverage for plan limit resolution and GraphQL responses across supported plan types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->