### PR TITLE
Institutional plan changes

### DIFF
--- a/lib/sanbase/api_call_limit/api_call_limit.ex
+++ b/lib/sanbase/api_call_limit/api_call_limit.ex
@@ -411,22 +411,55 @@ defmodule Sanbase.ApiCallLimit do
     end
   end
 
-  # `nil` for every plan whose limits follow from its name, i.e. everything but a bundle.
+  # `nil` for every plan whose limits follow from its name and that has no add-on -
+  # storing them would freeze numbers the plan tables should keep owning.
+  #
+  # Two cases store something instead. A bundle always does, because every bundle is
+  # named `BUNDLE` while the numbers differ per customer. Anything else does only when
+  # a grant adds calls on top (§8 task GR); Institutional is what that is for, but
+  # nothing here is Institutional-specific and a granted bundle picks it up too.
+  #
   # A bundle with no entitlement yet stores `nil` rather than raising: this runs on every
   # plan change, and failing would leave a stale plan name behind. The read path is loud.
   defp subscription_to_resolved_api_call_limits(%Subscription{} = sub) do
     plan_name = subscription_to_plan_name(sub)
+    extra_calls = sub |> Subscription.grant() |> Subscription.Grant.extra_api_calls()
 
-    with :bundle <- Sanbase.Billing.Plan.type_of_api_call_limit_plan(plan_name),
-         %{} = entitlement <- Subscription.bundle_entitlement(sub) do
-      limits = Sanbase.Billing.Plan.Bundle.Access.api_call_limits(entitlement)
+    case Sanbase.Billing.Plan.type_of_api_call_limit_plan(plan_name) do
+      :bundle ->
+        case Subscription.bundle_entitlement(sub) do
+          %{} = entitlement ->
+            entitlement
+            |> Sanbase.Billing.Plan.Bundle.Access.api_call_limits()
+            |> add_extra_calls(extra_calls)
 
-      # String keys, so what is written matches what jsonb reads back.
-      %{"month" => limits.month, "hour" => limits.hour, "minute" => limits.minute}
-    else
-      _ -> nil
+          _ ->
+            nil
+        end
+
+      _other when extra_calls > 0 ->
+        # `plan_has_limits?/1` first: an unlimited plan has no number to add to, and
+        # `plan_to_api_call_limits/1` would raise trying to read one.
+        if plan_has_limits?(plan_name) do
+          plan_name
+          |> plan_to_api_call_limits()
+          |> add_extra_calls(extra_calls)
+        end
+
+      _other ->
+        nil
     end
   end
+
+  # String keys, so what is written matches what jsonb reads back. Grants only ever add
+  # to the monthly allowance: hour and minute are burst protection for the
+  # infrastructure rather than something sold, so buying calls must not widen them.
+  defp add_extra_calls(%{month: month, hour: hour, minute: minute}, extra)
+       when is_integer(month) and is_integer(hour) and is_integer(minute) do
+    %{"month" => month + extra, "hour" => hour, "minute" => minute}
+  end
+
+  defp add_extra_calls(_limits, _extra), do: nil
 
   defp do_get_quota(%__MODULE__{has_limits_no_matter_plan: false}) do
     {:ok, %{quota: :infinity}}
@@ -571,7 +604,7 @@ defmodule Sanbase.ApiCallLimit do
       _ ->
         case Sanbase.Billing.Plan.type_of_api_call_limit_plan(plan) do
           :bundle ->
-            # Every bundle has a monthly call limit - a flat 100k plus the add-ons bought
+            # Every bundle has a monthly call limit - a flat 50k plus the add-ons bought
             # (§9). There is no unlimited bundle, so no entitlement is needed here.
             true
 
@@ -607,7 +640,9 @@ defmodule Sanbase.ApiCallLimit do
   For a bundle these were resolved when the subscription synced and stored on the
   row, because every bundle is named `BUNDLE` while the numbers differ per
   customer (§5.8). For every other plan the name identifies the numbers, and this
-  falls through to `plan_to_api_call_limits/1` unchanged.
+  falls through to `plan_to_api_call_limits/1` unchanged - unless a sales-applied
+  grant added calls on top, in which case the resolved total was stored at the same
+  point and is read from here (§8 task GR).
   """
   @spec acl_to_api_call_limits(%__MODULE__{}) :: %{
           month: non_neg_integer(),
@@ -617,9 +652,31 @@ defmodule Sanbase.ApiCallLimit do
   def acl_to_api_call_limits(%__MODULE__{api_calls_limit_plan: plan} = acl) do
     case Sanbase.Billing.Plan.type_of_api_call_limit_plan(plan) do
       :bundle -> bundle_api_call_limits(acl)
-      _other -> plan_to_api_call_limits(plan)
+      _other -> granted_or_plan_api_call_limits(acl, plan)
     end
   end
+
+  # A non-bundle row only carries resolved limits when a grant added calls to it, and a
+  # grant can only ever *add* - so the stored monthly total is taken exactly when it beats
+  # what the plan gives. Anything at or below the plan's number is a leftover rather than a
+  # grant (a customer who moved off a bundle, a bad backfill), and the ladder still wins.
+  #
+  # Hour and minute always come from the plan. They are burst protection for the
+  # infrastructure rather than something sold, so buying calls must not widen them.
+  defp granted_or_plan_api_call_limits(%__MODULE__{resolved_api_call_limits: limits}, plan)
+       when is_map(limits) do
+    plan_limits = plan_to_api_call_limits(plan)
+
+    case {Map.get(limits, "month"), plan_limits} do
+      {granted, %{month: from_plan}} when is_integer(granted) and is_integer(from_plan) ->
+        %{plan_limits | month: max(granted, from_plan)}
+
+      _ ->
+        plan_limits
+    end
+  end
+
+  defp granted_or_plan_api_call_limits(%__MODULE__{}, plan), do: plan_to_api_call_limits(plan)
 
   # A bundle row with nothing stored means the subscription never synced. Raising is
   # deliberate: invented numbers either refuse a paying customer or give calls away, and

--- a/lib/sanbase/billing/billing.ex
+++ b/lib/sanbase/billing/billing.ex
@@ -105,6 +105,81 @@ defmodule Sanbase.Billing do
     Catalog.sync_with_stripe()
   end
 
+  @doc ~s"""
+  Move Institutional yearly to its 2026-09-10 price of $9,588.
+
+  Run once, after the `Apply20260910PricingDecisions` migration:
+
+      Sanbase.Billing.switch_institutional_yearly_price()
+
+  ## Why this is not a migration
+
+  A Stripe Plan is immutable, so changing the amount means creating a new Plan and
+  pointing the row at it. A migration can only do half of that, and either half is a
+  broken state a deploy can stop in: the row priced at $9,588 while its `stripe_id`
+  still charges $9,500, or a purchasable row with no `stripe_id` at all.
+
+  So the order here is create-then-switch. The new Stripe Plan is created from an
+  in-memory copy carrying the new amount, and the row is only updated once that
+  succeeded - if Stripe fails, nothing local changed and the old price keeps working.
+
+  ## The old Stripe Plan is reported, not deleted
+
+  Deactivating it is a Stripe-side action with no wrapper here, and doing it before the
+  switch is confirmed would leave the live row pointing at a dead plan. The previous id
+  comes back in the result so it can be archived in the dashboard afterwards. Nothing is
+  subscribed to it - Institutional has never been on sale.
+
+  Idempotent: a row already at the new amount is left alone.
+  """
+  @spec switch_institutional_yearly_price() ::
+          {:ok, :already_applied}
+          | {:ok,
+             %{
+               plan_id: non_neg_integer(),
+               stripe_id: String.t(),
+               archive_in_stripe: String.t() | nil
+             }}
+          | {:error, term()}
+  def switch_institutional_yearly_price do
+    new_amount = 958_800
+
+    case Repo.get_by(Plan, name: "INSTITUTIONAL", interval: "year") do
+      nil ->
+        {:error, "No INSTITUTIONAL yearly plan row exists."}
+
+      %Plan{amount: ^new_amount} ->
+        {:ok, :already_applied}
+
+      %Plan{} = plan ->
+        %Plan{} = plan = Repo.preload(plan, :product)
+        previous_stripe_id = plan.stripe_id
+
+        case Sanbase.StripeApi.create_plan(%Plan{plan | amount: new_amount}) do
+          {:ok, stripe_plan} ->
+            case Plan.update_plan(plan, %{amount: new_amount, stripe_id: stripe_plan.id}) do
+              {:ok, updated} ->
+                {:ok,
+                 %{
+                   plan_id: updated.id,
+                   stripe_id: updated.stripe_id,
+                   archive_in_stripe: previous_stripe_id
+                 }}
+
+              {:error, error} ->
+                # The Stripe Plan exists and nothing points at it. Reported rather than
+                # cleaned up, because deleting it blind is the more dangerous of the two.
+                {:error,
+                 "Created Stripe plan #{stripe_plan.id} but could not update the local row: " <>
+                   "#{inspect(error)}. Archive #{stripe_plan.id} in Stripe before retrying."}
+            end
+
+          {:error, error} ->
+            {:error, "Could not create the replacement Stripe plan: #{inspect(error)}"}
+        end
+    end
+  end
+
   @doc """
   If user has enough SAN staked and has no active Sanbase subscription - create one
   """

--- a/lib/sanbase/billing/billing.ex
+++ b/lib/sanbase/billing/billing.ex
@@ -130,7 +130,10 @@ defmodule Sanbase.Billing do
   comes back in the result so it can be archived in the dashboard afterwards. Nothing is
   subscribed to it - Institutional has never been on sale.
 
-  Idempotent: a row already at the new amount is left alone.
+  Idempotent, and it checks rather than assumes: a row already at the new amount is left
+  alone only once Stripe confirms its plan charges that amount too. A row seeded at
+  $9,588 with no Stripe plan behind it, or one edited by hand, goes down the
+  create-and-switch path like any other.
   """
   @spec switch_institutional_yearly_price() ::
           {:ok, :already_applied}
@@ -148,35 +151,53 @@ defmodule Sanbase.Billing do
       nil ->
         {:error, "No INSTITUTIONAL yearly plan row exists."}
 
-      %Plan{amount: ^new_amount} ->
-        {:ok, :already_applied}
+      %Plan{amount: ^new_amount, stripe_id: stripe_id} = plan when is_binary(stripe_id) ->
+        # The local amount alone cannot tell a finished switch from a row seeded at the
+        # new figure, or from one edited by hand - both would leave Stripe still charging
+        # the old price while this reported success. So the Stripe Plan is asked.
+        case Sanbase.StripeApi.plan_amount(stripe_id) do
+          {:ok, ^new_amount} ->
+            {:ok, :already_applied}
 
-      %Plan{} = plan ->
-        %Plan{} = plan = Repo.preload(plan, :product)
-        previous_stripe_id = plan.stripe_id
-
-        case Sanbase.StripeApi.create_plan(%Plan{plan | amount: new_amount}) do
-          {:ok, stripe_plan} ->
-            case Plan.update_plan(plan, %{amount: new_amount, stripe_id: stripe_plan.id}) do
-              {:ok, updated} ->
-                {:ok,
-                 %{
-                   plan_id: updated.id,
-                   stripe_id: updated.stripe_id,
-                   archive_in_stripe: previous_stripe_id
-                 }}
-
-              {:error, error} ->
-                # The Stripe Plan exists and nothing points at it. Reported rather than
-                # cleaned up, because deleting it blind is the more dangerous of the two.
-                {:error,
-                 "Created Stripe plan #{stripe_plan.id} but could not update the local row: " <>
-                   "#{inspect(error)}. Archive #{stripe_plan.id} in Stripe before retrying."}
-            end
+          {:ok, _other_amount} ->
+            replace_institutional_yearly_price(plan, new_amount)
 
           {:error, error} ->
-            {:error, "Could not create the replacement Stripe plan: #{inspect(error)}"}
+            {:error,
+             "The local row is already at #{new_amount} but its Stripe plan #{stripe_id} " <>
+               "could not be read, so it is not safe to call this done: #{inspect(error)}"}
         end
+
+      %Plan{} = plan ->
+        replace_institutional_yearly_price(plan, new_amount)
+    end
+  end
+
+  defp replace_institutional_yearly_price(%Plan{} = plan, new_amount) do
+    %Plan{} = plan = Repo.preload(plan, :product)
+    previous_stripe_id = plan.stripe_id
+
+    case Sanbase.StripeApi.create_plan(%Plan{plan | amount: new_amount}) do
+      {:ok, stripe_plan} ->
+        case Plan.update_plan(plan, %{amount: new_amount, stripe_id: stripe_plan.id}) do
+          {:ok, updated} ->
+            {:ok,
+             %{
+               plan_id: updated.id,
+               stripe_id: updated.stripe_id,
+               archive_in_stripe: previous_stripe_id
+             }}
+
+          {:error, error} ->
+            # The Stripe Plan exists and nothing points at it. Reported rather than
+            # cleaned up, because deleting it blind is the more dangerous of the two.
+            {:error,
+             "Created Stripe plan #{stripe_plan.id} but could not update the local row: " <>
+               "#{inspect(error)}. Archive #{stripe_plan.id} in Stripe before retrying."}
+        end
+
+      {:error, error} ->
+        {:error, "Could not create the replacement Stripe plan: #{inspect(error)}"}
     end
   end
 

--- a/lib/sanbase/billing/plan/access_checker.ex
+++ b/lib/sanbase/billing/plan/access_checker.ex
@@ -7,6 +7,7 @@ defmodule Sanbase.Billing.Plan.AccessChecker do
   @type product_code :: String.t()
   @type plan_name :: String.t()
   @type entitlement :: Sanbase.Billing.Plan.Bundle.Entitlement.t() | nil
+  @type grant :: Sanbase.Billing.Subscription.Grant.t() | nil
 
   alias Sanbase.Billing.Plan
   alias Sanbase.Billing.Plan.{BundleAccessChecker, CustomAccessChecker, StandardAccessChecker}
@@ -113,13 +114,24 @@ defmodule Sanbase.Billing.Plan.AccessChecker do
   @doc """
   If the result from this function is nil, then no restrictions are applied.
   Respectively the `restrictedFrom` field has a value of nil as well.
+
+  The last argument is a sales-applied grant (§8 task GR). It is applied *after*
+  the plan has answered and can only widen the window - a metric the customer
+  bought full history for returns `nil`, which is what "no limit" already means
+  everywhere else here. Every other metric keeps the plan's answer, so a caller
+  with no grant sees exactly what it saw before.
+
+  This is the one function that needs the grant, because it is the only place a
+  history window is decided. `realtime_data_cut_off_in_days/5` needs nothing:
+  Institutional is already realtime.
   """
   @spec historical_data_in_days(
           query_or_argument,
           requested_product,
           subscription_product,
           plan_name,
-          entitlement
+          entitlement,
+          grant
         ) ::
           non_neg_integer() | nil
   def historical_data_in_days(
@@ -127,8 +139,36 @@ defmodule Sanbase.Billing.Plan.AccessChecker do
         requested_product,
         subscription_product,
         plan_name,
-        entitlement \\ nil
+        entitlement \\ nil,
+        grant \\ nil
       ) do
