### PR TITLE
List Institutional and Enterprise in productsWithPlans

### DIFF
--- a/lib/sanbase/billing/plan.ex
+++ b/lib/sanbase/billing/plan.ex
@@ -383,10 +383,17 @@ defmodule Sanbase.Billing.Plan do
   plan that flow cannot correctly create. The bundle catalog is served by
   `bundleCatalog` instead.
 
-  `INSTITUTIONAL` and `ENTERPRISE` are real priced plans and both are self-serve,
-  but they are still excluded here: this query backs the legacy pricing grid,
-  which renders a column per row and knows nothing about the three-column
-  offering. The new purchase surface addresses them by plan id (§8 **UI**).
+  `INSTITUTIONAL` and `ENTERPRISE` are real priced plans and both are self-serve.
+  They are listed only when `include_new_offering: true` is passed - the GraphQL
+  resolver passes `SaleControls.bundle_plans_visible?/1` for the caller, so the
+  rows appear once the offering is activated (and earlier for staff). That is how
+  the frontend learns their plan ids for `subscribe(planId:)` and
+  `updateSubscription(planId:)` without hardcoding them, and it is the same
+  switch `bundleCatalog` answers to, so the pricing page has one signal for the
+  whole offering. Every known consumer filters this list by a name allow-list, so
+  the extra rows are dropped by clients that do not know them. Only the exact
+  `ENTERPRISE` row is admitted: the legacy `ENTERPRISE_BASIC` / `ENTERPRISE_PLUS`
+  names stay excluded by the `ENTERPRISE%` prefix.
 
   `RETIRED_*` rows are excluded as well - withdrawn plans kept only so the
   subscriptions that reference them still resolve. The exclusion has to be by name
