### PR TITLE
API Bundle gets free sanbase access

### DIFF
--- a/lib/sanbase/billing/plan/bundle/bundle.ex
+++ b/lib/sanbase/billing/plan/bundle/bundle.ex
@@ -24,19 +24,22 @@ defmodule Sanbase.Billing.Plan.Bundle do
   """
 
   @equivalent_standard_plan "PRO"
+  @sanbase_equivalent_plan "FREE"
 
   @doc ~s"""
-  The standard plan a bundle behaves like for everything that is **not** metric,
-  query or signal access and **not** the API call quota.
+  The standard SanAPI plan a bundle behaves like for everything that is **not**
+  metric, query or signal access and **not** the API call quota.
 
   Those two things come from the entitlement, because they are what the customer
-  actually chose. Everything else - how many alerts they can create, how much
-  query credit they get, which ClickHouse repo their queries run against, and
-  their whole Sanbase experience - has no per-package answer and needs one
-  anyway.
+  actually chose. Everything else on the SanAPI side - how much query credit they
+  get, which ClickHouse repo their queries run against, how their query complexity
+  is divided, how large a monthly response volume they may pull - has no
+  per-package answer and needs one anyway. Bundles are priced against PRO, so PRO
+  is what they get.
 
-  Product's answer (§15 Q5): the same as a SanAPI PRO customer who has no
-  Sanbase subscription. Bundles are priced against PRO, so PRO is what they get.
+  **Not the Sanbase answer.** That is `sanbase_equivalent_plan/0`, and the two are
+  deliberately separate - see its docs for why collapsing them would be a quiet
+  downgrade of a paying customer.
 
   This mirrors what already happens for `CUSTOM_*` plans, which resolve to their
   `restricted_access_as_plan` for exactly the same reason - see
@@ -45,6 +48,34 @@ defmodule Sanbase.Billing.Plan.Bundle do
   """
   @spec equivalent_standard_plan() :: String.t()
   def equivalent_standard_plan, do: @equivalent_standard_plan
+
+  @doc ~s"""
+  The Sanbase plan a bundle customer gets when they have no Sanbase subscription
+  of their own: **FREE**.
+
+  A bundle is a SanAPI product. The packages say which *metrics* were bought,
+  which means nothing for Sanbase - so the question "what does a bundle customer
+  see in Sanbase?" has to be answered by a rule rather than by the entitlement,
+  and the rule is that they are not paying for Sanbase.
+
+  ## Why this is a separate function from `equivalent_standard_plan/0`
+
+  Because the two answers are genuinely different, and one constant serving both
+  would tie them together. Reading this one everywhere would put a paying API
+  customer on FREE's query-complexity divider and FREE's monthly response-size
+  cap - a 40x cut - with no error anywhere. Reading the other one everywhere is
+  what used to happen, and it gave away the full Sanbase PRO experience with it.
+
+  So there are two: this one is read at exactly the two Sanbase-facing sites
+  (`SanbaseWeb.Graphql.AuthPlug.effective_plan_name/2` and
+  `Sanbase.Billing.Plan.SanbaseAccessChecker`), and `equivalent_standard_plan/0`
+  at the SanAPI ones.
+
+  A bundle customer who also buys a Sanbase subscription is unaffected - their own
+  subscription is found first and this never comes up.
+  """
+  @spec sanbase_equivalent_plan() :: String.t()
+  def sanbase_equivalent_plan, do: @sanbase_equivalent_plan
 
   @doc ~s"""
   What a bundle subscription is made of, for showing to its owner.

--- a/lib/sanbase/billing/plan/standard_access_checker/sanbase_access_checker.ex
+++ b/lib/sanbase/billing/plan/standard_access_checker/sanbase_access_checker.ex
@@ -78,9 +78,11 @@ defmodule Sanbase.Billing.Plan.SanbaseAccessChecker do
   # itself rather than relying on the dispatcher.
   defp plan_stats(plan) do
     case Plan.type(plan) do
-      # Bundles are a SanAPI product; their Sanbase experience is PRO's.
+      # Bundles are a SanAPI product and Sanbase is not part of what was sold, so their
+      # Sanbase experience is FREE's. Institutional and Enterprise include Sanbase and
+      # are answered by name above.
       :bundle ->