+    query_or_argument
+    |> plan_historical_data_in_days(
+      requested_product,
+      subscription_product,
+      plan_name,
+      entitlement
+    )
+    |> apply_history_grant(grant, query_or_argument)
+  end
+
+  # A grant names metrics, so only a metric can be upgraded by one. Queries and signals
+  # carry no history window of their own that a package could have bought.
+  defp apply_history_grant(days, nil, _query_or_argument), do: days
+
+  defp apply_history_grant(days, grant, {:metric, metric}) do
+    if Sanbase.Billing.Subscription.Grant.full_history?(grant, metric), do: nil, else: days
+  end
+
+  defp apply_history_grant(days, _grant, _query_or_argument), do: days
+
+  defp plan_historical_data_in_days(
+         query_or_argument,
+         requested_product,
+         subscription_product,
+         plan_name,
+         entitlement
+       ) do
     case Plan.type(plan_name) do
       :bundle ->
         BundleAccessChecker.historical_data_in_days(

--- a/lib/sanbase/billing/plan/bundle/resolver.ex
+++ b/lib/sanbase/billing/plan/bundle/resolver.ex
@@ -22,7 +22,7 @@ defmodule Sanbase.Billing.Plan.Bundle.Resolver do
     * **Queries and signals** - `"all"` for every bundle. They are effectively
       unrestricted today and packages do not change that (§6.4). It still has to
       be said explicitly, because the access map denies by default.
-    * **Monthly API calls** - a flat 100,000 regardless of how many packages were
+    * **Monthly API calls** - a flat 50,000 regardless of how many packages were
       bought, plus any add-on tiers. Deliberately not summed per package.
     * **Hourly and per-minute limits** - a single base value, never summed. Rate
       limits protect infrastructure; they are not a thing being sold, so buying
@@ -51,8 +51,9 @@ defmodule Sanbase.Billing.Plan.Bundle.Resolver do
   require Logger
 
   # Flat, not per package. Decided by product: choosing several packages still
-  # gives one 100,000-call allowance.
-  @base_calls_per_month 100_000
+  # gives one 50,000-call allowance - "50k API request default if you buy one or
+  # all bundles". Was 100,000 until 2026-09-10.
+  @base_calls_per_month 50_000
 
   # Reused from sanapi_pro (api_call_limit/restrictions.ex) so bundle burst
   # behavior matches the tier bundles are priced against.

--- a/lib/sanbase/billing/plan/bundle/resolver.ex
+++ b/lib/sanbase/billing/plan/bundle/resolver.ex
@@ -51,8 +51,7 @@ defmodule Sanbase.Billing.Plan.Bundle.Resolver do
   require Logger
 
   # Flat, not per package. Decided by product: choosing several packages still
-  # gives one 50,000-call allowance - "50k API request default if you buy one or
-  # all bundles". Was 100,000 until 2026-09-10.
+  # gives one 50,000-call allowance.
   @base_calls_per_month 50_000
 
   # Reused from sanapi_pro (api_call_limit/restrictions.ex) so bundle burst

--- a/lib/sanbase/billing/plan/restrictions.ex
+++ b/lib/sanbase/billing/plan/restrictions.ex
@@ -26,21 +26,30 @@ defmodule Sanbase.Billing.Plan.Restrictions do
 
   @type query_or_argument :: {:metric, String.t()} | {:signal, String.t()} | {:query, atom()}
   @type entitlement :: Sanbase.Billing.Plan.Bundle.Entitlement.t() | nil
+  @type grant :: Sanbase.Billing.Subscription.Grant.t() | nil
 
   @doc ~s"""
   Describe the time restrictions on one metric, query or signal for a plan.
 
-  The last argument is only read by bundle plans, whose name identifies nothing -
-  see `Sanbase.Billing.Plan.AccessChecker.plan_has_access?/4`. Every other plan
-  ignores it, so existing four-argument callers are unaffected.
+  `entitlement` is only read by bundle plans, whose name identifies nothing - see
+  `Sanbase.Billing.Plan.AccessChecker.plan_has_access?/4`. `grant` is a
+  sales-applied add-on and widens the history window for the metrics it covers
+  (§8 task GR). Every other plan ignores both, so existing four-argument callers
+  are unaffected.
+
+  Both have to be passed here and not only at the data layer. This is what
+  `getAccessRestrictions` answers with, so if it kept saying "three years" while
+  the data layer served full history, the API would be contradicting itself.
   """
-  @spec get(query_or_argument, String.t(), String.t(), String.t(), entitlement) :: restriction()
+  @spec get(query_or_argument, String.t(), String.t(), String.t(), entitlement, grant) ::
+          restriction()
   def get(
         {type, name} = query_or_argument,
         requested_product,
         subscription_product,
         plan_name,
-        entitlement \\ nil
+        entitlement \\ nil,
+        grant \\ nil
       )
       when type in [:metric, :signal, :query] do
     type_str = to_string(type)
@@ -68,7 +77,8 @@ defmodule Sanbase.Billing.Plan.Restrictions do
               requested_product,
               subscription_product,
               query_or_argument,
-              entitlement
+              entitlement,
+              grant
             )
         end
     end
@@ -79,9 +89,9 @@ defmodule Sanbase.Billing.Plan.Restrictions do
   Return a list in which every element describes either a metric or a query.
   The elements are maps describing the time restrictions of the given metric/query.
   """
-  @spec get_all(String.t(), String.t(), :query | :metric | :signal | nil, entitlement) ::
+  @spec get_all(String.t(), String.t(), :query | :metric | :signal | nil, entitlement, grant) ::
           list(restriction)
-  def get_all(plan_name, product_code, filter \\ nil, entitlement \\ nil) do
+  def get_all(plan_name, product_code, filter \\ nil, entitlement \\ nil, grant \\ nil) do
     metrics = Sanbase.Metric.available_metrics() |> Enum.map(&{:metric, &1})
     signals = Sanbase.Signal.available_signals() |> Enum.map(&{:signal, &1})
     queries = Sanbase.Project.AvailableQueries.all_atom_names() |> Enum.map(&{:query, &1})
@@ -90,7 +100,7 @@ defmodule Sanbase.Billing.Plan.Restrictions do
     result =
       (queries ++ metrics ++ signals)
       |> Enum.map(fn query_or_argument ->
-        get(query_or_argument, product_code, product_code, plan_name, entitlement)
+        get(query_or_argument, product_code, product_code, plan_name, entitlement, grant)
       end)
 
     (get_extra_queries(plan_name, product_code) ++ result)
@@ -150,7 +160,8 @@ defmodule Sanbase.Billing.Plan.Restrictions do
          requested_product,
          subscription_product,
          query_or_metric,
-         entitlement
+         entitlement,
+         grant
        ) do
     now = Timex.now()
 
@@ -160,7 +171,8 @@ defmodule Sanbase.Billing.Plan.Restrictions do
              requested_product,
              subscription_product,
              plan_name,
-             entitlement
+             entitlement,
+             grant
            ) do
         nil -> nil
         days -> Timex.shift(now, days: -days)

--- a/lib/sanbase/billing/subscription/grant.ex
+++ b/lib/sanbase/billing/subscription/grant.ex
@@ -1,0 +1,156 @@
+defmodule Sanbase.Billing.Subscription.Grant do
+  @moduledoc ~s"""
+  An add-on sold by sales and applied by hand: extra monthly API calls, and full
+  history on individual data packages.
+
+  Stored as JSON on `subscriptions.grant`. See §8 task **GR** of
+  `docs/composable-api-plans-handover.md`.
+
+  ## Additive, never subtractive
+
+  A grant can only raise what the plan already gives. That is not a convention -
+  it is enforced where the grant is applied, and it is what makes a grant safe to
+  write without reasoning about how it interacts with the plan it sits on. There
+  is deliberately no way to express "fewer calls" or "less history".
+
+  ## Why the metric list is frozen here
+
+  `full_history_packages` says what was bought; `full_history_metrics` is that
+  list expanded against the package snapshot at the moment of the grant. The
+  expansion is stored so an access check is a membership test rather than a
+  reverse lookup from metric to category on every request - the same trade a
+  bundle entitlement makes with `metric_access`.
+
+  It also means a grant goes stale by design: a metric added to Market next month
+  is not covered until someone re-expands. That matches how the rest of this
+  epic treats a purchase - a customer keeps what they paid for until something
+  deliberately re-resolves them - and `package_snapshot_version` is what makes
+  the staleness visible.
+
+  ## `nil` cannot mean "no override"
+
+  Everywhere else in this codebase `historical_data_in_days: nil` means
+  *unlimited*. So a grant says which packages are upgraded and nothing else: the
+  absence of a package from `full_history_packages` is the only way to say
+  "leave this one alone". There is no day count to get wrong.
+
+  ## No expiry
+
+  A grant persists until an admin removes it. Product's decision (2026-09-10):
+  the add-on is charged as a one-off invoice raised outside the subscription, and
+  nothing ends the grant automatically. `granted_by_id` and `granted_at` are what
+  keep it auditable.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Sanbase.Billing.Plan.Bundle.Package
+
+  @type t :: %__MODULE__{}
+
+  @all_packages "all"
+
+  @primary_key false
+  embedded_schema do
+    field(:extra_api_calls_per_month, :integer, default: 0)
+
+    field(:full_history_packages, {:array, :string}, default: [])
+    field(:full_history_metrics, {:array, :string}, default: [])
+    field(:package_snapshot_version, :integer)
+
+    field(:note, :string)
+    field(:granted_by_id, :integer)
+    field(:granted_at, :utc_datetime)
+  end
+
+  @fields [
+    :extra_api_calls_per_month,
+    :full_history_packages,
+    :full_history_metrics,
+    :package_snapshot_version,
+    :note,
+    :granted_by_id,
+    :granted_at
+  ]
+
+  @doc ~s"""
+  The slug that means "every package", for a customer who upgraded the lot.
+
+  Stored explicitly rather than as the five slugs so that re-expanding such a
+  grant picks up a package added later, which is the one case where a customer
+  clearly did buy "all of it" rather than a list that happened to be complete.
+  """
+  @spec all_packages() :: String.t()
+  def all_packages, do: @all_packages
+
+  def changeset(%__MODULE__{} = grant, attrs) do
+    grant
+    |> cast(attrs, @fields)
+    |> validate_required([:note, :granted_at])
+    |> validate_number(:extra_api_calls_per_month, greater_than_or_equal_to: 0)
+    |> validate_change(:full_history_packages, &validate_packages/2)
+    |> validate_not_empty()
+  end
+
+  @doc ~s"""
+  Whether this grant upgrades the given metric to full history.
+
+  Answered from the frozen metric list, so it costs a membership test and never
+  reads the package snapshot. `"all"` short-circuits: a customer who upgraded
+  every package gets full history on anything they can see, including metrics
+  added since the grant was written.
+  """
+  @spec full_history?(t() | nil, String.t() | atom()) :: boolean()
+  def full_history?(nil, _metric), do: false
+
+  def full_history?(%__MODULE__{} = grant, metric) when is_binary(metric) do
+    %__MODULE__{full_history_packages: packages, full_history_metrics: metrics} = grant
+
+    @all_packages in (packages || []) or metric in (metrics || [])
+  end
+
+  def full_history?(%__MODULE__{} = grant, metric),
+    do: full_history?(grant, to_string(metric))
+
+  @doc ~s"""
+  How many extra monthly API calls this grant adds. Zero when there is none.
+  """
+  @spec extra_api_calls(t() | nil) :: non_neg_integer()
+  def extra_api_calls(nil), do: 0
+
+  def extra_api_calls(%__MODULE__{extra_api_calls_per_month: calls}) when is_integer(calls),
+    do: max(calls, 0)
+
+  def extra_api_calls(%__MODULE__{}), do: 0
+
+  # A grant that grants nothing is always a mistake - either a form submitted
+  # empty or a removal that should have cleared the whole embed. Storing it would
+  # leave a row that reads as an add-on while changing nothing.
+  defp validate_not_empty(changeset) do
+    calls = get_field(changeset, :extra_api_calls_per_month) || 0
+    packages = get_field(changeset, :full_history_packages) || []
+
+    if calls == 0 and packages == [] do
+      add_error(
+        changeset,
+        :extra_api_calls_per_month,
+        "a grant must add extra API calls, full history on at least one package, or both"
+      )
+    else
+      changeset
+    end
+  end
+
+  defp validate_packages(:full_history_packages, packages) when is_list(packages) do
+    known = [@all_packages | Package.slugs()]
+
+    case Enum.reject(packages, &(&1 in known)) do
+      [] -> []
+      unknown -> [full_history_packages: "unknown packages: #{Enum.join(unknown, ", ")}"]
+    end
+  end
+
+  defp validate_packages(:full_history_packages, _), do: [full_history_packages: "must be a list"]
+end

--- a/lib/sanbase/billing/subscription/grants.ex
+++ b/lib/sanbase/billing/subscription/grants.ex
@@ -32,6 +32,11 @@ defmodule Sanbase.Billing.Subscription.Grants do
   never changes one, so a granted allowance that was not pushed here would sit
   unapplied until some unrelated subscription change happened to trigger a
   refresh.
+
+  Because nothing self-heals, a failed refresh is not swallowed: the write still
+  succeeded, so these return `{:ok, subscription, :api_call_limits_not_refreshed}`
+  rather than an error, and the caller is expected to say so. Re-applying the grant
+  retries it.
   """
 
   alias Sanbase.Accounts.User
@@ -59,7 +64,9 @@ defmodule Sanbase.Billing.Subscription.Grants do
   only record of that agreement is an invoice raised elsewhere.
   """
   @spec grant(Subscription.t(), attrs(), User.t()) ::
-          {:ok, Subscription.t()} | {:error, Ecto.Changeset.t() | String.t()}
+          {:ok, Subscription.t()}
+          | {:ok, Subscription.t(), :api_call_limits_not_refreshed}
+          | {:error, Ecto.Changeset.t() | String.t()}
   def grant(%Subscription{} = subscription, attrs, %User{} = granted_by) do
     packages = attrs |> Map.get(:full_history_packages, []) |> Enum.uniq()
 
@@ -82,7 +89,10 @@ defmodule Sanbase.Billing.Subscription.Grants do
   @doc ~s"""
   Remove the grant, putting the customer back on exactly what their plan gives.
   """
-  @spec revoke(Subscription.t()) :: {:ok, Subscription.t()} | {:error, Ecto.Changeset.t()}
+  @spec revoke(Subscription.t()) ::
+          {:ok, Subscription.t()}
+          | {:ok, Subscription.t(), :api_call_limits_not_refreshed}
+          | {:error, Ecto.Changeset.t()}
   def revoke(%Subscription{} = subscription) do
     subscription
     |> Subscription.grant_changeset(nil)