@@ -407,11 +414,24 @@ defmodule Sanbase.Billing.Plan do
   exposed on the GraphQL plan type, so a caller that wants to hide such rows
   still can.
   """
-  def product_with_plans do
+  @spec product_with_plans(include_new_offering: boolean()) :: {:ok, [%Product{}]}
+  def product_with_plans(opts \\ []) do
+    include_new_offering = Keyword.get(opts, :include_new_offering, false)
+
     bundle_pattern = @bundle_prefix <> "%"
     institutional_pattern = @institutional_prefix <> "%"
     enterprise_pattern = @enterprise_prefix <> "%"
     retired_pattern = @retired_prefix <> "%"
+
+    new_offering_filter =
+      if include_new_offering do
+        dynamic([p, pl], not like(pl.name, ^enterprise_pattern) or pl.name == @enterprise_prefix)
+      else
+        dynamic(
+          [p, pl],
+          not like(pl.name, ^institutional_pattern) and not like(pl.name, ^enterprise_pattern)
+        )
+      end
 
     query =
       from(p in Product,
@@ -419,11 +439,10 @@ defmodule Sanbase.Billing.Plan do
         on: pl.product_id == p.id,
         where:
           not pl.is_ppp and not like(pl.name, ^bundle_pattern) and
-            not like(pl.name, ^institutional_pattern) and
-            not like(pl.name, ^enterprise_pattern) and
             not like(pl.name, ^retired_pattern) and
             (pl.name not in ^@business_plan_names or
                coalesce(pl.is_deprecated, false) == false),
+        where: ^new_offering_filter,
         order_by: [desc: pl.order, asc: pl.id],
         preload: [plans: pl]
       )

--- a/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/billing_resolver.ex
@@ -10,8 +10,12 @@ defmodule SanbaseWeb.Graphql.Resolvers.BillingResolver do
 
   require Logger
 
-  def products_with_plans(_root, _args, _resolution) do
-    Plan.product_with_plans()
+  def products_with_plans(_root, _args, resolution) do
+    # Institutional and Enterprise are listed once the offering is on sale (staff
+    # see them earlier), the same gate `bundleCatalog` uses.
+    visible? = Sanbase.Billing.Plan.SaleControls.bundle_plans_visible?(current_user(resolution))
+
+    Plan.product_with_plans(include_new_offering: visible?)
   end
 
   def plan_api_call_limits(%Plan{} = plan, _args, _resolution) do

--- a/test/sanbase/billing/plan/enterprise_test.exs
+++ b/test/sanbase/billing/plan/enterprise_test.exs
@@ -418,6 +418,20 @@ defmodule Sanbase.Billing.Plan.EnterpriseTest do
              end)
     end
 
+    test "is listed when the new offering is included, and the legacy rows still are not" do
+      # Only the exact `ENTERPRISE` name is admitted. `ENTERPRISE_BASIC` and friends
+      # must stay out even then, or `subscribe(planId: 105)` becomes discoverable again.
+      enterprise = enterprise_plan()
+      legacy = legacy_enterprise_plan()
+
+      assert {:ok, products} = Plan.product_with_plans(include_new_offering: true)
+
+      listed = Enum.flat_map(products, fn product -> Enum.map(product.plans, & &1.name) end)
+
+      assert enterprise.name in listed
+      refute legacy.name in listed
+    end
+
     test "a retired legacy row is out of the listing too" do
       # `ENTERPRISE_BASIC` and `ENTERPRISE_PLUS` were on the pricing page for four
       # years with no access-checker clause behind them, so buying one raised

--- a/test/sanbase/billing/plan/institutional_test.exs
+++ b/test/sanbase/billing/plan/institutional_test.exs
@@ -297,17 +297,23 @@ defmodule Sanbase.Billing.Plan.InstitutionalTest do
   end
 
   describe "the plan rows" do
-    test "are kept out of the pricing page listing" do
-      # Same reason the BUNDLE markers are: the Institutional column is rendered
-      # from its own copy, and listing the row would offer subscribe(plan_id:) a
-      # plan the pricing page does not drive.
+    test "are kept out of the pricing page listing by default" do
       institutional_plan("month")
 
       assert {:ok, products} = Plan.product_with_plans()
 
-      refute @plan in Enum.flat_map(products, fn product ->
-               Enum.map(product.plans, & &1.name)
-             end)
+      refute @plan in listed_names(products)
+    end
+
+    test "are listed when the new offering is included" do
+      # This is how the frontend learns the plan id for subscribe(planId:) instead
+      # of hardcoding 311/312.
+      monthly = institutional_plan("month")
+
+      assert {:ok, products} = Plan.product_with_plans(include_new_offering: true)
+
+      assert @plan in listed_names(products)
+      assert monthly.id in Enum.flat_map(products, fn p -> Enum.map(p.plans, & &1.id) end)
     end
 
     test "are toggled by the same switch as the bundle rows" do
@@ -345,6 +351,10 @@ defmodule Sanbase.Billing.Plan.InstitutionalTest do
     SanbaseWeb.Graphql.Complexity.from_to_interval(args, 5, %{
       context: %{auth: %{subscription: subscription}}
     })
+  end
+
+  defp listed_names(products) do
+    Enum.flat_map(products, fn product -> Enum.map(product.plans, & &1.name) end)
   end
 
   defp activate_offering do

--- a/test/sanbase_web/graphql/billing/subscribe_api_test.exs
+++ b/test/sanbase_web/graphql/billing/subscribe_api_test.exs
@@ -152,6 +152,57 @@ defmodule SanbaseWeb.Graphql.Billing.SubscribeApiTest do
     assert limits_by_name["CUSTOM"] == nil
   end
 
+  describe "#productsWithPlans and the new offering" do
+    setup context do
+      Sanbase.Repo.query!("ALTER SEQUENCE plans_id_seq RESTART WITH 9950")
+
+      institutional =
+        insert(:plan_pro,
+          id: 9951,
+          name: "INSTITUTIONAL",
+          product_id: context.product_api.id,
+          interval: "month",
+          amount: 79_900,
+          is_private: true,
+          is_deprecated: false,
+          stripe_id: "plan_institutional_" <> Ecto.UUID.generate()
+        )
+
+      %{institutional: institutional}
+    end
+
+    test "hides Institutional while the offering is off sale", context do
+      names = listed_plan_names(context.conn)
+
+      refute "INSTITUTIONAL" in names
+    end
+
+    test "lists Institutional with its id for a team member before go-live", context do
+      insert(:role_san_team)
+
+      {:ok, _} =
+        Sanbase.Accounts.UserRole.create(
+          context.user.id,
+          Sanbase.Accounts.Role.san_team_role_id()
+        )
+
+      plans =
+        context.conn
+        |> execute_query(products_with_plans_query(), "productsWithPlans")
+        |> Enum.flat_map(& &1["plans"])
+
+      institutional = Enum.find(plans, &(&1["name"] == "INSTITUTIONAL"))
+      assert institutional["id"] == to_string(context.institutional.id)
+    end
+
+    test "lists Institutional for everyone once the offering is activated", context do
+      insert(:role_san_team)
+      {:ok, _} = Sanbase.Billing.Plan.SaleControls.activate_bundle_plans()
+
+      assert "INSTITUTIONAL" in listed_plan_names(build_conn())
+    end
+  end
+
   describe "#currentUser[subscriptions]" do
     test "when there are subscriptions - currentUser return list of subscriptions", context do
       insert(:subscription_essential, user: context.user)
@@ -703,12 +754,19 @@ defmodule SanbaseWeb.Graphql.Billing.SubscribeApiTest do
     """
   end
 
+  defp listed_plan_names(conn) do
+    conn
+    |> execute_query(products_with_plans_query(), "productsWithPlans")
+    |> Enum.flat_map(fn product -> Enum.map(product["plans"], & &1["name"]) end)
+  end
+
   defp products_with_plans_query() do
     """
     {
       productsWithPlans {
         name
         plans {
+          id
           name
           apiCallLimits {
             month


### PR DESCRIPTION


## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added controlled visibility for the new Institutional and Enterprise offerings in product listings.
  - Authorized users can see the new offerings before general availability, while they remain hidden from others until activation.
  - The Enterprise listing includes only the current offering; legacy Enterprise plans remain excluded.

- **Bug Fixes**
  - Corrected product listings to prevent legacy Enterprise plans from appearing alongside the new offering.

- **Tests**
  - Added coverage for offering visibility, activation timing, and plan listing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->