-        standard_or_custom_plan_stats(Sanbase.Billing.Plan.Bundle.equivalent_standard_plan())
+        standard_or_custom_plan_stats(Sanbase.Billing.Plan.Bundle.sanbase_equivalent_plan())
 
       _ ->
         standard_or_custom_plan_stats(plan)

--- a/lib/sanbase_web/graphql/plugs/auth_plug.ex
+++ b/lib/sanbase_web/graphql/plugs/auth_plug.ex
@@ -329,8 +329,10 @@ defmodule SanbaseWeb.Graphql.AuthPlug do
   #
   # A bundle is the same case: its packages say which *metrics* were bought, which means
   # nothing for Sanbase, and letting the name through sends Sanbase access checks down the
-  # bundle path where the Sanbase limits have no per-package answer. Per product (§15 Q5)
-  # these customers get what a SanAPI PRO customer with no Sanbase subscription gets.
+  # bundle path where the Sanbase limits have no per-package answer. A bundle is a SanAPI
+  # product and Sanbase is not part of what was sold, so these customers get FREE - see
+  # `Bundle.sanbase_equivalent_plan/0`. Not `equivalent_standard_plan/0`: that one is the
+  # SanAPI-side answer and is still PRO.
   defp effective_plan_name(subscription, "SANBASE") do
     case subscription do
       %Subscription{plan: %{has_custom_restrictions: true, name: name}} ->
@@ -338,7 +340,7 @@ defmodule SanbaseWeb.Graphql.AuthPlug do
 
       %Subscription{plan: %{name: name}} = subscription ->
         case Sanbase.Billing.Plan.type(name) do
-          :bundle -> Sanbase.Billing.Plan.Bundle.equivalent_standard_plan()
+          :bundle -> Sanbase.Billing.Plan.Bundle.sanbase_equivalent_plan()
           _ -> Subscription.plan_name(subscription)
         end
 

--- a/test/sanbase/billing/plan_type_dispatch_test.exs
+++ b/test/sanbase/billing/plan_type_dispatch_test.exs
@@ -236,15 +236,21 @@ defmodule Sanbase.Billing.PlanTypeDispatchTest do
              ) == 0
     end
 
-    test "the Sanbase-side limits answer as the equivalent standard plan" do
-      # Product's answer to §15 Q5: a bundle customer gets what a SanAPI PRO
-      # customer with no Sanbase subscription gets. None of these four has a
-      # per-package answer, and before Q5 every one of them raised - so a bundle
-      # customer opening Sanbase got a 500.
-      equivalent = Bundle.equivalent_standard_plan()
-
+    test "the Sanbase side answers as FREE, the SanAPI side as the equivalent standard plan" do
+      # The two answers are deliberately different and a single constant serving both
+      # would tie them together. Collapsing them in either direction is a silent
+      # downgrade: towards FREE it puts a paying API customer on FREE's complexity
+      # divider and response-size cap, towards PRO it gives away Sanbase PRO.
+      #
+      # None of these has a per-package answer, and before §15 Q5 every one raised - so a
+      # bundle customer opening Sanbase got a 500.
       assert SanbaseAccessChecker.alerts_limit(@bundle_plan) ==
-               SanbaseAccessChecker.alerts_limit(equivalent)
+               SanbaseAccessChecker.alerts_limit(Bundle.sanbase_equivalent_plan())
+
+      refute SanbaseAccessChecker.alerts_limit(@bundle_plan) ==
+               SanbaseAccessChecker.alerts_limit(Bundle.equivalent_standard_plan())
+
+      equivalent = Bundle.equivalent_standard_plan()
 
       for product <- @products do
         assert Authorization.credits_limit(product, @bundle_plan) ==

--- a/test/sanbase_web/graphql/billing/bundle_api_access_test.exs
+++ b/test/sanbase_web/graphql/billing/bundle_api_access_test.exs
@@ -259,24 +259,50 @@ defmodule Sanbase.Billing.BundleApiAccessTest do
       subscribe(context.bundle_plan, ["social"])
     end
 