@@ -101,7 +111,9 @@ defmodule Sanbase.Billing.Subscription.Grants do
   visibly.
   """
   @spec re_expand(Subscription.t()) ::
-          {:ok, Subscription.t()} | {:error, Ecto.Changeset.t() | String.t()}
+          {:ok, Subscription.t()}
+          | {:ok, Subscription.t(), :api_call_limits_not_refreshed}
+          | {:error, Ecto.Changeset.t() | String.t()}
   def re_expand(%Subscription{grant: %Grant{} = grant} = subscription) do
     with {:ok, metrics, snapshot_version} <- expand(grant.full_history_packages) do
       attrs =
@@ -174,32 +186,63 @@ defmodule Sanbase.Billing.Subscription.Grants do
   defp version_of(%PackageSnapshot{version: version}), do: version
   defp version_of(_), do: nil
 
-  defp current_snapshot?(%Grant{full_history_packages: []}), do: true
+  # Only a grant with a frozen metric list can fall behind. An empty one expanded
+  # nothing, and "all packages" is stored as itself so it keeps covering packages added
+  # later - calling either stale would invite a pointless re-expand and make the warning
+  # mean less where it does matter.
+  defp current_snapshot?(%Grant{} = grant) do
+    packages = grant.full_history_packages || []
 
-  defp current_snapshot?(%Grant{package_snapshot_version: version}) do
-    case PackageSnapshot.latest() do
-      %PackageSnapshot{version: ^version} -> true
-      _ -> false
+    cond do
+      packages == [] ->
+        true
+
+      Grant.all_packages() in packages ->
+        true
+
+      true ->
+        case PackageSnapshot.latest() do
+          %PackageSnapshot{version: version} -> version == grant.package_snapshot_version
+          _ -> false
+        end
     end
   end
 
   # The subscription's user is what the api_call_limits row is keyed by. Preloaded
   # rather than assumed, because the callers here are admin screens holding a row
   # they queried for display.
+  #
+  # A failure here matters more than it looks: the grant row is already written, so the
+  # customer's entitlement says one thing while their quota says another, and nothing
+  # self-heals - the daily `ApiCallLimit.Sync` reconciles on plan name and a grant never
+  # changes one. So the error is reported rather than swallowed, and the caller is told
+  # the write landed but the allowance did not.
   defp refresh_api_call_limits({:ok, %Subscription{} = subscription}) do
     subscription = Repo.preload(subscription, [:user, :plan])
 
     case subscription.user do
       %User{} = user ->
-        Sanbase.ApiCallLimit.update_user_plan(user)
+        case Sanbase.ApiCallLimit.update_user_plan(user) do
+          {:ok, _} ->
+            {:ok, subscription}
+
+          error ->
+            Logger.error(
+              "[Grants] Wrote the grant on subscription #{subscription.id} but could not " <>
+                "refresh the API call limits for user #{user.id}: #{inspect(error)}. " <>
+                "Re-apply the grant to retry - nothing else will."
+            )
+
+            {:ok, subscription, :api_call_limits_not_refreshed}
+        end
 
       _ ->
         Logger.error(
           "[Grants] Subscription #{subscription.id} has no user; API call limits not refreshed."
         )
-    end
 
-    {:ok, subscription}
+        {:ok, subscription, :api_call_limits_not_refreshed}
+    end
   end
 
   defp refresh_api_call_limits(other), do: other

--- a/lib/sanbase/billing/subscription/grants.ex
+++ b/lib/sanbase/billing/subscription/grants.ex
@@ -1,0 +1,206 @@
+defmodule Sanbase.Billing.Subscription.Grants do
+  @moduledoc ~s"""
+  Writing, refreshing and removing sales-applied grants.
+
+  The counterpart of `Sanbase.Billing.Plan.Bundle.Resolver` for add-ons that were
+  sold outside the subscription: it turns "full history on Market, plus 200,000
+  calls" into the stored form the access and quota paths read. See §8 task **GR**
+  of `docs/composable-api-plans-handover.md`.
+
+  ## Expansion happens here, once
+
+  `full_history_packages` is what sales chose; `full_history_metrics` is that
+  choice resolved against the published package snapshot at the moment of the
+  grant. Doing it here means an access check is a membership test rather than a
+  metric-to-category lookup on every request - the same trade a bundle
+  entitlement makes with its metric list.
+
+  It also means a grant is frozen: a metric added to Market afterwards is not
+  covered until `re_expand/1` is called. That is the same rule the rest of this
+  epic applies to a purchase - a customer keeps what they paid for until someone
+  deliberately re-resolves them - and it is why the admin screen has a re-expand
+  action rather than silently refreshing.
+
+  `"all"` is the exception. A customer who upgraded every package gets full
+  history on anything they can see, including metrics that did not exist when the
+  grant was written, so nothing is expanded for it.
+
+  ## Every write refreshes the API call limits
+
+  `Sanbase.ApiCallLimit.update_user_plan/1` runs after each change. Nothing else
+  would: the daily `ApiCallLimit.Sync` reconciles on **plan name**, and a grant
+  never changes one, so a granted allowance that was not pushed here would sit
+  unapplied until some unrelated subscription change happened to trigger a
+  refresh.
+  """
+
+  alias Sanbase.Accounts.User
+  alias Sanbase.Billing.Plan.Bundle.PackageSnapshot
+  alias Sanbase.Billing.Subscription
+  alias Sanbase.Billing.Subscription.Grant
+  alias Sanbase.Repo
+
+  require Logger
+
+  @type attrs :: %{
+          optional(:extra_api_calls_per_month) => non_neg_integer(),
+          optional(:full_history_packages) => [String.t()],
+          optional(:note) => String.t()
+        }
+
+  @doc ~s"""
+  Write a grant onto a subscription, replacing any grant already there.
+
+  Replacing rather than merging is deliberate: a package dropped from the new
+  grant must lose the metrics the old one expanded for it, and a merge would keep
+  them.
+
+  `granted_by` is recorded because a grant is money someone agreed to, and the
+  only record of that agreement is an invoice raised elsewhere.
+  """
+  @spec grant(Subscription.t(), attrs(), User.t()) ::
+          {:ok, Subscription.t()} | {:error, Ecto.Changeset.t() | String.t()}
+  def grant(%Subscription{} = subscription, attrs, %User{} = granted_by) do
+    packages = attrs |> Map.get(:full_history_packages, []) |> Enum.uniq()
+
+    with {:ok, metrics, snapshot_version} <- expand(packages) do
+      attrs =
+        attrs
+        |> Map.put(:full_history_packages, packages)
+        |> Map.put(:full_history_metrics, metrics)
+        |> Map.put(:package_snapshot_version, snapshot_version)
+        |> Map.put(:granted_by_id, granted_by.id)
+        |> Map.put(:granted_at, DateTime.utc_now() |> DateTime.truncate(:second))
+
+      subscription
+      |> Subscription.grant_changeset(attrs)
+      |> Repo.update()
+      |> refresh_api_call_limits()
+    end
+  end
+
+  @doc ~s"""
+  Remove the grant, putting the customer back on exactly what their plan gives.
+  """
+  @spec revoke(Subscription.t()) :: {:ok, Subscription.t()} | {:error, Ecto.Changeset.t()}
+  def revoke(%Subscription{} = subscription) do
+    subscription
+    |> Subscription.grant_changeset(nil)
+    |> Repo.update()
+    |> refresh_api_call_limits()
+  end
+
+  @doc ~s"""
+  Re-expand an existing grant against the current package snapshot, keeping
+  everything else about it.
+
+  What this is for: a grant's metric list is frozen when it is written, so a
+  metric added to a granted package later is not covered. That is the intended
+  default - a customer keeps what they bought - but when the omission is an
+  oversight rather than a decision, this is how it is corrected, deliberately and
+  visibly.
+  """
+  @spec re_expand(Subscription.t()) ::
+          {:ok, Subscription.t()} | {:error, Ecto.Changeset.t() | String.t()}
+  def re_expand(%Subscription{grant: %Grant{} = grant} = subscription) do
+    with {:ok, metrics, snapshot_version} <- expand(grant.full_history_packages) do
+      attrs =
+        grant
+        |> Map.from_struct()
+        |> Map.put(:full_history_metrics, metrics)
+        |> Map.put(:package_snapshot_version, snapshot_version)
+
+      subscription
+      |> Subscription.grant_changeset(attrs)
+      |> Repo.update()
+      |> refresh_api_call_limits()
+    end
+  end
+
+  def re_expand(%Subscription{}), do: {:error, "This subscription has no grant to re-expand."}
+
+  @doc ~s"""
+  A human-readable summary of what a grant actually gives, for the admin screen.
+
+  Deliberately describes the *result* rather than echoing the form back: the
+  question someone answers with this is "did that do what I meant?", and the
+  stored packages alone do not answer it.
+  """
+  @spec describe(Subscription.t()) :: map()
+  def describe(%Subscription{grant: %Grant{} = grant} = subscription) do
+    # The plan may not be loaded - callers reach this holding whatever row they had -
+    # and a grant describes itself perfectly well without it.
+    plan_name =
+      case subscription.plan do
+        %Sanbase.Billing.Plan{name: name} -> name
+        _ -> nil
+      end
+
+    %{
+      extra_api_calls_per_month: Grant.extra_api_calls(grant),
+      full_history_packages: grant.full_history_packages,
+      full_history_metric_count: length(grant.full_history_metrics || []),
+      package_snapshot_version: grant.package_snapshot_version,
+      snapshot_is_current?: current_snapshot?(grant),
+      note: grant.note,
+      granted_by_id: grant.granted_by_id,
+      granted_at: grant.granted_at,
+      plan_name: plan_name
+    }
+  end
+
+  def describe(%Subscription{}), do: nil
+
+  # `"all"` is stored as itself rather than expanded, so a package added later is
+  # covered without anyone having to remember to re-expand.
+  defp expand([]), do: {:ok, [], nil}
+
+  defp expand(packages) do
+    if Grant.all_packages() in packages do
+      {:ok, [], PackageSnapshot.latest() |> version_of()}
+    else
+      case PackageSnapshot.latest() do
+        %PackageSnapshot{} = snapshot ->
+          {:ok, PackageSnapshot.metrics_for(snapshot, packages), snapshot.version}
+
+        _ ->
+          {:error,
+           "No package snapshot has been published yet, so there is nothing to expand a " <>
+             "full-history grant against. Publish one from /admin/bundle_packages first."}
+      end
+    end
+  end
+
+  defp version_of(%PackageSnapshot{version: version}), do: version
+  defp version_of(_), do: nil
+
+  defp current_snapshot?(%Grant{full_history_packages: []}), do: true
+
+  defp current_snapshot?(%Grant{package_snapshot_version: version}) do
+    case PackageSnapshot.latest() do
+      %PackageSnapshot{version: ^version} -> true
+      _ -> false
+    end
+  end
+
+  # The subscription's user is what the api_call_limits row is keyed by. Preloaded
+  # rather than assumed, because the callers here are admin screens holding a row
+  # they queried for display.
+  defp refresh_api_call_limits({:ok, %Subscription{} = subscription}) do
+    subscription = Repo.preload(subscription, [:user, :plan])
+
+    case subscription.user do
+      %User{} = user ->
+        Sanbase.ApiCallLimit.update_user_plan(user)
+
+      _ ->
+        Logger.error(
+          "[Grants] Subscription #{subscription.id} has no user; API call limits not refreshed."
+        )
+    end
+
+    {:ok, subscription}
+  end
+
+  defp refresh_api_call_limits(other), do: other
+end

--- a/lib/sanbase/billing/subscription/subscription.ex
+++ b/lib/sanbase/billing/subscription/subscription.ex
@@ -73,6 +73,13 @@ defmodule Sanbase.Billing.Subscription do
     # dropped a package could keep part of what it gave them.
     embeds_one(:bundle_entitlement, Sanbase.Billing.Plan.Bundle.Entitlement, on_replace: :delete)
 
+    # An add-on granted by sales and applied from the admin panel - extra API calls,
+    # full history on individual packages. Deliberately a separate column from
+    # `bundle_entitlement`: that one is recomputed from the Stripe items on every
+    # `customer.subscription.updated`, so a grant stored inside it would be erased by
+    # the next webhook. NULL unless someone granted something; see §8 task GR.
+    embeds_one(:grant, Sanbase.Billing.Subscription.Grant, on_replace: :delete)
+
     # Only bundle subscriptions have items - that is how the two are told apart without
     # asking Stripe.
     has_many(:items, Sanbase.Billing.Subscription.Item, on_delete: :delete_all)
@@ -156,6 +163,51 @@ defmodule Sanbase.Billing.Subscription do
       do: entitlement
 
   def bundle_entitlement(_), do: nil
+
+  @doc ~s"""
+  Sets the sales-applied grant, replacing any previous one outright.
+
+  Separate from `changeset/2` for the same reason `bundle_entitlement_changeset/2`
+  is: a grant is an entitlement decision, written only by the admin path that
+  records who granted it, never carried in with ordinary subscription attributes.
+
+  Pass `nil` to remove the grant. The replacement is wholesale - a partial update
+  would let a package dropped from the new grant keep the metrics the old one
+  expanded for it.
+  """
+  @spec grant_changeset(%__MODULE__{}, map() | nil) :: Ecto.Changeset.t()
+  def grant_changeset(%__MODULE__{} = subscription, nil) do
+    subscription
+    |> change()
+    |> put_embed(:grant, nil)
+  end
+
+  def grant_changeset(%__MODULE__{} = subscription, attrs) when is_map(attrs) do
+    changeset = subscription |> change()
+
+    %__MODULE__.Grant{}
+    |> __MODULE__.Grant.changeset(attrs)
+    |> case do
+      %{valid?: true} = grant_changeset ->
+        put_embed(changeset, :grant, Ecto.Changeset.apply_changes(grant_changeset))
+
+      invalid ->
+        changeset
+        |> put_embed(:grant, invalid)
+        |> Map.put(:valid?, false)
+    end
+  end
+
+  @doc ~s"""
+  The stored grant, or `nil` when there is none.
+
+  Total for the same reason `bundle_entitlement/1` is: callers hold whatever the
+  request context gave them, and a missing subscription, an anonymous user and an
+  unloaded association all mean the same thing here.
+  """
+  @spec grant(%__MODULE__{} | nil | term()) :: __MODULE__.Grant.t() | nil
+  def grant(%__MODULE__{grant: %__MODULE__.Grant{} = grant}), do: grant
+  def grant(_), do: nil
 
   @doc ~s"""
   Bundle subscriptions, newest first, with their user, plan and items loaded.

--- a/lib/sanbase/email/api_business_onboarding_list.ex
+++ b/lib/sanbase/email/api_business_onboarding_list.ex
@@ -1,16 +1,19 @@
 defmodule Sanbase.Email.ApiBusinessOnboardingList do
   @moduledoc """
   Keeps a Mailjet contact list populated with the email addresses of users who
-  buy an API "Business or higher" subscription - `BUSINESS_PRO`, `BUSINESS_MAX`
-  or a bespoke `CUSTOM*` contract. Product uses that list to trigger the
+  buy an API "Business or higher" subscription - `BUSINESS_PRO`, `BUSINESS_MAX`,
+  a bespoke `CUSTOM*` contract, or anything in the new offering (`BUNDLE*`,
+  `INSTITUTIONAL*`, `ENTERPRISE*`). Product uses that list to trigger the
   API-client onboarding email.
 
-  The new offering is deliberately absent: `BUNDLE`, `INSTITUTIONAL` and
-  `ENTERPRISE` customers do not land on this list. Whether they should is a
-  product question, not an oversight of this module - see §15 of
-  docs/composable-api-plans-handover.md. Note that `ENTERPRISE` here would *not*
-  be caught by the `CUSTOM*` pattern; it is a distinct fixed tier, despite the two
-  words having been used interchangeably before it existed.
+  The new offering was deliberately absent until product confirmed on 2026-09-10
+  that package and Institutional customers should get the same onboarding email -
+  see §15 Q16. `ENTERPRISE*` is matched explicitly rather than left to `CUSTOM*`:
+  negotiated Enterprise contracts are `CUSTOM_*` rows and covered either way, but
+  the fixed `ENTERPRISE` row is not, despite the two words having been used
+  interchangeably before that tier existed. The legacy `ENTERPRISE_BASIC` /
+  `ENTERPRISE_PLUS` plans were renamed out of the namespace, so the prefix is
+  unambiguous.
 
   Membership is add-only and driven purely by subscription state. There is no
   dedicated account setting - the onboarding email is part of the purchase and
@@ -39,6 +42,12 @@ defmodule Sanbase.Email.ApiBusinessOnboardingList do
 
   @list_atom :api_business_onboarding
   @business_plan_names ["BUSINESS_PRO", "BUSINESS_MAX"]
+
+  # Name prefixes that qualify on top of `@business_plan_names`. The two queries
+  # spell the same prefixes out as `like/2` clauses - Ecto has no portable way to
+  # share a prefix list across a query and a plain function, and a wrong answer
+  # here sends real email, so the duplication is the safer trade.
+  @qualifying_prefixes ["CUSTOM", "BUNDLE", "INSTITUTIONAL", "ENTERPRISE"]
 
   @doc "The Mailjet list atom, as registered in `Sanbase.Email.MailjetApi`."
   @spec list_atom() :: atom()
@@ -103,7 +112,10 @@ defmodule Sanbase.Email.ApiBusinessOnboardingList do
           where: s.status == :active,
           where: s.inserted_at >= ^since,
           where: p.product_id == ^Product.product_api(),
-          where: p.name in ^business_names or like(p.name, "CUSTOM%"),
+          where:
+            p.name in ^business_names or like(p.name, "CUSTOM%") or
+              like(p.name, "BUNDLE%") or like(p.name, "INSTITUTIONAL%") or
+              like(p.name, "ENTERPRISE%"),
           where: not is_nil(u.email) and u.email != "",
           distinct: true,
           select: u.email
@@ -208,7 +220,10 @@ defmodule Sanbase.Email.ApiBusinessOnboardingList do
           where: s.status == :active,
           where: s.inserted_at >= ^since,
           where: p.product_id == ^Product.product_api(),
-          where: p.name in ^@business_plan_names or like(p.name, "CUSTOM%"),
+          where:
+            p.name in ^@business_plan_names or like(p.name, "CUSTOM%") or
+              like(p.name, "BUNDLE%") or like(p.name, "INSTITUTIONAL%") or
+              like(p.name, "ENTERPRISE%"),
           select: s.id,
           limit: 1
         )
@@ -219,7 +234,7 @@ defmodule Sanbase.Email.ApiBusinessOnboardingList do
   defp business_or_higher_api_plan?(%{product_id: product_id, name: name})
        when is_binary(name) do
     product_id == Product.product_api() and
-      (name in @business_plan_names or String.starts_with?(name, "CUSTOM"))
+      (name in @business_plan_names or String.starts_with?(name, @qualifying_prefixes))
   end
 
   defp business_or_higher_api_plan?(_), do: false

--- a/lib/sanbase/email/api_business_onboarding_list.ex
+++ b/lib/sanbase/email/api_business_onboarding_list.ex
@@ -43,10 +43,7 @@ defmodule Sanbase.Email.ApiBusinessOnboardingList do
   @list_atom :api_business_onboarding
   @business_plan_names ["BUSINESS_PRO", "BUSINESS_MAX"]
 
-  # Name prefixes that qualify on top of `@business_plan_names`. The two queries
-  # spell the same prefixes out as `like/2` clauses - Ecto has no portable way to
-  # share a prefix list across a query and a plain function, and a wrong answer
-  # here sends real email, so the duplication is the safer trade.
+  # The two queries spell these out as `like/2` clauses; keep all three in step.
   @qualifying_prefixes ["CUSTOM", "BUNDLE", "INSTITUTIONAL", "ENTERPRISE"]
 
   @doc "The Mailjet list atom, as registered in `Sanbase.Email.MailjetApi`."

--- a/lib/sanbase/mcp/restrictions.ex
+++ b/lib/sanbase/mcp/restrictions.ex
@@ -54,7 +54,7 @@ defmodule Sanbase.MCP.Restrictions do
       | SANAPI  | BASIC, PRO, BUSINESS_PRO,          | max   |
       |         | BUSINESS_MAX, INSTITUTIONAL,       |       |
       |         | ENTERPRISE, CUSTOM, CUSTOM_*,      |       |
-      |         | PREMIUM                            |       |
+      |         | BUNDLE*, PREMIUM                   |       |
       +---------+------------------------------------+-------+
 
   Unauthenticated users are blocked at the server layer before reaching
@@ -157,6 +157,10 @@ defmodule Sanbase.MCP.Restrictions do
   defp classify("SANAPI", "CUSTOM"), do: :max
   defp classify("SANAPI", "PREMIUM"), do: :max
   defp classify("SANAPI", "CUSTOM_" <> _), do: :max
+  # Every bundle plan is named `BUNDLE`, and MCP is sold with the packages. Without
+  # this clause a paying bundle customer falls to the catch-all and gets the free
+  # tier - what they bought says nothing about MCP, so the name is enough here.
+  defp classify("SANAPI", "BUNDLE" <> _), do: :max
   defp classify("SANAPI", _), do: :free
 
   defp classify(_, _), do: :free

--- a/lib/sanbase/mcp/restrictions.ex
+++ b/lib/sanbase/mcp/restrictions.ex
@@ -157,9 +157,7 @@ defmodule Sanbase.MCP.Restrictions do
   defp classify("SANAPI", "CUSTOM"), do: :max
   defp classify("SANAPI", "PREMIUM"), do: :max
   defp classify("SANAPI", "CUSTOM_" <> _), do: :max
-  # Every bundle plan is named `BUNDLE`, and MCP is sold with the packages. Without
-  # this clause a paying bundle customer falls to the catch-all and gets the free
-  # tier - what they bought says nothing about MCP, so the name is enough here.
+  # Prefix-matched: every bundle plan is named `BUNDLE`, and MCP is sold with the packages.
   defp classify("SANAPI", "BUNDLE" <> _), do: :max
   defp classify("SANAPI", _), do: :free
 

--- a/lib/sanbase/stripe/stripe_api.ex
+++ b/lib/sanbase/stripe/stripe_api.ex
@@ -35,6 +35,21 @@ defmodule Sanbase.StripeApi do
   end
 
   @doc ~s"""
+  The amount a Stripe Plan actually charges, in cents.
+
+  Used to confirm that a local `plans` row and the Stripe Plan it points at agree on
+  price before treating a price change as already done - the local amount alone cannot
+  tell a completed switch from a row that was seeded at the new figure.
+  """
+  @spec plan_amount(String.t()) :: {:ok, non_neg_integer() | nil} | {:error, term()}
+  def plan_amount(stripe_plan_id) when is_binary(stripe_plan_id) do
+    case Stripe.Plan.retrieve(stripe_plan_id) do
+      {:ok, %{amount: amount}} -> {:ok, amount}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  @doc ~s"""
   Create a Stripe Product for a bundle catalog SKU (package or API-call add-on).
 
   Metadata `sanbase_sku` lets `find_bundle_product/1` reuse the product on re-sync.

--- a/lib/sanbase_web/controllers/generic_admin_controller.ex
+++ b/lib/sanbase_web/controllers/generic_admin_controller.ex
@@ -143,6 +143,7 @@ defmodule SanbaseWeb.GenericAdminController do
       {"Invoice Archives", ~p"/admin/invoices"},
       {"Bundle Packages", ~p"/admin/bundle_packages"},
       {"Bundle Subscriptions", ~p"/admin/bundle_subscriptions"},
+      {"Subscription Grants", ~p"/admin/subscription_grants"},
       {"Broadcast Notifications Overview", ~p"/admin/notifications/broadcast/overview"}
     ]
   end

--- a/lib/sanbase_web/graphql/middlewares/access_control/access_control.ex
+++ b/lib/sanbase_web/graphql/middlewares/access_control/access_control.ex
@@ -492,7 +492,8 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
       plan_name: plan_name,
       requested_product: requested_product,
       subscription_product: subscription_product,
-      entitlement: entitlement
+      entitlement: entitlement,
+      grant: grant
     } = context_to_plan_name_product_code(context)
 
     historical_data_in_days =
@@ -501,7 +502,8 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
         requested_product,
         subscription_product,
         plan_name,
-        entitlement
+        entitlement,
+        grant
       )
 
     realtime_data_cut_off_in_days =
@@ -621,7 +623,8 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
           plan_name: plan_name,
           requested_product: requested_product,
           subscription_product: subscription_product,
-          entitlement: entitlement
+          entitlement: entitlement,
+          grant: grant
         } = context_to_plan_name_product_code(context)
 
         query_or_argument = context[:__query_argument_atom_name__]
@@ -632,7 +635,8 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
             requested_product,
             subscription_product,
             plan_name,
-            entitlement
+            entitlement,
+            grant
           )
 
         resolution
@@ -702,7 +706,8 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
       plan_name: plan_name,
       requested_product: requested_product,
       subscription_product: subscription_product,
-      entitlement: bundle_entitlement(context)
+      entitlement: bundle_entitlement(context),
+      grant: grant(context)
     }
   end
 
@@ -712,4 +717,10 @@ defmodule SanbaseWeb.Graphql.Middlewares.AccessControl do
   # on the way to the access checker. See §5.8 of docs/composable-api-plans-handover.md.
   defp bundle_entitlement(context),
     do: Sanbase.Billing.Subscription.bundle_entitlement(context[:auth][:subscription])
+
+  # The sales-applied add-on, from the same subscription the plan name came from - so a
+  # grant can never be read against a different subscription than the one it was written
+  # against. `nil` for everyone who has no add-on, which is almost everyone. See §8 GR.
+  defp grant(context),
+    do: Sanbase.Billing.Subscription.grant(context[:auth][:subscription])
 end

--- a/lib/sanbase_web/graphql/resolvers/access_control_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/access_control_resolver.ex
@@ -10,6 +10,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.AccessControlResolver do
   end
 
   def get_access_restrictions(_root, args, %{context: context}) do
+    asked_for_another_plan? = Map.has_key?(args, :plan_name) or Map.has_key?(args, :plan)
+
     plan_name =
       Map.get(args, :plan_name) || Map.get(args, :plan) || context[:auth][:plan] || "FREE"
 
@@ -28,16 +30,40 @@ defmodule SanbaseWeb.Graphql.Resolvers.AccessControlResolver do
 
         filter = Map.get(args, :filter)
 
+        # A grant belongs to one customer, so it is only applied when the caller is asking
+        # about their own plan - naming a plan explicitly asks what that plan gives, not
+        # what this customer happens to have been granted on top of it.
+        grant =
+          if asked_for_another_plan?,
+            do: nil,
+            else: Sanbase.Billing.Subscription.grant(context[:auth][:subscription])
+
         Cache.wrap(
           fn ->
             restrictions =
-              Sanbase.Billing.Plan.Restrictions.get_all(plan_name, product_code, filter)
+              Sanbase.Billing.Plan.Restrictions.get_all(
+                plan_name,
+                product_code,
+                filter,
+                nil,
+                grant
+              )
 
             {:ok, restrictions}
           end,
-          {:get_access_restrictions, plan_name, product_code, filter}
+          # The grant is part of the key. Without it one granted customer's wider windows
+          # would be cached under the plan name and served to everyone else on that plan.
+          {:get_access_restrictions, plan_name, product_code, filter, grant_cache_key(grant)}
         ).()
     end
+  end
+
+  # Only the parts a grant can change the answer with. `nil` for the overwhelming
+  # majority of callers, which keeps their cache key exactly what it was before.
+  defp grant_cache_key(nil), do: nil
+
+  defp grant_cache_key(%Sanbase.Billing.Subscription.Grant{} = grant) do
+    :erlang.phash2({grant.full_history_packages, grant.full_history_metrics})
   end
 
   defp valid_plan_name?("CUSTOM_" <> _), do: true

--- a/lib/sanbase_web/graphql/resolvers/access_control_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/access_control_resolver.ex
@@ -10,10 +10,14 @@ defmodule SanbaseWeb.Graphql.Resolvers.AccessControlResolver do
   end
 
   def get_access_restrictions(_root, args, %{context: context}) do
-    asked_for_another_plan? = Map.has_key?(args, :plan_name) or Map.has_key?(args, :plan)
+    # An explicit `null` still arrives as a present key, and it falls through to the
+    # caller's own plan - so "did they name another plan?" has to be about the value
+    # that was resolved, not about the key being there. Keyed on presence, a
+    # `plan: null` would silently drop the caller's own grant.
+    named_plan = Map.get(args, :plan_name) || Map.get(args, :plan)
+    asked_for_another_plan? = not is_nil(named_plan)
 
-    plan_name =
-      Map.get(args, :plan_name) || Map.get(args, :plan) || context[:auth][:plan] || "FREE"
+    plan_name = named_plan || context[:auth][:plan] || "FREE"
 
     plan_name = plan_name |> to_string() |> String.upcase()
 
@@ -60,10 +64,15 @@ defmodule SanbaseWeb.Graphql.Resolvers.AccessControlResolver do
 
   # Only the parts a grant can change the answer with. `nil` for the overwhelming
   # majority of callers, which keeps their cache key exactly what it was before.
+  #
+  # The values go in whole rather than hashed here: `Cache.cache_key/3` already
+  # SHA-256s the finished key, so pre-hashing would only add a 32-bit collision
+  # surface in front of it - and a collision means one customer's wider windows
+  # served to another.
   defp grant_cache_key(nil), do: nil
 
   defp grant_cache_key(%Sanbase.Billing.Subscription.Grant{} = grant) do
-    :erlang.phash2({grant.full_history_packages, grant.full_history_metrics})
+    {grant.full_history_packages, grant.full_history_metrics}
   end
 
   defp valid_plan_name?("CUSTOM_" <> _), do: true

--- a/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
+++ b/lib/sanbase_web/graphql/resolvers/metric/metric_resolver.ex
@@ -222,7 +222,8 @@ defmodule SanbaseWeb.Graphql.Resolvers.MetricResolver do
             requested_product,
             subcription_product,
             plan_name,