-    test "is treated as the equivalent standard plan on Sanbase, not as a bundle", context do
-      # Product's answer to Q5: the same as a SanAPI PRO customer with no Sanbase
-      # subscription. So the bundle name must never reach a Sanbase access check -
-      # if it did, the package metric list would decide Sanbase access, and the
-      # Sanbase-specific limits have no per-package answer.
+    test "sees what a free Sanbase user sees, not what a PRO one does", context do
+      # The constants are pinned elsewhere; this is the customer-visible half of that
+      # decision, written out so changing it is a deliberate act rather than a diff in a
+      # module attribute nobody reads.
+      %{user: user} = context
+
+      subscription = Subscription.current_subscription(user.id, context.product_api.id)
+      assert Sanbase.Billing.Plan.plan_name(subscription.plan) == "BUNDLE"
+
+      checker = Sanbase.Billing.Plan.SanbaseAccessChecker
+
+      assert checker.alerts_limit("BUNDLE") == checker.alerts_limit("FREE")
+      refute checker.can_access_paywalled_insights?(subscription)
+
+      # Two years of history and a 30-day realtime lag, where a Sanbase PRO user has no
+      # limit and sees live data.
+      assert checker.historical_data_in_days("SANBASE", "BUNDLE") ==
+               checker.historical_data_in_days("SANBASE", "FREE")
+
+      assert checker.realtime_data_cut_off_in_days("SANBASE", "BUNDLE") ==
+               checker.realtime_data_cut_off_in_days("SANBASE", "FREE")
+    end
+
+    test "gets FREE on Sanbase and the equivalent standard plan on SanAPI", context do
+      # A bundle is a SanAPI product; Sanbase is not part of what was sold, so the
+      # Sanbase experience is FREE's. The bundle name must still never reach a Sanbase
+      # access check - if it did, the package metric list would decide Sanbase access,
+      # and the Sanbase-specific limits have no per-package answer.
       %{user: user} = context
 
       subscription = Subscription.current_subscription(user.id, context.product_api.id)
 
       assert Sanbase.Billing.Plan.plan_name(subscription.plan) == "BUNDLE"
 
-      # These four are the Sanbase-side limits. Before Q5 was answered every one
-      # of them raised for a bundle, so a bundle customer opening Sanbase got a
-      # 500.
-      equivalent = Bundle.equivalent_standard_plan()
-
+      # Before §15 Q5 was answered every one of these raised for a bundle, so a bundle
+      # customer opening Sanbase got a 500.
       assert Sanbase.Billing.Plan.SanbaseAccessChecker.alerts_limit("BUNDLE") ==
-               Sanbase.Billing.Plan.SanbaseAccessChecker.alerts_limit(equivalent)
+               Sanbase.Billing.Plan.SanbaseAccessChecker.alerts_limit(
+                 Bundle.sanbase_equivalent_plan()
+               )
+
+      # The SanAPI side is unchanged and still PRO's - the whole point of keeping the
+      # two answers apart.
+      equivalent = Bundle.equivalent_standard_plan()
 
       for product <- ["SANAPI", "SANBASE"] do
         assert Sanbase.Queries.Authorization.credits_limit(product, "BUNDLE") ==


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Ticket

<!--- Issue to which the pull request is related -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!--- ## Deployment steps -->
<!--- Deployment todo steps, if needed. Example: running seed files, mix tasks... -->

<!--- ## Usage -->
<!--- (Mainly graphql snippets that showcase how new API is used) -->

<!--- ## Screenshots -->
<!--- (if appropriate) -->

<!--- original: https://github.com/VeryBigThings/elixir_common/blob/98e723a3d1ecbc21107b3a2f98b8ab619ba28800/.github/pull_request_template.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Access Changes**
  - Bundle subscriptions now provide the Sanbase experience with FREE-level access limits.
  - Bundle subscribers without a separate Sanbase subscription can no longer access paywalled insights.
  - Historical data and real-time data availability for bundle subscriptions now match the FREE plan.

- **API Access**
  - SanAPI access for bundle subscriptions remains aligned with the existing PRO-level plan behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->