-            Sanbase.Billing.Subscription.bundle_entitlement(auth[:subscription])
+            Sanbase.Billing.Subscription.bundle_entitlement(auth[:subscription]),
+            Sanbase.Billing.Subscription.grant(auth[:subscription])
           )
 
         {:ok,

--- a/lib/sanbase_web/live/admin/subscription_grants_live.ex
+++ b/lib/sanbase_web/live/admin/subscription_grants_live.ex
@@ -1,0 +1,574 @@
+defmodule SanbaseWeb.Admin.SubscriptionGrantsLive do
+  @moduledoc ~s"""
+  Apply the add-ons sales sold: extra monthly API calls, and full history on
+  individual data packages.
+
+  The add-on is charged as a **separate one-off Stripe invoice** raised outside
+  the subscription, and then recorded here. So this screen moves entitlement, not
+  money - it will not charge anyone and it will not appear on an invoice.
+
+  ## Why this is not part of /admin/bundle_subscriptions
+
+  That page is a test rig: it creates local subscriptions with no Stripe object,
+  fires probe requests with an API key, and lists only bundles. This one acts on
+  **real, paying** subscriptions, most of them Institutional, which are not
+  bundles at all. Widening that page's queries would have mixed a sales tool into
+  a developer tool and put a "create a fake subscription" button next to a
+  customer's live plan.
+
+  ## What a grant can and cannot do
+
+  Only ever additive: more calls, wider history. There is deliberately no way to
+  take anything away, which is what makes applying one safe without reasoning
+  about how it interacts with the plan underneath.
+
+  See §8 task **GR** of `docs/composable-api-plans-handover.md`.
+  """
+
+  use SanbaseWeb, :live_view
+
+  import Ecto.Query
+
+  alias Sanbase.Accounts.User
+  alias Sanbase.Billing.Plan.Bundle.Package
+  alias Sanbase.Billing.Plan.Bundle.PackageSnapshot
+  alias Sanbase.Billing.Subscription
+  alias Sanbase.Billing.Subscription.Grant
+  alias Sanbase.Billing.Subscription.Grants
+  alias Sanbase.Repo
+
+  @active_statuses [:active, :past_due, :trialing]
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "Subscription grants")
+     |> assign(:user_query, "")
+     |> assign(:user_matches, [])
+     |> assign(:selected_user, nil)
+     |> assign(:subscriptions, [])
+     |> assign(:selected_id, nil)
+     |> assign(:form_extra_calls, 0)
+     |> assign(:form_packages, MapSet.new())
+     |> assign(:form_note, "")
+     |> assign(:latest_snapshot, PackageSnapshot.latest())}
+  end
+
+  # ── Finding the customer ────────────────────────────────────────────────
+
+  @impl true
+  def handle_event("search_user", %{"value" => query}, socket) do
+    {:noreply, socket |> assign(:user_query, query) |> assign(:user_matches, search_users(query))}
+  end
+
+  def handle_event("select_user", %{"id" => id}, socket) do
+    with {user_id, ""} <- Integer.parse(id),
+         {:ok, user} <- User.by_id(user_id) do
+      {:noreply,
+       socket
+       |> assign(:selected_user, user)
+       |> assign(:user_matches, [])
+       |> assign(:user_query, user.email || user.username || "user##{user.id}")
+       |> assign(:selected_id, nil)
+       |> load_subscriptions()}
+    else
+      _ -> {:noreply, put_flash(socket, :error, "Could not load that user.")}
+    end
+  end
+
+  def handle_event("clear_user", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:selected_user, nil)
+     |> assign(:user_query, "")
+     |> assign(:user_matches, [])
+     |> assign(:subscriptions, [])
+     |> assign(:selected_id, nil)}
+  end
+
+  def handle_event("select_subscription", %{"id" => id}, socket) do
+    socket = assign(socket, :selected_id, parse_non_negative(id, nil))
+
+    {:noreply, prefill_form(socket)}
+  end
+
+  # ── The form ────────────────────────────────────────────────────────────
+
+  def handle_event("set_extra_calls", %{"value" => value}, socket) do
+    {:noreply, assign(socket, :form_extra_calls, parse_non_negative(value, 0))}
+  end
+
+  def handle_event("set_note", %{"value" => value}, socket) do
+    {:noreply, assign(socket, :form_note, value)}
+  end
+
+  def handle_event("toggle_package", %{"slug" => slug}, socket) do
+    packages = socket.assigns.form_packages
+
+    packages =
+      if MapSet.member?(packages, slug),
+        do: MapSet.delete(packages, slug),
+        else: MapSet.put(packages, slug)
+
+    # "all" and a list of individual packages mean different things - "all" keeps
+    # covering packages added later - so the two are mutually exclusive rather than
+    # one being shorthand for the other.
+    packages =
+      cond do
+        slug == Grant.all_packages() and MapSet.member?(packages, slug) ->
+          MapSet.new([slug])
+
+        slug != Grant.all_packages() ->
+          MapSet.delete(packages, Grant.all_packages())
+
+        true ->
+          packages
+      end
+
+    {:noreply, assign(socket, :form_packages, packages)}
+  end
+
+  # ── Writing ─────────────────────────────────────────────────────────────
+
+  def handle_event("apply_grant", _params, socket) do
+    %{
+      selected_id: id,
+      form_extra_calls: extra_calls,
+      form_packages: packages,
+      form_note: note
+    } = socket.assigns
+
+    with_subscription(socket, id, fn socket, subscription ->
+      attrs = %{
+        extra_api_calls_per_month: extra_calls,
+        full_history_packages: MapSet.to_list(packages),
+        note: String.trim(note)
+      }
+
+      case Grants.grant(subscription, attrs, socket.assigns.current_user) do
+        {:ok, _subscription} ->
+          {:noreply,
+           socket
+           |> put_flash(:info, "Grant applied and API call limits refreshed.")
+           |> load_subscriptions()}
+
+        {:error, %Ecto.Changeset{} = changeset} ->
+          {:noreply, put_flash(socket, :error, changeset_message(changeset))}
+
+        {:error, message} ->
+          {:noreply, put_flash(socket, :error, to_string(message))}
+      end
+    end)
+  end
+
+  def handle_event("re_expand", %{"id" => id}, socket) do
+    with_subscription(socket, id, fn socket, subscription ->
+      case Grants.re_expand(subscription) do
+        {:ok, _} ->
+          {:noreply,
+           socket
+           |> put_flash(:info, "Re-expanded against the current package snapshot.")
+           |> load_subscriptions()}
+
+        {:error, %Ecto.Changeset{} = changeset} ->
+          {:noreply, put_flash(socket, :error, changeset_message(changeset))}
+
+        {:error, message} ->
+          {:noreply, put_flash(socket, :error, to_string(message))}
+      end
+    end)
+  end
+
+  def handle_event("revoke", %{"id" => id}, socket) do
+    with_subscription(socket, id, fn socket, subscription ->
+      case Grants.revoke(subscription) do
+        {:ok, _} ->
+          {:noreply,
+           socket
+           |> put_flash(:info, "Grant removed. The customer is back on what their plan gives.")
+           |> assign(:form_extra_calls, 0)
+           |> assign(:form_packages, MapSet.new())
+           |> assign(:form_note, "")
+           |> load_subscriptions()}
+
+        {:error, changeset} ->
+          {:noreply, put_flash(socket, :error, changeset_message(changeset))}
+      end
+    end)
+  end
+
+  # ── Data ────────────────────────────────────────────────────────────────
+
+  # Read from the database rather than the list an earlier render loaded: two tabs, or a
+  # subscription cancelled elsewhere, would otherwise write against a stale struct.
+  defp with_subscription(socket, id, fun) do
+    case fetch_subscription(id) do
+      nil ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "That subscription no longer exists - reloaded the list.")
+         |> assign(:selected_id, nil)
+         |> load_subscriptions()}
+
+      subscription ->
+        fun.(socket, subscription)
+    end
+  end
+
+  defp fetch_subscription(id) do
+    case parse_non_negative(id, nil) do
+      nil -> nil
+      id -> Repo.get(Subscription, id) |> Repo.preload([:plan, :user])
+    end
+  end
+
+  defp load_subscriptions(%{assigns: %{selected_user: %User{} = user}} = socket) do
+    subscriptions =
+      from(s in Subscription,
+        where: s.user_id == ^user.id,
+        where: s.status in ^@active_statuses,
+        order_by: [desc: s.id],
+        preload: [:plan]
+      )
+      |> Repo.all()
+
+    assign(socket, :subscriptions, subscriptions)
+  end
+
+  defp load_subscriptions(socket), do: assign(socket, :subscriptions, [])
+
+  # A grant is edited, not re-entered: selecting a subscription that already has one loads
+  # it into the form so a second grant does not silently wipe the first.
+  defp prefill_form(socket) do
+    case selected(socket.assigns) do
+      %Subscription{grant: %Grant{} = grant} ->
+        socket
+        |> assign(:form_extra_calls, Grant.extra_api_calls(grant))
+        |> assign(:form_packages, MapSet.new(grant.full_history_packages || []))
+        |> assign(:form_note, grant.note || "")
+
+      _ ->
+        socket
+        |> assign(:form_extra_calls, 0)
+        |> assign(:form_packages, MapSet.new())
+        |> assign(:form_note, "")
+    end
+  end
+
+  defp selected(%{selected_id: nil}), do: nil
+
+  defp selected(%{selected_id: id, subscriptions: subscriptions}),
+    do: Enum.find(subscriptions, &(&1.id == id))
+
+  defp search_users(query) when byte_size(query) < 2, do: []
+
+  defp search_users(query) do
+    query = String.trim(query)
+    pattern = "%" <> query <> "%"
+
+    base =
+      from(u in User,
+        where: ilike(u.email, ^pattern) or ilike(u.username, ^pattern),
+        order_by: [desc: u.id],
+        limit: 8,
+        select: %{id: u.id, email: u.email, username: u.username}
+      )
+
+    case Integer.parse(query) do
+      {id, ""} -> from(u in base, or_where: u.id == ^id)
+      _ -> base
+    end
+    |> Repo.all()
+  end
+
+  defp parse_non_negative(value, default) do
+    case value |> to_string() |> String.trim() |> Integer.parse() do
+      {number, ""} when number >= 0 -> number
+      _ -> default
+    end
+  end
+
+  defp changeset_message(changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {message, _opts} -> message end)
+    |> Enum.map_join("; ", fn {field, messages} ->
+      "#{field}: #{Enum.join(List.wrap(messages), ", ")}"
+    end)
+  end
+
+  defp package_options do
+    [%{slug: Grant.all_packages(), name: "All packages"} | Package.all()]
+  end
+
+  defp resolved_monthly_calls(%Subscription{} = subscription) do
+    plan_key =
+      Sanbase.ApiCallLimit.Restrictions.key(
+        "SANAPI",
+        Sanbase.Billing.Subscription.plan_name(subscription)
+      )
+
+    base = Sanbase.ApiCallLimit.Restrictions.call_limits_per_month()[plan_key]
+    extra = subscription |> Subscription.grant() |> Grant.extra_api_calls()
+
+    case base do
+      nil -> nil
+      base -> %{base: base, extra: extra, total: base + extra}
+    end
+  end
+
+  # ── Render ──────────────────────────────────────────────────────────────
+
+  @impl true
+  def render(assigns) do
+    assigns =
+      assigns
+      |> assign(:selected, selected(assigns))
+      |> assign(:package_options, package_options())
+
+    ~H"""
+    <div class="bg-base-200/40 min-h-full">
+      <div class="max-w-5xl mx-auto px-6 py-8 space-y-6">
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <h1 class="text-3xl font-bold">Subscription grants</h1>
+            <p class="text-sm text-base-content/60 mt-1">
+              Apply an add-on that sales already sold and invoiced separately.
+            </p>
+          </div>
+
+          <.link navigate={~p"/admin/bundle_subscriptions"} class="btn btn-sm btn-soft shrink-0">
+            Bundle subscriptions
+          </.link>
+        </div>
+
+        <div role="alert" class="alert alert-info">
+          <span class="text-sm">
+            This moves <strong>entitlement, not money</strong>.
+            The add-on is charged on a separate one-off Stripe invoice; nothing here bills anyone.
+            A grant only ever <strong>adds</strong> — more calls, wider history — and stays until
+            someone removes it.
+          </span>
+        </div>
+
+        <%!-- ── Find the customer ───────────────────────────────────────── --%>
+        <div class="card bg-base-100 border border-base-300 p-4 space-y-4">
+          <h2 class="font-semibold">Customer</h2>
+
+          <div class="relative">
+            <div class="flex gap-2">
+              <input
+                type="text"
+                value={@user_query}
+                phx-keyup="search_user"
+                phx-debounce="250"
+                placeholder="email, username or id"
+                class="input input-sm w-96"
+              />
+              <button :if={@selected_user} phx-click="clear_user" class="btn btn-sm btn-soft">
+                Clear
+              </button>
+            </div>
+
+            <ul
+              :if={@user_matches != []}
+              class="menu bg-base-100 border border-base-300 rounded-box absolute z-10 w-96 shadow-lg"
+            >
+              <li :for={match <- @user_matches}>
+                <a phx-click="select_user" phx-value-id={match.id}>
+                  {match.email || match.username || "user##{match.id}"}
+                  <span class="text-xs text-base-content/50">#{match.id}</span>
+                </a>
+              </li>
+            </ul>
+          </div>
+
+          <p :if={@selected_user && @subscriptions == []} class="text-sm text-base-content/60">
+            This user has no active subscription, so there is nothing to grant against.
+          </p>
+
+          <div :if={@subscriptions != []} class="overflow-x-auto">
+            <table class="table table-sm">
+              <thead>
+                <tr>
+                  <th></th>
+                  <th>Plan</th>
+                  <th>Interval</th>
+                  <th>Status</th>
+                  <th>Grant</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  :for={subscription <- @subscriptions}
+                  class={if @selected_id == subscription.id, do: "bg-base-200", else: ""}
+                >
+                  <td>
+                    <button
+                      phx-click="select_subscription"
+                      phx-value-id={subscription.id}
+                      class="btn btn-xs btn-soft"
+                    >
+                      Select
+                    </button>
+                  </td>
+                  <td class="font-mono text-xs">{subscription.plan.name}</td>
+                  <td class="text-xs">{subscription.plan.interval}</td>
+                  <td class="text-xs">{subscription.status}</td>
+                  <td class="text-xs">
+                    <span :if={is_nil(subscription.grant)} class="text-base-content/40">none</span>
+                    <span :if={subscription.grant} class="badge badge-sm badge-primary">granted</span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <%!-- ── What is granted now ─────────────────────────────────────── --%>
+        <div :if={@selected} class="card bg-base-100 border border-base-300 p-4 space-y-3">
+          <h2 class="font-semibold">
+            What {@selected.plan.name} gives this customer now
+          </h2>
+
+          <% calls = resolved_monthly_calls(@selected) %>
+
+          <div :if={calls} class="text-sm">
+            <span class="font-mono">{calls.total}</span>
+            API calls a month
+            <span :if={calls.extra > 0} class="text-base-content/60">
+              ({calls.base} from the plan + {calls.extra} granted)
+            </span>
+            <span :if={calls.extra == 0} class="text-base-content/60">
+              (from the plan; nothing granted)
+            </span>
+          </div>
+
+          <div :if={is_nil(calls)} class="text-sm text-base-content/60">
+            This plan's call allowance is not resolved from its name — check
+            /admin/bundle_subscriptions instead.
+          </div>
+
+          <% described = Grants.describe(@selected) %>
+
+          <div :if={described} class="space-y-1 text-sm">
+            <div>
+              Full history on:
+              <span :if={described.full_history_packages == []} class="text-base-content/60">
+                nothing
+              </span>
+              <span :for={slug <- described.full_history_packages} class="badge badge-sm mr-1">
+                {slug}
+              </span>
+              <span :if={described.full_history_metric_count > 0} class="text-base-content/60">
+                — {described.full_history_metric_count} metrics, snapshot v{described.package_snapshot_version}
+              </span>
+            </div>
+
+            <div :if={!described.snapshot_is_current?} role="alert" class="alert alert-warning py-2">
+              <span class="text-xs">
+                A newer package snapshot has been published since this grant was written, so
+                metrics added to those packages are not covered. Re-expand only if that omission
+                is an oversight — a customer keeping what they bought is the intended default.
+              </span>
+            </div>
+
+            <div class="text-base-content/60">
+              Note: {described.note}
+            </div>
+            <div class="text-xs text-base-content/50">
+              Granted by user #{described.granted_by_id} on {described.granted_at}
+            </div>
+
+            <div class="flex gap-2 pt-2">
+              <button
+                phx-click="re_expand"
+                phx-value-id={@selected.id}
+                class="btn btn-xs btn-soft"
+              >
+                Re-expand
+              </button>
+              <button
+                phx-click="revoke"
+                phx-value-id={@selected.id}
+                data-confirm="Remove this grant? The customer drops back to what their plan gives."
+                class="btn btn-xs btn-error btn-soft"
+              >
+                Remove grant
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <%!-- ── Grant form ──────────────────────────────────────────────── --%>
+        <div :if={@selected} class="card bg-base-100 border border-base-300 p-4 space-y-4">
+          <h2 class="font-semibold">Apply an add-on</h2>
+
+          <div :if={is_nil(@latest_snapshot)} role="alert" class="alert alert-error">
+            <span class="text-sm">
+              No package snapshot is published, so a full-history grant cannot be expanded.
+              <.link navigate={~p"/admin/bundle_packages"} class="link">Publish one first.</.link>
+              Extra API calls can still be granted.
+            </span>
+          </div>
+
+          <fieldset class="fieldset">
+            <legend class="fieldset-legend">Extra API calls a month</legend>
+            <input
+              type="number"
+              min="0"
+              step="10000"
+              value={@form_extra_calls}
+              phx-keyup="set_extra_calls"
+              phx-debounce="300"
+              class="input input-sm w-48"
+            />
+          </fieldset>
+
+          <fieldset class="fieldset">
+            <legend class="fieldset-legend">Full history on</legend>
+            <div class="flex flex-wrap gap-2">
+              <button
+                :for={package <- @package_options}
+                phx-click="toggle_package"
+                phx-value-slug={package.slug}
+                class={[
+                  "btn btn-sm",
+                  if(MapSet.member?(@form_packages, package.slug),
+                    do: "btn-primary",
+                    else: "btn-soft"
+                  )
+                ]}
+              >
+                {package.name}
+              </button>
+            </div>
+            <p class="text-xs text-base-content/50 mt-1">
+              "All packages" is not shorthand for ticking the five — it keeps covering a package
+              added later, while a list stays frozen as written.
+            </p>
+          </fieldset>
+
+          <fieldset class="fieldset">
+            <legend class="fieldset-legend">Note (required — invoice or contract reference)</legend>
+            <input
+              type="text"
+              value={@form_note}
+              phx-keyup="set_note"
+              phx-debounce="300"
+              placeholder="e.g. INV-1234, Q3 contract"
+              class="input input-sm w-full"
+            />
+          </fieldset>
+
+          <div>
+            <button phx-click="apply_grant" class="btn btn-sm btn-primary">
+              Apply grant
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/sanbase_web/live/admin/subscription_grants_live.ex
+++ b/lib/sanbase_web/live/admin/subscription_grants_live.ex
@@ -131,19 +131,27 @@ defmodule SanbaseWeb.Admin.SubscriptionGrantsLive do
 
   # ── Writing ─────────────────────────────────────────────────────────────
 
-  def handle_event("apply_grant", _params, socket) do
-    %{
-      selected_id: id,
-      form_extra_calls: extra_calls,
-      form_packages: packages,
-      form_note: note
-    } = socket.assigns
+  # The submitted params win over the assigns: the inputs are debounced, so a value typed
+  # and submitted within the debounce window has not reached the socket yet. The assigns
+  # are the fallback for anything the form did not carry.
+  def handle_event("apply_grant", params, socket) do
+    %{selected_id: id, form_packages: packages} = socket.assigns
+
+    extra_calls =
+      parse_non_negative(Map.get(params, "extra_api_calls"), socket.assigns.form_extra_calls)
+
+    note = Map.get(params, "note", socket.assigns.form_note) |> to_string() |> String.trim()
+
+    socket =
+      socket
+      |> assign(:form_extra_calls, extra_calls)
+      |> assign(:form_note, note)
 
     with_subscription(socket, id, fn socket, subscription ->
       attrs = %{
         extra_api_calls_per_month: extra_calls,
         full_history_packages: MapSet.to_list(packages),
-        note: String.trim(note)
+        note: note
       }
 
       subscription
@@ -544,60 +552,72 @@ defmodule SanbaseWeb.Admin.SubscriptionGrantsLive do
             </span>
           </div>
 
-          <fieldset class="fieldset">
-            <legend class="fieldset-legend">Extra API calls a month</legend>
-            <input
-              type="number"
-              min="0"
-              step="10000"
-              value={@form_extra_calls}
-              phx-keyup="set_extra_calls"
-              phx-debounce="300"
-              class="input input-sm w-48"
-            />
-          </fieldset>
+          <%!-- A real submit, not a click handler reading assigns: the inputs are debounced,
+          so a value typed and submitted straight away would otherwise be granted at its
+          previous value. The submitted params are the source of truth. --%>
+          <form phx-submit="apply_grant" class="space-y-4">
+            <fieldset class="fieldset">
+              <legend class="fieldset-legend">Extra API calls a month</legend>
+              <input
+                type="number"
+                min="0"
+                step="10000"
+                name="extra_api_calls"
+                value={@form_extra_calls}
+                phx-keyup="set_extra_calls"
+                phx-debounce="300"
+                class="input input-sm w-48"
+              />
+            </fieldset>
 
-          <fieldset class="fieldset">
-            <legend class="fieldset-legend">Full history on</legend>
-            <div class="flex flex-wrap gap-2">
-              <button
-                :for={package <- @package_options}
-                phx-click="toggle_package"
-                phx-value-slug={package.slug}
-                class={[
-                  "btn btn-sm",
-                  if(MapSet.member?(@form_packages, package.slug),
-                    do: "btn-primary",
-                    else: "btn-soft"
-                  )
-                ]}
-              >
-                {package.name}
+            <fieldset class="fieldset">
+              <legend class="fieldset-legend">Full history on</legend>
+              <div class="flex flex-wrap gap-2">
+                <%!-- type="button" because these live inside the form: a button without it
+                submits, so picking a package would apply the grant. --%>
+                <button
+                  :for={package <- @package_options}
+                  type="button"
+                  phx-click="toggle_package"
+                  phx-value-slug={package.slug}
+                  class={[
+                    "btn btn-sm",
+                    if(MapSet.member?(@form_packages, package.slug),
+                      do: "btn-primary",
+                      else: "btn-soft"
+                    )
+                  ]}
+                >
+                  {package.name}
+                </button>
+              </div>
+              <p class="text-xs text-base-content/50 mt-1">
+                "All packages" is not shorthand for ticking the five — it keeps covering a package
+                added later, while a list stays frozen as written.
+              </p>
+            </fieldset>
+
+            <fieldset class="fieldset">
+              <legend class="fieldset-legend">
+                Note (required — invoice or contract reference)
+              </legend>
+              <input
+                type="text"
+                name="note"
+                value={@form_note}
+                phx-keyup="set_note"
+                phx-debounce="300"
+                placeholder="e.g. INV-1234, Q3 contract"
+                class="input input-sm w-full"
+              />
+            </fieldset>
+
+            <div>
+              <button type="submit" class="btn btn-sm btn-primary">
+                Apply grant
               </button>
             </div>
-            <p class="text-xs text-base-content/50 mt-1">
-              "All packages" is not shorthand for ticking the five — it keeps covering a package
-              added later, while a list stays frozen as written.
-            </p>
-          </fieldset>
-
-          <fieldset class="fieldset">
-            <legend class="fieldset-legend">Note (required — invoice or contract reference)</legend>
-            <input
-              type="text"
-              value={@form_note}
-              phx-keyup="set_note"
-              phx-debounce="300"
-              placeholder="e.g. INV-1234, Q3 contract"
-              class="input input-sm w-full"
-            />
-          </fieldset>
-
-          <div>
-            <button phx-click="apply_grant" class="btn btn-sm btn-primary">
-              Apply grant
-            </button>
-          </div>
+          </form>
         </div>
       </div>
     </div>

--- a/lib/sanbase_web/live/admin/subscription_grants_live.ex
+++ b/lib/sanbase_web/live/admin/subscription_grants_live.ex
@@ -146,56 +146,61 @@ defmodule SanbaseWeb.Admin.SubscriptionGrantsLive do
         note: String.trim(note)
       }
 
-      case Grants.grant(subscription, attrs, socket.assigns.current_user) do
-        {:ok, _subscription} ->
-          {:noreply,
-           socket
-           |> put_flash(:info, "Grant applied and API call limits refreshed.")
-           |> load_subscriptions()}
-
-        {:error, %Ecto.Changeset{} = changeset} ->
-          {:noreply, put_flash(socket, :error, changeset_message(changeset))}
-
-        {:error, message} ->
-          {:noreply, put_flash(socket, :error, to_string(message))}
-      end
+      subscription
+      |> Grants.grant(attrs, socket.assigns.current_user)
+      |> handle_write(socket, "Grant applied and API call limits refreshed.")
     end)
   end
 
   def handle_event("re_expand", %{"id" => id}, socket) do
     with_subscription(socket, id, fn socket, subscription ->
-      case Grants.re_expand(subscription) do
-        {:ok, _} ->
-          {:noreply,
-           socket
-           |> put_flash(:info, "Re-expanded against the current package snapshot.")
-           |> load_subscriptions()}
-
-        {:error, %Ecto.Changeset{} = changeset} ->
-          {:noreply, put_flash(socket, :error, changeset_message(changeset))}
-
-        {:error, message} ->
-          {:noreply, put_flash(socket, :error, to_string(message))}
-      end
+      subscription
+      |> Grants.re_expand()
+      |> handle_write(socket, "Re-expanded against the current package snapshot.")
     end)
   end
 
   def handle_event("revoke", %{"id" => id}, socket) do
     with_subscription(socket, id, fn socket, subscription ->
-      case Grants.revoke(subscription) do
-        {:ok, _} ->
-          {:noreply,
-           socket
-           |> put_flash(:info, "Grant removed. The customer is back on what their plan gives.")
-           |> assign(:form_extra_calls, 0)
-           |> assign(:form_packages, MapSet.new())
-           |> assign(:form_note, "")
-           |> load_subscriptions()}
+      socket =
+        socket
+        |> assign(:form_extra_calls, 0)
+        |> assign(:form_packages, MapSet.new())
+        |> assign(:form_note, "")
 
-        {:error, changeset} ->
-          {:noreply, put_flash(socket, :error, changeset_message(changeset))}
-      end
+      subscription
+      |> Grants.revoke()
+      |> handle_write(socket, "Grant removed. The customer is back on what their plan gives.")
     end)
+  end
+
+  # The three writes report the same four outcomes, so they say so in one place.
+  #
+  # `:api_call_limits_not_refreshed` is the interesting one: the grant is stored but the
+  # quota row was not updated, and nothing will retry on its own - the daily reconciler
+  # matches on plan name and a grant never changes one. So it is a warning rather than
+  # either a success or an error, and it says what to do about it.
+  defp handle_write(result, socket, success_message) do
+    case result do
+      {:ok, _subscription} ->
+        {:noreply, socket |> put_flash(:info, success_message) |> load_subscriptions()}
+
+      {:ok, _subscription, :api_call_limits_not_refreshed} ->
+        {:noreply,
+         socket
+         |> put_flash(
+           :error,
+           "Saved, but the API call limits could not be refreshed - the customer's quota does " <>
+             "not reflect this yet. Apply it again to retry."
+         )
+         |> load_subscriptions()}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, put_flash(socket, :error, changeset_message(changeset))}
+
+      {:error, message} ->
+        {:noreply, put_flash(socket, :error, to_string(message))}
+    end
   end
 
   # ── Data ────────────────────────────────────────────────────────────────
@@ -289,12 +294,39 @@ defmodule SanbaseWeb.Admin.SubscriptionGrantsLive do
     end
   end
 
+  # A grant is an embed, so `traverse_errors/2` nests its errors one level down and a
+  # flat join would print the raw inner map at the admin. Flattened recursively with the
+  # path kept, so a failure reads "grant.note: can't be blank" rather than a dump.
   defp changeset_message(changeset) do
     changeset
     |> Ecto.Changeset.traverse_errors(fn {message, _opts} -> message end)
-    |> Enum.map_join("; ", fn {field, messages} ->
-      "#{field}: #{Enum.join(List.wrap(messages), ", ")}"
+    |> flatten_errors()
+    |> Enum.map_join("; ", fn {path, messages} -> "#{path}: #{Enum.join(messages, ", ")}" end)
+  end
+
+  defp flatten_errors(errors, prefix \\ nil) do
+    Enum.flat_map(errors, fn {field, value} ->
+      path = if prefix, do: "#{prefix}.#{field}", else: to_string(field)
+
+      case value do
+        %{} = nested -> flatten_errors(nested, path)
+        messages when is_list(messages) -> flatten_message_list(messages, path)
+        message -> [{path, [to_string(message)]}]
+      end
     end)
+  end
+
+  # A list entry is itself a map when the embed is a collection, so the two shapes are
+  # separated rather than assumed.
+  defp flatten_message_list(messages, path) do
+    {maps, strings} = Enum.split_with(messages, &is_map/1)
+
+    nested = Enum.flat_map(maps, &flatten_errors(&1, path))
+
+    case strings do
+      [] -> nested
+      strings -> [{path, Enum.map(strings, &to_string/1)} | nested]
+    end
   end
 
   defp package_options do

--- a/lib/sanbase_web/router.ex
+++ b/lib/sanbase_web/router.ex
@@ -272,6 +272,12 @@ defmodule SanbaseWeb.Router do
       end
     end
 
+    scope "/subscription_grants" do
+      live_session :subscription_grants_admin, on_mount: @admin_panel_on_mount do
+        live("/", Admin.SubscriptionGrantsLive)
+      end
+    end
+
     scope "/bundle_offering" do
       live_session :bundle_offering_admin, on_mount: @admin_panel_on_mount do
         live("/", Admin.BundleOfferingLive)

--- a/priv/repo/migrations/20260910090000_apply_2026_09_10_pricing_decisions.exs
+++ b/priv/repo/migrations/20260910090000_apply_2026_09_10_pricing_decisions.exs
@@ -1,0 +1,81 @@
+defmodule Sanbase.Repo.Migrations.Apply20260910PricingDecisions do
+  use Ecto.Migration
+
+  @moduledoc ~s"""
+  The plan-row half of the pricing decisions taken on 2026-09-10 (§8 task **PR**).
+
+  Three changes, all to rows added by earlier migrations in this epic and none of
+  them reachable by a customer yet - the whole offering is still held back by
+  `is_private` until someone activates it from `/admin/bundle_offering`.
+
+  ## Institutional yearly goes from $9,500 to $9,588
+
+  Exactly twelve times the $799 monthly price, so a year paid up front saves
+  nothing. That is deliberate and confirmed, unlike the bundles' two months free.
+
+  ## Institutional monthly is withdrawn
+
+  Institutional is sold yearly only. The row is deprecated rather than deleted:
+  `plans.is_deprecated` is already checked on both `subscribe` and
+  `update_subscription` (`billing_resolver.ex:27` and `:74`), so a deprecated row
+  can be neither newly bought nor switched into, while anything already pointing
+  at plan id 311 keeps resolving. Deleting it would break those references for no
+  gain.
+
+  ## Enterprise stops being a self-serve priced tier
+
+  "Call support, custom pricing" makes Enterprise a negotiated contract, which is
+  what `CUSTOM_*` already is. The `ENTERPRISE` row keeps its amount and is simply
+  taken out of sale; its clauses in the access checkers stay in place, dead but
+  harmless, so restoring a listed price later is an UPDATE rather than a revert.
+
+  ## The Stripe side is not done here
+
+  A Stripe Price cannot be edited. Changing Institutional's yearly amount means
+  creating a new Price and archiving the old one, which
+  `Sanbase.Billing.sync_products_with_stripe/0` does not do on its own - it only
+  fills in a missing `stripe_id`. So this migration also clears
+  `stripe_id` on the yearly row, which is what makes the next sync mint a Price
+  at the new amount instead of leaving the old one attached. Nothing is
+  subscribed to it, so no customer is affected.
+  """
+
+  @institutional_monthly_plan_id 311
+  @institutional_yearly_plan_id 312
+  @enterprise_yearly_plan_id 313
+
+  # In cents. 12 x $799.
+  @new_yearly_amount 958_800
+  @old_yearly_amount 950_000
+
+  def up do
+    execute("""
+    UPDATE plans
+    SET amount = #{@new_yearly_amount}, stripe_id = NULL
+    WHERE id = #{@institutional_yearly_plan_id} AND name = 'INSTITUTIONAL'
+    """)
+
+    execute("""
+    UPDATE plans SET is_deprecated = true
+    WHERE id = #{@institutional_monthly_plan_id} AND name = 'INSTITUTIONAL'
+    """)
+
+    execute("""
+    UPDATE plans SET is_deprecated = true
+    WHERE id = #{@enterprise_yearly_plan_id} AND name = 'ENTERPRISE'
+    """)
+  end
+
+  def down do
+    execute("""
+    UPDATE plans
+    SET amount = #{@old_yearly_amount}, stripe_id = NULL
+    WHERE id = #{@institutional_yearly_plan_id} AND name = 'INSTITUTIONAL'
+    """)
+
+    execute("""
+    UPDATE plans SET is_deprecated = false
+    WHERE id IN (#{@institutional_monthly_plan_id}, #{@enterprise_yearly_plan_id})
+    """)
+  end
+end

--- a/priv/repo/migrations/20260910090000_apply_2026_09_10_pricing_decisions.exs
+++ b/priv/repo/migrations/20260910090000_apply_2026_09_10_pricing_decisions.exs
@@ -4,14 +4,9 @@ defmodule Sanbase.Repo.Migrations.Apply20260910PricingDecisions do
   @moduledoc ~s"""
   The plan-row half of the pricing decisions taken on 2026-09-10 (§8 task **PR**).
 
-  Three changes, all to rows added by earlier migrations in this epic and none of
-  them reachable by a customer yet - the whole offering is still held back by
+  Two rows are taken out of sale, both added by earlier migrations in this epic and
+  neither reachable by a customer yet - the whole offering is still held back by
   `is_private` until someone activates it from `/admin/bundle_offering`.
-
-  ## Institutional yearly goes from $9,500 to $9,588
-
-  Exactly twelve times the $799 monthly price, so a year paid up front saves
-  nothing. That is deliberate and confirmed, unlike the bundles' two months free.
 
   ## Institutional monthly is withdrawn
 
@@ -29,32 +24,23 @@ defmodule Sanbase.Repo.Migrations.Apply20260910PricingDecisions do
   taken out of sale; its clauses in the access checkers stay in place, dead but
   harmless, so restoring a listed price later is an UPDATE rather than a revert.
 
-  ## The Stripe side is not done here
+  ## The price change is deliberately not here
 
-  A Stripe Price cannot be edited. Changing Institutional's yearly amount means
-  creating a new Price and archiving the old one, which
-  `Sanbase.Billing.sync_products_with_stripe/0` does not do on its own - it only
-  fills in a missing `stripe_id`. So this migration also clears
-  `stripe_id` on the yearly row, which is what makes the next sync mint a Price
-  at the new amount instead of leaving the old one attached. Nothing is
-  subscribed to it, so no customer is affected.
+  A Stripe Plan cannot be edited, so moving Institutional to $9,588 means creating a
+  new one and pointing the row at it. A migration cannot do that: it would have to
+  either write the new amount while the row still points at a Stripe Plan charging the
+  old one, or clear `stripe_id` and leave a priced, purchasable row with no Stripe
+  object behind it. Both are states a deploy can stop halfway through.
+
+  So the amount is moved by `Sanbase.Billing.switch_institutional_yearly_price/0`,
+  which creates the replacement first and only then updates the row - run it after this
+  migration. This file changes nothing but the three sale flags, which are plain data.
   """
 
   @institutional_monthly_plan_id 311
-  @institutional_yearly_plan_id 312
   @enterprise_yearly_plan_id 313
 
-  # In cents. 12 x $799.
-  @new_yearly_amount 958_800
-  @old_yearly_amount 950_000
-
   def up do
-    execute("""
-    UPDATE plans
-    SET amount = #{@new_yearly_amount}, stripe_id = NULL
-    WHERE id = #{@institutional_yearly_plan_id} AND name = 'INSTITUTIONAL'
-    """)
-
     execute("""
     UPDATE plans SET is_deprecated = true
     WHERE id = #{@institutional_monthly_plan_id} AND name = 'INSTITUTIONAL'
@@ -67,12 +53,6 @@ defmodule Sanbase.Repo.Migrations.Apply20260910PricingDecisions do
   end
 
   def down do
-    execute("""
-    UPDATE plans
-    SET amount = #{@old_yearly_amount}, stripe_id = NULL
-    WHERE id = #{@institutional_yearly_plan_id} AND name = 'INSTITUTIONAL'
-    """)
-
     execute("""
     UPDATE plans SET is_deprecated = false
     WHERE id IN (#{@institutional_monthly_plan_id}, #{@enterprise_yearly_plan_id})

--- a/priv/repo/migrations/20260910091000_add_grant_to_subscriptions.exs
+++ b/priv/repo/migrations/20260910091000_add_grant_to_subscriptions.exs
@@ -1,0 +1,35 @@
+defmodule Sanbase.Repo.Migrations.AddGrantToSubscriptions do
+  use Ecto.Migration
+
+  @moduledoc """
+  An add-on granted by sales and applied by hand in the admin panel: extra
+  monthly API calls, and full history on individual data packages.
+
+  Institutional's allowance and history window are otherwise fixed to the plan
+  name, so there is nowhere to record "this customer bought more". This is that
+  place. See docs/composable-api-plans-handover.md §8 task GR.
+
+  Lives on the subscription row rather than in its own table for the same reason
+  `bundle_entitlement` does (§5.4): the row is already loaded on every
+  authenticated request, so a column here costs nothing to read while a separate
+  table would cost a join.
+
+  Deliberately not the same column as `bundle_entitlement`. That one is recomputed
+  from scratch by `Bundle.Resolver.sync/1` on every `customer.subscription.updated`
+  event, and a grant stored inside it would be erased by the next webhook.
+
+  NULL for every subscription without an add-on, which is all of them today.
+  """
+
+  def up do
+    alter table(:subscriptions) do
+      add(:grant, :jsonb, null: true)
+    end
+  end
+
+  def down do
+    alter table(:subscriptions) do
+      remove(:grant)
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,10 +2,10 @@
 -- PostgreSQL database dump
 --
 
-\restrict Ht0dgMfoCcp9ggpJRwljPSZbr703PZ8381AxQWntRtd925ASKDeq2Z40cFs96iN
+\restrict IokZ7KwyDYQ63KrrEvsPeIcdhaj5ki4govFsKQyUkkhFvVJLxqOHMY4bIrnKUhs
 
--- Dumped from database version 17.9 (Homebrew)
--- Dumped by pg_dump version 17.9 (Homebrew)
+-- Dumped from database version 17.10 (Homebrew)
+-- Dumped by pg_dump version 17.10 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -5009,7 +5009,8 @@ CREATE TABLE public.subscriptions (
     inserted_at timestamp without time zone,
     updated_at timestamp without time zone,
     type public.subscription_type DEFAULT 'fiat'::public.subscription_type NOT NULL,
-    bundle_entitlement jsonb
+    bundle_entitlement jsonb,
+    "grant" jsonb
 );
 
 
@@ -12315,7 +12316,7 @@ ALTER TABLE ONLY public.webinar_registrations
 -- PostgreSQL database dump complete
 --
 
-\unrestrict Ht0dgMfoCcp9ggpJRwljPSZbr703PZ8381AxQWntRtd925ASKDeq2Z40cFs96iN
+\unrestrict IokZ7KwyDYQ63KrrEvsPeIcdhaj5ki4govFsKQyUkkhFvVJLxqOHMY4bIrnKUhs
 
 INSERT INTO public."schema_migrations" (version) VALUES (20171008200815);
 INSERT INTO public."schema_migrations" (version) VALUES (20171008203355);
@@ -12920,3 +12921,5 @@ INSERT INTO public."schema_migrations" (version) VALUES (20260812120000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260813090000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260902130000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260903120000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260910090000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260910091000);

--- a/test/sanbase/billing/plan/bundle/resolver_test.exs
+++ b/test/sanbase/billing/plan/bundle/resolver_test.exs
@@ -96,17 +96,17 @@ defmodule Sanbase.Billing.Plan.Bundle.ResolverTest do
     test "one package gets the flat monthly allowance" do
       {:ok, attrs} = Resolver.resolve([item("market", :package)], @snapshot)
 
-      assert attrs.api_call_limits["month"] == 100_000
+      assert attrs.api_call_limits["month"] == 50_000
     end
 
     test "five packages get the same flat allowance, not five times it" do
-      # Decided by product: choosing several packages still gives one 100,000
+      # Decided by product: choosing several packages still gives one 50,000
       # allowance. Summing per package is the thing this pins against.
       items = Enum.map(Bundle.Package.slugs(), &item(&1, :package))
 
       {:ok, attrs} = Resolver.resolve(items, @snapshot)
 
-      assert attrs.api_call_limits["month"] == 100_000
+      assert attrs.api_call_limits["month"] == 50_000
       assert length(attrs.packages) == 5
     end
 
@@ -117,7 +117,7 @@ defmodule Sanbase.Billing.Plan.Bundle.ResolverTest do
           @snapshot
         )
 
-      assert attrs.api_call_limits["month"] == 600_000
+      assert attrs.api_call_limits["month"] == 550_000
     end
 
     test "several units of an add-on multiply" do
@@ -127,7 +127,7 @@ defmodule Sanbase.Billing.Plan.Bundle.ResolverTest do
           @snapshot
         )
 
-      assert attrs.api_call_limits["month"] == 1_600_000
+      assert attrs.api_call_limits["month"] == 1_550_000
     end
 
     test "burst limits never grow with the number of packages" do
@@ -235,7 +235,7 @@ defmodule Sanbase.Billing.Plan.Bundle.ResolverTest do
       stored = Repo.get!(Subscription, subscription.id).bundle_entitlement
 
       assert stored.packages == ["market", "social"]
-      assert stored.api_call_limits["month"] == 100_000
+      assert stored.api_call_limits["month"] == 50_000
       assert stored.package_snapshot_version == PackageSnapshot.latest().version
     end
 
@@ -312,7 +312,7 @@ defmodule Sanbase.Billing.Plan.Bundle.ResolverTest do
       limits =
         Bundle.Access.api_call_limits(Repo.get!(Subscription, subscription.id).bundle_entitlement)
 
-      assert limits == %{month: 600_000, hour: 30_000, minute: 600}
+      assert limits == %{month: 550_000, hour: 30_000, minute: 600}
     end
 
     test "refuses when no snapshot has been published", %{subscription: subscription} do

--- a/test/sanbase/billing/stripe_event_bundle_sync_test.exs
+++ b/test/sanbase/billing/stripe_event_bundle_sync_test.exs
@@ -606,7 +606,7 @@ defmodule Sanbase.Billing.StripeEventBundleSyncTest do
       assert items["api_calls_500k"].quantity == 2
 
       entitlement = Subscription.by_stripe_id(sub.stripe_id).bundle_entitlement
-      assert entitlement.api_call_limits["month"] == 100_000 + 2 * 500_000
+      assert entitlement.api_call_limits["month"] == 50_000 + 2 * 500_000
     end
   end
 
@@ -622,7 +622,7 @@ defmodule Sanbase.Billing.StripeEventBundleSyncTest do
 
       acl = acl(user)
       assert acl.api_calls_limit_plan == "sanapi_bundle"
-      assert acl.resolved_api_call_limits["month"] == 100_000
+      assert acl.resolved_api_call_limits["month"] == 50_000
 
       canceled = %{stripe_sub | status: "canceled"}
 

--- a/test/sanbase/billing/subscription/grant_test.exs
+++ b/test/sanbase/billing/subscription/grant_test.exs
@@ -1,0 +1,460 @@
+defmodule Sanbase.Billing.Subscription.GrantTest do
+  @moduledoc ~s"""
+  Sales-applied add-ons: extra monthly API calls and full history on individual
+  data packages. See §8 task **GR** of `docs/composable-api-plans-handover.md`.
+
+  Two properties carry most of the weight here and each has its own block.
+
+  **A grant can only add.** It may raise a call allowance or widen a history
+  window and never the reverse, which is what makes applying one safe without
+  reasoning about the plan underneath. That is enforced in code, so it is pinned
+  in code.
+
+  **No grant means nothing changed.** Every answer for a customer without one has
+  to be byte-identical to what it was before grants existed, because that is
+  every customer today. The access-matrix fixture proves it across the whole
+  surface; these tests prove it at the two functions that learned about grants.
+  """
+
+  use Sanbase.DataCase, async: false
+
+  import Sanbase.Factory
+
+  alias Sanbase.ApiCallLimit
+  alias Sanbase.Billing.Plan
+  alias Sanbase.Billing.Plan.AccessChecker
+  alias Sanbase.Billing.Plan.Bundle.PackageSnapshot
+  alias Sanbase.Billing.Subscription
+  alias Sanbase.Billing.Subscription.Grant
+  alias Sanbase.Billing.Subscription.Grants
+  alias Sanbase.Repo
+
+  @plan "INSTITUTIONAL"
+  @acl_plan "sanapi_institutional"
+
+  # Three years, the Institutional window every ungranted metric keeps.
+  @institutional_history 3 * 365
+
+  # Both are restricted metrics with a real history window, so the plan's three years
+  # is observable and a grant widening it to "no limit" is too. A freely available
+  # metric has no window at all and would prove nothing either way.
+  @market_metric "mvrv_usd"
+  @social_metric "social_volume_total"
+
+  setup do
+    snapshot = publish_snapshot()
+    user = insert(:user)
+    subscription = insert_institutional_subscription(user)
+
+    %{user: user, subscription: subscription, snapshot: snapshot}
+  end
+
+  describe "the changeset" do
+    test "refuses a grant that grants nothing" do
+      # A form submitted empty would otherwise store a row that reads as an add-on
+      # while changing nothing, which is worse than an error.
+      changeset = Grant.changeset(%Grant{}, base_attrs())
+
+      refute changeset.valid?
+      assert errors_on(changeset)[:extra_api_calls_per_month]
+    end
+
+    test "refuses an unknown package" do
+      changeset =
+        Grant.changeset(%Grant{}, base_attrs(full_history_packages: ["market", "nonsense"]))
+
+      refute changeset.valid?
+      assert errors_on(changeset)[:full_history_packages]
+    end
+
+    test "refuses a negative call grant" do
+      changeset = Grant.changeset(%Grant{}, base_attrs(extra_api_calls_per_month: -1))
+
+      refute changeset.valid?
+    end
+
+    test "requires a note" do
+      # The only record that money changed hands is an invoice raised elsewhere, so
+      # the reference has to live with the grant.
+      changeset =
+        Grant.changeset(%Grant{}, %{extra_api_calls_per_month: 1000, granted_at: now()})
+
+      refute changeset.valid?
+      assert errors_on(changeset)[:note]
+    end
+
+    test "accepts calls alone, packages alone, and both" do
+      for attrs <- [
+            base_attrs(extra_api_calls_per_month: 1000),
+            base_attrs(full_history_packages: ["market"]),
+            base_attrs(extra_api_calls_per_month: 1000, full_history_packages: ["market"])
+          ] do
+        assert Grant.changeset(%Grant{}, attrs).valid?
+      end
+    end
+  end
+
+  describe "writing a grant" do
+    test "expands the chosen packages into metrics and records who granted it", context do
+      %{subscription: subscription, user: user, snapshot: snapshot} = context
+
+      {:ok, subscription} =
+        Grants.grant(
+          subscription,
+          %{full_history_packages: ["market"], note: "INV-1"},
+          user
+        )
+
+      grant = Subscription.grant(subscription)
+
+      assert grant.full_history_packages == ["market"]
+      assert @market_metric in grant.full_history_metrics
+      refute @social_metric in grant.full_history_metrics
+      assert grant.package_snapshot_version == snapshot.version
+      assert grant.granted_by_id == user.id
+      assert grant.granted_at
+    end
+
+    test "\"all\" is stored as itself rather than expanded", context do
+      %{subscription: subscription, user: user} = context
+
+      {:ok, subscription} =
+        Grants.grant(
+          subscription,
+          %{full_history_packages: [Grant.all_packages()], note: "INV-2"},
+          user
+        )
+
+      grant = Subscription.grant(subscription)
+
+      # Nothing is frozen, so a package added later is covered without anyone
+      # having to remember to re-expand.
+      assert grant.full_history_metrics == []
+      assert Grant.full_history?(grant, "a_metric_that_did_not_exist_yet")
+    end
+
+    test "replaces rather than merges", context do
+      %{subscription: subscription, user: user} = context
+
+      {:ok, subscription} =
+        Grants.grant(subscription, %{full_history_packages: ["market"], note: "INV-1"}, user)
+
+      {:ok, subscription} =
+        Grants.grant(subscription, %{full_history_packages: ["social"], note: "INV-2"}, user)
+
+      grant = Subscription.grant(subscription)
+
+      # The dropped package must lose the metrics it expanded, or removing a
+      # package from a grant would leave what it gave behind.
+      assert grant.full_history_packages == ["social"]
+      refute @market_metric in grant.full_history_metrics
+      assert @social_metric in grant.full_history_metrics
+    end
+
+    test "revoking puts the customer back on exactly the plan", context do
+      %{subscription: subscription, user: user} = context
+
+      {:ok, subscription} =
+        Grants.grant(subscription, %{extra_api_calls_per_month: 200_000, note: "INV-1"}, user)
+
+      {:ok, subscription} = Grants.revoke(subscription)
+
+      assert Subscription.grant(subscription) == nil
+      assert acl_month(user) == plan_month()
+    end
+  end
+
+  describe "history: what the grant widens and what it leaves alone" do
+    test "no grant answers exactly as the plan does" do
+      assert history_for(@market_metric, nil) == @institutional_history
+      assert history_for(@social_metric, nil) == @institutional_history
+    end
+
+    test "a granted package gets full history and nothing else moves", context do
+      %{subscription: subscription, user: user} = context
+
+      {:ok, subscription} =
+        Grants.grant(subscription, %{full_history_packages: ["market"], note: "INV-1"}, user)
+
+      grant = Subscription.grant(subscription)
+
+      # `nil` is what "no limit" already means everywhere else here.
+      assert history_for(@market_metric, grant) == nil
+      assert history_for(@social_metric, grant) == @institutional_history
+    end
+
+    test "granting every package widens everything", context do
+      %{subscription: subscription, user: user} = context
+
+      {:ok, subscription} =
+        Grants.grant(
+          subscription,
+          %{full_history_packages: [Grant.all_packages()], note: "INV-1"},
+          user
+        )
+
+      grant = Subscription.grant(subscription)
+
+      assert history_for(@market_metric, grant) == nil
+      assert history_for(@social_metric, grant) == nil
+    end
+
+    test "a calls-only grant does not touch history", context do
+      %{subscription: subscription, user: user} = context
+
+      {:ok, subscription} =
+        Grants.grant(subscription, %{extra_api_calls_per_month: 200_000, note: "INV-1"}, user)
+
+      grant = Subscription.grant(subscription)
+
+      assert history_for(@market_metric, grant) == @institutional_history
+    end
+
+    test "queries and signals are unaffected", context do
+      %{subscription: subscription, user: user} = context
+
+      {:ok, subscription} =
+        Grants.grant(
+          subscription,
+          %{full_history_packages: [Grant.all_packages()], note: "INV-1"},
+          user
+        )
+
+      grant = Subscription.grant(subscription)
+
+      # A package sells metrics. There is no history window on a query or signal
+      # that a package could have bought, so "all" must not reach them.
+      for query_or_argument <- [{:query, :miners_balance}, {:signal, "dai_mint"}] do
+        assert AccessChecker.historical_data_in_days(
+                 query_or_argument,
+                 "SANAPI",
+                 "SANAPI",
+                 @plan,
+                 nil,
+                 grant
+               ) ==
+                 AccessChecker.historical_data_in_days(
+                   query_or_argument,
+                   "SANAPI",
+                   "SANAPI",
+                   @plan
+                 )
+      end
+    end
+  end
+
+  describe "API calls" do
+    test "a grant is added to the plan's allowance", context do
+      %{subscription: subscription, user: user} = context
+
+      {:ok, _} =
+        Grants.grant(subscription, %{extra_api_calls_per_month: 200_000, note: "INV-1"}, user)
+
+      assert acl_month(user) == plan_month() + 200_000
+    end
+
+    test "the burst limits are not widened", context do
+      %{subscription: subscription, user: user} = context
+
+      {:ok, _} =
+        Grants.grant(subscription, %{extra_api_calls_per_month: 200_000, note: "INV-1"}, user)
+
+      limits = user |> acl() |> ApiCallLimit.acl_to_api_call_limits()
+      from_plan = ApiCallLimit.plan_to_api_call_limits(@acl_plan)
+
+      # Hour and minute protect the infrastructure; they are not a thing being sold.
+      assert limits.hour == from_plan.hour
+      assert limits.minute == from_plan.minute
+    end
+
+    test "a history-only grant leaves the allowance alone", context do
+      %{subscription: subscription, user: user} = context
+
+      {:ok, _} =
+        Grants.grant(subscription, %{full_history_packages: ["market"], note: "INV-1"}, user)
+
+      assert acl_month(user) == plan_month()
+    end
+
+    test "a stored value below the plan's is a leftover and is ignored" do
+      # A customer who moved off a bundle, or a bad backfill. A grant can only add,
+      # so anything at or under the plan's number cannot be one.
+      acl = %ApiCallLimit{
+        api_calls_limit_plan: "sanapi_pro",
+        resolved_api_call_limits: %{"month" => 1, "hour" => 1, "minute" => 1}
+      }
+
+      assert ApiCallLimit.acl_to_api_call_limits(acl) ==
+               ApiCallLimit.plan_to_api_call_limits("sanapi_pro")
+    end
+  end
+
+  describe "re-expanding" do
+    test "picks up metrics added to a granted package since the grant", context do
+      %{subscription: subscription, user: user} = context
+
+      {:ok, subscription} =
+        Grants.grant(subscription, %{full_history_packages: ["market"], note: "INV-1"}, user)
+
+      refute "grant_test_late_market_metric" in Subscription.grant(subscription).full_history_metrics
+
+      categorize("grant_test_late_market_metric", category_for("Market"))
+      {:ok, _} = PackageSnapshot.publish()
+
+      {:ok, subscription} = Grants.re_expand(subscription)
+      grant = Subscription.grant(subscription)
+
+      assert "grant_test_late_market_metric" in grant.full_history_metrics
+      # Everything else about the grant survives - this refreshes, it does not rewrite.
+      assert grant.note == "INV-1"
+      assert grant.granted_by_id == user.id
+    end
+
+    test "a grant is frozen until someone re-expands it", context do
+      %{subscription: subscription, user: user} = context
+
+      {:ok, subscription} =
+        Grants.grant(subscription, %{full_history_packages: ["market"], note: "INV-1"}, user)
+
+      categorize("grant_test_another_late_metric", category_for("Market"))
+      {:ok, _} = PackageSnapshot.publish()
+
+      # Deliberate: a customer keeps what they bought until someone decides otherwise.
+      refute Grant.full_history?(
+               Subscription.grant(subscription),
+               "grant_test_another_late_metric"
+             )
+    end
+
+    test "says so when there is nothing to re-expand", context do
+      assert {:error, message} = Grants.re_expand(context.subscription)
+      assert message =~ "no grant"
+    end
+  end
+
+  describe "describe/1" do
+    test "reports the resolved result and whether the snapshot has moved on", context do
+      %{subscription: subscription, user: user} = context
+
+      {:ok, subscription} =
+        Grants.grant(
+          subscription,
+          %{extra_api_calls_per_month: 200_000, full_history_packages: ["market"], note: "INV-1"},
+          user
+        )
+
+      described = Grants.describe(subscription)
+
+      assert described.extra_api_calls_per_month == 200_000
+      assert described.full_history_packages == ["market"]
+      assert described.full_history_metric_count > 0
+      assert described.snapshot_is_current?
+
+      categorize("grant_test_yet_another_metric", category_for("Market"))
+      {:ok, _} = PackageSnapshot.publish()
+
+      refute Grants.describe(Repo.reload(subscription)).snapshot_is_current?
+    end
+
+    test "is nil without a grant", context do
+      assert Grants.describe(context.subscription) == nil
+    end
+  end
+
+  # ── Helpers ─────────────────────────────────────────────────────────────
+
+  defp base_attrs(extra \\ []) do
+    Map.merge(%{note: "INV-0", granted_at: now()}, Map.new(extra))
+  end
+
+  defp now, do: DateTime.utc_now() |> DateTime.truncate(:second)
+
+  defp history_for(metric, grant) do
+    AccessChecker.historical_data_in_days(
+      {:metric, metric},
+      "SANAPI",
+      "SANAPI",
+      @plan,
+      nil,
+      grant
+    )
+  end
+
+  defp plan_month, do: ApiCallLimit.plan_to_api_call_limits(@acl_plan).month
+
+  defp acl_month(user),
+    do: user |> acl() |> ApiCallLimit.acl_to_api_call_limits() |> Map.get(:month)
+
+  defp acl(user), do: Repo.get_by!(ApiCallLimit, user_id: user.id)
+
+  defp insert_institutional_subscription(user) do
+    product_api_id = Sanbase.Billing.Product.product_api()
+
+    # The migration seeds this row against products.id = 1, which does not exist when
+    # the test database is migrated - so it is created here, with an explicit id out of
+    # the factories' way.
+    plan =
+      Repo.get_by(Plan, name: @plan, interval: "year", product_id: product_api_id) ||
+        insert(:plan_pro,
+          id: 9801,
+          name: @plan,
+          product_id: product_api_id,
+          interval: "year",
+          amount: 958_800,
+          is_private: true,
+          stripe_id: "plan_institutional_year_" <> Ecto.UUID.generate()
+        )
+
+    insert(:subscription_pro,
+      user_id: user.id,
+      plan_id: plan.id,
+      status: :active,
+      stripe_id: "sub_grant_" <> Ecto.UUID.generate()
+    )
+    |> Repo.preload([:plan, :user])
+  end
+
+  # Two categorized metrics in two different packages, so a grant on one is
+  # observably not a grant on the other.
+  defp publish_snapshot do
+    Sanbase.Billing.Plan.Bundle.Package.all()
+    |> Enum.with_index()
+    |> Enum.each(fn {package, index} ->
+      {:ok, _} =
+        Sanbase.Metric.Category.MetricCategory.create(%{
+          name: package.category,
+          display_order: index
+        })
+    end)
+
+    categorize_existing(@market_metric, category_for("Market"))
+    categorize_existing(@social_metric, category_for("Social"))
+
+    {:ok, snapshot} = PackageSnapshot.publish()
+    snapshot
+  end
+
+  defp category_for(name), do: Repo.get_by!(Sanbase.Metric.Category.MetricCategory, name: name)
+
+  defp categorize(metric, category) do
+    registry = Sanbase.MetricRegistryHelpers.create_registry_metric(metric)
+
+    map_to_category(registry, category)
+  end
+
+  # The seeded registry already holds the real metrics, so these are looked up rather
+  # than created - creating one would collide with the seed.
+  defp categorize_existing(metric, category) do
+    {:ok, registry} = Sanbase.Metric.Registry.by_name(metric)
+
+    map_to_category(registry, category)
+  end
+
+  defp map_to_category(registry, category) do
+    {:ok, _} =
+      Sanbase.Metric.Category.MetricCategoryMapping.create(%{
+        metric_registry_id: registry.id,
+        category_id: category.id
+      })
+  end
+end

--- a/test/sanbase/billing/subscription/grant_test.exs
+++ b/test/sanbase/billing/subscription/grant_test.exs
@@ -359,6 +359,26 @@ defmodule Sanbase.Billing.Subscription.GrantTest do
     test "is nil without a grant", context do
       assert Grants.describe(context.subscription) == nil
     end
+
+    test "an \"all packages\" grant never reports as stale", context do
+      %{subscription: subscription, user: user} = context
+
+      {:ok, subscription} =
+        Grants.grant(
+          subscription,
+          %{full_history_packages: [Grant.all_packages()], note: "INV-1"},
+          user
+        )
+
+      categorize("grant_test_metric_after_all", category_for("Market"))
+      {:ok, _} = PackageSnapshot.publish()
+
+      # Nothing was frozen, so a newer snapshot leaves nothing behind and there is
+      # nothing to re-expand. Warning here would make the warning mean less where it
+      # does matter.
+      assert Grants.describe(Repo.reload(subscription)).snapshot_is_current?
+      assert Grant.full_history?(Subscription.grant(subscription), "grant_test_metric_after_all")
+    end
   end
 
   # ── Helpers ─────────────────────────────────────────────────────────────

--- a/test/sanbase/email/api_business_onboarding_list_test.exs
+++ b/test/sanbase/email/api_business_onboarding_list_test.exs
@@ -42,6 +42,20 @@ defmodule Sanbase.Email.ApiBusinessOnboardingListTest do
 
       assert :ok = ApiBusinessOnboardingList.maybe_add(subscription)
     end
+
+    test "the new offering is on the list too", %{user: user} do
+      # Product confirmed on 2026-09-10 that package and Institutional customers get the
+      # same onboarding email (§15 Q16). Before that a customer could pay for a year of
+      # Institutional and receive nothing while a Business Pro customer was onboarded.
+      for {name, id} <- [{"BUNDLE", 9911}, {"INSTITUTIONAL", 9913}, {"ENTERPRISE", 9915}] do
+        subscription = insert_new_offering_subscription(user, name, id) |> reload()
+
+        expect(MockMailjetApi, :subscribe, fn @list, "biz@example.com" -> :ok end)
+
+        assert :ok = ApiBusinessOnboardingList.maybe_add(subscription)
+        assert ApiBusinessOnboardingList.eligible?(subscription)
+      end
+    end
   end
 
   describe "maybe_add/1 ignores non-eligible subscribers" do
@@ -240,5 +254,34 @@ defmodule Sanbase.Email.ApiBusinessOnboardingListTest do
 
       assert ApiBusinessOnboardingList.eligible_user_emails() == []
     end
+  end
+
+  # The migrations seed these against products.id = 1, which does not exist in a freshly
+  # migrated test database, so the rows are created here with ids out of the factories' way.
+  defp insert_new_offering_subscription(user, plan_name, plan_id) do
+    product_api_id = Sanbase.Billing.Product.product_api()
+
+    plan =
+      Sanbase.Repo.get_by(Sanbase.Billing.Plan,
+        name: plan_name,
+        interval: "year",
+        product_id: product_api_id
+      ) ||
+        insert(:plan_pro,
+          id: plan_id,
+          name: plan_name,
+          product_id: product_api_id,
+          interval: "year",
+          amount: 958_800,
+          is_private: true,
+          stripe_id: "plan_#{String.downcase(plan_name)}_year_" <> Ecto.UUID.generate()
+        )
+
+    insert(:subscription_pro,
+      user_id: user.id,
+      plan_id: plan.id,
+      status: :active,
+      stripe_id: "sub_#{String.downcase(plan_name)}_" <> Ecto.UUID.generate()
+    )
   end
 end

--- a/test/sanbase/mcp/mcp_rate_limit_test.exs
+++ b/test/sanbase/mcp/mcp_rate_limit_test.exs
@@ -173,6 +173,39 @@ defmodule Sanbase.MCP.RateLimitTest do
       user = insert(:user)
       assert :free == Restrictions.tier_for_user(user)
     end
+
+    test "a bundle customer gets the max tier, not the free one" do
+      # MCP is sold with the packages, and every bundle subscription is named `BUNDLE`.
+      # Without a clause for that name it falls to the SANAPI catch-all and a paying
+      # customer silently gets 15 calls a minute.
+      user = insert(:user)
+      product_api_id = Sanbase.Billing.Product.product_api()
+
+      plan =
+        Sanbase.Repo.get_by(Sanbase.Billing.Plan,
+          name: "BUNDLE",
+          interval: "month",
+          product_id: product_api_id
+        ) ||
+          insert(:plan_pro,
+            id: 9901,
+            name: "BUNDLE",
+            product_id: product_api_id,
+            interval: "month",
+            amount: 0,
+            is_private: true,
+            stripe_id: "plan_bundle_month_" <> Ecto.UUID.generate()
+          )
+
+      insert(:subscription_pro,
+        user_id: user.id,
+        plan_id: plan.id,
+        status: :active,
+        stripe_id: "sub_bundle_" <> Ecto.UUID.generate()
+      )
+
+      assert :max == Restrictions.tier_for_user(user)
+    end
   end
 
   defp insert_invocations(user_id, tool_name, count) do

--- a/test/sanbase_web/graphql/billing/bundle_mutations_api_test.exs
+++ b/test/sanbase_web/graphql/billing/bundle_mutations_api_test.exs
@@ -102,7 +102,7 @@ defmodule SanbaseWeb.Graphql.BundleMutationsApiTest do
         # the current-period package list and its item carries the removal date.
         assert Enum.sort(bundle["packages"]) == ["market", "social"]
         assert bundle["apiCallsAddon"] == nil
-        assert bundle["apiCallLimits"]["month"] == 100_000
+        assert bundle["apiCallLimits"]["month"] == 50_000
         assert is_integer(bundle["apiCallLimits"]["hour"])
         assert bundle["realtimeDataCutOffInDays"] == 0
 

--- a/test/sanbase_web/live/admin/subscription_grants_live_test.exs
+++ b/test/sanbase_web/live/admin/subscription_grants_live_test.exs
@@ -80,18 +80,15 @@ defmodule SanbaseWeb.Admin.SubscriptionGrantsLiveTest do
 
     view = select_customer(conn, customer)
 
-    view |> element("button[phx-click=apply_grant]") |> render_click()
+    html = submit_grant(view, %{"extra_api_calls" => "0", "note" => ""})
 
-    # The grant form starts empty, so this is the refusal to store a grant that
-    # grants nothing rather than a silent no-op. The field path is asserted because a
-    # grant is an embed: its errors nest one level down, and a flat join would show the
-    # admin the raw inner map instead of a sentence.
-    html = render(view)
+    # An empty form is the refusal to store a grant that grants nothing rather than a
+    # silent no-op. The field path is asserted because a grant is an embed: its errors
+    # nest one level down, and a flat join would show the admin the raw inner map
+    # instead of a sentence.
     assert html =~ "grant.extra_api_calls_per_month: a grant must add extra API calls"
 
-    view |> render_hook("set_extra_calls", %{"value" => "200000"})
-    view |> render_hook("set_note", %{"value" => "INV-1"})
-    view |> element("button[phx-click=apply_grant]") |> render_click()
+    submit_grant(view, %{"extra_api_calls" => "200000", "note" => "INV-1"})
 
     grant = customer |> subscription_of() |> Subscription.grant()
     assert grant.extra_api_calls_per_month == 200_000
@@ -110,8 +107,7 @@ defmodule SanbaseWeb.Admin.SubscriptionGrantsLiveTest do
     view = select_customer(conn, customer)
 
     view |> element("button[phx-value-slug=market]") |> render_click()
-    view |> render_hook("set_note", %{"value" => "INV-2"})
-    view |> element("button[phx-click=apply_grant]") |> render_click()
+    submit_grant(view, %{"extra_api_calls" => "0", "note" => "INV-2"})
 
     grant = customer |> subscription_of() |> Subscription.grant()
 
@@ -125,9 +121,7 @@ defmodule SanbaseWeb.Admin.SubscriptionGrantsLiveTest do
 
     view = select_customer(conn, customer)
 
-    view |> render_hook("set_extra_calls", %{"value" => "200000"})
-    view |> render_hook("set_note", %{"value" => "INV-3"})
-    view |> element("button[phx-click=apply_grant]") |> render_click()
+    submit_grant(view, %{"extra_api_calls" => "200000", "note" => "INV-3"})
 
     view |> element("button[phx-click=revoke]") |> render_click()
 
@@ -137,7 +131,27 @@ defmodule SanbaseWeb.Admin.SubscriptionGrantsLiveTest do
     assert acl.resolved_api_call_limits == nil
   end
 
+  test "a value typed and submitted before the debounce fires is the one granted", context do
+    %{conn: conn, customer: customer} = context
+
+    view = select_customer(conn, customer)
+
+    # No set_extra_calls / set_note hook first: the inputs are debounced, so this is a
+    # form submitted inside the debounce window. Read from the assigns instead of the
+    # submitted params, this would grant 0 calls and refuse for a missing note.
+    submit_grant(view, %{"extra_api_calls" => "125000", "note" => "INV-typed-fast"})
+
+    grant = customer |> subscription_of() |> Subscription.grant()
+
+    assert grant.extra_api_calls_per_month == 125_000
+    assert grant.note == "INV-typed-fast"
+  end
+
   # ── Helpers ─────────────────────────────────────────────────────────────
+
+  defp submit_grant(view, params) do
+    view |> form("form[phx-submit=apply_grant]", params) |> render_submit()
+  end
 
   defp select_customer(conn, customer) do
     {:ok, view, _html} = live(conn, "/admin/subscription_grants")

--- a/test/sanbase_web/live/admin/subscription_grants_live_test.exs
+++ b/test/sanbase_web/live/admin/subscription_grants_live_test.exs
@@ -83,8 +83,11 @@ defmodule SanbaseWeb.Admin.SubscriptionGrantsLiveTest do
     view |> element("button[phx-click=apply_grant]") |> render_click()
 
     # The grant form starts empty, so this is the refusal to store a grant that
-    # grants nothing rather than a silent no-op.
-    assert render(view) =~ "must add extra API calls"
+    # grants nothing rather than a silent no-op. The field path is asserted because a
+    # grant is an embed: its errors nest one level down, and a flat join would show the
+    # admin the raw inner map instead of a sentence.
+    html = render(view)
+    assert html =~ "grant.extra_api_calls_per_month: a grant must add extra API calls"
 
     view |> render_hook("set_extra_calls", %{"value" => "200000"})
     view |> render_hook("set_note", %{"value" => "INV-1"})

--- a/test/sanbase_web/live/admin/subscription_grants_live_test.exs
+++ b/test/sanbase_web/live/admin/subscription_grants_live_test.exs
@@ -1,0 +1,170 @@
+defmodule SanbaseWeb.Admin.SubscriptionGrantsLiveTest do
+  @moduledoc ~s"""
+  The screen sales uses to apply an add-on it already sold and invoiced
+  separately. See §8 task **GR** of `docs/composable-api-plans-handover.md`.
+
+  What is asserted here is what would make the screen dangerous rather than
+  merely broken: that applying a grant actually reaches the quota path, that
+  removing one puts the customer back exactly where they were, and that the page
+  says out loud that it does not charge anybody.
+  """
+
+  use SanbaseWeb.ConnCase, async: false
+
+  @moduletag capture_log: true
+
+  import Phoenix.LiveViewTest
+  import Sanbase.Factory
+
+  alias Sanbase.Accounts.UserRole
+  alias Sanbase.ApiCallLimit
+  alias Sanbase.Billing.Plan.Bundle.PackageSnapshot
+  alias Sanbase.Billing.Subscription
+  alias Sanbase.Metric.Category.MetricCategory
+  alias Sanbase.Metric.Category.MetricCategoryMapping
+  alias Sanbase.Repo
+
+  @packaged_metrics %{
+    "market" => "price_usd",
+    "development" => "dev_activity",
+    "social" => "social_volume_total",
+    "onchain_core" => "mvrv_usd",
+    "onchain_labels" => "nvt"
+  }
+
+  setup context do
+    Repo.query!("ALTER SEQUENCE plans_id_seq RESTART WITH 9601")
+
+    institutional_plan =
+      insert(:plan_pro,
+        id: 9600,
+        name: "INSTITUTIONAL",
+        interval: "year",
+        product_id: context.product_api.id,
+        amount: 958_800,
+        stripe_id: "stripe_plan_" <> Ecto.UUID.generate()
+      )
+
+    categorize_metrics()
+    {:ok, _snapshot} = PackageSnapshot.publish(notes: "test")
+
+    admin = insert(:user, email: "admin#{System.unique_integer([:positive])}@santiment.net")
+    role = insert(:role_admin_panel_owner)
+    {:ok, _} = UserRole.create(admin.id, role.id)
+    {:ok, jwt_tokens} = SanbaseWeb.Guardian.get_jwt_tokens(admin)
+
+    customer = insert(:user, email: "customer#{System.unique_integer([:positive])}@example.com")
+
+    subscription =
+      insert(:subscription_pro,
+        user_id: customer.id,
+        plan_id: institutional_plan.id,
+        status: :active,
+        stripe_id: "sub_inst_" <> Ecto.UUID.generate()
+      )
+
+    conn = Plug.Test.init_test_session(build_conn(), jwt_tokens)
+
+    %{conn: conn, admin: admin, customer: customer, subscription: subscription}
+  end
+
+  test "says plainly that it moves entitlement and not money", %{conn: conn} do
+    {:ok, _view, html} = live(conn, "/admin/subscription_grants")
+
+    assert html =~ "Subscription grants"
+    assert html =~ "entitlement, not money"
+  end
+
+  test "applying a grant reaches the quota path", context do
+    %{conn: conn, customer: customer} = context
+
+    view = select_customer(conn, customer)
+
+    view |> element("button[phx-click=apply_grant]") |> render_click()
+
+    # The grant form starts empty, so this is the refusal to store a grant that
+    # grants nothing rather than a silent no-op.
+    assert render(view) =~ "must add extra API calls"
+
+    view |> render_hook("set_extra_calls", %{"value" => "200000"})
+    view |> render_hook("set_note", %{"value" => "INV-1"})
+    view |> element("button[phx-click=apply_grant]") |> render_click()
+
+    grant = customer |> subscription_of() |> Subscription.grant()
+    assert grant.extra_api_calls_per_month == 200_000
+    assert grant.note == "INV-1"
+
+    # The daily reconciler matches on plan name and would never notice a grant, so
+    # the screen has to push the new allowance itself.
+    acl = Repo.get_by!(ApiCallLimit, user_id: customer.id)
+    plan_month = ApiCallLimit.plan_to_api_call_limits("sanapi_institutional").month
+    assert acl.resolved_api_call_limits["month"] == plan_month + 200_000
+  end
+
+  test "granting a package stores the metrics it expanded to", context do
+    %{conn: conn, customer: customer} = context
+
+    view = select_customer(conn, customer)
+
+    view |> element("button[phx-value-slug=market]") |> render_click()
+    view |> render_hook("set_note", %{"value" => "INV-2"})
+    view |> element("button[phx-click=apply_grant]") |> render_click()
+
+    grant = customer |> subscription_of() |> Subscription.grant()
+
+    assert grant.full_history_packages == ["market"]
+    assert @packaged_metrics["market"] in grant.full_history_metrics
+    refute @packaged_metrics["social"] in grant.full_history_metrics
+  end
+
+  test "removing a grant puts the customer back on the plan", context do
+    %{conn: conn, customer: customer} = context
+
+    view = select_customer(conn, customer)
+
+    view |> render_hook("set_extra_calls", %{"value" => "200000"})
+    view |> render_hook("set_note", %{"value" => "INV-3"})
+    view |> element("button[phx-click=apply_grant]") |> render_click()
+
+    view |> element("button[phx-click=revoke]") |> render_click()
+
+    assert customer |> subscription_of() |> Subscription.grant() == nil
+
+    acl = Repo.get_by!(ApiCallLimit, user_id: customer.id)
+    assert acl.resolved_api_call_limits == nil
+  end
+
+  # ── Helpers ─────────────────────────────────────────────────────────────
+
+  defp select_customer(conn, customer) do
+    {:ok, view, _html} = live(conn, "/admin/subscription_grants")
+
+    view |> render_hook("search_user", %{"value" => customer.email})
+    view |> render_hook("select_user", %{"id" => to_string(customer.id)})
+    view |> element("button[phx-click=select_subscription]") |> render_click()
+
+    view
+  end
+
+  defp subscription_of(customer) do
+    Repo.get_by!(Subscription, user_id: customer.id)
+  end
+
+  defp categorize_metrics do
+    Sanbase.Billing.Plan.Bundle.Package.all()
+    |> Enum.with_index()
+    |> Enum.each(fn {package, index} ->
+      {:ok, category} =
+        MetricCategory.create(%{name: package.category, display_order: index})
+
+      # Mapped by module/metric rather than through the registry: this case does not
+      # seed the registry, and what the snapshot needs is the metric name.
+      {:ok, _} =
+        MetricCategoryMapping.create(%{
+          module: "Sanbase.Metric.SubscriptionGrantsTestAdapter",
+          metric: Map.fetch!(@packaged_metrics, package.slug),
+          category_id: category.id
+        })
+    end)
+  end
+end


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Pricing decisions (2026-09-10)

- Institutional yearly $9,500 → **$9,588**; monthly withdrawn (yearly only)
- Enterprise withdrawn as a self-serve priced tier — negotiated deals go through `CUSTOM_*`
- Bundle allowance **100,000 → 50,000** calls/month, still flat for one or all packages
- All withdrawals via `is_deprecated`, which already blocks both `subscribe` and `updateSubscription` server-side. Rows kept, not deleted.

## Institutional add-ons (sales-applied grants)

Sales sells extra API calls and full history per data package, charges them on a separate one-off Stripe invoice, then applies them in the admin panel. Nothing is added to the Stripe subscription.

- New `subscriptions.grant` column. Deliberately not `bundle_entitlement`, which is recomputed from Stripe items on every webhook and would erase a grant.
- Grants are **additive only** — enforced in code at both write and read, so one can never shorten a window or lower an allowance.
- History is resolved **per metric**: a granted package gets full history, everything else keeps the plan's 3 years. The metric list is expanded once against the published package snapshot, so access checks stay a membership test.
- Institutional remains a `:standard` plan — Sanbase MAX, BusinessMax ClickHouse repo, complexity 7 and MCP tier still answer from the plan name.
- Applied consistently at the data layer, `getAccessRestrictions` and metric metadata, so the API cannot serve one window while advertising another.
- Grants persist until removed; no expiry.
- New admin screen at `/admin/subscription_grants` (apply, re-expand against the current snapshot, remove).

## Fixes

- **Bundle customers were getting the free MCP tier.** Every bundle is named `BUNDLE`, which had no clause in `MCP.Restrictions` and fell to the SANAPI catch-all. MCP is sold with the packages.
- `BUNDLE%`, `INSTITUTIONAL%` and `ENTERPRISE%` added to the API onboarding email list (§15 Q16).


## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin tools for granting subscriptions extra monthly API calls and expanded historical access by data package.
  * Grants now support package selection, notes, re-expansion, and revocation.
  * Added support for updated bundle, institutional, and enterprise plans across onboarding and access tiers.
  * Added a process for switching the Institutional yearly plan to the new pricing.

* **Changes**
  * Bundle subscriptions now include a 50,000-call monthly base allowance.
  * Granted API call allowances and historical access are reflected in customer restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->